### PR TITLE
Renamed variable HEROKU_URL to MY_HEROKU_URL

### DIFF
--- a/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/heroku.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/heroku.md
@@ -251,14 +251,14 @@ Create a new `server.js` in a new [env](/developer-docs/latest/setup-deployment-
 
 ```js
 module.exports = ({ env }) => ({
-  url: env('HEROKU_URL'),
+  url: env('MY_HEROKU_URL'),
 });
 ```
 
-You will also need to set the environment variable in Heroku for the `HEROKU_URL`. This will populate the variable with something like `https://your-app.herokuapp.com`.
+You will also need to set the environment variable in Heroku for the `MY_HEROKU_URL`. This will populate the variable with something like `https://your-app.herokuapp.com`.
 
 ```bash
-heroku config:set HEROKU_URL=$(heroku info -s | grep web_url | cut -d= -f2)
+heroku config:set MY_HEROKU_URL=$(heroku info -s | grep web_url | cut -d= -f2)
 ```
 
 #### 6. Install the `pg` node module


### PR DESCRIPTION
The variable HEROKU_URL also works but is provoking a disturbing warning when being set with heroku config:set ...
```
Warning: The "HEROKU_" namespace is protected and shouldn't be used.
```

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

Change the Heroku variable name to prevent collision with Heroku protected name prefix  "HEROKU_".

### Why is it needed?

Not to confuse the user with a warning.

### Related issue(s)/PR(s)

None that I know.
