### PR TITLE
Add a metaTitle and a metaDescription to every doc pages

### DIFF
--- a/.algolia/docsearch.config.json
+++ b/.algolia/docsearch.config.json
@@ -1,0 +1,26 @@
+{
+  "index_name": "documentation",
+  "start_urls": ["https://strapi.io/documentation"],
+  "selectors": {
+    "lvl0": {
+      "selector": "p.sidebar-heading",
+      "global": true,
+      "default_value": "Documentation"
+    },
+    "lvl1": ".content__default h1",
+    "lvl2": ".content__default h2",
+    "lvl3": ".content__default h3",
+    "lvl4": ".content__default h4",
+    "lvl5": ".content__default h5",
+    "text": ".content__default p, .content__default li",
+    "lang": {
+      "selector": "/html/@lang",
+      "type": "xpath",
+      "global": true
+    }
+  },
+  "strip_chars": " .,;:#",
+  "custom_settings": {
+    "attributesForFaceting": ["lang"]
+  }
+}

--- a/docs/developer-docs/latest/concepts/draft-and-publish.md
+++ b/docs/developer-docs/latest/concepts/draft-and-publish.md
@@ -1,3 +1,8 @@
+---
+title: Draft and publish - Strapi Developer Documentation
+description: The draft and publish feature allows you to save your content as a draft, to publish it later.
+---
+
 # Draft and publish
 
 The draft and publish feature allows you to save your content as a draft, to publish it later.

--- a/docs/developer-docs/latest/developer-resources/cli/CLI.md
+++ b/docs/developer-docs/latest/developer-resources/cli/CLI.md
@@ -1,3 +1,8 @@
+---
+title: CLI - Strapi Developer Documentation
+description: Strapi comes with a full featured Command Line Interface (CLI) which lets you scaffold and manage your project in seconds.
+---
+
 # Command Line Interface (CLI)
 
 Strapi comes with a full featured Command Line Interface (CLI) which lets you scaffold and manage your project in seconds.

--- a/docs/developer-docs/latest/developer-resources/content-api/content-api.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/content-api.md
@@ -1,4 +1,6 @@
 ---
+title: Content API - Strapi Developer Documentation
+description: Interact with your Content-Types using the REST API endpoints Strapi generates for you.
 sidebarDepth: 3
 ---
 

--- a/docs/developer-docs/latest/developer-resources/content-api/integrations.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations.md
@@ -1,3 +1,8 @@
+---
+title: Integrations - Strapi Developer Documentation
+description: Integrate Strapi with a multitude of frameworks, frontend or backend programming languages.
+---
+
 # Integrations
 
 Strapi generates an API for you to access your content. But how can you connect a React, Ruby, Gatsby application to it?

--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/11ty.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/11ty.md
@@ -1,6 +1,6 @@
 ---
 title: Get started with 11ty - Strapi Developer Documentation
-description: Build powerful applications using Strapi, the leading open-source headless cms and 11ty.
+description: Build powerful applications using Strapi, the leading open-source headless CMS and 11ty.
 ---
 
 # Getting Started with 11ty

