### PR TITLE
Add testAddress option to email docs | email test feature 

### DIFF
--- a/developer-docs/latest/plugins/email.md
+++ b/developer-docs/latest/plugins/email.md
@@ -96,11 +96,11 @@ The string after the last `@` represents your desired [semver](https://docs.npmj
 
 ### Configure your provider
 
-After installing your provider you will need to add some settings in `config/plugins.js`.
-If this file doesn't exists, you'll need to create it.
+After installing your provider you will need to add some settings in `config/plugins.js`. If this file doesn't exists, you'll need to create it. Check the README of each provider to know what configuration settings the provider needs.
 
-> ⚠️ Do note that filename has to come with correct spelling, plugin with 's' (plural). -> `plugins.js`
-> Check the README of each provider to know what configuration settings the provider needs.
+::: tip
+Make sure you have the correct spelling of the configuration filename, it is written in plural (with a trailing 's'): `plugins.js`.
+:::
 
 Here is an example of a configuration made for the provider [strapi-provider-email-sendgrid](https://www.npmjs.com/package/strapi-provider-email-sendgrid).
 
@@ -117,6 +117,7 @@ module.exports = ({ env }) => ({
     settings: {
       defaultFrom: 'juliasedefdjian@strapi.io',
       defaultReplyTo: 'juliasedefdjian@strapi.io',
+      testAddress: 'juliasedefdjian@strapi.io',
     },
   },
   // ...


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

Adds the config option for an email testAddress.

### Why is it needed?

Docs for [email test feature](https://github.com/strapi/strapi/pull/8156).

### Related issue(s)/PR(s)

strapi/strapi#8156
strapi/strapi#5935