### PR TITLE
correct strapi logo name

### DIFF
--- a/developer-docs/latest/admin-panel/customization.md
+++ b/developer-docs/latest/admin-panel/customization.md
@@ -121,7 +121,7 @@ npm run build
 
 To change the top-left displayed admin panel's logo, add your custom image at `./admin/src/assets/images/logo-strapi.png`.
 
-To change the login page's logo, add your custom image at `./admin/src/assets/images/logo_strapi.png`.
+To change the login page's logo, add your custom image at `./admin/src/assets/images/logo-strapi.png`.
 
 ::: tip
 make sure the size of your image is the same as the existing one (434px x 120px).


### PR DESCRIPTION


<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

`./admin/src/assets/images/logo_strapi.png` does not work

BUT, `./admin/src/assets/images/logo-strapi.png` works

### Why is it needed?

There was a confusion between which to use _ or - in `logo-strapi.png`.
I had first tried to use `logo_strapi.png` and had to wait for the build to finish and the server to start again which took some time but it did not work. However, `logo-strapi.png` worked (after rebuilding again).

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
