### PR TITLE
Add collapsable sub-menus to dev docs

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -23,9 +23,18 @@ const sidebar = {
           children: [
             ['/developer-docs/latest/setup-deployment-guides/installation/cli.md', 'CLI'],
             ['/developer-docs/latest/setup-deployment-guides/installation/docker.md', 'Docker'],
-            ['/developer-docs/latest/setup-deployment-guides/installation/digitalocean-one-click.md', 'DigitalOcean One-Click'],
-            ['/developer-docs/latest/setup-deployment-guides/installation/platformsh.md', 'Platform.sh One-Click'],
-            ['/developer-docs/latest/setup-deployment-guides/installation/render.md', 'Render One-Click'],
+            [
+              '/developer-docs/latest/setup-deployment-guides/installation/digitalocean-one-click.md',
+              'DigitalOcean One-Click',
+            ],
+            [
+              '/developer-docs/latest/setup-deployment-guides/installation/platformsh.md',
+              'Platform.sh One-Click',
+            ],
+            [
+              '/developer-docs/latest/setup-deployment-guides/installation/render.md',
+              'Render One-Click',
+            ],
           ],
         },
         ['/developer-docs/latest/setup-deployment-guides/file-structure.md', 'Project structure'],
@@ -38,30 +47,69 @@ const sidebar = {
           children: [
             {
               title: 'Hosting Provider Guides',
-              path: '/developer-docs/latest/setup-deployment-guides/deployment.html#hosting-provider-guides',
+              path:
+                '/developer-docs/latest/setup-deployment-guides/deployment.html#hosting-provider-guides',
               collapsable: true,
               children: [
-                ['/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/21yunbox.md', '21YunBox'],
-                ['/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/amazon-aws.md', 'Amazon AWS'],
-                ['/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/azure.md', 'Azure'],
-                ['/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/digitalocean.md', 'DigitalOcean'],
-                ['/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/google-app-engine.md', 'Google App Engine'],
-                ['/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/heroku.md', 'Heroku'],
-                ['/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/qovery.md', 'Qovery'],
-                ['/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/render.md', 'Render'],
+                [
+                  '/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/21yunbox.md',
+                  '21YunBox',
+                ],
+                [
+                  '/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/amazon-aws.md',
+                  'Amazon AWS',
+                ],
+                [
+                  '/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/azure.md',
+                  'Azure',
+                ],
+                [
+                  '/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/digitalocean-app-platform.md',
+                  'DigitalOcean App Platform',
+                ],
+                [
+                  '/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/digitalocean.md',
+                  'DigitalOcean Droplets',
+                ],
+                [
+                  '/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/google-app-engine.md',
+                  'Google App Engine',
+                ],
+                [
+                  '/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/heroku.md',
+                  'Heroku',
+                ],
+                [
+                  '/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/qovery.md',
+                  'Qovery',
+                ],
+                [
+                  '/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/render.md',
+                  'Render',
+                ],
               ],
-              sidebarDepth: 2
+              sidebarDepth: 2,
             },
             {
               title: 'Optional Software Guides',
-              path: '/developer-docs/latest/setup-deployment-guides/deployment.html#optional-software-guides',
+              path:
+                '/developer-docs/latest/setup-deployment-guides/deployment.html#optional-software-guides',
               collapsable: true,
               children: [
-                ['/developer-docs/latest/setup-deployment-guides/deployment/optional-software/caddy-proxy.md', 'Caddy'],
-                ['/developer-docs/latest/setup-deployment-guides/deployment/optional-software/haproxy-proxy.md', 'HAProxy'],
-                ['/developer-docs/latest/setup-deployment-guides/deployment/optional-software/nginx-proxy.md', 'Nginx']
+                [
+                  '/developer-docs/latest/setup-deployment-guides/deployment/optional-software/caddy-proxy.md',
+                  'Caddy',
+                ],
+                [
+                  '/developer-docs/latest/setup-deployment-guides/deployment/optional-software/haproxy-proxy.md',
+                  'HAProxy',
+                ],
+                [
+                  '/developer-docs/latest/setup-deployment-guides/deployment/optional-software/nginx-proxy.md',
+                  'Nginx',
+                ],
               ],
-              sidebarDepth: 2
+              sidebarDepth: 2,
             },
           ],
           sidebarDepth: 0,
@@ -99,24 +147,60 @@ const sidebar = {
           sidebarDepth: 1,
           children: [
             ['/developer-docs/latest/developer-resources/content-api/integrations/react', 'React'],
-            ['/developer-docs/latest/developer-resources/content-api/integrations/vue-js', 'Vue.js'],
-            ['/developer-docs/latest/developer-resources/content-api/integrations/angular', 'Angular'],
-            ['/developer-docs/latest/developer-resources/content-api/integrations/next-js', 'Next.js'],
-            ['/developer-docs/latest/developer-resources/content-api/integrations/nuxt-js', 'Nuxt.js'],
-            ['/developer-docs/latest/developer-resources/content-api/integrations/graphql', 'GraphQL'],
-            ['/developer-docs/latest/developer-resources/content-api/integrations/gatsby', 'Gatsby'],
-            ['/developer-docs/latest/developer-resources/content-api/integrations/gridsome', 'Gridsome'],
-            ['/developer-docs/latest/developer-resources/content-api/integrations/jekyll', 'Jekyll'],
+            [
+              '/developer-docs/latest/developer-resources/content-api/integrations/vue-js',
+              'Vue.js',
+            ],
+            [
+              '/developer-docs/latest/developer-resources/content-api/integrations/angular',
+              'Angular',
+            ],
+            [
+              '/developer-docs/latest/developer-resources/content-api/integrations/next-js',
+              'Next.js',
+            ],
+            [
+              '/developer-docs/latest/developer-resources/content-api/integrations/nuxt-js',
+              'Nuxt.js',
+            ],
+            [
+              '/developer-docs/latest/developer-resources/content-api/integrations/graphql',
+              'GraphQL',
+            ],
+            [
+              '/developer-docs/latest/developer-resources/content-api/integrations/gatsby',
+              'Gatsby',
+            ],
+            [
+              '/developer-docs/latest/developer-resources/content-api/integrations/gridsome',
+              'Gridsome',
+            ],
+            [
+              '/developer-docs/latest/developer-resources/content-api/integrations/jekyll',
+              'Jekyll',
+            ],
             ['/developer-docs/latest/developer-resources/content-api/integrations/11ty', '11ty'],
-            ['/developer-docs/latest/developer-resources/content-api/integrations/svelte', 'Svelte'],
-            ['/developer-docs/latest/developer-resources/content-api/integrations/sapper', 'Sapper'],
+            [
+              '/developer-docs/latest/developer-resources/content-api/integrations/svelte',
+              'Svelte',
+            ],
+            [
+              '/developer-docs/latest/developer-resources/content-api/integrations/sapper',
+              'Sapper',
+            ],
             ['/developer-docs/latest/developer-resources/content-api/integrations/ruby', 'Ruby'],
-            ['/developer-docs/latest/developer-resources/content-api/integrations/python', 'Python'],
+            [
+              '/developer-docs/latest/developer-resources/content-api/integrations/python',
+              'Python',
+            ],
             ['/developer-docs/latest/developer-resources/content-api/integrations/dart', 'Dart'],
-            ['/developer-docs/latest/developer-resources/content-api/integrations/flutter', 'Flutter'],
+            [
+              '/developer-docs/latest/developer-resources/content-api/integrations/flutter',
+              'Flutter',
+            ],
             ['/developer-docs/latest/developer-resources/content-api/integrations/go', 'Go'],
             ['/developer-docs/latest/developer-resources/content-api/integrations/php', 'PHP'],
-          ]
+          ],
         },
         ['/developer-docs/latest/developer-resources/cli/CLI', 'Command Line Interface'],
         [
@@ -232,7 +316,9 @@ const sidebar = {
     {
       collapsable: false,
       title: 'General settings',
-      children: [['/user-docs/latest/settings/managing-global-settings', 'Managing global settings']],
+      children: [
+        ['/user-docs/latest/settings/managing-global-settings', 'Managing global settings'],
+      ],
     },
   ],
 };
