### PR TITLE
Fix SEO metatags containing `:` character

### DIFF
--- a/docs/user-docs/latest/content-types-builder/creating-new-content-type.md
+++ b/docs/user-docs/latest/content-types-builder/creating-new-content-type.md
@@ -1,6 +1,6 @@
 ---
 title: Creating Content-Types - Strapi User Guide
-description: The Content-Types Builder allows to create new content-types: single and collection types.
+description: The Content-Types Builder allows to create new content-types (single and collection types).
 ---
 
 # Creating content-types

--- a/docs/user-docs/latest/content-types-builder/introduction-to-content-types-builder.md
+++ b/docs/user-docs/latest/content-types-builder/introduction-to-content-types-builder.md
@@ -1,6 +1,6 @@
 ---
 title: Content-Types Builder - Strapi User Guide
-description: From the Content-Types Builder, administrators can create and manage content-types: collection types and single types but also components.
+description: From the Content-Types Builder, administrators can create and manage content-types (collection types and single types but also components).
 ---
 
 # Introduction to the Content-Types Builder


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

Fix SEO metatags that include `:` in their description.

### Why is it needed?

YAML validation failed, the tool considers what is before `:` as a key.
