### PR TITLE
Updated the full details in --quickstart flag

### DIFF
--- a/developer-docs/latest/installation/cli.md
+++ b/developer-docs/latest/installation/cli.md
@@ -56,7 +56,7 @@ npx create-strapi-app my-project --quickstart
 ::::
 
 ::: tip
-If you want to use specific database, you don't have to use the `--quickstart` flag. The CLI will let you choose the database of your choice. The `--quickstart` flag sets the database  to SQLite.
+If you want to use specific database, you don't have to use the `--quickstart` flag. The CLI will let you choose the database of your choice. The `--quickstart` flag sets the database to SQLite.
 :::
 
 :::tip

--- a/developer-docs/latest/installation/cli.md
+++ b/developer-docs/latest/installation/cli.md
@@ -56,7 +56,7 @@ npx create-strapi-app my-project --quickstart
 ::::
 
 ::: tip
-If you want to use specific database, you don't have to use the `--quickstart` flag. The CLI will let you choose the database of your choice. The --quickstart flag sets the database  to SQLite.
+If you want to use specific database, you don't have to use the `--quickstart` flag. The CLI will let you choose the database of your choice. The `--quickstart` flag sets the database  to SQLite.
 :::
 
 :::tip

--- a/developer-docs/latest/installation/cli.md
+++ b/developer-docs/latest/installation/cli.md
@@ -56,7 +56,7 @@ npx create-strapi-app my-project --quickstart
 ::::
 
 ::: tip
-If you want to use specific database, you don't have to use the `--quickstart` flag. The CLI will let you choose the database of your choice.
+If you want to use specific database, you don't have to use the `--quickstart` flag. The CLI will let you choose the database of your choice. The --quickstart flag sets the database  to SQLite.
 :::
 
 :::tip


### PR DESCRIPTION
The SqLite database is not motioned anywhere in starting line of code with --quickstart.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

This gives the information about the database used by --quickstart flag

### Why is it needed?

Beginners copies the code but than they do not know what database that they are using while using --quickstart.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
