### PR TITLE
remove subdomain in caddy code examples

### DIFF
--- a/developer-docs/latest/deployment/caddy-proxy.md
+++ b/developer-docs/latest/deployment/caddy-proxy.md
@@ -60,7 +60,7 @@ Example Domain: `example.com/api`
 **Path —** `/etc/caddy/Caddyfile`
 
 ```
-http://api.example.com {
+http://example.com {
   root * /var/www
   file_server
   route /api* {
@@ -93,7 +93,7 @@ Example Admin Domain: `example.com/dashboard`
 **Path —** `/etc/caddy/Caddyfile`
 
 ```
-http://api.example.com {
+http://example.com {
   root * /var/www
   file_server
   route /api* {


### PR DESCRIPTION
For Sub-Folder (unified and split) code examples in the Caddy deployment, there is still a sub domain (api.*) which might confuse people

### What does it do?

Removed the sub domain "api." for both unified and split code examples in caddy deployment

### Why is it needed?

Given the example its wrong and might confuse people 
