### PR TITLE
Add sslCA to configurations

### DIFF
--- a/developer-docs/latest/concepts/configurations.md
+++ b/developer-docs/latest/concepts/configurations.md
@@ -507,6 +507,7 @@ You can find [supported database and versions](../installation/cli.md#databases)
       - `uri` (string): This can overide all previous configurations - _optional_
     - `options` Options used for database connection.
       - `ssl` (boolean): For ssl database connection.
+      - `sslCA` (string): Pass content (not filepath!) of server's root CA for ssl connection.
       - `debug` (boolean): Show database exchanges and errors.
       - `authenticationDatabase` (string): Connect with authentication.
 


### PR DESCRIPTION
Document sslCA option for MongoDB connections

### Related issue(s)/PR(s)

relates to https://github.com/strapi/strapi/pull/9339