@@ -427,8 +513,8 @@ module.exports = {
               },
               {
                 text: 'General Settings',
-                link: '/user-docs/latest/settings/managing-global-settings.html'
-              }
+                link: '/user-docs/latest/settings/managing-global-settings.html',
+              },
             ],
           },
         ],

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -14,6 +14,7 @@ const sidebar = {
       collapsable: false,
       title: '⚙️ Setup & Deployment',
       sidebarDepth: 0,
+      initialOpenGroupIndex: -1, // make sure that no subgroup is expanded by default
       children: [
         {
           title: 'Installation',

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -13,11 +13,61 @@ const sidebar = {
     {
       collapsable: false,
       title: '⚙️ Setup & Deployment',
+      sidebarDepth: 0,
       children: [
-        ['/developer-docs/latest/setup-deployment-guides/installation.md', 'Installation'],
+        {
+          title: 'Installation',
+          path: '/developer-docs/latest/setup-deployment-guides/installation.html',
+          collapsable: true,
+          sidebarDepth: 1,
+          children: [
+            ['/developer-docs/latest/setup-deployment-guides/installation/cli.md', 'CLI'],
+            ['/developer-docs/latest/setup-deployment-guides/installation/docker.md', 'Docker'],
+            ['/developer-docs/latest/setup-deployment-guides/installation/digitalocean-one-click.md', 'DigitalOcean One-Click'],
+            ['/developer-docs/latest/setup-deployment-guides/installation/platformsh.md', 'Platform.sh One-Click'],
+            ['/developer-docs/latest/setup-deployment-guides/installation/render.md', 'Render One-Click'],
+          ],
+        },
         ['/developer-docs/latest/setup-deployment-guides/file-structure.md', 'Project structure'],
         ['/developer-docs/latest/setup-deployment-guides/configurations.md', 'Configurations'],
-        ['/developer-docs/latest/setup-deployment-guides/deployment.md', 'Deployment'],
+        {
+          title: 'Deployment',
+          path: '/developer-docs/latest/setup-deployment-guides/deployment',
+          collapsable: true,
+          initialOpenGroupIndex: -1, // make sure that no subgroup is open by default — if set to 0, 'Hosting Provider Guides' is expanded
+          children: [
+            {
+              title: 'Hosting Provider Guides',
+              path: '/developer-docs/latest/setup-deployment-guides/deployment.html#hosting-provider-guides',
+              collapsable: true,
+              children: [
+                ['/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/21yunbox.md', '21YunBox'],
+                ['/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/amazon-aws.md', 'Amazon AWS'],
+                ['/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/azure.md', 'Azure'],
+                ['/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/digitalocean.md', 'DigitalOcean'],
+                ['/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/google-app-engine.md', 'Google App Engine'],
+                ['/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/heroku.md', 'Heroku'],
+                ['/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/qovery.md', 'Qovery'],
+                ['/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/render.md', 'Render'],
+              ],
+              sidebarDepth: 2
+            },
+            {
+              title: 'Optional Software Guides',
+              path: '/developer-docs/latest/setup-deployment-guides/deployment.html#optional-software-guides',
+              collapsable: true,
+              children: [
+                ['/developer-docs/latest/setup-deployment-guides/deployment/optional-software/caddy-proxy.md', 'Caddy'],
+                ['/developer-docs/latest/setup-deployment-guides/deployment/optional-software/haproxy-proxy.md', 'HAProxy'],
+                ['/developer-docs/latest/setup-deployment-guides/deployment/optional-software/nginx-proxy.md', 'Nginx']
+              ],
+              sidebarDepth: 2
+            },
+            ['/developer-docs/latest/setup-deployment-guides/deployment.html#recommended-requirements', 'Recommended Requirements'],
+            ['/developer-docs/latest/setup-deployment-guides/deployment.html#application-configuration','Application Configuration']
+          ],
+          sidebarDepth: 0,
+        },
       ],
     },
     {
@@ -41,9 +91,35 @@ const sidebar = {
     {
       collapsable: false,
       title: '💻 Developer Resources',
+      sidebarDepth: 2,
       children: [
         ['/developer-docs/latest/developer-resources/content-api/content-api.md', 'Content API'],
-        ['/developer-docs/latest/developer-resources/content-api/integrations.md', 'Integrations'],
+        {
+          title: 'Integrations',
+          path: '/developer-docs/latest/developer-resources/content-api/integrations.html',
+          collapsable: true,
+          sidebarDepth: 1,
+          children: [
+            ['/developer-docs/latest/developer-resources/content-api/integrations/react', 'React'],
+            ['/developer-docs/latest/developer-resources/content-api/integrations/vue-js', 'Vue.js'],
+            ['/developer-docs/latest/developer-resources/content-api/integrations/angular', 'Angular'],
+            ['/developer-docs/latest/developer-resources/content-api/integrations/next-js', 'Next.js'],
+            ['/developer-docs/latest/developer-resources/content-api/integrations/nuxt-js', 'Nuxt.js'],
+            ['/developer-docs/latest/developer-resources/content-api/integrations/graphql', 'GraphQL'],
+            ['/developer-docs/latest/developer-resources/content-api/integrations/gatsby', 'Gatsby'],
+            ['/developer-docs/latest/developer-resources/content-api/integrations/gridsome', 'Gridsome'],
+            ['/developer-docs/latest/developer-resources/content-api/integrations/jekyll', 'Jekyll'],
+            ['/developer-docs/latest/developer-resources/content-api/integrations/11ty', '11ty'],
+            ['/developer-docs/latest/developer-resources/content-api/integrations/svelte', 'Svelte'],
+            ['/developer-docs/latest/developer-resources/content-api/integrations/sapper', 'Sapper'],
+            ['/developer-docs/latest/developer-resources/content-api/integrations/ruby', 'Ruby'],
+            ['/developer-docs/latest/developer-resources/content-api/integrations/python', 'Python'],
+            ['/developer-docs/latest/developer-resources/content-api/integrations/dart', 'Dart'],
+            ['/developer-docs/latest/developer-resources/content-api/integrations/flutter', 'Flutter'],
+            ['/developer-docs/latest/developer-resources/content-api/integrations/go', 'Go'],
+            ['/developer-docs/latest/developer-resources/content-api/integrations/php', 'PHP'],
+          ]
+        },
         ['/developer-docs/latest/developer-resources/cli/CLI', 'Command Line Interface'],
         [
           '/developer-docs/latest/developer-resources/global-strapi/api-reference',

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -63,8 +63,6 @@ const sidebar = {
               ],
               sidebarDepth: 2
             },
-            ['/developer-docs/latest/setup-deployment-guides/deployment.html#recommended-requirements', 'Recommended Requirements'],
-            ['/developer-docs/latest/setup-deployment-guides/deployment.html#application-configuration','Application Configuration']
           ],
           sidebarDepth: 0,
         },

--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/11ty.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/11ty.md
@@ -4,7 +4,7 @@ This integration guide is following the [Getting started guide](/developer-docs/
 
 If you haven't gone through the getting started guide, the way you request a Strapi API with [11ty](https://www.11ty.dev/) remains the same except that you will not fetch the same content.
 
-### Create an 11ty app
+## Create an 11ty app
 
 Create a `package.json` file, install and save Eleventy into your project.
 
@@ -37,7 +37,7 @@ npx @11ty/eleventy
 # Wrote 0 files in 0.02 seconds (v0.11.0)
 ```
 
-### Configure 11ty
+## Configure 11ty
 
 11ty do not create any file structure for you. It's up to you to do it.
 
@@ -117,7 +117,7 @@ yarn add axios eleventy-plugin-error-overlay html-minifier
 
 ::::
 
-### GET Request your collection type
+## GET Request your collection type
 
 Execute a `GET` request on the `restaurant` Collection Type in order to fetch all your restaurants.
 

--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/angular.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/angular.md
@@ -4,7 +4,7 @@ This integration guide is following the [Getting started guide](/developer-docs/
 
 If you haven't gone through the getting started guide, the way you request a Strapi API with [Angular](https://angular.io) remains the same except that you will not fetch the same content.
 
-### Create a Angular app
+## Create a Angular app
 
 Create a basic Angular application using [angular CLI](https://angular.io/guide/setup-local).
 
@@ -12,7 +12,7 @@ Create a basic Angular application using [angular CLI](https://angular.io/guide/
 npx -p @angular/cli ng new angular-app
 ```
 
-### Use an HTTP client
+## Use an HTTP client
 
 Many HTTP clients are available but in this documentation we'll use [Axios](https://github.com/axios/axios) and [Fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API).
 
@@ -34,7 +34,7 @@ No installation needed
 
 ::::
 
-### GET Request your collection type
+## GET Request your collection type
 
 Execute a `GET` request on the `restaurant` Collection Type in order to fetch all your restaurants.
 
@@ -210,7 +210,7 @@ export class AppComponent implements OnInit {
 
 ::::
 
-### POST Request your collection type
+## POST Request your collection type
 
 Execute a `POST` request on the `restaurant` Collection Type in order to create a restaurant.
 

--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/dart.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/dart.md
@@ -4,7 +4,7 @@ This integration guide is following the [Getting started guide](/developer-docs/
 
 If you haven't gone through the getting started guide, the way you request a Strapi API with [Dart](https://dart.dev/) remains the same except that you will not fetch the same content.
 
-### Create a Dart file
+## Create a Dart file
 
 Be sure to have [Dart installed](https://dart.dev/get-dart) on your computer.
 
@@ -13,7 +13,7 @@ take dart-app
 touch main.dart
 ```
 
-### Use an HTTP client
+## Use an HTTP client
 
 We'll use [http](https://pub.dev/packages/http) for making HTTP requests.
 
@@ -31,7 +31,7 @@ dependencies:
 dart pub get
 ```
 
-### GET Request your collection type
+## GET Request your collection type
 
 Execute a `GET` request on the `restaurant` Collection Type in order to fetch all your restaurants.
 
@@ -114,7 +114,7 @@ void main() {
 }
 ```
 
-### POST Request your collection type
+## POST Request your collection type
 
 Execute a `POST` request on the `restaurant` Collection Type in order to create a restaurant.
 
@@ -204,7 +204,7 @@ void main() {
 }
 ```
 
-### PUT Request your collection type
+## PUT Request your collection type
 
 Execute a `PUT` request on the `restaurant` Collection Type in order to update the category of a restaurant.
 

--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/flutter.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/flutter.md
@@ -4,7 +4,7 @@ This integration guide is following the [Getting started guide](/developer-docs/
 
 If you haven't gone through the getting started guide, the way you request a Strapi API with [Flutter](https://flutter.dev/) remains the same except that you will not fetch the same content.
 
-### Create a Flutter application
+## Create a Flutter application
 
 Be sure to have [Flutter installed](https://flutter.dev/docs/get-started/install) on your computer.
 
@@ -13,7 +13,7 @@ flutter create flutterapp
 cd flutterapp
 ```
 
-### Use an HTTP client
+## Use an HTTP client
 
 We'll use [http](https://pub.dev/packages/http) for making HTTP requests.
 
@@ -40,7 +40,7 @@ dependencies:
 flutter pub get
 ```
 
-### GET Request your collection type
+## GET Request your collection type
 
 Execute a `GET` request on the `restaurant` Collection Type in order to fetch all your restaurants.
 
@@ -98,7 +98,7 @@ _Response_
 ]
 ```
 
-### POST Request your collection type
+## POST Request your collection type
 
 Execute a `POST` request on the `restaurant` Collection Type in order to create a restaurant.
 
@@ -149,7 +149,7 @@ _Response_
 }
 ```
 
-### PUT Request your collection type
+## PUT Request your collection type
 
 Execute a `PUT` request on the `restaurant` Collection Type in order to update the category of a restaurant.
 

--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/gatsby.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/gatsby.md
@@ -4,7 +4,7 @@ This integration guide is following the [Getting started guide](/developer-docs/
 
 If you haven't gone through the getting started guide, the way you request a Strapi API with [Gatsby](https://www.gatsbyjs.org/) remains the same except that you will not fetch the same content.
 
-### Create a Gatsby app
+## Create a Gatsby app
 
 Create a basic Gatsby application using the [Gatsby CLI](https://www.gatsbyjs.org/docs/gatsby-cli/).
 
@@ -12,7 +12,7 @@ Create a basic Gatsby application using the [Gatsby CLI](https://www.gatsbyjs.or
 gatsby new gatsby-app
 ```
 
-### Configure Gatsby
+## Configure Gatsby
 
 Gatsby is a [Static Site Generator](https://www.staticgen.com/) and will fetch your content from Strapi at build time. You need to configure Gatsby to communicate with your Strapi application.
 
@@ -36,7 +36,7 @@ yarn add gatsby-source-strapi
 },
 ```
 
-### GET Request your collection type
+## GET Request your collection type
 
 Execute a `GET` request on the `restaurant` Collection Type in order to fetch all your restaurants.
 

--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/go.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/go.md
@@ -5,7 +5,7 @@ This integration guide is following the [Getting started guide](/developer-docs/
 If you haven't gone through the getting started guide, the way you request a Strapi API with [GO](https://golang.org/) remains the same except that you will not fetch the same content.
 
 
-### Create a Go file
+## Create a Go file
 
 Be sure to have [Go installed](https://golang.org/doc/install) on your computer.
 
@@ -17,7 +17,7 @@ Go has inbuilt module/package needed to make HTTP Requests like GET, POST PUT, D
 We will use it("net/http") along with other modules/packages.
 
 
-### GET Request your collection type
+## GET Request your collection type
 
 Execute a `GET` request on the `restaurant` Collection Type in order to fetch all your restaurants.
 
@@ -85,7 +85,7 @@ func getD() {
 	}
 }
 ```
-### POST Request your collection type
+## POST Request your collection type
 
 Execute a `POST` request on the `restaurant` Collection Type in order to create a restaurant.
 
@@ -169,7 +169,7 @@ func postD() {
 ```	  
 
 
-### PUT Request your collection type
+## PUT Request your collection type
 
 Execute a `PUT` request on the `restaurant` Collection Type in order to update the category of a restaurant.
 

--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/graphql.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/graphql.md
@@ -4,7 +4,7 @@ This integration guide is following the [Getting started guide](/developer-docs/
 
 If you haven't gone through the getting started guide, the way you request a Strapi API with [GraphQL](https://graphql.org/) remains the same except that you will not fetch the same content.
 
-### Install the GraphQL plugin
+## Install the GraphQL plugin
 
 Install the graphql plugin in your Strapi project.
 
@@ -36,7 +36,7 @@ strapi install graphql
 
 ::::
 
-### Fetch your Restaurant collection type
+## Fetch your Restaurant collection type
 
 Play with the [GraphQL Playground](http://localhost:1337/graphql) to fetch your content.
 
@@ -163,7 +163,7 @@ export default {
 
 ::::
 
-### Fetch your Category collection type
+## Fetch your Category collection type
 
 _Request_
 
@@ -201,7 +201,7 @@ _Response_
 }
 ```
 
-### Examples
+## Examples
 
 :::: tabs
 

--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/gridsome.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/gridsome.md
@@ -4,7 +4,7 @@ This integration guide is following the [Getting started guide](/developer-docs/
 
 If you haven't gone through the getting started guide, the way you request a Strapi API with [Gridsome](https://gridsome.org/) remains the same except that you will not fetch the same content.
 
-### Create a Gridsome app
+## Create a Gridsome app
 
 Create a basic Gridsome application using the [Gridsome CLI](https://gridsome.org/docs/gridsome-cli/).
 
@@ -12,7 +12,7 @@ Create a basic Gridsome application using the [Gridsome CLI](https://gridsome.or
 gridsome create gridsome-app
 ```
 
-### Configure Gridsome
+## Configure Gridsome
 
 Gridsome is a [Static Site Generator](https://www.staticgen.com/) and will fetch your content from Strapi at build time. You need to configure Gridsome to communicate with your Strapi application.
 
@@ -38,7 +38,7 @@ module.exports = {
 };
 ```
 
-### GET Request your collection type
+## GET Request your collection type
 
 Execute a `GET` request on the `restaurant` Collection Type in order to fetch all your restaurants.
 

--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/jekyll.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/jekyll.md
@@ -4,7 +4,7 @@ This integration guide is following the [Getting started guide](/developer-docs/
 
 If you haven't gone through the getting started guide, the way you request a Strapi API with [Jekyll](https://jekyllrb.com) remains the same except that you will not fetch the same content.
 
-### Create a Jekyll app
+## Create a Jekyll app
 
 Be sure to have [Jekyll installed](https://jekyllrb.com/docs/installation/) on your computer.
 
@@ -12,7 +12,7 @@ Be sure to have [Jekyll installed](https://jekyllrb.com/docs/installation/) on y
 jekyll new jekyll-app
 ```
 
-### Configure Jekyll
+## Configure Jekyll
 
 Jekyll is a [Static Site Generator](https://www.staticgen.com/) and will fetch your content from Strapi at build time. You need to configure Jekyll to communicate with your Strapi application.
 
@@ -53,7 +53,7 @@ strapi:
 bundle install
 ```
 
-### GET Request your collection type
+## GET Request your collection type
 
 Execute a `GET` request on the `restaurant` Collection Type in order to fetch all your restaurants.
 

--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/next-js.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/next-js.md
@@ -4,7 +4,7 @@ This integration guide is following the [Getting started guide](/developer-docs/
 
 If you haven't gone through the getting started guide, the way you request a Strapi API with [Next.js](https://nextjs.org/) remains the same except that you will not fetch the same content.
 
-### Create a Next.js app
+## Create a Next.js app
 
 Create a basic Next.js application.
 
@@ -28,7 +28,7 @@ npx create-next-app nextjs-app
 
 ::::
 
-### Use an HTTP client
+## Use an HTTP client
 
 Many HTTP clients are available but in this documentation we'll use [Axios](https://github.com/axios/axios) and [Fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API).
 
@@ -50,7 +50,7 @@ No installation needed.
 
 ::::
 
-### GET Request your collection type
+## GET Request your collection type
 
 Execute a `GET` request on the `restaurant` Collection Type in order to fetch all your restaurants.
 
@@ -222,7 +222,7 @@ export default Home;
 
 ::::
 
-### POST Request your collection type
+## POST Request your collection type
 
 Execute a `POST` request on the `restaurant` Collection Type in order to create a restaurant.
 
@@ -552,7 +552,7 @@ export default Home;
 
 ::::
 
-### PUT Request your collection type
+## PUT Request your collection type
 
 Execute a `PUT` request on the `restaurant` Collection Type in order to update the category of a restaurant.
 

--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/nuxt-js.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/nuxt-js.md
@@ -4,7 +4,7 @@ This integration guide is following the [Getting started guide](/developer-docs/
 
 If you haven't gone through the getting started guide, the way you request a Strapi API with [Nuxt.js](https://nuxtjs.org/) remains the same except that you will not fetch the same content.
 
-### Create a Nuxt.js app
+## Create a Nuxt.js app
 
 Create a basic Nuxt.js application with [create-nuxt-app](https://github.com/nuxt/create-nuxt-app).
 
@@ -28,7 +28,7 @@ npx create-nuxt-app nuxtjs-app
 
 ::::
 
-### Use an HTTP client
+## Use an HTTP client
 
 Many HTTP clients are available but in this documentation we'll use [Axios](https://github.com/axios/axios) and [Fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API).
 
@@ -70,7 +70,7 @@ No installation needed
 
 ::::
 
-### GET Request your collection type
+## GET Request your collection type
 
 Execute a `GET` request on the `restaurant` Collection Type in order to fetch all your restaurants.
 
@@ -310,7 +310,7 @@ export default {
 
 ::::
 
-### POST Request your collection type
+## POST Request your collection type
 
 Execute a `POST` request on the `restaurant` Collection Type in order to create a restaurant.
 
@@ -676,7 +676,7 @@ export default {
 
 ::::
 
-### PUT Request your collection type
+## PUT Request your collection type
 
 Execute a `PUT` request on the `restaurant` Collection Type in order to update the category of a restaurant.
 

--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/php.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/php.md
@@ -4,7 +4,7 @@ This integration guide is following the [Getting started guide](/developer-docs/
 
 If you haven't gone through the getting started guide, the way you request a Strapi API with [PHP](https://php.net/) remains the same except that you will not fetch the same content.
 
-### Create a PHP file
+## Create a PHP file
 
 Be sure to have [PHP installed](https://www.php.net/manual/en/install.php) on your computer.
 
@@ -13,7 +13,7 @@ touch strapi.php
 ```
 We will use cURL, a built-in PHP extension that allows us to receive and send information via the URL syntax.
 
-### GET Request your collection type
+## GET Request your collection type
 
 Execute a `GET` request on the `restaurant` Collection Type in order to fetch all your restaurants.
 
@@ -76,7 +76,7 @@ getRestaurants();
 
 ```
 
-### POST Request your collection type
+## POST Request your collection type
 
 Execute a `POST` request on the `restaurant` Collection Type in order to create a restaurant.
 
@@ -175,7 +175,7 @@ postRestaurant();
 
 ```
 
-### PUT Request your collection type
+## PUT Request your collection type
 
 Execute a `PUT` request on the `restaurant` Collection Type in order to update the category of a restaurant.
 

--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/python.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/python.md
@@ -4,7 +4,7 @@ This integration guide is following the [Getting started guide](/developer-docs/
 
 If you haven't gone through the getting started guide, the way you request a Strapi API with [Python](https://www.python.org/) remains the same except that you will not fetch the same content.
 
-### Create a Python file
+## Create a Python file
 
 Be sure to have [Python installed](https://wiki.python.org/moin/BeginnersGuide/Download) on your computer.
 
@@ -12,7 +12,7 @@ Be sure to have [Python installed](https://wiki.python.org/moin/BeginnersGuide/D
 touch script.py
 ```
 
-### Use an HTTP client
+## Use an HTTP client
 
 Many HTTP clients are available but in this documentation we'll use [Requests](https://github.com/psf/requests).
 
@@ -20,7 +20,7 @@ Many HTTP clients are available but in this documentation we'll use [Requests](h
 python -m pip install requests
 ```
 
-### GET Request your collection type
+## GET Request your collection type
 
 Execute a `GET` request on the `restaurant` Collection Type in order to fetch all your restaurants.
 
@@ -92,7 +92,7 @@ restaurant = Restaurant()
 print(restaurant.all())
 ```
 
-### POST Request your collection type
+## POST Request your collection type
 
 Execute a `POST` request on the `restaurant` Collection Type in order to create a restaurant.
 
@@ -172,7 +172,7 @@ print(restaurant.create({
 }))
 ```
 
-### PUT Request your collection type
+## PUT Request your collection type
 
 Execute a `PUT` request on the `restaurant` Collection Type in order to update the category of a restaurant.
 

--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/react.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/react.md
@@ -4,7 +4,7 @@ This integration guide is following the [Getting started guide](/developer-docs/
 
 If you haven't gone through the getting started guide, the way you request a Strapi API with [React](https://reactjs.org/) remains the same except that you will not fetch the same content.
 
-### Create a React app
+## Create a React app
 
 Create a basic React application using [create-react-app](https://reactjs.org/docs/create-a-new-react-app.html).
 
@@ -28,7 +28,7 @@ npx create-react-app react-app
 
 ::::
 
-### Use an HTTP client
+## Use an HTTP client
 
 Many HTTP clients are available but in this documentation we'll use [Axios](https://github.com/axios/axios) and [Fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API).
 
@@ -50,7 +50,7 @@ No installation needed
 
 ::::
 
-### GET Request your collection type
+## GET Request your collection type
 
 Execute a `GET` request on the `restaurant` Collection Type in order to fetch all your restaurants.
 
@@ -253,7 +253,7 @@ export default App;
 
 ::::
 
-### POST Request your collection type
+## POST Request your collection type
 
 Execute a `POST` request on the `restaurant` Collection Type in order to create a restaurant.
 
@@ -638,7 +638,7 @@ export default App;
 
 ::::
 
-### PUT Request your collection type
+## PUT Request your collection type
 
 Execute a `PUT` request on the `restaurant` Collection Type in order to update the category of a restaurant.
 

--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/ruby.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/ruby.md
@@ -4,7 +4,7 @@ This integration guide is following the [Getting started guide](/developer-docs/
 
 If you haven't gone through the getting started guide, the way you request a Strapi API with [Ruby](https://www.ruby-lang.org/en/) remains the same except that you will not fetch the same content.
 
-### Create a Ruby file
+## Create a Ruby file
 
 Be sure to have [Ruby installed](https://www.ruby-lang.org/en/documentation/installation/) on your computer.
 
@@ -13,7 +13,7 @@ mkdir ruby-app && cd ruby-app
 touch script.rb
 ```
 
-### Use an HTTP client
+## Use an HTTP client
 
 Many HTTP clients are available but in this documentation we'll use [HTTParty](https://github.com/jnunemaker/httparty).
 
@@ -31,7 +31,7 @@ gem "httparty"
 bundle install
 ```
 
-### GET Request your collection type
+## GET Request your collection type
 
 Execute a `GET` request on the `restaurant` Collection Type in order to fetch all your restaurants.
 
@@ -104,7 +104,7 @@ restaurant = Restaurant.new
 puts restaurant.all
 ```
 
-### POST Request your collection type
+## POST Request your collection type
 
 Execute a `POST` request on the `restaurant` Collection Type in order to create a restaurant.
 
@@ -190,7 +190,7 @@ puts restaurant.create({
 })
 ```
 
-### PUT Request your collection type
+## PUT Request your collection type
 
 Execute a `PUT` request on the `restaurant` Collection Type in order to update the category of a restaurant.
 

--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/sapper.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/sapper.md
@@ -4,7 +4,7 @@ This integration guide is following the [Getting started guide](/developer-docs/
 
 If you haven't gone through the getting started guide, the way you request a Strapi API with [Sapper](https://sapper.svelte.dev) remains the same except that you will not fetch the same content.
 
-### Create a Sapper app
+## Create a Sapper app
 
 First, install Degit by running `npm install -g degit` in your command-line interface (CLI).
 
@@ -16,7 +16,7 @@ Create a basic Sapper application using webpack:
 npx degit "sveltejs/sapper-template#webpack" sapper-app
 ```
 
-### Use an HTTP client
+## Use an HTTP client
 
 Many HTTP clients are available but in this documentation we'll use [Axios](https://github.com/axios/axios) and [Fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API).
 
@@ -38,7 +38,7 @@ No installation needed
 
 ::::
 
-### GET Request your collection type
+## GET Request your collection type
 
 Execute a `GET` request on the `restaurant` Collection Type in order to fetch all your restaurants.
 
@@ -214,7 +214,7 @@ onMount(async () => {
 
 ::::
 
-### POST Request your collection type
+## POST Request your collection type
 
 Execute a `POST` request on the `restaurant` Collection Type in order to create a restaurant.
 
@@ -450,7 +450,7 @@ onMount(async () => {
 
 ::::
 
-### PUT Request your collection type
+## PUT Request your collection type
 
 Execute a `PUT` request on the `restaurant` Collection Type in order to update the category of a restaurant.
 

--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/svelte.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/svelte.md
@@ -4,7 +4,7 @@ This integration guide is following the [Getting started guide](/developer-docs/
 
 If you haven't gone through the getting started guide, the way you request a Strapi API with [Svelte](https://svelte.dev) remains the same except that you will not fetch the same content.
 
-### Create a Svelte app
+## Create a Svelte app
 
 First, install Degit by running `npm install -g degit` in your command-line interface (CLI).
 
@@ -38,7 +38,7 @@ No installation needed
 
 ::::
 
-### GET Request your collection type
+## GET Request your collection type
 
 Execute a `GET` request on the `restaurant` Collection Type in order to fetch all your restaurants.
 
@@ -214,7 +214,7 @@ onMount(async () => {
 
 ::::
 
-### POST Request your collection type
+## POST Request your collection type
 
 Execute a `POST` request on the `restaurant` Collection Type in order to create a restaurant.
 
@@ -450,7 +450,7 @@ onMount(async () => {
 
 ::::
 
-### PUT Request your collection type
+## PUT Request your collection type
 
 Execute a `PUT` request on the `restaurant` Collection Type in order to update the category of a restaurant.
 

--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/vue-js.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/vue-js.md
@@ -4,7 +4,7 @@ This integration guide is following the [Getting started guide](/developer-docs/
 
 If you haven't gone through the getting started guide, the way you request a Strapi API with [Vue.js](https://vuejs.org/) remains the same except that you will not fetch the same content.
 
-### Create a Vue.js app
+## Create a Vue.js app
 
 Create a basic Vue.js application using [Vue CLI](https://cli.vuejs.org).
 
@@ -12,7 +12,7 @@ Create a basic Vue.js application using [Vue CLI](https://cli.vuejs.org).
 vue create vue-app
 ```
 
-### Use an HTTP client
+## Use an HTTP client
 
 Many HTTP clients are available but in this documentation we'll use [Axios](https://github.com/axios/axios) and [Fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API).
 
@@ -34,7 +34,7 @@ No installation needed
 
 ::::
 
-### GET Request your collection type
+## GET Request your collection type
 
 Execute a `GET` request on the `restaurant` Collection Type in order to fetch all your restaurants.
 
@@ -220,7 +220,7 @@ export default {
 
 ::::
 
-### POST Request your collection type
+## POST Request your collection type
 
 Execute a `POST` request on the `restaurant` Collection Type in order to create a restaurant.
 
@@ -489,7 +489,7 @@ export default {
 
 ::::
 
-### PUT Request your collection type
+## PUT Request your collection type
 
 Execute a `PUT` request on the `restaurant` Collection Type in order to update the category of a restaurant.
 

--- a/docs/developer-docs/latest/setup-deployment-guides/deployment.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment.md
@@ -6,6 +6,149 @@ Strapi gives you many possible deployment options for your project or applicatio
 Deploying **databases** along with Strapi is covered in the [Databases Guide](/developer-docs/latest/setup-deployment-guides/configurations.md#databases-installation-guides).
 :::
 
+## General guidelines
+
+::: warning PREREQUISITES
+To provide the best possible environment for Strapi there are a few requirements, these apply in both a development (local) as well as a staging and production workflow.
+
+- Node LTS (v12 or V14) **Note that odd-number releases of Node will never be supported (e.g. v13, v15).**
+- NPM v6 or whatever ships with the LTS Node versions
+- Typical standard build tools for your OS (the `build-essentials` package on most Debian-based systems)
+- At least 1 CPU core (Highly recommended at least 2)
+- At least 2 GB of RAM (Moderately recommended 4)
+- Minimum required storage space recommended by your OS or 32 GB of **free** space
+- A supported database version
+  - MySQL >= 5.6
+  - MariaDB >= 10.1
+  - PostgreSQL >= 10
+  - SQLite >= 3
+  - MongoDB >= 3.6
+- A supported operating system
+  - Ubuntu >= 18.04 (LTS-Only)
+  - Debian >= 9.x
+  - CentOS/RHEL >= 8
+  - macOS Mojave or newer (ARM not supported)
+  - Windows 10
+  - Docker - [docker repo](https://github.com/strapi/strapi-docker)
+:::
+### Application Configuration
+
+#### 1. Configure
+
+We always recommend you use environment variables to configure your application based on the environment. Here is an example:
+
+**Path —** `./config/server.js`.
+
+```js
+module.exports = ({ env }) => ({
+  host: env('APP_HOST', '0.0.0.0'),
+  port: env.int('NODE_PORT', 1337),
+});
+```
+
+Then you can create a `.env` file or directly use the deployment platform you use to set environment variables:
+
+**Path —** `.env`.
+
+```
+APP_HOST=10.0.0.1
+NODE_PORT=1338
+```
+
+::: tip
+To learn more about configuration you can read the documentation [here](/developer-docs/latest/setup-deployment-guides/configurations.md)
+:::
+
+#### 2. Launch the server
+
+Before running your server in production you need to build your admin panel for production
+
+:::: tabs
+
+::: tab yarn
+
+```bash
+NODE_ENV=production yarn build
+```
+
+:::
+
+::: tab npm
+
+```bash
+NODE_ENV=production npm run build
+```
+
+:::
+
+::: tab Windows
+
+```bash
+npm install cross-env
+```
+
+Then in your `package.json` scripts section:
+
+```bash
+"production": "cross-env NODE_ENV=production npm run build"
+```
+
+:::
+
+::::
+
+Run the server with the `production` settings.
+
+:::: tabs
+
+::: tab yarn
+
+```bash
+NODE_ENV=production yarn start
+```
+
+:::
+
+::: tab npm
+
+```bash
+NODE_ENV=production npm start
+```
+
+:::
+
+::: tab Windows
+
+```bash
+npm install cross-env
+```
+
+Then in your `package.json` scripts section:
+
+```bash
+"production": "cross-env NODE_ENV=production npm start"
+```
+
+:::
+
+::::
+
+::: warning
+We highly recommend using [pm2](https://github.com/Unitech/pm2/) to manage your process.
+:::
+
+If you need a server.js file to be able to run `node server.js` instead of `npm run start` then create a `./server.js` file as follows:
+
+```js
+const strapi = require('strapi');
+
+strapi(/* {...} */).start();
+```
+
+### Advanced configurations
+
+If you want to host the administration on another server than the API, [please take a look at this dedicated section](/developer-docs/latest/development/admin-customization.md#deployment).
+
 ## Hosting Provider Guides
 
 Manual guides for deployment on various platforms, for One-click and docker please see the [installation](/developer-docs/latest/setup-deployment-guides/installation.md) guides.
@@ -167,144 +310,3 @@ Additional guides for optional software additions that compliment or improve the
 	</InstallLink>
 </div>
 
-## Recommended requirements
-
-To provide the best possible environment for Strapi there are a few requirements, these apply in both a development (local) as well as a staging and production workflow.
-
-- Node LTS (v12 or V14) **Note that odd-number releases of Node will never be supported (e.g. v13, v15).**
-- NPM v6 or whatever ships with the LTS Node versions
-- Typical standard build tools for your OS (the `build-essentials` package on most Debian-based systems)
-- At least 1 CPU core (Highly recommended at least 2)
-- At least 2 GB of RAM (Moderately recommended 4)
-- Minimum required storage space recommended by your OS or 32 GB of **free** space
-- A supported database version
-  - MySQL >= 5.6
-  - MariaDB >= 10.1
-  - PostgreSQL >= 10
-  - SQLite >= 3
-  - MongoDB >= 3.6
-- A supported operating system
-  - Ubuntu >= 18.04 (LTS-Only)
-  - Debian >= 9.x
-  - CentOS/RHEL >= 8
-  - macOS Mojave or newer (ARM not supported)
-  - Windows 10
-  - Docker - [docker repo](https://github.com/strapi/strapi-docker)
-
-## Application Configuration
-
-### 1. Configure
-
-We always recommend you use environment variables to configure your application based on the environment. Here is an example:
-
-**Path —** `./config/server.js`.
-
-```js
-module.exports = ({ env }) => ({
-  host: env('APP_HOST', '0.0.0.0'),
-  port: env.int('NODE_PORT', 1337),
-});
-```
-
-Then you can create a `.env` file or directly use the deployment platform you use to set environment variables:
-
-**Path —** `.env`.
-
-```
-APP_HOST=10.0.0.1
-NODE_PORT=1338
-```
-
-::: tip
-To learn more about configuration you can read the documentation [here](/developer-docs/latest/setup-deployment-guides/configurations.md)
-:::
-
-### 2. Launch the server
-
-Before running your server in production you need to build your admin panel for production
-
-:::: tabs
-
-::: tab yarn
-
-```bash
-NODE_ENV=production yarn build
-```
-
-:::
-
-::: tab npm
-
-```bash
-NODE_ENV=production npm run build
-```
-
-:::
-
-::: tab Windows
-
-```bash
-npm install cross-env
-```
-
-Then in your `package.json` scripts section:
-
-```bash
-"production": "cross-env NODE_ENV=production npm run build"
-```
-
-:::
-
-::::
-
-Run the server with the `production` settings.
-
-:::: tabs
-
-::: tab yarn
-
-```bash
-NODE_ENV=production yarn start
-```
-
-:::
-
-::: tab npm
-
-```bash
-NODE_ENV=production npm start
-```
-
-:::
-
-::: tab Windows
-
-```bash
-npm install cross-env
-```
-
-Then in your `package.json` scripts section:
-
-```bash
-"production": "cross-env NODE_ENV=production npm start"
-```
-
-:::
-
-::::
-
-::: warning
-We highly recommend using [pm2](https://github.com/Unitech/pm2/) to manage your process.
-:::
-
-If you need a server.js file to be able to run `node server.js` instead of `npm run start` then create a `./server.js` file as follows:
-
-```js
-const strapi = require('strapi');
-
-strapi(/* {...} */).start();
-```
-
-### Advanced configurations
-
-If you want to host the administration on another server than the API, [please take a look at this dedicated section](/developer-docs/latest/development/admin-customization.md#deployment).


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

## What does it do?

* Updates the `config.js` VuePress file to add collapsable sub-menus for installation, deployment and integration guides.

* Fix mis-use of h3 instead of h2 in all integration guides, so that the proper structure is reflected in sidebar

https://user-images.githubusercontent.com/4233866/114887130-71bbeb80-9e08-11eb-8b21-3eacd5327ec7.mov

## Why is it needed?

The dev docs restructuring made it a bit harder to know where you are in the sidebar.

***

## Known issue

* **Deployment** item in sidebar has an annoying bug: 

   * Both links highlighted
   * Both of them don't work (behavior not supported by VuePress), so they link to the page, not to the section (anchor)

![Screenshot 2021-04-15 at 16 42 59](https://user-images.githubusercontent.com/4233866/114888598-aed4ad80-9e09-11eb-8f65-c21593c7a728.png)


Explanations and possible workarounds below.

**tl;dr:** ❓  Should I simply remove the links "Recommended Requirements" and "Advanced Configuration" in the sidebar?

**=> We choose to [rework the structure of deployment page and remove unsupported anchor links in sidebar](https://github.com/strapi/documentation/pull/235/commits/749168bdf02936174d65b6a3ae255637e0f178c0)**

***

### Why it happens

* By default, sub-Items in the sidebar are automatically filled in by VuePress: it detects h2 and h3 elements (depending on the `sidebarDepth` config parameter)
* Our `<InstallLinks />`, `<IntegrationLinks />` and other-groups-of-links VuePress components (rendering as these big blue buttons) do not use proper HTML headings (`<h2>`, `<h3>`…).
* So I had to manually insert links to these guides in the sidebar, by creating nested groups in the config file, like this:
```
 children: [
    {
       title: '…',
       path: '…',
       children: [
           ['/path-to-guide', 'guide title'],
           …
       ]
    }
 ]
```
This is [partially documented in VuePress](https://vuepress.vuejs.org/theme/default-theme-config.html#sidebar-groups) but this [StackOverflow answer](https://stackoverflow.com/a/60405072) was more explicit and helpful.

* However, it turns out that our document structure for the `deployment.md` file makes things messy with VuePress sidebar.

   * if I don't specify any `sidebarDepth` parameter for this group, the sidebar replicates all h2 within each children 😅 ![Screenshot 2021-04-15 at 16 53 37](https://user-images.githubusercontent.com/4233866/114890351-38d14600-9e0b-11eb-96d5-9b9a4fa8c5d9.png)
   * I have to specify `sidebarDepth=0` to prevent this — but then no h2 appears, meaning we miss links to "Recommended Requirements" and "Application Configuration" in the sidebar
![Screenshot 2021-04-15 at 16 57 38](https://user-images.githubusercontent.com/4233866/114890895-b4cb8e00-9e0b-11eb-9ff6-171541dd1da4.png)
   * If I manually add these links (to "Recommended Requirements" and "Application Configuration") in the sidebar, like I did in the code of this PR, it seems that sidebar [does not support manually linking to anchors](https://github.com/vuejs/vuepress/issues/1289) (`#`) — therefore, both links appear highlighted in the sidebar because they both point to the same page, not to the anchors 😕
   
![Screenshot 2021-04-15 at 17 00 59](https://user-images.githubusercontent.com/4233866/114891670-5e128400-9e0c-11eb-87e0-4e35c4324a23.png)


### Possible solutions

**Solution A.** Remove links for "Recommended Requirements" and "Application Configuration" in sidebar, and do nothing else — readers will have to scroll to find them

**Solution B.** Same (remove the 2 anchor links) but move both subsections higher in the page, so that readers know about it (and can still access guides easily from the sidebar)
![Screenshot 2021-04-15 at 17 10 00](https://user-images.githubusercontent.com/4233866/114892990-8b136680-9e0d-11eb-9bc7-0b7f98dbff3c.png)

❓ **Which solution is best**, A or B?

**=> we choose solution B, [rework the structure of deployment page and remove unsupported anchor links in sidebar](https://github.com/strapi/documentation/pull/235/commits/749168bdf02936174d65b6a3ae255637e0f178c0)**

## Linked PR

#224 (i18n dev docs) has the initial implementation idea and adds a collapsable sidebar item for Strapi plugins
