### PR TITLE
SSO documentation update

### DIFF
--- a/developer-docs/latest/concepts/sso.md
+++ b/developer-docs/latest/concepts/sso.md
@@ -3,7 +3,7 @@
 Single-Sign-On on Strapi allows you to configure additional sign-in and sign-up methods for your administration panel.
 
 ::: warning CAUTION
-It is currently not possible to associate a unique SSO provider to an email address used for a specific Strapi account. For more information, and workarounds to solve this issue, [please refer to the dedicated GitHub issue](https://github.com/strapi/strapi/issues/9466#issuecomment-783587648).
+It is currently not possible to associate a unique SSO provider to an email address used for a Strapi account. For more information and workarounds to solve this issue, [please refer to the dedicated GitHub issue](https://github.com/strapi/strapi/issues/9466#issuecomment-783587648).
 :::
 
 ## Prerequisites

--- a/developer-docs/latest/concepts/sso.md
+++ b/developer-docs/latest/concepts/sso.md
@@ -3,7 +3,7 @@
 Single-Sign-On on Strapi allows you to configure additional sign-in and sign-up methods for your administration panel.
 
 ::: warning CAUTION
-It is currently not possible to associate a unique SSO provider to an email address used for a Strapi account. For more information and workarounds to solve this issue, [please refer to the dedicated GitHub issue](https://github.com/strapi/strapi/issues/9466#issuecomment-783587648).
+It is currently not possible to associate a unique SSO provider to an email address used for a Strapi account, meaning that the access to a Strapi account cannot be restricted to only one SSO provider. For more information and workarounds to solve this issue, [please refer to the dedicated GitHub issue](https://github.com/strapi/strapi/issues/9466#issuecomment-783587648).
 :::
 
 ## Prerequisites

--- a/developer-docs/latest/concepts/sso.md
+++ b/developer-docs/latest/concepts/sso.md
@@ -2,6 +2,10 @@
 
 Single-Sign-On on Strapi allows you to configure additional sign-in and sign-up methods for your administration panel.
 
+::: warning CAUTION
+It is currently not possible to associate a unique SSO provider to an email address used for a specific Strapi account. For more information, and workarounds to solve this issue, [please refer to the dedicated GitHub issue](https://github.com/strapi/strapi/issues/9466#issuecomment-783587648).
+:::
+
 ## Prerequisites
 
 - A Strapi application running on version 3.5.0 or higher is required.


### PR DESCRIPTION
Add a note to inform that SSO providers can't be associated with Strapi accounts.