### PR TITLE
Added components directory to the file structure

### DIFF
--- a/developer-docs/latest/concepts/file-structure.md
+++ b/developer-docs/latest/concepts/file-structure.md
@@ -11,6 +11,7 @@ By default, your project's structure will look like this:
     - [`/models`](./models.md): contains the API's models.
     - [`/services`](./services.md): contains the API's custom services.
 - `/build`: contains your admin panel UI build.
+- [`/components`](./models.md#components): contains the components used by the API's models.
 - [`/config`](./configurations.md)
   - [`/functions`](./configurations.md#functions): contains lifecycle or generic functions of the project.
     - [`/responses`](./configurations.md#responses): contains custom responses.


### PR DESCRIPTION
Also added the link that goes to the related guide page.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

Adds components directory to the file structure page

### Why is it needed?

I was making a custom docker container but it was failing because I skipped adding this directory to my volume. It is a necessary directory for stable operation and should be included in the file structure page.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
