### PR TITLE
Adding deployment to DigitalOcean App Platform

### DIFF
--- a/docs/developer-docs/latest/setup-deployment-guides/deployment.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment.md
@@ -83,7 +83,7 @@ Manual guides for deployment on various platforms, for One-click and docker plea
 		<template #icon>
 			<svg width="178" height="177" viewBox="0 0 178 177" xmlns="http://www.w3.org/2000/svg"><g fill="#fff" fill-rule="evenodd"><path d="M89 176.5v-34.2c36.2 0 64.3-35.9 50.4-74-5.1-14-16.4-25.3-30.5-30.4-38.1-13.8-74 14.2-74 50.4H.8C.8 30.6 56.6-14.4 117.1 4.5c26.4 8.3 47.5 29.3 55.7 55.7 18.9 60.5-26.1 116.3-83.8 116.3z" fill-rule="nonzero"></path><path d="M89.1 142.5H55v-34.1h34.1zM55 168.6H28.9v-26.1H55zM28.9 142.5H7v-21.9h21.9v21.9z"></path></g></svg>
 		</template>
-		<template #title>DigitalOcean</template>
+		<template #title>DigitalOcean Droplets</template>
 		<template #description>
 			Manual step by step guide for deploying on DigitalOcean droplets
 		</template>

--- a/docs/developer-docs/latest/setup-deployment-guides/deployment.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment.md
@@ -67,6 +67,18 @@ Manual guides for deployment on various platforms, for One-click and docker plea
 </div>
 
 <div>
+	<InstallLink link="deployment/hosting-guides/digitalocean-app-platform.html">
+		<template #icon>
+			<svg width="178" height="177" viewBox="0 0 178 177" xmlns="http://www.w3.org/2000/svg"><g fill="#fff" fill-rule="evenodd"><path d="M89 176.5v-34.2c36.2 0 64.3-35.9 50.4-74-5.1-14-16.4-25.3-30.5-30.4-38.1-13.8-74 14.2-74 50.4H.8C.8 30.6 56.6-14.4 117.1 4.5c26.4 8.3 47.5 29.3 55.7 55.7 18.9 60.5-26.1 116.3-83.8 116.3z" fill-rule="nonzero"></path><path d="M89.1 142.5H55v-34.1h34.1zM55 168.6H28.9v-26.1H55zM28.9 142.5H7v-21.9h21.9v21.9z"></path></g></svg>
+		</template>
+		<template #title>DigitalOcean App Platform</template>
+		<template #description>
+			Manual step by step guide for deploying on DigitalOcean App Platform
+		</template>
+	</InstallLink>
+</div>
+
+<div>
 	<InstallLink link="deployment/hosting-guides/digitalocean.html">
 		<template #icon>
 			<svg width="178" height="177" viewBox="0 0 178 177" xmlns="http://www.w3.org/2000/svg"><g fill="#fff" fill-rule="evenodd"><path d="M89 176.5v-34.2c36.2 0 64.3-35.9 50.4-74-5.1-14-16.4-25.3-30.5-30.4-38.1-13.8-74 14.2-74 50.4H.8C.8 30.6 56.6-14.4 117.1 4.5c26.4 8.3 47.5 29.3 55.7 55.7 18.9 60.5-26.1 116.3-83.8 116.3z" fill-rule="nonzero"></path><path d="M89.1 142.5H55v-34.1h34.1zM55 168.6H28.9v-26.1H55zM28.9 142.5H7v-21.9h21.9v21.9z"></path></g></svg>

