### PR TITLE
add Microsoft SSO documentation

### DIFF
--- a/developer-docs/latest/concepts/sso.md
+++ b/developer-docs/latest/concepts/sso.md
@@ -291,6 +291,69 @@ module.exports = ({ env }) => ({
 });
 ```
 :::::
+::::: tab Microsoft
+
+Using: [passport-azure-ad-oauth2](https://github.com/auth0/passport-azure-ad-oauth2#readme)
+
+:::: tabs
+
+::: tab yarn
+
+```bash
+yarn add passport-azure-ad-oauth2 jsonwebtoken
+```
+
+:::
+
+::: tab npm
+
+```bash
+npm install --save passport-azure-ad-oauth2 jsonwebtoken
+```
+
+:::
+
+::::
+
+`/config/server.js`
+
+```jsx
+"use strict";
+
+const AzureAdOAuth2Strategy = require('passport-azure-ad-oauth2');
+const jwt = require('jsonwebtoken');
+
+module.exports = ({ env }) => ({
+  // ...
+  admin: {
+    // ...
+    auth: {
+      // ...
+      providers: [
+        {
+          uid: 'azure_ad_oauth2',
+          displayName: 'Microsoft',
+          icon: 'https://upload.wikimedia.org/wikipedia/commons/thumb/9/96/Microsoft_logo_%282012%29.svg/320px-Microsoft_logo_%282012%29.svg.png',
+          createStrategy: strapi => new AzureAdOAuth2Strategy({
+            clientID: env('MICROSOFT_CLIENT_ID', ''),
+            clientSecret: env('MICROSOFT_CLIENT_SECRET', ''),
+            scope: ['user:email'],
+            tenant: env('MICROSOFT_TENANT_ID', ''),
+            callbackURL: strapi.admin.services.passport.getStrategyCallbackURL('azure_ad_oauth2'),
+          }, (accessToken, refreshToken, params, profile, done) => {
+            var waadProfile = jwt.decode(params.id_token, '', true);
+            done(null, {
+              email: waadProfile.upn,
+              username: waadProfile.upn
+            });
+          }),
+        },
+      ],
+    },
+  },
+});
+```
+:::::
 ::::::
 
 ## Advanced Customization


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

Adds documentation for Microsoft as an admin SSO provider

### Why is it needed?

Adding Azure AD OAuth2 can be a little different than some of the other providers since it relies on decoding the returned token rather than just grabbing profile.email data

### Related issue(s)/PR(s)

None that I know of

### Notes
 
I grabbed the first microsoft logo I could find. There may be a more official CDN url for the logo. Also, my Markdown preview tools were not digging the whole  ```:::: tab``` thing, so double check that I'm using that correctly