### PR TITLE
Fix link to `createlocalization` in user guide

### DIFF
--- a/docs/developer-docs/latest/development/plugins/i18n.md
+++ b/docs/developer-docs/latest/development/plugins/i18n.md
@@ -225,7 +225,7 @@ To create another localization for an existing localized entry, send a POST requ
 When creating a localization for existing localized entries, the body of the POST request can only accept localized fields.
 
 ::: tip TIP
-The Content-Type should have the [`createlocalization` permission](/documentation/user-docs/latest/users-roles-permissions/configuring-administrator-roles.md#collection-and-single-types) enabled, otherwise the POST request will return a `403: Forbidden` status.
+The Content-Type should have the [`createlocalization` permission](/user-docs/latest/users-roles-permissions/configuring-administrator-roles.md#collection-and-single-types) enabled, otherwise the POST request will return a `403: Forbidden` status.
 :::
 
 #### Creating a localization for a collection type


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

Fixed a i18n link from dev docs to user guide

### Why is it needed?

Added `/documentation` in path which caused a 404.
