### PR TITLE
✏️ Fix Typo in concepts/queries.md

### DIFF
--- a/developer-docs/latest/concepts/queries.md
+++ b/developer-docs/latest/concepts/queries.md
@@ -372,7 +372,7 @@ Please note that if you are using the [draft system](draft-and-publish.md), Stra
 **Example**
 
 ```js
-const _ = require('loadsh');
+const _ = require('lodash');
 
 const knex = strapi.connections.default;
 const result = await knex('restaurants')
@@ -382,7 +382,7 @@ const result = await knex('restaurants')
   .select('restaurants.name as restaurant')
   .select('chef.name as chef')
 
-// Loadsh's groupBy method can be used to 
+// Lodash's groupBy method can be used to 
 // return a grouped key-value object generated from 
 // the response
 


### PR DESCRIPTION
Just a small typo. The `lodash` package was written as `loadsh`.