### PR TITLE
Fix Heroku deployment guide for DB SSL and server.js

### DIFF
--- a/developer-docs/latest/deployment/heroku.md
+++ b/developer-docs/latest/deployment/heroku.md
@@ -182,7 +182,7 @@ This should print something like this: `DATABASE_URL: postgres://ebitxebvixeeqd:
 
 #### 3. Set Database variables automatically
 
-Strapi expects a variable for each database connection configuration (host, username, etc.). So, from the url above, we will deconstruct that environment variable using [pg-connection-string](https://www.npmjs.com/package/pg-connection-string). Heroku will sometimes change the above url, so it's best to automate the deconstruction of it, as Heroku will automatically update the `DATABASE_URL` environment variable.
+Strapi expects a variable for each database connection configuration (host, username, etc.). So, from the url above, Strapi will deconstruct that environment variable using [pg-connection-string](https://www.npmjs.com/package/pg-connection-string) package. Heroku will sometimes change the above url, so it's best to automate the deconstruction of it, as Heroku will automatically update the `DATABASE_URL` environment variable.
 
 Install the package:
 
@@ -232,7 +232,7 @@ module.exports = ({ env }) => ({
 });
 ```
 
-We also need to set the `NODE_ENV` variable on Heroku to `production` to ensure this new database configuration file is used.
+You also need to set the `NODE_ENV` variable on Heroku to `production` to ensure this new database configuration file is used.
 
 ```bash
 heroku config:set NODE_ENV=production
@@ -240,7 +240,7 @@ heroku config:set NODE_ENV=production
 
 #### 5. Create your Strapi server config for production
 
-Create a new `server.js` in a new [env](../concepts/configurations.html#environments) folder. In this file we only need one key, the `url`, to notify Strapi what our public Heroku domain is. All other settings will automatically be pulled from the default `./config/server.js`.
+Create a new `server.js` in a new [env](../concepts/configurations.html#environments) folder. In this file you only need one key, the `url`, to notify Strapi what our public Heroku domain is. All other settings will automatically be pulled from the default `./config/server.js`.
 
 `Path: ./config/env/production/server.js`
 
@@ -250,7 +250,7 @@ module.exports = ({ env }) => ({
 });
 ```
 
-And finally we just need to set the environment variable in Heroku for the `HEROKU_URL`. This will populate the variable with something like `https://your-app.herokuapp.com`.
+You will also need to set the environment variable in Heroku for the `HEROKU_URL`. This will populate the variable with something like `https://your-app.herokuapp.com`.
 
 ```bash
 heroku config:set HEROKU_URL=$(heroku info -s | grep web_url | cut -d= -f2)

--- a/developer-docs/latest/deployment/heroku.md
+++ b/developer-docs/latest/deployment/heroku.md
@@ -15,22 +15,22 @@ Download and install the `Heroku CLI` for your operating system:
 
 :::: tabs
 
-::: tab "Mac O/S"
+::: tab Ubuntu
+Run the following from your terminal:
+
+```bash
+sudo snap install --classic heroku
+```
+
+:::
+
+::: tab Mac
 [Download the installer](https://cli-assets.heroku.com/heroku.pkg)
 
 Also available via Homebrew:
 
 ```bash
 brew tap heroku/brew && brew install heroku
-```
-
-:::
-
-::: tab Ubuntu
-Run the following from your terminal:
-
-```bash
-sudo snap install --classic heroku
 ```
 
 :::
@@ -200,7 +200,7 @@ yarn add pg-connection-string
 
 #### 4. Create your Heroku database config file for production
 
-Create a new `database.js` in a new [env](../concepts/configurations.html#environments) folder. When you run locally you should be using the `./config/database.js` which should be set to use SQLite.
+Create a new `database.js` in a new [env](../concepts/configurations.html#environments) folder. When you run locally you should be using the `./config/database.js` which could be set to use SQLite, however it's recommended you use PostgreSQL locally also, for information on configuring your local database, please see the [database documentation](../concepts/configurations.md#database).
 
 `Path: ./config/env/production/database.js`
 
@@ -220,9 +220,12 @@ module.exports = ({ env }) => ({
         database: config.database,
         username: config.user,
         password: config.password,
+        ssl: {
+          rejectUnauthorized: false
+        }
       },
       options: {
-        ssl: false,
+        ssl: true,
       },
     },
   },
@@ -235,7 +238,25 @@ We also need to set the `NODE_ENV` variable on Heroku to `production` to ensure 
 heroku config:set NODE_ENV=production
 ```
 
-#### 5. Install the `pg` node module
+#### 5. Create your Strapi server config for production
+
+Create a new `server.js` in a new [env](../concepts/configurations.html#environments) folder. In this file we only need one key, the `url`, to notify Strapi what our public Heroku domain is. All other settings will automatically be pulled from the default `./config/server.js`.
+
+`Path: ./config/env/production/server.js`
+
+```js
+module.exports = ({ env }) => ({
+  url: env('HEROKU_URL'),
+});
+```
+
+And finally we just need to set the environment variable in Heroku for the `HEROKU_URL`. This will populate the variable with something like `https://your-app.herokuapp.com`.
+
+```bash
+heroku config:set HEROKU_URL=$(heroku info -s | grep web_url | cut -d= -f2)
+```
+
+#### 6. Install the `pg` node module
 
 Unless you originally installed Strapi with PostgreSQL, you need to install the [pg](https://www.npmjs.com/package/pg) node module.
 


### PR DESCRIPTION
Added updated config options for the database file, cleaned up the guide a little bit, and added step to configure the server.js