### PR TITLE
Fix Jekyll install link in integration guide

### DIFF
--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/jekyll.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/jekyll.md
@@ -6,7 +6,7 @@ If you haven't gone through the getting started guide, the way you request a Str
 
 ### Create a Jekyll app
 
-Be sure to have [Jekyll installed](https://jekyllrb.com/) on your computer.
+Be sure to have [Jekyll installed](https://jekyllrb.com/docs/installation/) on your computer.
 
 ```bash
 jekyll new jekyll-app


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

Fix installation link for Jekyll 

### Why is it needed?

Previous one linked to Jekyll homepage