### PR TITLE
Updating pricing links and EE Support

### DIFF
--- a/docs/developer-docs/latest/getting-started/introduction.md
+++ b/docs/developer-docs/latest/getting-started/introduction.md
@@ -36,5 +36,5 @@ You can join [GitHub](https://github.com/strapi/strapi) and the [forum](https://
 
 Strapi is offered as free and open-source for users who wish to self-host the software. When having an issue or a question, the [forum](https://forum.strapi.io) is great first place to reach out for help. Both the Strapi community and core developers often check this platform and answer posts.
 
-For enterprise support, please fill in the form on the [Support page](https://strapi.io/support) of the Strapi website.
+For enterprise support, please see our [Enterprise Support platform](https://support.strapi.io/support/home), please note that you will need to have an active enterprise license to place tickets.
 

--- a/docs/developer-docs/latest/getting-started/troubleshooting.md
+++ b/docs/developer-docs/latest/getting-started/troubleshooting.md
@@ -34,7 +34,7 @@ When this new plugin release, there is two versions:
 - Community Edition
 - Enterprise Edition
 
-By default, the Community Edition includes 3 pre-defined roles (Administrators, Editor, Author). Upgrading to the Enterprise Edition will unlock an unlimited number of roles. There will be certain other field level permission limitations based on the edition and we will be building a detailed guide as to what is included within the "Basic" vs "Advanced" RBAC features. To learn more about what is included as well as pricing please see our [pricing page](https://strapi.io/pricing).
+By default, the Community Edition includes 3 pre-defined roles (Administrators, Editor, Author). Upgrading to the Enterprise Edition will unlock an unlimited number of roles. There will be certain other field level permission limitations based on the edition and we will be building a detailed guide as to what is included within the "Basic" vs "Advanced" RBAC features. To learn more about what is included as well as pricing please see our [pricing page](https://strapi.io/pricing-self-hosted).
 
 ## Relations aren't maintaining their sort order
 

--- a/docs/developer-docs/latest/setup-deployment-guides/configurations.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/configurations.md
@@ -1115,7 +1115,7 @@ An image named `company-logo.png` in `./public/` is accessible through `/company
 The dotfiles are not exposed. It means that every file name that starts with `.`, such as `.htaccess` or `.gitignore`, are not served.
 :::
 
-### Single Sign On <GoldBadge link="https://strapi.io/pricing/" withLinkIcon />
+### Single Sign On <GoldBadge link="https://strapi.io/pricing-self-hosted/" withLinkIcon />
 
 ***
 
@@ -1576,7 +1576,7 @@ module.exports = () => ({
 });
 ```
 
-### Role-Based Access Control <BronzeBadge link="https://strapi.io/pricing"/> <SilverBadge link="https://strapi.io/pricing"/> <GoldBadge link="https://strapi.io/pricing" withLinkIcon/>
+### Role-Based Access Control <BronzeBadge link="https://strapi.io/pricing-self-hosted"/> <SilverBadge link="https://strapi.io/pricing-self-hosted"/> <GoldBadge link="https://strapi.io/pricing-self-hosted" withLinkIcon/>
 
 ::: warning 🚧 This API is considered unstable for now.
 <br>

--- a/docs/user-docs/latest/getting-started/introduction.md
+++ b/docs/user-docs/latest/getting-started/introduction.md
@@ -10,7 +10,7 @@ Before going any further into this user guide, we recommend you to acknowledge t
 
 - **Versions** <br> Strapi is constantly evolving and growing. This implies that new releases are quite frequent, to improve what is already available but also to add new features to Strapi. For every new Strapi version, we communicate through our main channels and by sending notifications both on your terminal (when launching your Strapi application), and on your application's admin panel. We always recommend to use the latest version, especially since our documentation including this user guide, are only aligned with the latest version<!-- (see Update Strapi version or refer to our migration guides to update your Strapi application) -->. If you are on an older version of Strapi, some information in this documentation may not apply to your application.
 
-- **License and Pricing Plans** <br> As a Strapi user you have the choice between using the Community Edition, which is entirely free, or one of the 3 paid plans of the Enterprise Edition: Bronze, Silver, and Gold (see [Pricing and Plans](https://strapi.io/pricing)). In this user guide if a feature is only available for the Enterprise Edition, a badge is displayed beside the section's title to indicate which plans allow access to that feature (e.g. <BronzeBadge link="https://strapi.io/pricing"/> <SilverBadge link="https://strapi.io/pricing"/> <GoldBadge link="https://strapi.io/pricing"/>).
+- **License and Pricing Plans** <br> As a Strapi user you have the choice between using the Community Edition, which is entirely free, or one of the 3 paid plans of the Enterprise Edition: Bronze, Silver, and Gold (see [Pricing and Plans](https://strapi.io/pricing-self-hosted)). In this user guide if a feature is only available for the Enterprise Edition, a badge is displayed beside the section's title to indicate which plans allow access to that feature (e.g. <BronzeBadge link="https://strapi.io/pricing-self-hosted"/> <SilverBadge link="https://strapi.io/pricing-self-hosted"/> <GoldBadge link="https://strapi.io/pricing-self-hosted"/>).
 
 - **Roles and Permissions** <br> Some features of the admin panel, as well as the content managed with Strapi itself, are ruled by a system of permissions. From your Strapi admin panel, you have the possibility to define, at a detailed level, the roles and permissions of all administrators and end-users. In this user guide, all features and possible options are documented. It is however possible, depending on your role and permissions, that you may not be able to access all these features and options. In that case, please refer to the main Super Admin of your Strapi application.
 
@@ -32,7 +32,7 @@ To access the admin panel:
 2. Enter your credentials to log in.
 3. Click on the **Log in** button. You should be redirected to the homepage of the admin panel.
 
-### Using SSO for authentication <GoldBadge withLinkIcon link="https://strapi.io/pricing" />
+### Using SSO for authentication <GoldBadge withLinkIcon link="https://strapi.io/pricing-self-hosted" />
 
 If your Strapi application was configured to allow authentication through SSO (see [Configuring Single Sign-On](../settings/managing-global-settings.md)), you can access the admin panel using a specific provider instead of logging in with a regular Strapi administrator account.
 

--- a/docs/user-docs/latest/settings/managing-global-settings.md
+++ b/docs/user-docs/latest/settings/managing-global-settings.md
@@ -2,7 +2,7 @@
 
 Global settings for plugins and features are managed from *General > Settings* in the main navigation of the admin panel.
 
-## Configuring Single Sign-On <GoldBadge withLinkIcon link="https://strapi.io/pricing" />
+## Configuring Single Sign-On <GoldBadge withLinkIcon link="https://strapi.io/pricing-self-hosted" />
 
 Single Sign-On (SSO) can be made available on a Strapi application to allow administrators to authenticate through an identity provider (e.g. Microsoft Azure Active Directory).
 

--- a/docs/user-docs/latest/users-roles-permissions/configuring-administrator-roles.md
+++ b/docs/user-docs/latest/users-roles-permissions/configuring-administrator-roles.md
@@ -21,7 +21,7 @@ By default, 3 administrator roles are defined for any Strapi application:
 - Super Admin: to be able to access all features and settings. This is the role attributed by default to the first administrator at the creation of the Strapi application.
 
 ::: warning IMPORTANT
-If you use your Strapi application with the Community Edition (see [Pricing and Plans](https://strapi.io/pricing)), your use of the RBAC feature will be limited. Only the 3 default roles are available, as you cannot create more roles and cannot delete the default ones. It is however possible to edit them, but to an extent:
+If you use your Strapi application with the Community Edition (see [Pricing and Plans](https://strapi.io/pricing-self-hosted)), your use of the RBAC feature will be limited. Only the 3 default roles are available, as you cannot create more roles and cannot delete the default ones. It is however possible to edit them, but to an extent:
 
 - You can only configure permissions for the content-types, but not for the plugins and settings of the Strapi application.
 - Configuring permissions in detail is only available for the Enterprise Edition. With the Community Edition, although you can choose which fields of a content type are accessible, these fields are automatically fully accessible with all permissions.
@@ -29,7 +29,7 @@ If you use your Strapi application with the Community Edition (see [Pricing and 
 
 :::
 
-## Creating a new role <BronzeBadge link="https://strapi.io/pricing"/> <SilverBadge link="https://strapi.io/pricing"/> <GoldBadge link="https://strapi.io/pricing" withLinkIcon/>
+## Creating a new role <BronzeBadge link="https://strapi.io/pricing-self-hosted"/> <SilverBadge link="https://strapi.io/pricing-self-hosted"/> <GoldBadge link="https://strapi.io/pricing-self-hosted" withLinkIcon/>
 
 On the top right side of the *Administration panel > Roles* interface, an **Add new role** button is displayed. It allows to create a new role for administrators of your Strapi application.
 
@@ -40,7 +40,7 @@ Clicking on the **Add new role** button will redirect you to the roles edition i
 In the *Roles* interface, from the table, you can click on the duplicate button <Fa-Copy /> to create a new role by duplicating an existing one.
 :::
 
-## Deleting a role <BronzeBadge link="https://strapi.io/pricing"/> <SilverBadge link="https://strapi.io/pricing"/> <GoldBadge link="https://strapi.io/pricing" withLinkIcon/>
+## Deleting a role <BronzeBadge link="https://strapi.io/pricing-self-hosted"/> <SilverBadge link="https://strapi.io/pricing-self-hosted"/> <GoldBadge link="https://strapi.io/pricing-self-hosted" withLinkIcon/>
 
 Administrator roles can be deleted from the *Administration panel > Roles* interface. However, they can only be deleted once they are no more attributed to any administrator of the Strapi application.
 
@@ -95,7 +95,7 @@ To configure Collection or Single Types permissions for a role:
 5. Repeat steps 2 to 4 for each content type available to which the role should give access.
 6. Click on the **Save** button on the top right corner.
 
-#### Plugins and Settings <BronzeBadge link="https://strapi.io/pricing"/> <SilverBadge link="https://strapi.io/pricing"/> <GoldBadge link="https://strapi.io/pricing" withLinkIcon/>
+#### Plugins and Settings <BronzeBadge link="https://strapi.io/pricing-self-hosted"/> <SilverBadge link="https://strapi.io/pricing-self-hosted"/> <GoldBadge link="https://strapi.io/pricing-self-hosted" withLinkIcon/>
 
 The Plugins and Settings categories both display a sub-category per available plugin or setting of the Strapi application. Each sub-category contains its own specific set of permissions.
 
@@ -137,7 +137,7 @@ Settings permissions can be configured for all settings accessible from *General
 
 4. Click on the **Save** button on the top right corner.
 
-### Setting custom conditions for permissions <BronzeBadge link="https://strapi.io/pricing"/> <SilverBadge link="https://strapi.io/pricing"/> <GoldBadge link="https://strapi.io/pricing" withLinkIcon/>
+### Setting custom conditions for permissions <BronzeBadge link="https://strapi.io/pricing-self-hosted"/> <SilverBadge link="https://strapi.io/pricing-self-hosted"/> <GoldBadge link="https://strapi.io/pricing-self-hosted" withLinkIcon/>
 
 For each permission of each category, a **Settings** button is displayed. It allows to push the permission configuration further by defining additional conditions for the administrators to be granted the permission. There are 2 default additional conditions:
 


### PR DESCRIPTION
Updates all references from: https://strapi.io/pricing/ to  https://strapi.io/pricing-self-hosted/

Also updated the EE support block to point to the new support platform.