### PR TITLE
Remove reference to plugin route prefix disable boolean

### DIFF
--- a/developer-docs/latest/plugin-development/backend-development.md
+++ b/developer-docs/latest/plugin-development/backend-development.md
@@ -12,9 +12,7 @@ Please refer to [router documentation](../concepts/routing.md) for information.
 
 **Route prefix**
 
-Each route of a plugin is prefixed by the name of the plugin (eg: `/my-plugin/my-plugin-route`).
-
-To disable the prefix, add the `prefix` attribute to each concerned route, like below:
+Each route of a plugin is prefixed by the name of the plugin (eg: `/my-plugin/my-plugin-route`). Using the `prefix` key you can change this option to something custom. Currently it is not possible to disable the prefix, see the following [GitHub issue](https://github.com/strapi/strapi/issues/9232) for this.
 
 ```json
 {
@@ -23,7 +21,7 @@ To disable the prefix, add the `prefix` attribute to each concerned route, like 
   "handler": "MyPlugin.action",
   "config": {
     "policies": [],
-    "prefix": false
+    "prefix": "my-custom-prefix"
   }
 }
 ```
@@ -52,7 +50,7 @@ You already have `User` model defining in your `./api/user/models/User.settings.
 
 ```js
 module.exports = {
-  findUser: async function(params) {
+  findUser: async function (params) {
     // This `User` global variable will always make a reference the User model defining in your `./api/xxx/models/User.settings.json`.
     return await User.find();
   },

--- a/developer-docs/latest/plugin-development/backend-development.md
+++ b/developer-docs/latest/plugin-development/backend-development.md
@@ -12,7 +12,7 @@ Please refer to [router documentation](../concepts/routing.md) for information.
 
 **Route prefix**
 
-Each route of a plugin is prefixed by the name of the plugin (eg: `/my-plugin/my-plugin-route`). Using the `prefix` key you can change this option to something custom. Currently it is not possible to disable the prefix, see the following [GitHub issue](https://github.com/strapi/strapi/issues/9232) for this.
+Each route of a plugin is prefixed by the name of the plugin (eg: `/my-plugin/my-plugin-route`). Using the `prefix` key you can change this option to something custom. You can disable the prefix, by setting the `config.prefix` key to an empty string.
 
 ```json
 {


### PR DESCRIPTION


<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

Removes the reference to disabling plugin route prefixes with a boolean until it can be handled in the Strapi Code

### Why is it needed?

Requested by @alexandrebodin to remove it from docs

### Related issue(s)/PR(s)

See: https://github.com/strapi/strapi/issues/9232