--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/11ty.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/11ty.md
@@ -1,3 +1,8 @@
+---
+title: Get started with 11ty - Strapi Developer Documentation
+description: Build powerful applications using Strapi, the leading open-source headless cms and 11ty.
+---
+
 # Getting Started with 11ty
 
 This integration guide is following the [Getting started guide](/developer-docs/latest/getting-started/quick-start.md). We assume that you have completed [Step 8](/developer-docs/latest/getting-started/quick-start.md#_8-publish-the-content) and therefore can consume the API by browsing this [url](http://localhost:1337/restaurants).

--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/angular.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/angular.md
@@ -1,3 +1,8 @@
+---
+title: Get started with Angular - Strapi Developer Documentation
+description: Build powerful applications using Strapi, the leading open-source headless cms and Angular.
+---
+
 # Getting Started with Angular
 
 This integration guide is following the [Getting started guide](/developer-docs/latest/getting-started/quick-start.md). We assume that you have completed [Step 8](/developer-docs/latest/getting-started/quick-start.md#_8-publish-the-content) and therefore can consume the API by browsing this [url](http://localhost:1337/restaurants).

--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/dart.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/dart.md
@@ -1,3 +1,8 @@
+---
+title: Get started with Dart - Strapi Developer Documentation
+description: Build powerful applications using Strapi, the leading open-source headless cms and Dart.
+---
+
 # Getting Started with Dart
 
 This integration guide is following the [Getting started guide](/developer-docs/latest/getting-started/quick-start.html). We assume that you have completed [Step 8](/developer-docs/latest/getting-started/quick-start.html#_8-publish-the-content) and therefore can consume the API by browsing this [url](http://localhost:1337/restaurants).

--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/flutter.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/flutter.md
@@ -1,3 +1,8 @@
+---
+title: Get started with Flutter - Strapi Developer Documentation
+description: Build powerful applications using Strapi, the leading open-source headless cms and Flutter.
+---
+
 # Getting Started with Flutter
 
 This integration guide is following the [Getting started guide](/developer-docs/latest/getting-started/quick-start.html). We assume that you have completed [Step 8](/developer-docs/latest/getting-started/quick-start.html#_8-publish-the-content) and therefore can consume the API by browsing this [url](http://localhost:1337/restaurants).

--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/gatsby.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/gatsby.md
@@ -1,3 +1,8 @@
+---
+title: Get started with Gatsby - Strapi Developer Documentation
+description: Build powerful applications using Strapi, the leading open-source headless cms and Gatsby.
+---
+
 # Getting Started with Gatsby
 
 This integration guide is following the [Getting started guide](/developer-docs/latest/getting-started/quick-start.md). We assume that you have completed [Step 8](/developer-docs/latest/getting-started/quick-start.md#_8-publish-the-content) and therefore can consume the API by browsing this [url](http://localhost:1337/restaurants).

--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/go.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/go.md
@@ -1,3 +1,8 @@
+---
+title: Get started with Go - Strapi Developer Documentation
+description: Build powerful applications using Strapi, the leading open-source headless cms and Go.
+---
+
 # Getting Started with GO
 
 This integration guide is following the [Getting started guide](/developer-docs/latest/getting-started/quick-start.md). We assume that you have completed [Step 8](/developer-docs/latest/getting-started/quick-start.html#_8-publish-the-content) and therefore can consume the API by browsing this [url](http://localhost:1337/restaurants).

--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/graphql.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/graphql.md
@@ -1,3 +1,8 @@
+---
+title: Get started with GraphQL - Strapi Developer Documentation
+description: Build powerful applications using Strapi, the leading open-source headless cms and GraphQL.
+---
+
 # Getting Started with GraphQL
 
 This integration guide is following the [Getting started guide](/developer-docs/latest/getting-started/quick-start.md). We assume that you have completed [Step 8](/developer-docs/latest/getting-started/quick-start.md#_8-publish-the-content) and therefore can consume the API by browsing this [url](http://localhost:1337/restaurants).

--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/gridsome.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/gridsome.md
@@ -1,3 +1,8 @@
+---
+title: Get started with Gridsome - Strapi Developer Documentation
+description: Build powerful applications using Strapi, the leading open-source headless cms and Gridsome.
+---
+
 # Getting Started with Gridsome
 
 This integration guide is following the [Getting started guide](/developer-docs/latest/getting-started/quick-start.md). We assume that you have completed [Step 8](/developer-docs/latest/getting-started/quick-start.md#_8-publish-the-content) and therefore can consume the API by browsing this [url](http://localhost:1337/restaurants).

--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/jekyll.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/jekyll.md
@@ -1,3 +1,8 @@
+---
+title: Get started with Jekyll - Strapi Developer Documentation
+description: Build powerful applications using Strapi, the leading open-source headless cms and Jekyll.
+---
+
 # Getting Started with Jekyll
 
 This integration guide is following the [Getting started guide](/developer-docs/latest/getting-started/quick-start.md). We assume that you have completed [Step 8](/developer-docs/latest/getting-started/quick-start.md#_8-publish-the-content) and therefore can consume the API by browsing this [url](http://localhost:1337/restaurants).

--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/next-js.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/next-js.md
@@ -1,3 +1,8 @@
+---
+title: Get started with Next.js - Strapi Developer Documentation
+description: Build powerful applications using Strapi, the leading open-source headless cms and Next.js.
+---
+
 # Getting Started with Next.js
 
 This integration guide is following the [Getting started guide](/developer-docs/latest/getting-started/quick-start.md). We assume that you have completed [Step 8](/developer-docs/latest/getting-started/quick-start.md#_8-publish-the-content) and therefore can consume the API by browsing this [url](http://localhost:1337/restaurants).

--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/nuxt-js.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/nuxt-js.md
@@ -1,3 +1,8 @@
+---
+title: Get started with Nuxt.js - Strapi Developer Documentation
+description: Build powerful applications using Strapi, the leading open-source headless cms and Nuxt.js.
+---
+
 # Getting Started with Nuxt.js
 
 This integration guide is following the [Getting started guide](/developer-docs/latest/getting-started/quick-start.md). We assume that you have completed [Step 8](/developer-docs/latest/getting-started/quick-start.md#_8-publish-the-content) and therefore can consume the API by browsing this [url](http://localhost:1337/restaurants).

--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/php.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/php.md
@@ -1,3 +1,8 @@
+---
+title: Get started with PHP - Strapi Developer Documentation
+description: Build powerful applications using Strapi, the leading open-source headless cms and PHP.
+---
+
 # Getting Started with PHP
 
 This integration guide is following the [Getting started guide](/developer-docs/latest/getting-started/quick-start.md). We assume that you have completed [Step 8](/developer-docs/latest/getting-started/quick-start.html#_8-publish-the-content) and therefore can consume the API by browsing this [url](http://localhost:1337/restaurants).
@@ -150,18 +155,18 @@ function postRestaurant(){
         'description' => 'Omo, this is a place that varieties of soup with catfish🦈',
          'categories' => [2]
       );
-      
+
       // Initializes a new cURL session
       $curl = curl_init();
-      
+
       curl_setopt($curl, CURLOPT_URL, 'http://localhost:1337/restaurants');
-      
+
       curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-      
+
       // Set the CURLOPT_POST for POST request
       curl_setopt($curl, CURLOPT_POST, true);
       curl_setopt($curl, CURLOPT_POSTFIELDS,  json_encode($restaurants));
-      
+
       curl_setopt($curl, CURLOPT_HTTPHEADER, [
           'Content-Type: application/json'
       ]);
@@ -243,14 +248,14 @@ function postRestaurant(){
         'description' => 'Omo, this is a place that varieties of soup with catfish🦈',
          'categories' => [2]
       );
-      
+
       // Initializes a new cURL session
       $curl = curl_init();
-      
+
       curl_setopt($curl, CURLOPT_URL, 'http://localhost:1337/restaurants');
-      
+
       curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-      
+
       // Set the CURLOPT_POST for POST request
       curl_setopt($curl, CURLOPT_POST, true);
       curl_setopt($curl, CURLOPT_POSTFIELDS,  json_encode($restaurants));

--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/python.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/python.md
@@ -1,3 +1,8 @@
+---
+title: Get started with Python - Strapi Developer Documentation
+description: Build powerful applications using Strapi, the leading open-source headless cms and Python.
+---
+
 # Getting Started with Python
 
 This integration guide is following the [Getting started guide](/developer-docs/latest/getting-started/quick-start.md). We assume that you have completed [Step 8](/developer-docs/latest/getting-started/quick-start.md#_8-publish-the-content) and therefore can consume the API by browsing this [url](http://localhost:1337/restaurants).

--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/react.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/react.md
@@ -1,3 +1,8 @@
+---
+title: Get started with React - Strapi Developer Documentation
+description: Build powerful applications using Strapi, the leading open-source headless cms and React.
+---
+
 # Getting Started with React
 
 This integration guide is following the [Getting started guide](/developer-docs/latest/getting-started/quick-start.md). We assume that you have completed [Step 8](/developer-docs/latest/getting-started/quick-start.md#_8-publish-the-content) and therefore can consume the API by browsing this [url](http://localhost:1337/restaurants).

--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/ruby.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/ruby.md
@@ -1,3 +1,8 @@
+---
+title: Get started with Ruby - Strapi Developer Documentation
+description: Build powerful applications using Strapi, the leading open-source headless cms and Ruby.
+---
+
 # Getting Started with Ruby
 
 This integration guide is following the [Getting started guide](/developer-docs/latest/getting-started/quick-start.md). We assume that you have completed [Step 8](/developer-docs/latest/getting-started/quick-start.md#_8-publish-the-content) and therefore can consume the API by browsing this [url](http://localhost:1337/restaurants).

--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/sapper.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/sapper.md
@@ -1,3 +1,8 @@
+---
+title: Get started with Sapper - Strapi Developer Documentation
+description: Build powerful applications using Strapi, the leading open-source headless cms and Sapper.
+---
+
 # Getting Started with Sapper
 
 This integration guide is following the [Getting started guide](/developer-docs/latest/getting-started/quick-start.md). We assume that you have completed [Step 8](/developer-docs/latest/getting-started/quick-start.md#_8-publish-the-content) and therefore can consume the API by browsing this [url](http://localhost:1337/restaurants).

--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/svelte.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/svelte.md
@@ -1,3 +1,8 @@
+---
+title: Get started with Svelte - Strapi Developer Documentation
+description: Build powerful applications using Strapi, the leading open-source headless cms and Svelte.
+---
+
 # Getting Started with Svelte
 
 This integration guide is following the [Getting started guide](/developer-docs/latest/getting-started/quick-start.md). We assume that you have completed [Step 8](/developer-docs/latest/getting-started/quick-start.md#_8-publish-the-content) and therefore can consume the API by browsing this [url](http://localhost:1337/restaurants).

--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/vue-js.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/vue-js.md
@@ -1,3 +1,8 @@
+---
+title: Get started with Vue.js - Strapi Developer Documentation
+description: Build powerful applications using Strapi, the leading open-source headless cms and Vue.js.
+---
+
 # Getting Started with Vue.js
 
 This integration guide is following the [Getting started guide](/developer-docs/latest/getting-started/quick-start.md). We assume that you have completed [Step 8](/developer-docs/latest/getting-started/quick-start.md#_8-publish-the-content) and therefore can consume the API by browsing this [url](http://localhost:1337/restaurants).

--- a/docs/developer-docs/latest/developer-resources/global-strapi/api-reference.md
+++ b/docs/developer-docs/latest/developer-resources/global-strapi/api-reference.md
@@ -1,3 +1,8 @@
+---
+title: API Reference - Strapi Developer Documentation
+description: Discover our concise reference documentation containing all the information to work with your Strapi API
+---
+
 # API reference
 
 - strapi

--- a/docs/developer-docs/latest/development/admin-customization.md
+++ b/docs/developer-docs/latest/development/admin-customization.md
@@ -1,3 +1,8 @@
+---
+title: Admin panel customization - Strapi Developer Documentation
+description: The administration panel of Strapi can be customized according to your needs, so you can make it reflect your identity.
+---
+
 # Admin panel customization
 
 ## Admin extension

--- a/docs/developer-docs/latest/development/backend-customization.md
+++ b/docs/developer-docs/latest/development/backend-customization.md
@@ -1,3 +1,8 @@
+---
+title: Backend customization - Strapi Developer Documentation
+description: The backend of Strapi can be customized according to your needs, so you can create your own backend behavior.
+---
+
 # Backend customization
 
 <!--- BEGINNING OF ROUTING --->

--- a/docs/developer-docs/latest/development/local-plugins-customization.md
+++ b/docs/developer-docs/latest/development/local-plugins-customization.md
@@ -1,3 +1,8 @@
+---
+title: Local plugins - Strapi Developer Documentation
+description: Strapi allows you to create your own custom local plugins that will work exactly the same as external ones.
+---
+
 # Local plugins
 
 ## Quick start
@@ -18,7 +23,7 @@ In a new terminal window:
 Generate a new plugin: `cd /path/to/myDevelopmentProject && strapi generate:plugin my-plugin`
 
 ::: tip NOTE
-After you have successfully generated a plugin, you need to run `strapi build` which adds the new plugin to the admin panel. 
+After you have successfully generated a plugin, you need to run `strapi build` which adds the new plugin to the admin panel.
 :::
 
 ## Plugin Folders and Files Architecture

--- a/docs/developer-docs/latest/development/plugin-customization.md
+++ b/docs/developer-docs/latest/development/plugin-customization.md
@@ -1,6 +1,6 @@
 ---
 title: Strapi plugins - Strapi Developer Documentation
-description: In Strapi you can install plugins in your `node_modules`. This allows for easy updates and respect best practices.
+description: In Strapi you can install plugins in your node_modules. This allows for easy updates and respect best practices.
 ---
 
 # Strapi plugins

--- a/docs/developer-docs/latest/development/plugin-customization.md
+++ b/docs/developer-docs/latest/development/plugin-customization.md
@@ -1,3 +1,8 @@
+---
+title: Strapi plugins - Strapi Developer Documentation
+description: In Strapi you can install plugins in your `node_modules`. This allows for easy updates and respect best practices.
+---
+
 # Strapi plugins
 
 In Strapi you can install plugins in your `node_modules`. This allows for easy updates and respect best practices. To customize those installed plugins you can work in the `/extensions` directory. It contains all the plugins' customizable files.

--- a/docs/developer-docs/latest/development/plugins/documentation.md
+++ b/docs/developer-docs/latest/development/plugins/documentation.md
@@ -1,6 +1,6 @@
 ---
 title: API Documentation - Strapi Developer Documentation
-description: By using SWAGGER UI, the API documentation plugin takes out most of your pain to generate your documentation.
+description: By using Swagger UI, the API documentation plugin takes out most of your pain to generate your documentation.
 ---
 
 # API Documentation

--- a/docs/developer-docs/latest/development/plugins/documentation.md
+++ b/docs/developer-docs/latest/development/plugins/documentation.md
@@ -1,6 +1,6 @@
 ---
 title: API Documentation - Strapi Developer Documentation
-description: By using SWAGGER UI, the documentation plugin takes out most of your pain to generate your documentation.
+description: By using SWAGGER UI, the API documentation plugin takes out most of your pain to generate your documentation.
 ---
 
 # API Documentation

--- a/docs/developer-docs/latest/development/plugins/documentation.md
+++ b/docs/developer-docs/latest/development/plugins/documentation.md
@@ -1,3 +1,8 @@
+---
+title: API Documentation - Strapi Developer Documentation
+description: By using SWAGGER UI, the documentation plugin takes out most of your pain to generate your documentation.
+---
+
 # API Documentation
 
 Now that you have created your API it's really important to document its available end-points. The documentation plugin takes out most of your pain to generate your documentation. This plugin uses [SWAGGER UI](https://swagger.io/solutions/api-documentation/) to visualize your API's documentation.

--- a/docs/developer-docs/latest/development/plugins/email.md
+++ b/docs/developer-docs/latest/development/plugins/email.md
@@ -1,3 +1,8 @@
+---
+title: Email - Strapi Developer Documentation
+description: Send email from your server or externals providers.
+---
+
 # Email
 
 Thanks to the plugin `Email`, you can send email from your server or externals providers such as **Sendgrid**.

--- a/docs/developer-docs/latest/development/plugins/graphql.md
+++ b/docs/developer-docs/latest/development/plugins/graphql.md
@@ -1,3 +1,8 @@
+---
+title: GraphQL - Strapi Developer Documentation
+description: Use a GraphQL endpoint in your Strapi project to fetch and mutate your content.
+---
+
 # GraphQL
 
 By default Strapi create [REST endpoints](/developer-docs/latest/developer-resources/content-api/content-api.md#api-endpoints) for each of your content types. With the GraphQL plugin, you will be able to add a GraphQL endpoint to fetch and mutate your content.

--- a/docs/developer-docs/latest/development/plugins/upload.md
+++ b/docs/developer-docs/latest/development/plugins/upload.md
@@ -1,3 +1,8 @@
+---
+title: Upload - Strapi Developer Documentation
+description: Upload any kind of file on your server or external providers.
+---
+
 # Upload
 
 Thanks to the plugin `Upload`, you can upload any kind of file on your server or external providers such as **AWS S3**.

--- a/docs/developer-docs/latest/development/plugins/users-permissions.md
+++ b/docs/developer-docs/latest/development/plugins/users-permissions.md
@@ -1,4 +1,6 @@
 ---
+title: Roles & Permissions - Strapi Developer Documentation
+description: Protect your API with a full authentication process based on JWT and manage the permissions between the groups of users.
 sidebarDepth: 2
 ---
 

--- a/docs/developer-docs/latest/getting-started/introduction.md
+++ b/docs/developer-docs/latest/getting-started/introduction.md
@@ -1,3 +1,8 @@
+---
+title: Strapi Developer Documentation
+description: This documentation contains all technical documentation related to the setup, deployment, update and customization of your Strapi application.
+---
+
 # Welcome to the Strapi developer documentation!
 
 This documentation contains all technical documentation related to the setup, deployment, update and customization of your Strapi application.
@@ -37,4 +42,3 @@ You can join [GitHub](https://github.com/strapi/strapi) and the [forum](https://
 Strapi is offered as free and open-source for users who wish to self-host the software. When having an issue or a question, the [forum](https://forum.strapi.io) is great first place to reach out for help. Both the Strapi community and core developers often check this platform and answer posts.
 
 For enterprise support, please fill in the form on the [Support page](https://strapi.io/support) of the Strapi website.
-

--- a/docs/developer-docs/latest/getting-started/quick-start.md
+++ b/docs/developer-docs/latest/getting-started/quick-start.md
@@ -1,3 +1,8 @@
+---
+title: Quick Start Guide - Strapi Developer Documentation
+description: Get ready to get Strapi, your favorite open-source headless cms up and running in less than 3 minutes.
+---
+
 # Quick Start Guide
 
 Get ready to get Strapi up and running in **less than 3 minutes** 🚀.

--- a/docs/developer-docs/latest/getting-started/troubleshooting.md
+++ b/docs/developer-docs/latest/getting-started/troubleshooting.md
@@ -1,4 +1,6 @@
 ---
+title: Troubleshooting - Strapi Developer Documentation
+description: Find some answers and solutions to most common issues that you may experience when working with Strapi.
 sidebarDepth: 0
 ---
 

--- a/docs/developer-docs/latest/getting-started/usage-information.md
+++ b/docs/developer-docs/latest/getting-started/usage-information.md
@@ -1,4 +1,6 @@
 ---
+title: Usage information - Strapi Developer Documentation
+description: We are committed to providing a solution, with Strapi, that exceeds the expectations of the users and community. We are also committed to continuing to develop and make Strapi even better than it is today.
 sidebarDepth: 0
 ---
 

--- a/docs/developer-docs/latest/guides/api-token.md
+++ b/docs/developer-docs/latest/guides/api-token.md
@@ -1,3 +1,8 @@
+---
+title: API Tokens - Strapi Developer Documentation
+description: Learn in this guide how to create an API token system in your Strapi project to execute request as an authenticated use.
+---
+
 # API tokens
 
 In this guide we will see how you can create an API token system to execute request as an authenticated user.

--- a/docs/developer-docs/latest/guides/api-token.md
+++ b/docs/developer-docs/latest/guides/api-token.md
@@ -1,6 +1,6 @@
 ---
 title: API Tokens - Strapi Developer Documentation
-description: Learn in this guide how to create an API token system in your Strapi project to execute request as an authenticated use.
+description: Learn in this guide how to create an API token system in your Strapi project to execute request as an authenticated user.
 ---
 
 # API tokens

--- a/docs/developer-docs/latest/guides/auth-request.md
+++ b/docs/developer-docs/latest/guides/auth-request.md
@@ -1,3 +1,8 @@
+---
+title: Authenticated request - Strapi Developer Documentation
+description: Learn in this guide how you can request the API of your Strapi project as an authenticated user.
+---
+
 # Authenticated request
 
 In this guide you will see how you can request the API as an authenticated user.

--- a/docs/developer-docs/latest/guides/client.md
+++ b/docs/developer-docs/latest/guides/client.md
@@ -1,3 +1,8 @@
+---
+title: Client - Strapi Developer Documentation
+description: Learn in this guide how to setup a connection with a third party client and use it everywhere in your code.
+---
+
 # Setup a third party client
 
 This guide will explain how to setup a connection with a third party client and use it everywhere in your code.

--- a/docs/developer-docs/latest/guides/count-graphql.md
+++ b/docs/developer-docs/latest/guides/count-graphql.md
@@ -1,3 +1,8 @@
+---
+title: Count with GraphQL - Strapi Developer Documentation
+description: Learn in this guide how to count data with a GraphQL query.
+---
+
 # Count with GraphQL
 
 This guide explains how to count data with a GraphQL query.

--- a/docs/developer-docs/latest/guides/custom-admin.md
+++ b/docs/developer-docs/latest/guides/custom-admin.md
@@ -1,3 +1,8 @@
+---
+title: Custom Admin - Strapi Developer Documentation
+description: Learn in this guide how you can customize the admin panel of your Strapi project.
+---
+
 # Custom admin
 
 In this guide we will see how you can customize the admin panel.

--- a/docs/developer-docs/latest/guides/custom-data-response.md
+++ b/docs/developer-docs/latest/guides/custom-data-response.md
@@ -1,3 +1,8 @@
+---
+title: Custom Data Response - Strapi Developer Documentation
+description: Learn in this guide how you can customize your Strapi project API's response.
+---
+
 # Custom data response
 
 In this guide we will see how you can customize your API's response.

--- a/docs/developer-docs/latest/guides/draft.md
+++ b/docs/developer-docs/latest/guides/draft.md
@@ -1,3 +1,8 @@
+---
+title: Draft System - Strapi Developer Documentation
+description: Learn in this guide how to create a draft system that will allow you to manage draft, published, and archive status inside your Strapi project.
+---
+
 # Draft system
 
 This guide will explain how to create a draft system that will allow you to manage draft, published, and archive status.

--- a/docs/developer-docs/latest/guides/error-catching.md
+++ b/docs/developer-docs/latest/guides/error-catching.md
@@ -1,3 +1,8 @@
+---
+title: Error Catching - Strapi Developer Documentation
+description: Learn in this guide how you can catch errors and send them to the Application Monitoring / Error Tracking Software you want.
+---
+
 # Error catching
 
 In this guide we will see how you can catch errors and send them to the Application Monitoring / Error Tracking Software you want.

--- a/docs/developer-docs/latest/guides/external-data.md
+++ b/docs/developer-docs/latest/guides/external-data.md
@@ -1,3 +1,8 @@
+---
+title: External Data - Strapi Developer Documentation
+description: Learn in this guide how to fetch data from an external service to use it in your Strapi project.
+---
+
 # Fetching external data
 
 This guide explains how to fetch data from an external service to use it in your app.

--- a/docs/developer-docs/latest/guides/is-owner.md
+++ b/docs/developer-docs/latest/guides/is-owner.md
@@ -1,3 +1,8 @@
+---
+title: Is Owner - Strapi Developer Documentation
+description: Learn in this guide how to restrict content editing to content authors only.
+---
+
 # Create is owner policy
 
 This guide will explain how to restrict content editing to content authors only.

--- a/docs/developer-docs/latest/guides/jwt-validation.md
+++ b/docs/developer-docs/latest/guides/jwt-validation.md
@@ -1,3 +1,8 @@
+---
+title: JWT validation - Strapi Developer Documentation
+description: Learn in this guide how to validate a JWT (JSON Web Token) with a third party service.
+---
+
 # JWT validation
 
 In this guide we will see how to validate a `JWT` (JSON Web Token) with a third party service.

--- a/docs/developer-docs/latest/guides/process-manager.md
+++ b/docs/developer-docs/latest/guides/process-manager.md
@@ -1,4 +1,6 @@
 ---
+title: Process Manager - Strapi Developer Documentation
+description: Learn in this guide how you can start a Strapi application using a process manager.
 sidebarDepth: 2
 ---
 

--- a/docs/developer-docs/latest/guides/registering-a-field-in-admin.md
+++ b/docs/developer-docs/latest/guides/registering-a-field-in-admin.md
@@ -1,3 +1,8 @@
+---
+title: Field Registering - Strapi Developer Documentation
+description: Learn in this guide how you can create a new Field for your administration panel.
+---
+
 # Creating a new Field in the administration panel
 
 In this guide we will see how you can create a new Field for your administration panel.

--- a/docs/developer-docs/latest/guides/scheduled-publication.md
+++ b/docs/developer-docs/latest/guides/scheduled-publication.md
@@ -1,3 +1,8 @@
+---
+title: Scheduled Publication - Strapi Developer Documentation
+description: Learn in this guide how to create an article schedule system.
+---
+
 # Scheduled publication
 
 This guide will explain how to create an article schedule system.

--- a/docs/developer-docs/latest/guides/secure-your-app.md
+++ b/docs/developer-docs/latest/guides/secure-your-app.md
@@ -1,3 +1,8 @@
+---
+title: Secure your application - Strapi Developer Documentation
+description: Learn in this guide how you can secure your Strapi application by using a third party provider.
+---
+
 # Secure your application
 
 In this guide we will see how you can secure your Strapi application by using a third party provider.

--- a/docs/developer-docs/latest/guides/send-email.md
+++ b/docs/developer-docs/latest/guides/send-email.md
@@ -1,3 +1,8 @@
+---
+title: Send Email - Strapi Developer Documentation
+description: Learn in this guide how to use the Email plugin to send email where you want in your Strapi app.
+---
+
 # Send email programmatically
 
 In this guide we will see how to use the Email plugin to send email where you want in your app.

--- a/docs/developer-docs/latest/guides/slug.md
+++ b/docs/developer-docs/latest/guides/slug.md
@@ -1,3 +1,8 @@
+---
+title: Slug System - Strapi Developer Documentation
+description: Learn in this guide how to create a slug system for a Post, Article or any Content Type you want in your Strapi project.
+---
+
 # Create a slug system
 
 This guide will explain how to create a slug system for a Post, Article or any Content Type you want.

--- a/docs/developer-docs/latest/guides/unit-testing.md
+++ b/docs/developer-docs/latest/guides/unit-testing.md
@@ -1,4 +1,6 @@
 ---
+title: Unit Testing - Strapi Developer Documentation
+description: Learn in this guide how you can run basic unit tests for a Strapi application using a testing framework.
 sidebarDepth: 2
 ---
 

--- a/docs/developer-docs/latest/setup-deployment-guides/configurations.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/configurations.md
@@ -1,4 +1,6 @@
 ---
+title: Configurations - Strapi Developer Documentation
+description: Learn how you can manage and customize the configuration of your Strapi application.
 sidebarDepth: 3
 ---
 

--- a/docs/developer-docs/latest/setup-deployment-guides/configurations/databases/mongodb.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/configurations/databases/mongodb.md
@@ -1,3 +1,8 @@
+---
+title: MongoDB - Strapi Developer Documentation
+description: Learn how to install MongoDB on your computer and using it for your Strapi application.
+---
+
 # MongoDB Installation
 
 ## Install MongoDB locally
@@ -311,7 +316,7 @@ DATABASE_NAME=myFirstDatabase
 ```
 
 
-::: 
+:::
 
 ::: tab Combined Method
 

--- a/docs/developer-docs/latest/setup-deployment-guides/configurations/databases/sqlite.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/configurations/databases/sqlite.md
@@ -1,3 +1,8 @@
+---
+title: MongoDB - Strapi Developer Documentation
+description: Learn how you can use SQLite for your Strapi application.
+---
+
 # SQLite Installation
 
 SQLite is the default ([Quick Start](/developer-docs/latest/getting-started/quick-start.md)) and recommended database to quickly create an app locally.

--- a/docs/developer-docs/latest/setup-deployment-guides/deployment.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment.md
@@ -1,3 +1,8 @@
+---
+title: Deployment - Strapi Developer Documentation
+description: The following documentation covers how to develop locally with Strapi and deploy Strapi with various hosting options.
+---
+
 # Deployment
 
 Strapi gives you many possible deployment options for your project or application. Strapi can be deployed on traditional hosting servers or services such as 21YunBox, Render, Heroku, AWS, Azure and others. The following documentation covers how to develop locally with Strapi and deploy Strapi with various hosting options.

--- a/docs/developer-docs/latest/setup-deployment-guides/deployment.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment.md
@@ -1,6 +1,6 @@
 ---
 title: Deployment - Strapi Developer Documentation
-description: The following documentation covers how to develop locally with Strapi and deploy Strapi with various hosting options.
+description: Learn how to develop locally with Strapi and deploy Strapi with various hosting options.
 ---
 
 # Deployment

--- a/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/21yunbox.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/21yunbox.md
@@ -1,3 +1,8 @@
+---
+title: 21YunBox Deployment - Strapi Developer Documentation
+description: Learn in this guide how to update an existing Strapi project so it can be deployed on 21YunBox.
+---
+
 # 21YunBox
 
 This guide explains how to update an existing Strapi project so it can be deployed on [21YunBox](https://www.21yunbox.com).

--- a/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/amazon-aws.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/amazon-aws.md
@@ -1,3 +1,8 @@
+---
+title: AWS Deployment - Strapi Developer Documentation
+description: Learn in this guide how to deploy your Strapi application on AWS EC2, host your database on AWS RDS and upload your assets on AWS S3.
+---
+
 # Amazon AWS
 
 This is a step-by-step guide for deploying a Strapi project to [Amazon AWS EC2](https://aws.amazon.com/ec2/). This guide will connect to an [Amazon AWS RDS](https://aws.amazon.com/rds/) for managing and hosting the database. Optionally, this guide will show you how to connect host and serve images on [Amazon AWS S3](https://aws.amazon.com/s3/).

--- a/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/azure.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/azure.md
@@ -1,3 +1,8 @@
+---
+title: Azure Deployment - Strapi Developer Documentation
+description: Learn in this guide how to deploy your Strapi application on Microsoft Azure.
+---
+
 # Azure
 
 This is a step-by-step guide for deploying a Strapi project to [Azure](https://azure.microsoft.com/en-us/). Databases can be on a [Azure Virtual Machine](https://azure.microsoft.com/en-us/services/virtual-machines/), hosted externally as a service, or via the [Azure Managed Databases](https://azure.microsoft.com/en-us/services/postgresql/). Prior to starting this guide, you should have created a [Strapi project](/developer-docs/latest/getting-started/quick-start.md). And have read through the [configuration](/developer-docs/latest/setup-deployment-guides/deployment.md#application-configuration) section.

--- a/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/digitalocean-app-platform.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/digitalocean-app-platform.md
@@ -1,3 +1,8 @@
+---
+title: DigitalOcean App Platform Deployment - Strapi Developer Documentation
+description: Learn in this guide how to deploy your Strapi application on DigitalOcean App Platform.
+---
+
 # DigitalOcean App Platform
 
 This is a step-by-step guide for deploying a Strapi project to [DigitalOcean's App Platform](https://digitalocean.com). App Platform is DigitalOcean's Platform as a Service (PaaS) that will handle deploying, networking, SSL, and more for your app. It is the easiest way to deploy Strapi to DigitalOcean.

--- a/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/digitalocean.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/digitalocean.md
@@ -1,3 +1,8 @@
+---
+title: DigitalOcean Deployment - Strapi Developer Documentation
+description: Learn in this guide how to deploy your Strapi application on DigitalOcean.
+---
+
 # DigitalOcean
 
 This is a step-by-step guide for deploying a Strapi project to [DigitalOcean](https://www.digitalocean.com/). Databases can be on a [DigitalOcean Droplet](https://www.digitalocean.com/docs/droplets/) or hosted externally as a service. Prior to starting this guide, you should have created a [Strapi project](/developer-docs/latest/getting-started/quick-start.md). And have read through the [configuration](/developer-docs/latest/setup-deployment-guides/deployment.md#application-configuration) section.

--- a/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/digitalocean.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/digitalocean.md
@@ -1,6 +1,6 @@
 ---
-title: DigitalOcean Deployment - Strapi Developer Documentation
-description: Learn in this guide how to deploy your Strapi application on DigitalOcean.
+title: DigitalOcean Droplet Deployment - Strapi Developer Documentation
+description: Learn in this guide how to deploy your Strapi application on DigitalOcean Droplets.
 ---
 
 # DigitalOcean Droplets
@@ -411,9 +411,14 @@ const exec = require('child_process').exec;
 const PM2_CMD = 'cd ~ && pm2 startOrRestart ecosystem.config.js';
 
 http
-  .createServer(function (req, res) {
-    req.on('data', function (chunk) {
-      let sig = 'sha1=' + crypto.createHmac('sha1', secret).update(chunk.toString()).digest('hex');
+  .createServer(function(req, res) {
+    req.on('data', function(chunk) {
+      let sig =
+        'sha1=' +
+        crypto
+          .createHmac('sha1', secret)
+          .update(chunk.toString())
+          .digest('hex');
 
       if (req.headers['x-hub-signature'] == sig) {
         exec(`cd ${repo} && git pull && ${PM2_CMD}`, (error, stdout, stderr) => {

--- a/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/google-app-engine.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/google-app-engine.md
@@ -1,3 +1,8 @@
+---
+title: Google App Engine Deployment - Strapi Developer Documentation
+description: Learn in this guide how to deploy your Strapi application on Google App Engine and how to upload your assets on Google Cloud Sorage.
+---
+
 # Google App Engine
 
 In this guide we are going to:

--- a/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/google-app-engine.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/google-app-engine.md
@@ -1,6 +1,6 @@
 ---
 title: Google App Engine Deployment - Strapi Developer Documentation
-description: Learn in this guide how to deploy your Strapi application on Google App Engine and how to upload your assets on Google Cloud Sorage.
+description: Learn in this guide how to deploy your Strapi application on Google App Engine and how to upload your assets on Google Cloud Storage.
 ---
 
 # Google App Engine

--- a/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/heroku.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/heroku.md
@@ -1,3 +1,8 @@
+---
+title: Heroku Deployment - Strapi Developer Documentation
+description: Learn in this guide how to deploy your Strapi application on Heroku.
+---
+
 # Heroku
 
 This is a step-by-step guide for deploying a Strapi project on [Heroku](https://www.heroku.com/). Databases that work well with Strapi and Heroku are provided instructions on how to get started.

--- a/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/qovery.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/qovery.md
@@ -1,13 +1,18 @@
+---
+title: Qovery Deployment - Strapi Developer Documentation
+description: Learn in this guide how to deploy your Strapi application on Qovery.
+---
+
 # Qovery
 
-This is a step-by-step guide for deploying a Strapi project on [Qovery](https://www.qovery.com). 
+This is a step-by-step guide for deploying a Strapi project on [Qovery](https://www.qovery.com).
 
-Qovery is a CaaS for developers to deploy their full-stack applications on AWS, GCP, Azure and Digital Ocean. Qovery provides access to managed PostgreSQL and free SSL. 
+Qovery is a CaaS for developers to deploy their full-stack applications on AWS, GCP, Azure and Digital Ocean. Qovery provides access to managed PostgreSQL and free SSL.
 
 ::: tip
 Qovery provides free hosting for individual developers.
 :::
- 
+
 ## Deploying with the web interface
 ### 1. Create a Qovery Account
 Visit [the Qovery dashboard](https://start.qovery.com) to create an account if you don't already have one.
@@ -65,7 +70,7 @@ routers:
 - name: main
   custom_domains: # optional: only if you want to use your domain
   - branch: master
-    domain: my.domain.tld 
+    domain: my.domain.tld
   routes:
   - application_name: strapi
     paths:

--- a/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/render.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/render.md
@@ -1,3 +1,8 @@
+---
+title: Render Deployment - Strapi Developer Documentation
+description: Learn in this guide how to deploy your Strapi application on Render.
+---
+
 # Render
 
 This guide explains how to update an existing Strapi project so it can be deployed on [Render](https://render.com).

--- a/docs/developer-docs/latest/setup-deployment-guides/file-structure.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/file-structure.md
@@ -1,6 +1,6 @@
 ---
 title: Project Structure - Strapi Developer Documentation
-description: The following documentation covers the project structure of any default Strapi application.
+description: Discover the project structure of any default Strapi application.
 ---
 
 # Project structure

--- a/docs/developer-docs/latest/setup-deployment-guides/file-structure.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/file-structure.md
@@ -1,3 +1,8 @@
+---
+title: Project Structure - Strapi Developer Documentation
+description: The following documentation covers the project structure of any default Strapi application.
+---
+
 # Project structure
 
 By default, the structure of your Strapi project looks as shown below:

--- a/docs/developer-docs/latest/setup-deployment-guides/installation.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/installation.md
@@ -1,6 +1,6 @@
 ---
 title: Installation - Strapi Developer Documentation
-description: The following documentation covers many different options to install Strapi and getting started on using it.
+description: Learn many different options to install Strapi and getting started on using it.
 ---
 
 # Installation

--- a/docs/developer-docs/latest/setup-deployment-guides/installation.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/installation.md
@@ -1,3 +1,8 @@
+---
+title: Installation - Strapi Developer Documentation
+description: The following documentation covers many different options to install Strapi and getting started on using it.
+---
+
 # Installation
 
 Strapi gives you many possible installation options for your project or application. Strapi can be installed on your computer or services such as Render, DigitalOcean, Amazon AWS, or Platform.sh. The following documentation covers many different options to install Strapi and getting started on using it.

--- a/docs/developer-docs/latest/setup-deployment-guides/installation/cli.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/installation/cli.md
@@ -1,3 +1,8 @@
+---
+title: Install from CLI - Strapi Developer Documentation
+description: Fast-track local install for getting Strapi running on your computer in less than a minute.
+---
+
 # Installing from CLI
 
 Fast-track local install for getting Strapi running on your computer.

--- a/docs/developer-docs/latest/setup-deployment-guides/installation/digitalocean-one-click.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/installation/digitalocean-one-click.md
@@ -1,3 +1,8 @@
+---
+title: DigitalOcean One-click - Strapi Developer Documentation
+description: Quickly deploy a Strapi application on DigitalOcean by simply using their One-click button.
+---
+
 # DigitalOcean One-click
 
 [DigitalOcean](https://www.digitalocean.com/) provide a simple way to deploy Strapi with an easy click of the mouse.

--- a/docs/developer-docs/latest/setup-deployment-guides/installation/docker.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/installation/docker.md
@@ -1,3 +1,8 @@
+---
+title: Install from Docker - Strapi Developer Documentation
+description: Quickly create a Strapi application using our officials Strapi Docker images.
+---
+
 # Installing using Docker
 
 If you're already familiar with Docker, you are probably looking for our official Docker images over [Docker Hub](https://hub.docker.com/r/strapi/strapi).

--- a/docs/developer-docs/latest/setup-deployment-guides/installation/docker.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/installation/docker.md
@@ -1,6 +1,6 @@
 ---
 title: Install from Docker - Strapi Developer Documentation
-description: Quickly create a Strapi application using our officials Strapi Docker images.
+description: Quickly create a Strapi application using our official Strapi Docker images.
 ---
 
 # Installing using Docker

--- a/docs/developer-docs/latest/setup-deployment-guides/installation/platformsh.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/installation/platformsh.md
@@ -1,3 +1,8 @@
+---
+title: Install using Platform.sh - Strapi Developer Documentation
+description: Quickly deploy a Strapi application using the official Platform.sh Strapi template.
+---
+
 # Installing using Platform.sh
 
 [Platform.sh](https://platform.sh/) gives you an easy way to get started and deploy your Strapi application.

--- a/docs/developer-docs/latest/setup-deployment-guides/installation/render.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/installation/render.md
@@ -1,3 +1,8 @@
+---
+title: Render One-Click - Strapi Developer Documentation
+description: Quickly deploy a Strapi application on Render by simply using their One-click button.
+---
+
 # Render One-Click Deploy
 
 This guide explains how to deploy a new Strapi project on [Render](https://render.com) in one click.

--- a/docs/developer-docs/latest/setup-deployment-guides/installation/templates.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/installation/templates.md
@@ -1,3 +1,8 @@
+---
+title: Templates - Strapi Developer Documentation
+description: Quickly create a pre-made Strapi application designed for a specific use case. It allows you to quickly bootstrap a custom Strapi app.
+---
+
 # Templates
 
 A template is a pre-made Strapi configuration designed for a specific use case. It allows you to quickly bootstrap a custom Strapi app.

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides.md
@@ -1,6 +1,6 @@
 ---
 title: Migrate Guides - Strapi Developer Documentation
-description: The following documentation includes all the migration guides for a Strapi application.
+description: All the migration guides for a Strapi application.
 ---
 
 # Migrations guides

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides.md
@@ -1,6 +1,11 @@
+---
+title: Migrate Guides - Strapi Developer Documentation
+description: The following documentation includes all the migration guides for a Strapi application.
+---
+
 # Migrations guides
 
-Please also refer to the following [update guide](update-version.md) for a better understanding of how to update your project. 
+Please also refer to the following [update guide](update-version.md) for a better understanding of how to update your project.
 
 **Pay special attention to the [note](update-version.md#extensions) about upgrading if you are using the extensions system.**
 

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-1-to-3.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-1-to-3.md
@@ -1,6 +1,6 @@
 ---
 title: Migrate from v1 to v3 - Strapi Developer Documentation
-description: The following documentation covers how you can migrate your Strapi application from v1 to v3.
+description: Learn how you can migrate your Strapi application from v1 to v3.
 ---
 
 # Migrating from v1 to v3

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-1-to-3.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-1-to-3.md
@@ -1,3 +1,8 @@
+---
+title: Migrate from v1 to v3 - Strapi Developer Documentation
+description: The following documentation covers how you can migrate your Strapi application from v1 to v3.
+---
+
 # Migrating from v1 to v3
 
 To be honest with all of you, the migration process won't be easy. The new version introduces a lot of breaking changes especially on the query part. Some features are still not available for the moment such as the authentication, users & permissions, email, media upload and GraphQL. **If you're using one of theses features, you shouldn't be able to migrate unless you rewrite these features from scratch.**

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-3.0.x-to-3.1.x.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-3.0.x-to-3.1.x.md
@@ -1,6 +1,6 @@
 ---
 title: Migrate from 3.0.x to 3.1.x - Strapi Developer Documentation
-description: The following documentation covers how you can migrate your Strapi application from 3.0.x to 3.1.x.
+description: Learn how you can migrate your Strapi application from 3.0.x to 3.1.x.
 ---
 
 # Migration guide from 3.0.x to 3.1.x

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-3.0.x-to-3.1.x.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-3.0.x-to-3.1.x.md
@@ -1,3 +1,8 @@
+---
+title: Migrate from 3.0.x to 3.1.x - Strapi Developer Documentation
+description: The following documentation covers how you can migrate your Strapi application from 3.0.x to 3.1.x.
+---
+
 # Migration guide from 3.0.x to 3.1.x
 
 **Make sure your server is not running until the end of the migration**

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-3.1.x-to-3.2.x.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-3.1.x-to-3.2.x.md
@@ -1,6 +1,6 @@
 ---
 title: Migrate from 3.1.x to 3.2.3 - Strapi Developer Documentation
-description: The following documentation covers how you can migrate your Strapi application from 3.1.x to 3.2.3.
+description: Learn how you can migrate your Strapi application from 3.1.x to 3.2.3.
 ---
 
 # Migration guide from 3.1.x to 3.2.3

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-3.1.x-to-3.2.x.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-3.1.x-to-3.2.x.md
@@ -1,3 +1,8 @@
+---
+title: Migrate from 3.1.x to 3.2.3 - Strapi Developer Documentation
+description: The following documentation covers how you can migrate your Strapi application from 3.1.x to 3.2.3.
+---
+
 # Migration guide from 3.1.x to 3.2.3
 
 **Make sure your server is not running until the end of the migration**

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-3.2.3-to-3.2.4.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-3.2.3-to-3.2.4.md
@@ -1,6 +1,6 @@
 ---
 title: Migrate from 3.2.3 to 3.2.4 - Strapi Developer Documentation
-description: The following documentation covers how you can migrate your Strapi application from 3.2.3 to 3.2.4.
+description: Learn how you can migrate your Strapi application from 3.2.3 to 3.2.4.
 ---
 
 # Migration guide from 3.2.3 to 3.2.4

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-3.2.3-to-3.2.4.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-3.2.3-to-3.2.4.md
@@ -1,3 +1,8 @@
+---
+title: Migrate from 3.2.3 to 3.2.4 - Strapi Developer Documentation
+description: The following documentation covers how you can migrate your Strapi application from 3.2.3 to 3.2.4.
+---
+
 # Migration guide from 3.2.3 to 3.2.4
 
 **Make sure your server is not running until the end of the migration**

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-3.2.5-to-3.3.0.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-3.2.5-to-3.3.0.md
@@ -1,3 +1,8 @@
+---
+title: Migrate from 3.2.5 to 3.3.0 - Strapi Developer Documentation
+description: The following documentation covers how you can migrate your Strapi application from 3.2.5 to 3.3.0.
+---
+
 # Migration guide from 3.2.5 to 3.3.0
 
 **Make sure your server is not running until the end of the migration**

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-3.2.5-to-3.3.0.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-3.2.5-to-3.3.0.md
@@ -1,6 +1,6 @@
 ---
 title: Migrate from 3.2.5 to 3.3.0 - Strapi Developer Documentation
-description: The following documentation covers how you can migrate your Strapi application from 3.2.5 to 3.3.0.
+description: Learn how you can migrate your Strapi application from 3.2.5 to 3.3.0.
 ---
 
 # Migration guide from 3.2.5 to 3.3.0

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-3.3.x-to-3.4.0.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-3.3.x-to-3.4.0.md
@@ -1,3 +1,8 @@
+---
+title: Migrate from 3.3.x to 3.4.0 - Strapi Developer Documentation
+description: The following documentation covers how you can migrate your Strapi application from 3.3.x to 3.4.0.
+---
+
 # Migration guide from 3.3.x to 3.4.0
 
 **Make sure your server is not running until the end of the migration**

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-3.3.x-to-3.4.0.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-3.3.x-to-3.4.0.md
@@ -1,6 +1,6 @@
 ---
 title: Migrate from 3.3.x to 3.4.0 - Strapi Developer Documentation
-description: The following documentation covers how you can migrate your Strapi application from 3.3.x to 3.4.0.
+description: Learn how you can migrate your Strapi application from 3.3.x to 3.4.0.
 ---
 
 # Migration guide from 3.3.x to 3.4.0

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-3.4.x-to-3.4.4.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-3.4.x-to-3.4.4.md
@@ -1,3 +1,8 @@
+---
+title: Migrate from 3.4.x to 3.4.4 - Strapi Developer Documentation
+description: The following documentation covers how you can migrate your Strapi application from 3.4.x to 3.4.4.
+---
+
 # Migration guide from 3.4.x to 3.4.4
 
 **Make sure your server is not running until the end of the migration**

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-3.4.x-to-3.4.4.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-3.4.x-to-3.4.4.md
@@ -1,6 +1,6 @@
 ---
 title: Migrate from 3.4.x to 3.4.4 - Strapi Developer Documentation
-description: The following documentation covers how you can migrate your Strapi application from 3.4.x to 3.4.4.
+description: Learn how you can migrate your Strapi application from 3.4.x to 3.4.4.
 ---
 
 # Migration guide from 3.4.x to 3.4.4

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.10-to-alpha.11.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.10-to-alpha.11.md
@@ -1,3 +1,8 @@
+---
+title: Migrate from alpha.10 to alpha.11 - Strapi Developer Documentation
+description: The following documentation covers how you can migrate your Strapi application from alpha.10 to alpha.11.
+---
+
 # Migration guide from alpha.10 to alpha.11
 
 **Here are the major changes:**

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.10-to-alpha.11.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.10-to-alpha.11.md
@@ -1,6 +1,6 @@
 ---
 title: Migrate from alpha.10 to alpha.11 - Strapi Developer Documentation
-description: The following documentation covers how you can migrate your Strapi application from alpha.10 to alpha.11.
+description: Learn how you can migrate your Strapi application from alpha.10 to alpha.11.
 ---
 
 # Migration guide from alpha.10 to alpha.11

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.11-to-alpha.12.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.11-to-alpha.12.md
@@ -1,3 +1,8 @@
+---
+title: Migrate from alpha.11 to alpha.12 - Strapi Developer Documentation
+description: The following documentation covers how you can migrate your Strapi application from alpha.11 to alpha.12.
+---
+
 # Migration guide from alpha.11 to alpha.12
 
 This migration guide is a mix of migrations from 3.0.0-alpha.11.1 to 3.0.0-alpha.11.2, 3.0.0-alpha.11.2 to 3.0.0-alpha.11.3 and from 3.0.0-alpha.11.3 to 3.0.0-alpha.12.1.3.

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.11-to-alpha.12.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.11-to-alpha.12.md
@@ -1,6 +1,6 @@
 ---
 title: Migrate from alpha.11 to alpha.12 - Strapi Developer Documentation
-description: The following documentation covers how you can migrate your Strapi application from alpha.11 to alpha.12.
+description: Learn how you can migrate your Strapi application from alpha.11 to alpha.12.
 ---
 
 # Migration guide from alpha.11 to alpha.12

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.12.1-to-alpha.12.2.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.12.1-to-alpha.12.2.md
@@ -1,6 +1,6 @@
 ---
 title: Migrate from alpha.12.1 to alpha.12.2 - Strapi Developer Documentation
-description: The following documentation covers how you can migrate your Strapi application from alpha.12.1 to alpha.12.2.
+description: Learn how you can migrate your Strapi application from alpha.12.1 to alpha.12.2.
 ---
 
 # Migration guide from alpha.12.1 to alpha.12.2

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.12.1-to-alpha.12.2.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.12.1-to-alpha.12.2.md
@@ -1,3 +1,8 @@
+---
+title: Migrate from alpha.12.1 to alpha.12.2 - Strapi Developer Documentation
+description: The following documentation covers how you can migrate your Strapi application from alpha.12.1 to alpha.12.2.
+---
+
 # Migration guide from alpha.12.1 to alpha.12.2
 
 **Here are the major changes:**

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.12.2-to-alpha.12.3.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.12.2-to-alpha.12.3.md
@@ -1,6 +1,6 @@
 ---
 title: Migrate from alpha.12.2 to alpha.12.3 - Strapi Developer Documentation
-description: The following documentation covers how you can migrate your Strapi application from alpha.12.2 to alpha.12.3.
+description: Learn how you can migrate your Strapi application from alpha.12.2 to alpha.12.3.
 ---
 
 # Migration guide from alpha.12.2 to alpha.12.3

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.12.2-to-alpha.12.3.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.12.2-to-alpha.12.3.md
@@ -1,3 +1,8 @@
+---
+title: Migrate from alpha.12.2 to alpha.12.3 - Strapi Developer Documentation
+description: The following documentation covers how you can migrate your Strapi application from alpha.12.2 to alpha.12.3.
+---
+
 # Migration guide from alpha.12.2 to alpha.12.3
 
 **Here are the major changes:**

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.12.3-to-alpha.12.4.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.12.3-to-alpha.12.4.md
@@ -1,6 +1,6 @@
 ---
 title: Migrate from alpha.12.3 to alpha.12.4 - Strapi Developer Documentation
-description: The following documentation covers how you can migrate your Strapi application from alpha.12.3 to alpha.12.4.
+description: Learn how you can migrate your Strapi application from alpha.12.3 to alpha.12.4.
 ---
 
 # Migration guide from alpha.12.3 to alpha.12.4

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.12.3-to-alpha.12.4.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.12.3-to-alpha.12.4.md
@@ -1,3 +1,8 @@
+---
+title: Migrate from alpha.12.3 to alpha.12.4 - Strapi Developer Documentation
+description: The following documentation covers how you can migrate your Strapi application from alpha.12.3 to alpha.12.4.
+---
+
 # Migration guide from alpha.12.3 to alpha.12.4
 
 **Here are the major changes:**

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.12.4-to-alpha.12.5.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.12.4-to-alpha.12.5.md
@@ -1,3 +1,8 @@
+---
+title: Migrate from alpha.12.4 to alpha.12.5 - Strapi Developer Documentation
+description: The following documentation covers how you can migrate your Strapi application from alpha.12.4 to alpha.12.5.
+---
+
 # Migration guide from alpha.12.4 to alpha.12.5
 
 **Here are the major changes:**

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.12.4-to-alpha.12.5.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.12.4-to-alpha.12.5.md
@@ -1,6 +1,6 @@
 ---
 title: Migrate from alpha.12.4 to alpha.12.5 - Strapi Developer Documentation
-description: The following documentation covers how you can migrate your Strapi application from alpha.12.4 to alpha.12.5.
+description: Learn how you can migrate your Strapi application from alpha.12.4 to alpha.12.5.
 ---
 
 # Migration guide from alpha.12.4 to alpha.12.5

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.12.5-to-alpha.12.6.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.12.5-to-alpha.12.6.md
@@ -1,3 +1,8 @@
+---
+title: Migrate from alpha.12.5 to alpha.12.6 - Strapi Developer Documentation
+description: The following documentation covers how you can migrate your Strapi application from alpha.12.5 to alpha.12.6.
+---
+
 # Migration guide from alpha.12.5 to alpha.12.6
 
 **Here are the major changes:**

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.12.5-to-alpha.12.6.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.12.5-to-alpha.12.6.md
@@ -1,6 +1,6 @@
 ---
 title: Migrate from alpha.12.5 to alpha.12.6 - Strapi Developer Documentation
-description: The following documentation covers how you can migrate your Strapi application from alpha.12.5 to alpha.12.6.
+description: Learn how you can migrate your Strapi application from alpha.12.5 to alpha.12.6.
 ---
 
 # Migration guide from alpha.12.5 to alpha.12.6

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.12.6-to-alpha.12.7.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.12.6-to-alpha.12.7.md
@@ -1,6 +1,6 @@
 ---
 title: Migrate from alpha.12.6 to alpha.12.7 - Strapi Developer Documentation
-description: The following documentation covers how you can migrate your Strapi application from alpha.12.6 to alpha.12.7.
+description: Learn how you can migrate your Strapi application from alpha.12.6 to alpha.12.7.
 ---
 
 # Migration guide from alpha.12.6 to alpha.12.7

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.12.6-to-alpha.12.7.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.12.6-to-alpha.12.7.md
@@ -1,3 +1,8 @@
+---
+title: Migrate from alpha.12.6 to alpha.12.7 - Strapi Developer Documentation
+description: The following documentation covers how you can migrate your Strapi application from alpha.12.6 to alpha.12.7.
+---
+
 # Migration guide from alpha.12.6 to alpha.12.7
 
 **Here are the major changes:**

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.12.7-to-alpha.13.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.12.7-to-alpha.13.md
@@ -1,6 +1,6 @@
 ---
 title: Migrate from alpha.12.7 to alpha.13 - Strapi Developer Documentation
-description: The following documentation covers how you can migrate your Strapi application from alpha.12.7 to alpha.13.
+description: Learn how you can migrate your Strapi application from alpha.12.7 to alpha.13.
 ---
 
 # Migration guide from alpha.12.7 to alpha.13

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.12.7-to-alpha.13.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.12.7-to-alpha.13.md
@@ -1,3 +1,8 @@
+---
+title: Migrate from alpha.12.7 to alpha.13 - Strapi Developer Documentation
+description: The following documentation covers how you can migrate your Strapi application from alpha.12.7 to alpha.13.
+---
+
 # Migration guide from alpha.12.7 to alpha.13
 
 **Here are the major changes:**

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.13-to-alpha.13.1.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.13-to-alpha.13.1.md
@@ -1,3 +1,8 @@
+---
+title: Migrate from alpha.13 to alpha.13.1 - Strapi Developer Documentation
+description: The following documentation covers how you can migrate your Strapi application from alpha.13 to alpha.13.1.
+---
+
 # Migration guide from alpha.13 to alpha.13.1
 
 **Here are the major changes:**

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.13-to-alpha.13.1.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.13-to-alpha.13.1.md
@@ -1,6 +1,6 @@
 ---
 title: Migrate from alpha.13 to alpha.13.1 - Strapi Developer Documentation
-description: The following documentation covers how you can migrate your Strapi application from alpha.13 to alpha.13.1.
+description: Learn how you can migrate your Strapi application from alpha.13 to alpha.13.1.
 ---
 
 # Migration guide from alpha.13 to alpha.13.1

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.13.1-to-alpha.14.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.13.1-to-alpha.14.md
@@ -1,3 +1,8 @@
+---
+title: Migrate from alpha.13.1 to alpha.14 - Strapi Developer Documentation
+description: The following documentation covers how you can migrate your Strapi application from alpha.13.1 to alpha.14.
+---
+
 # Migration guide from alpha.13.1 to alpha.14
 
 **Here are the major changes:**

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.13.1-to-alpha.14.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.13.1-to-alpha.14.md
@@ -1,6 +1,6 @@
 ---
 title: Migrate from alpha.13.1 to alpha.14 - Strapi Developer Documentation
-description: The following documentation covers how you can migrate your Strapi application from alpha.13.1 to alpha.14.
+description: Learn how you can migrate your Strapi application from alpha.13.1 to alpha.14.
 ---
 
 # Migration guide from alpha.13.1 to alpha.14

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.14-to-alpha.14.1.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.14-to-alpha.14.1.md
@@ -1,6 +1,6 @@
 ---
 title: Migrate from alpha.14 to alpha.14.1 - Strapi Developer Documentation
-description: The following documentation covers how you can migrate your Strapi application from alpha.14 to alpha.14.1.
+description: Learn how you can migrate your Strapi application from alpha.14 to alpha.14.1.
 ---
 
 # Migration guide from alpha.14 to alpha.14.1

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.14-to-alpha.14.1.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.14-to-alpha.14.1.md
@@ -1,3 +1,8 @@
+---
+title: Migrate from alpha.14 to alpha.14.1 - Strapi Developer Documentation
+description: The following documentation covers how you can migrate your Strapi application from alpha.14 to alpha.14.1.
+---
+
 # Migration guide from alpha.14 to alpha.14.1
 
 **Here are the major changes:**

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.14.1-to-alpha.14.2.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.14.1-to-alpha.14.2.md
@@ -1,3 +1,8 @@
+---
+title: Migrate from alpha.14.1 to alpha.14.2 - Strapi Developer Documentation
+description: The following documentation covers how you can migrate your Strapi application from alpha.14.1 to alpha.14.2.
+---
+
 # Migration guide from alpha.14.1 to alpha.14.2
 
 **Here are the major changes:**

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.14.1-to-alpha.14.2.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.14.1-to-alpha.14.2.md
@@ -1,6 +1,6 @@
 ---
 title: Migrate from alpha.14.1 to alpha.14.2 - Strapi Developer Documentation
-description: The following documentation covers how you can migrate your Strapi application from alpha.14.1 to alpha.14.2.
+description: Learn how you can migrate your Strapi application from alpha.14.1 to alpha.14.2.
 ---
 
 # Migration guide from alpha.14.1 to alpha.14.2

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.14.2-to-alpha.14.3.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.14.2-to-alpha.14.3.md
@@ -1,3 +1,8 @@
+---
+title: Migrate from alpha.14.2 to alpha.14.3 - Strapi Developer Documentation
+description: The following documentation covers how you can migrate your Strapi application from alpha.14.2 to alpha.14.3.
+---
+
 # Migration guide from alpha.14.2 to alpha.14.3
 
 **Here are the major changes:**

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.14.2-to-alpha.14.3.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.14.2-to-alpha.14.3.md
@@ -1,6 +1,6 @@
 ---
 title: Migrate from alpha.14.2 to alpha.14.3 - Strapi Developer Documentation
-description: The following documentation covers how you can migrate your Strapi application from alpha.14.2 to alpha.14.3.
+description: Learn how you can migrate your Strapi application from alpha.14.2 to alpha.14.3.
 ---
 
 # Migration guide from alpha.14.2 to alpha.14.3

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.14.3-to-alpha.14.4.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.14.3-to-alpha.14.4.md
@@ -1,6 +1,6 @@
 ---
 title: Migrate from alpha.14.3 to alpha.14.4 - Strapi Developer Documentation
-description: The following documentation covers how you can migrate your Strapi application from alpha.14.3 to alpha.14.4.
+description: Learn how you can migrate your Strapi application from alpha.14.3 to alpha.14.4.
 ---
 
 # Migration guide from alpha.14.3 to alpha.14.4

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.14.3-to-alpha.14.4.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.14.3-to-alpha.14.4.md
@@ -1,3 +1,8 @@
+---
+title: Migrate from alpha.14.3 to alpha.14.4 - Strapi Developer Documentation
+description: The following documentation covers how you can migrate your Strapi application from alpha.14.3 to alpha.14.4.
+---
+
 # Migration guide from alpha.14.3 to alpha.14.4
 
 **Useful links:**

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.14.4-to-alpha.14.5.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.14.4-to-alpha.14.5.md
@@ -1,3 +1,8 @@
+---
+title: Migrate from alpha.14.4 to alpha.14.5 - Strapi Developer Documentation
+description: The following documentation covers how you can migrate your Strapi application from alpha.14.4 to alpha.14.5.
+---
+
 # Migration guide from alpha.14.4 to alpha.14.5
 
 **Here are the major changes:**

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.14.4-to-alpha.14.5.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.14.4-to-alpha.14.5.md
@@ -1,6 +1,6 @@
 ---
 title: Migrate from alpha.14.4 to alpha.14.5 - Strapi Developer Documentation
-description: The following documentation covers how you can migrate your Strapi application from alpha.14.4 to alpha.14.5.
+description: Learn how you can migrate your Strapi application from alpha.14.4 to alpha.14.5.
 ---
 
 # Migration guide from alpha.14.4 to alpha.14.5

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.14.5-to-alpha.15.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.14.5-to-alpha.15.md
@@ -1,6 +1,6 @@
 ---
 title: Migrate from alpha.14.5 to alpha.15 - Strapi Developer Documentation
-description: The following documentation covers how you can migrate your Strapi application from alpha.14.5 to alpha.15.
+description: Learn how you can migrate your Strapi application from alpha.14.5 to alpha.15.
 ---
 
 # Migration guide from alpha.14.5 to alpha.15

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.14.5-to-alpha.15.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.14.5-to-alpha.15.md
@@ -1,3 +1,8 @@
+---
+title: Migrate from alpha.14.5 to alpha.15 - Strapi Developer Documentation
+description: The following documentation covers how you can migrate your Strapi application from alpha.14.5 to alpha.15.
+---
+
 # Migration guide from alpha.14.5 to alpha.15
 
 **Here are the major changes:**

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.15-to-alpha.16.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.15-to-alpha.16.md
@@ -1,3 +1,8 @@
+---
+title: Migrate from alpha.15 to alpha.16 - Strapi Developer Documentation
+description: The following documentation covers how you can migrate your Strapi application from alpha.15 to alpha.16.
+---
+
 # Migration guide from alpha.15 to alpha.16
 
 **Here are the major changes:**

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.15-to-alpha.16.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.15-to-alpha.16.md
@@ -1,6 +1,6 @@
 ---
 title: Migrate from alpha.15 to alpha.16 - Strapi Developer Documentation
-description: The following documentation covers how you can migrate your Strapi application from alpha.15 to alpha.16.
+description: Learn how you can migrate your Strapi application from alpha.15 to alpha.16.
 ---
 
 # Migration guide from alpha.15 to alpha.16

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.16-to-alpha.17.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.16-to-alpha.17.md
@@ -1,3 +1,8 @@
+---
+title: Migrate from alpha.16 to alpha.17 - Strapi Developer Documentation
+description: The following documentation covers how you can migrate your Strapi application from alpha.16 to alpha.17.
+---
+
 # Migration guide from alpha.16 to alpha.17
 
 **Here are the major changes:**

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.16-to-alpha.17.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.16-to-alpha.17.md
@@ -1,6 +1,6 @@
 ---
 title: Migrate from alpha.16 to alpha.17 - Strapi Developer Documentation
-description: The following documentation covers how you can migrate your Strapi application from alpha.16 to alpha.17.
+description: Learn how you can migrate your Strapi application from alpha.16 to alpha.17.
 ---
 
 # Migration guide from alpha.16 to alpha.17

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.17-to-alpha.18.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.17-to-alpha.18.md
@@ -1,6 +1,6 @@
 ---
 title: Migrate from alpha.17 to alpha.18 - Strapi Developer Documentation
-description: The following documentation covers how you can migrate your Strapi application from alpha.17 to alpha.18.
+description: Learn how you can migrate your Strapi application from alpha.17 to alpha.18.
 ---
 
 # Migration guide from alpha.17 to alpha.18

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.17-to-alpha.18.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.17-to-alpha.18.md
@@ -1,3 +1,8 @@
+---
+title: Migrate from alpha.17 to alpha.18 - Strapi Developer Documentation
+description: The following documentation covers how you can migrate your Strapi application from alpha.17 to alpha.18.
+---
+
 # Migration guide from alpha.17 to alpha.18
 
 **Here are the major changes:**

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.18-to-alpha.19.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.18-to-alpha.19.md
@@ -1,6 +1,6 @@
 ---
 title: Migrate from alpha.18 to alpha.19 - Strapi Developer Documentation
-description: The following documentation covers how you can migrate your Strapi application from alpha.18 to alpha.19.
+description: Learn how you can migrate your Strapi application from alpha.18 to alpha.19.
 ---
 
 # Migration guide from alpha.18 to alpha.19

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.18-to-alpha.19.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.18-to-alpha.19.md
@@ -1,3 +1,8 @@
+---
+title: Migrate from alpha.18 to alpha.19 - Strapi Developer Documentation
+description: The following documentation covers how you can migrate your Strapi application from alpha.18 to alpha.19.
+---
+
 # Migration guide from alpha.18 to alpha.19
 
 **Here are the major changes:**

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.19-to-alpha.20.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.19-to-alpha.20.md
@@ -1,6 +1,6 @@
 ---
 title: Migrate from alpha.19 to alpha.20 - Strapi Developer Documentation
-description: The following documentation covers how you can migrate your Strapi application from alpha.19 to alpha.20.
+description: Learn how you can migrate your Strapi application from alpha.19 to alpha.20.
 ---
 
 # Migration guide from alpha.19 to alpha.20

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.19-to-alpha.20.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.19-to-alpha.20.md
@@ -1,3 +1,8 @@
+---
+title: Migrate from alpha.19 to alpha.20 - Strapi Developer Documentation
+description: The following documentation covers how you can migrate your Strapi application from alpha.19 to alpha.20.
+---
+
 # Migration guide from alpha.19 to alpha.20
 
 **Here are the major changes:**

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.20-to-alpha.21.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.20-to-alpha.21.md
@@ -1,6 +1,6 @@
 ---
 title: Migrate from alpha.20 to alpha.21 - Strapi Developer Documentation
-description: The following documentation covers how you can migrate your Strapi application from alpha.20 to alpha.21.
+description: Learn how you can migrate your Strapi application from alpha.20 to alpha.21.
 ---
 
 # Migration guide from alpha.20 to alpha.21

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.20-to-alpha.21.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.20-to-alpha.21.md
@@ -1,3 +1,8 @@
+---
+title: Migrate from alpha.20 to alpha.21 - Strapi Developer Documentation
+description: The following documentation covers how you can migrate your Strapi application from alpha.20 to alpha.21.
+---
+
 # Migration guide from alpha.20 to alpha.21
 
 **Here are the major changes:**

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.21-to-alpha.22.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.21-to-alpha.22.md
@@ -1,3 +1,8 @@
+---
+title: Migrate from alpha.21 to alpha.22 - Strapi Developer Documentation
+description: The following documentation covers how you can migrate your Strapi application from alpha.21 to alpha.22.
+---
+
 # Migration guide from alpha.21 to alpha.22
 
 **Here are the major changes:**

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.21-to-alpha.22.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.21-to-alpha.22.md
@@ -1,6 +1,6 @@
 ---
 title: Migrate from alpha.21 to alpha.22 - Strapi Developer Documentation
-description: The following documentation covers how you can migrate your Strapi application from alpha.21 to alpha.22.
+description: Learn how you can migrate your Strapi application from alpha.21 to alpha.22.
 ---
 
 # Migration guide from alpha.21 to alpha.22

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.22-to-alpha.23.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.22-to-alpha.23.md
@@ -1,3 +1,8 @@
+---
+title: Migrate from alpha.22 to alpha.23 - Strapi Developer Documentation
+description: The following documentation covers how you can migrate your Strapi application from alpha.22 to alpha.23.
+---
+
 # Migration guide from alpha.22 to alpha.23
 
 **Here are the major changes:**

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.22-to-alpha.23.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.22-to-alpha.23.md
@@ -1,6 +1,6 @@
 ---
 title: Migrate from alpha.22 to alpha.23 - Strapi Developer Documentation
-description: The following documentation covers how you can migrate your Strapi application from alpha.22 to alpha.23.
+description: Learn how you can migrate your Strapi application from alpha.22 to alpha.23.
 ---
 
 # Migration guide from alpha.22 to alpha.23

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.23-to-alpha.24.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.23-to-alpha.24.md
@@ -1,6 +1,6 @@
 ---
 title: Migrate from alpha.23 to alpha.24 - Strapi Developer Documentation
-description: The following documentation covers how you can migrate your Strapi application from alpha.23 to alpha.24.
+description: Learn how you can migrate your Strapi application from alpha.23 to alpha.24.
 ---
 
 # Migration guide from alpha.23 to alpha.24

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.23-to-alpha.24.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.23-to-alpha.24.md
@@ -1,3 +1,8 @@
+---
+title: Migrate from alpha.23 to alpha.24 - Strapi Developer Documentation
+description: The following documentation covers how you can migrate your Strapi application from alpha.23 to alpha.24.
+---
+
 # Migration guide from alpha.23 to alpha.24
 
 **Here are the major changes:**

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.24-to-alpha.25.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.24-to-alpha.25.md
@@ -1,6 +1,6 @@
 ---
 title: Migrate from alpha.24 to alpha.25.2 - Strapi Developer Documentation
-description: The following documentation covers how you can migrate your Strapi application from alpha.24 to alpha.25.2.
+description: Learn how you can migrate your Strapi application from alpha.24 to alpha.25.2.
 ---
 
 # Migration guide from alpha.24 to alpha.25.2

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.24-to-alpha.25.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.24-to-alpha.25.md
@@ -1,3 +1,8 @@
+---
+title: Migrate from alpha.24 to alpha.25.2 - Strapi Developer Documentation
+description: The following documentation covers how you can migrate your Strapi application from alpha.24 to alpha.25.2.
+---
+
 # Migration guide from alpha.24 to alpha.25.2
 
 **Here are the major changes:**

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.25-to-alpha.26.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.25-to-alpha.26.md
@@ -1,3 +1,8 @@
+---
+title: Migrate from alpha.25 to alpha.26.2s - Strapi Developer Documentation
+description: The following documentation covers how you can migrate your Strapi application from alpha.25 to alpha.26.2s.
+---
+
 # Migration guide from alpha.25 to alpha.26.2
 
 **Here are the major changes:**

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.25-to-alpha.26.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.25-to-alpha.26.md
@@ -1,6 +1,6 @@
 ---
 title: Migrate from alpha.25 to alpha.26.2s - Strapi Developer Documentation
-description: The following documentation covers how you can migrate your Strapi application from alpha.25 to alpha.26.2s.
+description: Learn how you can migrate your Strapi application from alpha.25 to alpha.26.2s.
 ---
 
 # Migration guide from alpha.25 to alpha.26.2

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.26-to-beta.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.26-to-beta.md
@@ -1,3 +1,8 @@
+---
+title: Migrate to v3.0.0-beta.x - Strapi Developer Documentation
+description: The following documentation covers how you can migrate your Strapi application to v3.0.0-beta.x.
+---
+
 # Migration Guide
 
 Upgrading your Strapi application to `v3.0.0-beta.x`.

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.26-to-beta.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.26-to-beta.md
@@ -1,6 +1,6 @@
 ---
 title: Migrate to v3.0.0-beta.x - Strapi Developer Documentation
-description: The following documentation covers how you can migrate your Strapi application to v3.0.0-beta.x.
+description: Learn how you can migrate your Strapi application to v3.0.0-beta.x.
 ---
 
 # Migration Guide

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.7.4-to-alpha.8.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.7.4-to-alpha.8.md
@@ -1,3 +1,8 @@
+---
+title: Migrate from alpha.7.4 to alpha.8 - Strapi Developer Documentation
+description: The following documentation covers how you can migrate your Strapi application from alpha.7.4 to alpha.8.
+---
+
 # Migration guide from alpha.7.4 to alpha.8
 
 **Here are the major changes:**

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.7.4-to-alpha.8.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.7.4-to-alpha.8.md
@@ -1,6 +1,6 @@
 ---
 title: Migrate from alpha.7.4 to alpha.8 - Strapi Developer Documentation
-description: The following documentation covers how you can migrate your Strapi application from alpha.7.4 to alpha.8.
+description: Learn how you can migrate your Strapi application from alpha.7.4 to alpha.8.
 ---
 
 # Migration guide from alpha.7.4 to alpha.8

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.8-to-alpha.9.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.8-to-alpha.9.md
@@ -1,3 +1,8 @@
+---
+title: Migrate from alpha.8 to alpha.9 - Strapi Developer Documentation
+description: The following documentation covers how you can migrate your Strapi application from alpha.8 to alpha.9.
+---
+
 # Migration guide from alpha.8 to alpha.9
 
 **Here are the major changes:**

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.8-to-alpha.9.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.8-to-alpha.9.md
@@ -1,6 +1,6 @@
 ---
 title: Migrate from alpha.8 to alpha.9 - Strapi Developer Documentation
-description: The following documentation covers how you can migrate your Strapi application from alpha.8 to alpha.9.
+description: Learn how you can migrate your Strapi application from alpha.8 to alpha.9.
 ---
 
 # Migration guide from alpha.8 to alpha.9

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.9-to-alpha.10.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.9-to-alpha.10.md
@@ -1,6 +1,6 @@
 ---
 title: Migrate from alpha.9 to alpha.10 - Strapi Developer Documentation
-description: The following documentation covers how you can migrate your Strapi application from alpha.9 to alpha.10.
+description: Learn how you can migrate your Strapi application from alpha.9 to alpha.10.
 ---
 
 # Migration guide from alpha.9 to alpha.10

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.9-to-alpha.10.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.9-to-alpha.10.md
@@ -1,3 +1,8 @@
+---
+title: Migrate from alpha.9 to alpha.10 - Strapi Developer Documentation
+description: The following documentation covers how you can migrate your Strapi application from alpha.9 to alpha.10.
+---
+
 # Migration guide from alpha.9 to alpha.10
 
 **Here are the major changes:**

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-beta.15-to-beta.16.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-beta.15-to-beta.16.md
@@ -1,3 +1,8 @@
+---
+title: Migrate from beta.15 to beta.16 - Strapi Developer Documentation
+description: The following documentation covers how you can migrate your Strapi application from beta.15 to beta.16.
+---
+
 # Migration guide from beta.15 to beta.16
 
 Upgrading your Strapi application to `v3.0.0-beta.16`.

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-beta.15-to-beta.16.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-beta.15-to-beta.16.md
@@ -1,6 +1,6 @@
 ---
 title: Migrate from beta.15 to beta.16 - Strapi Developer Documentation
-description: The following documentation covers how you can migrate your Strapi application from beta.15 to beta.16.
+description: Learn how you can migrate your Strapi application from beta.15 to beta.16.
 ---
 
 # Migration guide from beta.15 to beta.16

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-beta.16-to-beta.17.4.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-beta.16-to-beta.17.4.md
@@ -1,6 +1,6 @@
 ---
 title: Migrate to beta.17.4 - Strapi Developer Documentation
-description: The following documentation covers how you can migrate your Strapi application to beta.17.4.
+description: Learn how you can migrate your Strapi application to beta.17.4.
 ---
 
 # Migration guide from beta.16.8 through beta.17.3 to beta.17.4

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-beta.16-to-beta.17.4.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-beta.16-to-beta.17.4.md
@@ -1,3 +1,8 @@
+---
+title: Migrate to beta.17.4 - Strapi Developer Documentation
+description: The following documentation covers how you can migrate your Strapi application to beta.17.4.
+---
+
 # Migration guide from beta.16.8 through beta.17.3 to beta.17.4
 
 Upgrading your Strapi application to `v3.0.0-beta.17.4`.

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-beta.17-to-beta.18.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-beta.17-to-beta.18.md
@@ -1,6 +1,6 @@
 ---
 title: Migrate to beta.18 - Strapi Developer Documentation
-description: The following documentation covers how you can migrate your Strapi application to beta.18.
+description: Learn how you can migrate your Strapi application to beta.18.
 ---
 
 # Migration guide from beta.17.4 through beta.17.8 to beta.18

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-beta.17-to-beta.18.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-beta.17-to-beta.18.md
@@ -1,3 +1,8 @@
+---
+title: Migrate to beta.18 - Strapi Developer Documentation
+description: The following documentation covers how you can migrate your Strapi application to beta.18.
+---
+
 # Migration guide from beta.17.4 through beta.17.8 to beta.18
 
 Upgrading your Strapi application to `v3.0.0-beta.18`.

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-beta.18-to-beta.19.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-beta.18-to-beta.19.md
@@ -1,3 +1,8 @@
+---
+title: Migrate from beta.18.x to beta.19 - Strapi Developer Documentation
+description: The following documentation covers how you can migrate your Strapi application from beta.18.x to beta.19.
+---
+
 # Migration guide from beta.18.x to beta.19
 
 Upgrading your Strapi application to `v3.0.0-beta.19`.

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-beta.18-to-beta.19.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-beta.18-to-beta.19.md
@@ -1,6 +1,6 @@
 ---
 title: Migrate from beta.18.x to beta.19 - Strapi Developer Documentation
-description: The following documentation covers how you can migrate your Strapi application from beta.18.x to beta.19.
+description: Learn how you can migrate your Strapi application from beta.18.x to beta.19.
 ---
 
 # Migration guide from beta.18.x to beta.19

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-beta.19-to-beta.19.4.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-beta.19-to-beta.19.4.md
@@ -1,3 +1,8 @@
+---
+title: Migrate from beta.19.x to beta.19.4 - Strapi Developer Documentation
+description: The following documentation covers how you can migrate your Strapi application from beta.19.x to beta.19.4.
+---
+
 # Migration guide from beta.19.x to beta.19.4
 
 Upgrading your Strapi application to `v3.0.0-beta.19.4`.

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-beta.19-to-beta.19.4.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-beta.19-to-beta.19.4.md
@@ -1,6 +1,6 @@
 ---
 title: Migrate from beta.19.x to beta.19.4 - Strapi Developer Documentation
-description: The following documentation covers how you can migrate your Strapi application from beta.19.x to beta.19.4.
+description: Learn how you can migrate your Strapi application from beta.19.x to beta.19.4.
 ---
 
 # Migration guide from beta.19.x to beta.19.4

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-beta.19-to-beta.20.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-beta.19-to-beta.20.md
@@ -1,6 +1,6 @@
 ---
 title: Migrate from beta.19.x to beta.20 - Strapi Developer Documentation
-description: The following documentation covers how you can migrate your Strapi application from beta.19.x to beta.20.
+description: Learn how you can migrate your Strapi application from beta.19.x to beta.20.
 ---
 
 # Migration guide from beta.19.x to beta.20

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-beta.19-to-beta.20.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-beta.19-to-beta.20.md
@@ -1,3 +1,8 @@
+---
+title: Migrate from beta.19.x to beta.20 - Strapi Developer Documentation
+description: The following documentation covers how you can migrate your Strapi application from beta.19.x to beta.20.
+---
+
 # Migration guide from beta.19.x to beta.20
 
 Upgrading your Strapi application to `v3.0.0-beta.20`.

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-beta.20-to-3.0.0.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-beta.20-to-3.0.0.md
@@ -1,6 +1,6 @@
 ---
 title: Migrate from 3.0.0-beta.20 to 3.0.0 - Strapi Developer Documentation
-description: The following documentation covers how you can migrate your Strapi application from 3.0.0-beta.20 to 3.0.0.
+description: Learn how you can migrate your Strapi application from 3.0.0-beta.20 to 3.0.0.
 ---
 
 # Migration guide from 3.0.0-beta.20 to 3.0.0

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-beta.20-to-3.0.0.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-beta.20-to-3.0.0.md
@@ -1,3 +1,8 @@
+---
+title: Migrate from 3.0.0-beta.20 to 3.0.0 - Strapi Developer Documentation
+description: The following documentation covers how you can migrate your Strapi application from 3.0.0-beta.20 to 3.0.0.
+---
+
 # Migration guide from 3.0.0-beta.20 to 3.0.0
 
 Upgrading your Strapi application to `3.0.0`.

--- a/docs/developer-docs/latest/update-migration-guides/update-version.md
+++ b/docs/developer-docs/latest/update-migration-guides/update-version.md
@@ -1,3 +1,8 @@
+---
+title: Update Strapi version - Strapi Developer Documentation
+description: The following documentation covers how to upgrade your application to the latest version of Strapi.
+---
+
 # Update Strapi version
 
 With this guide you will know how to upgrade your application to the latest version of Strapi.

--- a/docs/user-docs/latest/content-manager/configuring-view-of-content-type.md
+++ b/docs/user-docs/latest/content-manager/configuring-view-of-content-type.md
@@ -1,3 +1,8 @@
+---
+title: Configuring views of a content type - Strapi User Guide
+description: The following documentation covers how you can configure the view of a content type in your Strapi application.
+---
+
 # Configuring the views of a content type
 
 Depending on their type, content types can be divided into 2 interfaces: the list view and the edit view. Both interfaces can be configured.
@@ -98,7 +103,7 @@ In the edit view of a content type, in the right side of the interface, a **Conf
 ::: warning IMPORTANT
 The settings and display of a component's fields cannot be managed and reordered through the entry's edit view configuration page. Click on the **Set the component's layout** button of a component to access the component's own configuration page. You will find the exact same settings and display options as for the entry, but that will specifically apply to your component.
 
-Note also that the settings are defined for the component itself, which means that the settings will automatically be applied for every other content type where the component is used. 
+Note also that the settings are defined for the component itself, which means that the settings will automatically be applied for every other content type where the component is used.
 :::
 
 #### Relational fields

--- a/docs/user-docs/latest/content-manager/configuring-view-of-content-type.md
+++ b/docs/user-docs/latest/content-manager/configuring-view-of-content-type.md
@@ -1,6 +1,6 @@
 ---
 title: Configuring views of a content type - Strapi User Guide
-description: The following documentation covers how you can configure the view of a content type in your Strapi application.
+description: Instructions to configure the edit view and list view of a content type in a Strapi application.
 ---
 
 # Configuring the views of a content type

--- a/docs/user-docs/latest/content-manager/introduction-to-content-manager.md
+++ b/docs/user-docs/latest/content-manager/introduction-to-content-manager.md
@@ -1,3 +1,8 @@
+---
+title: Content Manager - Strapi User Guide
+description: Divided in 2 categories, the Content Manager contains the available collection and single content-types, which were created beforehand using the Content-Types Builder.
+---
+
 # Introduction to the Content Manager
 
 The Content Manager is a core plugin of Strapi. It is a feature that is always activated by default and cannot be deleted. It is accessible both when the application is in a development and production environment.

--- a/docs/user-docs/latest/content-manager/introduction-to-content-manager.md
+++ b/docs/user-docs/latest/content-manager/introduction-to-content-manager.md
@@ -1,6 +1,6 @@
 ---
 title: Content Manager - Strapi User Guide
-description: Divided in 2 categories, the Content Manager contains the available collection and single content-types, which were created beforehand using the Content-Types Builder.
+description: Introduction to the Content Manager which allows to write content for collection types and single types.
 ---
 
 # Introduction to the Content Manager

--- a/docs/user-docs/latest/content-manager/managing-relational-fields.md
+++ b/docs/user-docs/latest/content-manager/managing-relational-fields.md
@@ -1,3 +1,8 @@
+---
+title: Managing Relational Fields - Strapi User Guide
+description: Relation-type fields added to a content-type from the Content-Types Builder allow to establish a relation with another content-type -mandatorily a collection type. These fields are called "relational fields".
+---
+
 # Managing relational fields
 
 Relation-type fields added to a content-type from the Content-Types Builder allow to establish a relation with another content-type -mandatorily a collection type. These fields are called "relational fields".

--- a/docs/user-docs/latest/content-manager/managing-relational-fields.md
+++ b/docs/user-docs/latest/content-manager/managing-relational-fields.md
@@ -1,6 +1,6 @@
 ---
 title: Managing Relational Fields - Strapi User Guide
-description: Relation-type fields added to a content-type from the Content-Types Builder allow to establish a relation with another content-type -mandatorily a collection type. These fields are called "relational fields".
+description: Instructions to manage relation-type fields, called "relational fields", which establish a relation between two content-types.
 ---
 
 # Managing relational fields

--- a/docs/user-docs/latest/content-manager/saving-and-publishing-content.md
+++ b/docs/user-docs/latest/content-manager/saving-and-publishing-content.md
@@ -1,6 +1,6 @@
 ---
 title: Saving & Publishishing content - Strapi User Guide
-description: Strapi allows you to manage your content throughout its whole lifecycle, whether you are working on its draft version, about to finish it and share it with the world, or wanting to delete it when it's obsolete.
+description: Instructions to manage content throughout its whole lifecycle, from the draft version to the deletion of the obsolete content.
 ---
 
 # Saving, publishing and deleting content

--- a/docs/user-docs/latest/content-manager/saving-and-publishing-content.md
+++ b/docs/user-docs/latest/content-manager/saving-and-publishing-content.md
@@ -1,3 +1,8 @@
+---
+title: Saving & Publishishing content - Strapi User Guide
+description: Strapi allows you to manage your content throughout its whole lifecycle, whether you are working on its draft version, about to finish it and share it with the world, or wanting to delete it when it's obsolete.
+---
+
 # Saving, publishing and deleting content
 
 Strapi allows you to manage your content throughout its whole lifecycle, whether you are working on its draft version, about to finish it and share it with the world, or wanting to delete it when it's obsolete.

--- a/docs/user-docs/latest/content-manager/writing-content.md
+++ b/docs/user-docs/latest/content-manager/writing-content.md
@@ -1,3 +1,8 @@
+---
+title: Writing Content - Strapi User Guide
+description: In Strapi, writing content consists in filling up fields, which are meant to contain specific content (e.g. text, numbers, media etc.).
+---
+
 # Writing content
 
 In Strapi, writing content consists in filling up fields, which are meant to contain specific content (e.g. text, numbers, media etc.). These fields were configured for the collection or single type beforehand, through the Content-Types Builder.

--- a/docs/user-docs/latest/content-manager/writing-content.md
+++ b/docs/user-docs/latest/content-manager/writing-content.md
@@ -1,6 +1,6 @@
 ---
 title: Writing Content - Strapi User Guide
-description: In Strapi, writing content consists in filling up fields, which are meant to contain specific content (e.g. text, numbers, media etc.).
+description: Instructions to write content by filling up fields that are meant to contain specific content (e.g. text, numbers, media etc.).
 ---
 
 # Writing content

--- a/docs/user-docs/latest/content-types-builder/configuring-fields-content-type.md
+++ b/docs/user-docs/latest/content-types-builder/configuring-fields-content-type.md
@@ -1,6 +1,6 @@
 ---
 title: Fields for Content Types - Strapi User Guide
-description: Content-types are composed of one or several fields. Each field is designed to contain specific kind of data, filled up in the Content Manager
+description: Instructions to configure in the Content-Types Builder the fields that compose each content-type.
 ---
 
 # Configuring fields for content types

--- a/docs/user-docs/latest/content-types-builder/configuring-fields-content-type.md
+++ b/docs/user-docs/latest/content-types-builder/configuring-fields-content-type.md
@@ -1,3 +1,8 @@
+---
+title: Fields for Content Types - Strapi User Guide
+description: Content-types are composed of one or several fields. Each field is designed to contain specific kind of data, filled up in the Content Manager
+---
+
 # Configuring fields for content types
 
 ::: warning The Content-Types Builder is only accessible to create and update content-types when your Strapi application is in a development environment, else it will be in a read-only mode in other environments.
@@ -9,7 +14,7 @@ Content-types are composed of one or several fields. Each field is designed to c
 In the Content-Types Builder, fields can be added at the creation of a new content-type or component, or afterward when a content-type or component is edited or updated. The following documentation lists all existing regular fields but also tackles the specificities of components and dynamic zones. For each, you will find a definition, explanation of the form they take once in the Content Manager, and instructions to configure them.
 
 ::: tip NOTE
-Depending on what content-type or component is being created or edited, not all fields -including components and dynamic zones- are always available. 
+Depending on what content-type or component is being created or edited, not all fields -including components and dynamic zones- are always available.
 :::
 
 ![Select a field](../assets/content-types-builder/fields-selection.png)
@@ -182,8 +187,8 @@ Configuring the base settings of the Relation field consists in choosing with wh
 
 1. Click on the 2nd grey box to define the content-type B. It must be an already created collection type.
 2. Click on the icon representing the relation to establish between the content-types.
-3. Choose the *Field name* of the content-type A, meaning the name that will be used for the field in the content-type A. 
-4. (optional if disabled by the relation type) Choose the *Field name* of the content-type B. 
+3. Choose the *Field name* of the content-type A, meaning the name that will be used for the field in the content-type A.
+4. (optional if disabled by the relation type) Choose the *Field name* of the content-type B.
 
 :::
 
@@ -197,7 +202,7 @@ Configuring the base settings of the Relation field consists in choosing with wh
 
 :::
 
-:::: 
+::::
 
 ### <img width="28" src="../assets/content-types-builder/field-icon_email.png"> Email
 

--- a/docs/user-docs/latest/content-types-builder/creating-new-content-type.md
+++ b/docs/user-docs/latest/content-types-builder/creating-new-content-type.md
@@ -1,3 +1,8 @@
+---
+title: Creating Content-Types - Strapi User Guide
+description: The Content-Types Builder allows to create new content-types: single and collection types.
+---
+
 # Creating content-types
 
 ::: warning The Content-Types Builder is only accessible to create and update content-types when your Strapi application is in a development environment, else it will be in a read-only mode in other environments.

--- a/docs/user-docs/latest/content-types-builder/introduction-to-content-types-builder.md
+++ b/docs/user-docs/latest/content-types-builder/introduction-to-content-types-builder.md
@@ -1,3 +1,8 @@
+---
+title: Content-Types Builder - Strapi User Guide
+description: From the Content-Types Builder, administrators can create and manage content-types: collection types and single types but also components.
+---
+
 # Introduction to the Content-Types Builder
 
 The Content-Types Builder is a core plugin of Strapi. It is a feature that is always activated by default and cannot be deleted. The Content-Types Builder is however only accessible when the application is in a development environment.

--- a/docs/user-docs/latest/content-types-builder/managing-content-types.md
+++ b/docs/user-docs/latest/content-types-builder/managing-content-types.md
@@ -1,3 +1,8 @@
+---
+title: Managing Content-types - Strapi User Guide
+description: The Content-Types Builder allows to manage any existing content-type or component, even if it is already being used in the Content Manager. They can only be managed one at a time.
+---
+
 # Managing content-types
 
 ::: warning The Content-Types Builder is only accessible to create and update content-types when your Strapi application is in a development environment, else it will be in a read-only mode in other environments.

--- a/docs/user-docs/latest/getting-started/introduction.md
+++ b/docs/user-docs/latest/getting-started/introduction.md
@@ -1,3 +1,8 @@
+---
+title: Strapi User Guide
+description: This user guide contains the functional documentation related to all features available in the admin panel of your Strapi application.
+---
+
 # Welcome to the Strapi user guide!
 
 This user guide contains the functional documentation related to all features available in the admin panel of your Strapi application.

--- a/docs/user-docs/latest/plugins/introduction-to-plugins.md
+++ b/docs/user-docs/latest/plugins/introduction-to-plugins.md
@@ -1,6 +1,6 @@
 ---
 title: Plugins - Strapi User Guide
-description: Learn how you can use different plugins in your Strapi application in the Admin UI.
+description: Reference guide to all Strapi plugins and instructions to use these plugins.
 ---
 
 # Introduction to plugins

--- a/docs/user-docs/latest/plugins/introduction-to-plugins.md
+++ b/docs/user-docs/latest/plugins/introduction-to-plugins.md
@@ -1,3 +1,8 @@
+---
+title: Plugins - Strapi User Guide
+description: Learn how you can use different plugins in your Strapi application in the Admin UI.
+---
+
 # Introduction to plugins
 
 ::: warning 🚧 This section of the user guide is a work in progress. Stay tuned!

--- a/docs/user-docs/latest/settings/managing-global-settings.md
+++ b/docs/user-docs/latest/settings/managing-global-settings.md
@@ -1,6 +1,6 @@
 ---
 title: Global Settings - Strapi User Guide
-description: Learn how you can manage the global settings of your Strapi application in the Admin UI.
+description: Instructions to manage the global settings of a Strapi application in the admin panel.
 ---
 
 # Managing global settings

--- a/docs/user-docs/latest/settings/managing-global-settings.md
+++ b/docs/user-docs/latest/settings/managing-global-settings.md
@@ -1,3 +1,8 @@
+---
+title: Global Settings - Strapi User Guide
+description: Learn how you can manage the global settings of your Strapi application in the Admin UI.
+---
+
 # Managing global settings
 
 Global settings for plugins and features are managed from *General > Settings* in the main navigation of the admin panel.

--- a/docs/user-docs/latest/users-roles-permissions/configuring-administrator-roles.md
+++ b/docs/user-docs/latest/users-roles-permissions/configuring-administrator-roles.md
@@ -1,3 +1,8 @@
+---
+title: Configure Administrator Roles - Strapi User Guide
+description: Administrators are the users of an admin panel of a Strapi application. Administrator accounts and roles are managed with the Role-Based Access Control (RBAC) feature.
+---
+
 # Configuring administrator roles
 
 Administrators are the users of an admin panel of a Strapi application. Administrator accounts and roles are managed with the Role-Based Access Control (RBAC) feature. It is available in the *Administration panel* section of the Settings interface, accessible from *General > Settings* in the main navigation of the admin panel.
@@ -33,7 +38,7 @@ If you use your Strapi application with the Community Edition (see [Pricing and 
 
 On the top right side of the *Administration panel > Roles* interface, an **Add new role** button is displayed. It allows to create a new role for administrators of your Strapi application.
 
-To create a new role, click on the **Add new role** button. 
+To create a new role, click on the **Add new role** button.
 Clicking on the **Add new role** button will redirect you to the roles edition interface, where you will be able to edit the role's details and configure its permissions (see [Editing a role](#editing-role-s-details)).
 
 ::: tip 💡 TIP
@@ -116,7 +121,7 @@ By default, plugins permissions can be configured for the Content-Type Builder, 
 | Content-Type-Builder | <ul><li>General</li><ul><li>"Read" - gives access to the Content-Types Builder plugin in read-only mode</li></ul></ul> |
 | Upload <br> *(Media Library)* | <ul><li>General</li><ul><li>"Access the Media Library" - gives access to the Media Library plugin</li></ul></ul> <ul><li>Assets</li><ul><li>"Create (upload)" - allows to upload media files</li><li>"Update (crop, details, replace) + delete" - allows to edit uploaded media files</li><li>"Download" - allows to download uploaded media files</li><li>"Copy link" - allows to copy the link of an uploaded media file</li></ul></ul> |    
 | Content-Manager | <ul><li>Single types</li><ul><li>"Configure view" - allows to configure the edit view of a single type</li></ul></ul><ul><li>Collection types</li><ul><li>"Configure view" - allows to configure the edit view of a collection type</li></ul></ul><ul><li>Components</li><ul><li>"Configure Layout" - allows to configure the layout of a component</li></ul></ul> |
-| Users-Permissions | <ul><li>Roles</li><ul><li>"Create" - allows to create end-user roles</li><li>"Read" - allows to see created end-user roles</li><li>"Update" - allows to edit end-user roles</li><li>"Delete" - allows to delete end-user roles</li></ul></ul><ul><li>Providers</li><ul><li>"Read" - allows to see providers</li><li>"Edit" - allows to edit providers</li></ul></ul><ul><li>Email Templates</li><ul><li>"Read" - allows to access the email templates</li><li>"Edit" - allows to edit email templates</li></ul></ul><ul><li>Advanced settings</li><ul><li>"Read" - allows to access the advanced settings of the Users & Permissions plugin</li><li>"Edit" - allows to edit advanced settings</li></ul></ul> 👉 Path reminder to the Users & Permissions plugin: <br> *General > Settings > Users & Permissions plugin* | 
+| Users-Permissions | <ul><li>Roles</li><ul><li>"Create" - allows to create end-user roles</li><li>"Read" - allows to see created end-user roles</li><li>"Update" - allows to edit end-user roles</li><li>"Delete" - allows to delete end-user roles</li></ul></ul><ul><li>Providers</li><ul><li>"Read" - allows to see providers</li><li>"Edit" - allows to edit providers</li></ul></ul><ul><li>Email Templates</li><ul><li>"Read" - allows to access the email templates</li><li>"Edit" - allows to edit email templates</li></ul></ul><ul><li>Advanced settings</li><ul><li>"Read" - allows to access the advanced settings of the Users & Permissions plugin</li><li>"Edit" - allows to edit advanced settings</li></ul></ul> 👉 Path reminder to the Users & Permissions plugin: <br> *General > Settings > Users & Permissions plugin* |
 
 :::
 
@@ -129,7 +134,7 @@ Settings permissions can be configured for all settings accessible from *General
 | Media Library | <ul><li>General</li><ul><li>"Access the Media Library settings page" - gives access to Media Library settings</li></ul></ul> 👉 Path reminder to Media Library settings: <br> *General > Settings > Global Settings - Media Library* |
 | Plugins and Marketplace | <ul><li>Marketplace</li><ul><li>"Access the Marketplace" - gives access to the Marketplace</li></ul></ul><ul><li>Plugins</li><ul><li>"Install (only for dev env)" - allows to install new plugins when in a development environment</li><li>"Uninstall (only for dev env)" - allows to uninstall plugins when in a development environment</li></ul></ul> |    
 | Webhooks | <ul><li>General</li><ul><li>"Create" - allows to create webhooks</li><li>"Read" - allows to see created webhooks</li><li>"Update" - allows to edit webhooks</li><li>"Delete" - allows to delete webhooks</li></ul></ul> 👉 Path reminder to Webhook settings: <br> *General > Settings > Global Settings - Webhook* |
-| Users and Roles | <ul><li>Users</li><ul><li>"Create (invite)" - allows to create administrator accounts</li><li>"Read" - allows to see existing administrator accounts</li><li>"Update" - allows to edit administrator accounts</li><li>"Delete" - allows to delete administrator accounts</li></ul></ul><ul><li>Roles</li><ul><li>"Create" - allows to create administrator roles</li><li>"Read" - allows to see created administrator roles</li><li>"Update" - allows to edit administrator roles</li><li>"Delete" - allows to delete administrator roles</li></ul></ul> 👉 Path reminder to the RBAC feature: <br> *General > Settings > Administration Panel* | 
+| Users and Roles | <ul><li>Users</li><ul><li>"Create (invite)" - allows to create administrator accounts</li><li>"Read" - allows to see existing administrator accounts</li><li>"Update" - allows to edit administrator accounts</li><li>"Delete" - allows to delete administrator accounts</li></ul></ul><ul><li>Roles</li><ul><li>"Create" - allows to create administrator roles</li><li>"Read" - allows to see created administrator roles</li><li>"Update" - allows to edit administrator roles</li><li>"Delete" - allows to delete administrator roles</li></ul></ul> 👉 Path reminder to the RBAC feature: <br> *General > Settings > Administration Panel* |
 
 :::
 

--- a/docs/user-docs/latest/users-roles-permissions/configuring-administrator-roles.md
+++ b/docs/user-docs/latest/users-roles-permissions/configuring-administrator-roles.md
@@ -1,6 +1,6 @@
 ---
 title: Configure Administrator Roles - Strapi User Guide
-description: Administrators are the users of an admin panel of a Strapi application. Administrator accounts and roles are managed with the Role-Based Access Control (RBAC) feature.
+description: Instructions to configure the administrator roles of a Strapi application with the Role-Based Access Control (RBAC) feature.
 ---
 
 # Configuring administrator roles

--- a/docs/user-docs/latest/users-roles-permissions/introduction-to-users-roles-permissions.md
+++ b/docs/user-docs/latest/users-roles-permissions/introduction-to-users-roles-permissions.md
@@ -1,6 +1,6 @@
 ---
 title: Users, Roles & Permissions - Strapi User Guide
-description: Some features of the admin panel, as well as the content managed with Strapi itself, are ruled by a system of permissions.
+description: Introduction to the system of permissions of Strapi which gives access to features of the admin panel.
 ---
 
 # Introduction to users, roles & permissions

--- a/docs/user-docs/latest/users-roles-permissions/introduction-to-users-roles-permissions.md
+++ b/docs/user-docs/latest/users-roles-permissions/introduction-to-users-roles-permissions.md
@@ -1,3 +1,8 @@
+---
+title: Users, Roles & Permissions - Strapi User Guide
+description: Some features of the admin panel, as well as the content managed with Strapi itself, are ruled by a system of permissions.
+---
+
 # Introduction to users, roles & permissions
 
 Some features of the admin panel, as well as the content managed with Strapi itself, are ruled by a system of permissions. These permissions can be assigned to roles, which are associated with the users who have access to the admin panel, the administrators. But it is also possible to grant permissions more publicly, to give access to content to the end-users of your Strapi application.

--- a/docs/user-docs/latest/users-roles-permissions/managing-administrators.md
+++ b/docs/user-docs/latest/users-roles-permissions/managing-administrators.md
@@ -1,6 +1,6 @@
 ---
 title: Managing Administrators - Strapi User Guide
-description: Administrators are the users of an admin panel of a Strapi project. They can be managed with the Role-Based Access Control (RBAC) feature.
+description: Instructions to manage the administrators of a Strapi application with the Role-Based Access Control (RBAC) feature.
 ---
 
 # Managing administrator accounts

--- a/docs/user-docs/latest/users-roles-permissions/managing-administrators.md
+++ b/docs/user-docs/latest/users-roles-permissions/managing-administrators.md
@@ -1,3 +1,8 @@
+---
+title: Managing Administrators - Strapi User Guide
+description: Administrators are the users of an admin panel of a Strapi project. They can be managed with the Role-Based Access Control (RBAC) feature.
+---
+
 # Managing administrator accounts
 
 Administrators are the users of an admin panel of a Strapi application. Administrator accounts and roles are managed with the Role-Based Access Control (RBAC) feature. It is available in the *Administration panel* section of the Settings interface, accessible from *General > Settings* in the main navigation of the admin panel.


### PR DESCRIPTION
### What does it do?

This PR only adds a metaTitle and a metaDescription to every doc pages.
Sorry for this kind of PR, it brings changes to every .md files but it will have a big positive impact for our website health and SEO.

This PR will also add a `docsearch.config.json` file for indexing our documentation.
Please @derrickmehaffy, tell me where I can commit the `docsearch.config.json` file :)

### Why is it needed?

Because crawlers need to see different metaTitle and metaDescription for different pages on a unique domain.