### PR TITLE
Update digitalocean.md

### DIFF
--- a/developer-docs/latest/deployment/digitalocean.md
+++ b/developer-docs/latest/deployment/digitalocean.md
@@ -221,7 +221,8 @@ Next, navigate to the `my-project` folder, the root for Strapi. You will now nee
 ```bash
 cd ./my-project/
 npm install
-NODE_ENV=production npm run build
+NODE_ENV=production 
+npm run build
 ```
 
 Strapi uses `Port: 1337` by default. You will need to configure your `ufw firewall` to allow access to this port, for testing and installation purposes. After you have installed and [configured NGINX](https://www.digitalocean.com/community/tutorials/how-to-install-nginx-on-ubuntu-18-04), you need to `sudo ufw deny 1337`, to close the port to outside traffic.


### PR DESCRIPTION
### What does it do?

Adds line break to indicate that "NODE_ENV=production" and "npm run build" are separate commands.

### Why is it needed?

Without the line break, developers unfamiliar with npm might be confused and think it's a single command.

### Related issue(s)/PR(s)

N/A.