--- a/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/digitalocean-app-platform.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/digitalocean-app-platform.md
@@ -7,7 +7,7 @@ Databases can be created using DigitalOcean's [Managed Databases](https://www.di
 Prior to starting this guide, you should have created a [Strapi project](/developer-docs/latest/getting-started/quick-start.md). And have read through the [configuration](/developer-docs/latest/setup-deployment-guides/deployment.md#application-configuration) section.
 
 ::: tip
-Strapi does have a [One-Click](/developer-docs/latest/setup-deployment-guides/installation/digitalocean-one-click.md) deployment option for DigitalOcean and can also be deployed to DigitalOcean Droplets.
+Strapi does have a [One-Click](/developer-docs/latest/setup-deployment-guides/installation/digitalocean-one-click.md) deployment option for DigitalOcean and can also be deployed to [DigitalOcean Droplets](/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/digitalocean.md).
 :::
 
 ### DigitalOcean Install Requirements

--- a/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/digitalocean-app-platform.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/digitalocean-app-platform.md
@@ -1,0 +1,99 @@
+# DigitalOcean App Platform
+
+This is a step-by-step guide for deploying a Strapi project to [DigitalOcean's App Platform](https://digitalocean.com). App Platform is DigitalOcean's Platform as a Service (PaaS) that will handle deploying, networking, SSL, and more for your app. It is the easiest way to deploy Strapi to DigitalOcean.
+
+Databases can be created using DigitalOcean's [Managed Databases](https://www.digitalocean.com/products/managed-databases/).
+
+Prior to starting this guide, you should have created a [Strapi project](/developer-docs/latest/getting-started/quick-start.md). And have read through the [configuration](/developer-docs/latest/setup-deployment-guides/deployment.md#application-configuration) section.
+
+::: tip
+Strapi does have a [One-Click](/developer-docs/latest/setup-deployment-guides/installation/digitalocean-one-click.md) deployment option for DigitalOcean and can also be deployed to DigitalOcean Droplets.
+:::
+
+### DigitalOcean Install Requirements
+
+- If you don't have a DigitalOcean account you will need to create one, you can use [this referral link](https://try.digitalocean.com/strapi/) to get \$100 of free credits!
+
+## Configure Your Strapi Project for Deployment
+
+To deploy your Strapi app, you will need to create a database configuration file. You will be using PostgreSQL for this example but you are able to connect to any of the [databases](https://docs.digitalocean.com/products/databases/) provided by DigitalOcean and [supported by Strapi](/developer-docs/latest/setup-deployment-guides/configurations.html#database).
+
+You will configure a database for production. With the setup below, you will only need to set **one environment variable** for the `DATABASE_URL` to connect to your PostgreSQL database. Add the following to `config/env/production/database.js`:
+
+```javascript
+const parse = require('pg-connection-string').parse;
+const config = parse(process.env.DATABASE_URL);
+
+module.exports = () => ({
+  defaultConnection: 'default',
+  connections: {
+    default: {
+      connector: 'bookshelf',
+      settings: {
+        client: 'postgres',
+        host: config.host,
+        port: config.port,
+        database: config.database,
+        username: config.user,
+        password: config.password,
+        ssl: {
+          rejectUnauthorized: false,
+        },
+      },
+      options: {},
+    },
+  },
+});
+```
+
+Your application is now ready to deploy to DigitalOcean App Platform.
+
+## Deploying Strapi to DigitalOcean App Platform
+
+App Platform lets you deploy your application directly from a [GitHub](https://github.com) repo. [Gitlab](https://gitlab.com) is also supported.
+
+### Step 1. Log in to your [DigitalOcean account](https://cloud.digitalocean.com/login).
+
+### Step 2. Create a new "App" by clicking "Apps" in the "Create" dropdown
+
+### Step 3. Choose GitHub (or wherever you have your Strapi repo)
+
+### Step 4. Select your repository
+
+Choose your repository, your branch, and keep "Autodeploy code changes" checked if you want DigitalOcean to deploy every time you push to this GitHub branch.
+
+### Step 5. Configure your app
+
+Here you will configure how DigitalOcean App Platform deploys your Strapi app. You can leave most things default. The only things you need to change are shown below:
+
+- **Environment Variables**: Add `DATABASE_URL`: `${db.DATABASE_URL}`
+- **Build Command**: `NODE_ENV=production npm run build`
+- **Run Command**: `NODE_ENV=production npm start`
+
+### Step 6. Add a Database
+
+Click on the Add a Database button. You can create a development PostgreSQL database while testing your application. Alternatively, you can add a Managed Database that you have created.
+
+Name your database (default name is `db`). Whatever you name your database here is what you should use in the environment variables in Step 5 above. For instance, we name the database `db` and we use the environment variable value: `${db.DATABASE_URL}`
+
+Click "Next".
+
+### Step 7. Name your app
+
+Name your app. This will also change what domain your app will live on: `https://app-name.ondigitalocean.app`
+
+Select the region closest to you and your users. Static components are served on our global CDN.
+
+### Step 8. Choose your plan
+
+For prototype applications, you can choose the Basic plan. For applications that are expecting production traffic, you can choose the Pro plan. You will also see the pricing for your database that you have chosen.
+
+Choose your container size based on how much traffic you believe your app will have. It is a good practice to start on the smaller sizes, monitor the metrics of your app, and scale up as your app grows. App Platform allows us to scale vertically or horizontally with the click of a button.
+
+### Step 9. Launch!
+
+DigitalOcean will now deploy your application and you will be taken to the dashboard where you can view your app, make adjustments, and visit your new Strapi app.
+
+## Next Steps
+
+You have the ability to size your application, add components like a static site, and add a domain.

--- a/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/digitalocean.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/digitalocean.md
@@ -1,8 +1,8 @@
-# DigitalOcean
+# DigitalOcean Droplets
 
 This is a step-by-step guide for deploying a Strapi project to [DigitalOcean](https://www.digitalocean.com/) Droplet. If you want to deploy your Strapi project from GitHub, you can deploy to DigitalOcean's Platform as a Service (PaaS) called [App Platform](/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/digitalocean-app-platform.md).
 
-Databases can be on a [DigitalOcean Droplet](https://www.digitalocean.com/docs/droplets/) or hosted externally as a service using [DigitalOcean Managed Databases](https://www.digitalocean.com/products/managed-databases/). 
+Databases can be on a [DigitalOcean Droplet](https://www.digitalocean.com/docs/droplets/) or hosted externally as a service using [DigitalOcean Managed Databases](https://www.digitalocean.com/products/managed-databases/).
 
 Prior to starting this guide, you should have created a [Strapi project](/developer-docs/latest/getting-started/quick-start.md). And have read through the [configuration](/developer-docs/latest/setup-deployment-guides/deployment.md#application-configuration) section.
 
@@ -406,14 +406,9 @@ const exec = require('child_process').exec;
 const PM2_CMD = 'cd ~ && pm2 startOrRestart ecosystem.config.js';
 
 http
-  .createServer(function(req, res) {
-    req.on('data', function(chunk) {
-      let sig =
-        'sha1=' +
-        crypto
-          .createHmac('sha1', secret)
-          .update(chunk.toString())
-          .digest('hex');
+  .createServer(function (req, res) {
+    req.on('data', function (chunk) {
+      let sig = 'sha1=' + crypto.createHmac('sha1', secret).update(chunk.toString()).digest('hex');
 
       if (req.headers['x-hub-signature'] == sig) {
         exec(`cd ${repo} && git pull && ${PM2_CMD}`, (error, stdout, stderr) => {

--- a/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/digitalocean.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/digitalocean.md
@@ -1,6 +1,10 @@
 # DigitalOcean
 
-This is a step-by-step guide for deploying a Strapi project to [DigitalOcean](https://www.digitalocean.com/). Databases can be on a [DigitalOcean Droplet](https://www.digitalocean.com/docs/droplets/) or hosted externally as a service. Prior to starting this guide, you should have created a [Strapi project](/developer-docs/latest/getting-started/quick-start.md). And have read through the [configuration](/developer-docs/latest/setup-deployment-guides/deployment.md#application-configuration) section.
+This is a step-by-step guide for deploying a Strapi project to [DigitalOcean](https://www.digitalocean.com/) Droplet. If you want to deploy your Strapi project from GitHub, you can deploy to DigitalOcean's Platform as a Service (PaaS) called [App Platform](/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/digitalocean-app-platform.md).
+
+Databases can be on a [DigitalOcean Droplet](https://www.digitalocean.com/docs/droplets/) or hosted externally as a service using [DigitalOcean Managed Databases](https://www.digitalocean.com/products/managed-databases/). 
+
+Prior to starting this guide, you should have created a [Strapi project](/developer-docs/latest/getting-started/quick-start.md). And have read through the [configuration](/developer-docs/latest/setup-deployment-guides/deployment.md#application-configuration) section.
 
 ::: tip
 Strapi does have a [One-Click](/developer-docs/latest/setup-deployment-guides/installation/digitalocean-one-click.md) deployment option for DigitalOcean


### PR DESCRIPTION
### What does it do?

Added 1 file to the deployments section to deploy Strapi to DigitalOcean's new Platform as a Service (App Platform)

### Why is it needed?

We should show users how to quickly deploy to DigitalOcean's new offering