### PR TITLE
Update Graphql filters documentation

### DIFF
--- a/docs/developer-docs/latest/development/plugins/graphql.md
+++ b/docs/developer-docs/latest/development/plugins/graphql.md
@@ -271,6 +271,8 @@ You can also apply different parameters to the query to make more complex querie
   - `<field>_gte`: Greater than or equal to.
   - `<field>_contains`: Contains.
   - `<field>_containss`: Contains sensitive.
+  - `<field>_ncontains`: Doesn't contain.
+  - `<field>_ncontainss`: Doesn't contain, case sensitive
   - `<field>_in`: Matches any value in the array of values.
   - `<field>_nin`: Doesn't match any value in the array of values.
   - `<field>_null`: Equals null/Not equals null


### PR DESCRIPTION
Added ncontains and ncontainss to graphql filters description. Was actually hard to find this, till i looked into content-api filters, hope it helps someone.

### What does it do?

Updated documentation for graphql filters.

### Why is it needed?

Was hard to find that strapi even has a ncontains filter.

