### PR TITLE
Change validateEntity to validateEntityCreation

### DIFF
--- a/developer-docs/latest/concepts/services.md
+++ b/developer-docs/latest/concepts/services.md
@@ -139,7 +139,7 @@ module.exports = {
    */
 
   async create(data, { files } = {}) {
-    const validData = await strapi.entityValidator.validateEntity(strapi.models.restaurant, data);
+    const validData = await strapi.entityValidator.validateEntityCreation(strapi.models.restaurant, data);
     const entry = await strapi.query('restaurant').create(validData);
 
     if (files) {


### PR DESCRIPTION
### What does it do?

Fix wrong function call in documentation from validateEntity to validateEntityCreation

### Why is it needed?

Function was not renamed in documentation

### Related issue(s)/PR(s)

Apparently it was already fixed but got lost in the transition to the documentation repo

https://github.com/strapi/strapi/pull/8429
