### PR TITLE
Fixed method signature for resolver

### DIFF
--- a/docs/developer-docs/latest/development/plugins/graphql.md
+++ b/docs/developer-docs/latest/development/plugins/graphql.md
@@ -587,11 +587,11 @@ module.exports = {
       restaurantsByCategories: {
         description: 'Return the restaurants open by the category',
         resolverOf: 'application::restaurant.restaurant.findByCategories', // Will apply the same policy on the custom resolver as the controller's action `findByCategories`.
-        resolver: async (obj, options, ctx) => {
-          // ctx is the context of the Koa request.
-          await strapi.controllers.restaurants.findByCategories(ctx);
+        resolver: async (obj, options, { context }) => {
+          // context is the context of the Koa request.
+          await strapi.controllers.restaurants.findByCategories(context);
 
-          return ctx.body.restaurants || `There is no restaurant.`;
+          return context.body.restaurants || `There is no restaurant.`;
         },
       },
     },
@@ -865,7 +865,7 @@ module.exports = {
       restaurants: {
         description: 'Return a list of restaurants by chef',
         resolverOf: 'application::restaurant.restaurant.find', // Will apply the same policy on the custom resolver as the controller's action `find` located in `Restaurant.js`.
-        resolver: (obj, options, context) => {
+        resolver: (obj, options, { context }) => {
           // You can return a raw JSON object or a promise.
 
           return [


### PR DESCRIPTION
Fixed method signature for the resolver example: `async (..., { context })` instead of `async (..., context)`

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

Fixed typos in method signatures for the resolvers

### Why is it needed?

Examples weren't working correctly with the given code snippet

### State

PR is ready to be merged.
