### PR TITLE
FIXED: Authorization header missing quotes in graphql

### DIFF
--- a/developer-docs/latest/plugins/graphql.md
+++ b/developer-docs/latest/plugins/graphql.md
@@ -48,7 +48,7 @@ mutation {
 }
 ```
 
-Then on each request, send along an `Authorization` header in the form of `{ Authorization: "Bearer YOUR_JWT_GOES_HERE" }`. This can be set in the HTTP Headers section of your GraphQL Playground.
+Then on each request, send along an `Authorization` header in the form of `{ "Authorization": "Bearer YOUR_JWT_GOES_HERE" }`. This can be set in the HTTP Headers section of your GraphQL Playground.
 
 ## Configurations
 


### PR DESCRIPTION
### What does it do?

Enclosing Authorization with quotes in header example in graphql docs.

### Why is it needed?

It saves time for future devs copy-pasting from docs and not realizing the missing the quotes.

### Related issue(s)/PR(s)

fixes #43