### PR TITLE
Update GitHub Issue Form template

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -3,29 +3,34 @@ about: Create a report to help us improve the Strapi documentation.
 title: "[Bug]: "
 labels: "type: bug, status: pending reproduction"
 issue_body: true
-inputs:
+body:
 - type: input
   attributes:
     label: Link to the documentation page or resource
-    required: true
     placeholder: https://strapi.io/documentation/developer-docs/latest/somepage.html
+  validations:
+    required: true
 - type: textarea
   attributes:
     label: Describe the bug
-    required: true
     placeholder: "A clear and concise description of what the bug is."
+  validations:
+    required: true
 - type: textarea
   attributes:
     label: Additional context
-    required: false
     placeholder: "Add any other context about the problem here."
+  validations:
+    required: false
 - type: textarea
   attributes:
     label: Suggested improvements or fixes
-    required: false
     placeholder: "A clear and concise description of what you want to happen."
+  validations:
+    required: false
 - type: textarea
   attributes:
     label: Related issue(s)/PR(s)
-    required: false
     placeholder: "Let us know if this is related to any issue/pull request."
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/DOC_REQUEST.yml
+++ b/.github/ISSUE_TEMPLATE/DOC_REQUEST.yml
@@ -3,24 +3,28 @@ about: Suggest a new part of the documentation we are missing!
 title: "[Request]: "
 labels: "type: doc request"
 issue_body: false
-inputs:
+body:
 - type: textarea
   attributes:
     label: Summary
-    required: true
     placeholder: Quick summary what's this documentation request about.
+  validations:
+    required: true
 - type: textarea
   attributes:
     label: Why is it needed?
-    required: true
     placeholder: "A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]"
+  validations:
+    required: true
 - type: textarea
   attributes:
     label: Suggested solution(s)
-    required: false
     placeholder: "A clear and concise description of what you want to happen."
+  validations:
+    required: false
 - type: textarea
   attributes:
     label: Related issue(s)/PR(s)
-    required: false
     placeholder: "Let us know if this is related to any issue/pull request."
+  validations:
+    required: false


### PR DESCRIPTION
This PR fixes the bug report and doc request templates!

Details: https://gh-community.github.io/issue-template-feedback/changes/#what-do-i-need-to-do

### What does it do?

This PR updates the YAML config for the issue template to comply with the updated structure.

### Why is it needed?

We made breaking changes to the Issue Forms Alpha YAML config, as part of a greater GitHub initiative. You can [read more about this here](https://gh-community.github.io/issue-template-feedback/changes/).

### Related issue(s)/PR(s)

Issue Forms Alpha
