### PR TITLE
feat: add Register mutation before Login mutation

### DIFF
--- a/docs/developer-docs/latest/development/plugins/graphql.md
+++ b/docs/developer-docs/latest/development/plugins/graphql.md
@@ -36,6 +36,24 @@ strapi install graphql
 
 Then, start your app and open your browser at [http://localhost:1337/graphql](http://localhost:1337/graphql). You should see the interface (**GraphQL Playground**) that will help you to write GraphQL query to explore your data.
 
+## Registration
+
+Usually you need to sign up or register before being recognized as a user then perform authorized requests.
+
+```graphql
+mutation {
+  register(input: { username: "username", email: "email", password: "password" }) {
+    jwt
+    user {
+      username
+      email
+    }
+  }
+}
+```
+
+You should see a new user is created in `Users` collection type in your Strapi admin panel.
+
 ## Authentication
 
 To perform authorized requests, you must first get a JWT:


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

Added `Register` mutation before `Login` mutation. I took `Register` mutation from [this repo](https://github.com/kevinadhiguna/strapi-graphql-documentation) and modified it :

```
mutation {
  register(input: { username: "username", email: "email", password: "password" }) {
    jwt
    user {
      username
      email
    }
  }
}
```

### Why is it needed?

GraphQL plugin docs in strapi.io explains how to perform CRUD actions and how to login to send authorized requests but I think it should include how to register a user before logging in to gain JWT. 