### PR TITLE
fix(configurations): fix ssl configuration for postgres

### DIFF
--- a/docs/developer-docs/latest/setup-deployment-guides/configurations.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/configurations.md
@@ -114,11 +114,6 @@ module.exports = ({ env }) => ({
         username: env('DATABASE_USERNAME', 'strapi'),
         password: env('DATABASE_PASSWORD', 'strapi'),
         schema: env('DATABASE_SCHEMA', 'public'), // Not Required
-        ssl: {
-          rejectUnauthorized: env.bool('DATABASE_SSL_SELF', false), // For self-signed certificates
-        },
-      },
-      options: {
         ssl: env.bool('DATABASE_SSL', false),
       },
     },

--- a/docs/developer-docs/latest/setup-deployment-guides/configurations.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/configurations.md
@@ -96,9 +96,9 @@ You can find [supported database and versions](/developer-docs/latest/setup-depl
 
 ::::
 
-:::: tabs
+::::: tabs
 
-::: tab PostgreSQL
+:::: tab PostgreSQL
 
 ```js
 module.exports = ({ env }) => ({
@@ -118,10 +118,32 @@ module.exports = ({ env }) => ({
           rejectUnauthorized: env.bool('DATABASE_SSL_SELF', false), // For self-signed certificates
         },
       },
+      options: {},
     },
   },
 });
 ```
+
+::: warning
+We are aware that there is an issue regarding **SSL support for the server**.
+In order to fix it, you have to to set the `ssl:{}` object as a boolean in order to disable it. See below for example:
+```js
+module.exports = ({ env }) => ({
+  defaultConnection: 'default',
+  connections: {
+    default: {
+      connector: 'bookshelf',
+      settings: {
+        client: 'postgres',
+          ...
+        ssl: env('DATABASE_SSL', false)
+      },
+      options: {},
+    },
+  },
+});
+```
+:::
 
 Please note that if you need client side SSL CA verification you will need to use the `ssl:{}` object with the fs module to convert your CA certificate to a string. You can see an example below:
 
@@ -138,14 +160,15 @@ module.exports = ({ env }) => ({
           ca: fs.readFileSync(`${__dirname}/path/to/your/ca-certificate.crt`).toString(),
         },
       },
+      options: {},
     },
   },
 });
 ```
 
-:::
+::::
 
-::: tab MySQL/MariaDB
+:::: tab MySQL/MariaDB
 
 ```js
 module.exports = ({ env }) => ({
@@ -167,9 +190,9 @@ module.exports = ({ env }) => ({
 });
 ```
 
-:::
+::::
 
-::: tab SQLite
+:::: tab SQLite
 
 ```js
 module.exports = ({ env }) => ({
@@ -189,9 +212,9 @@ module.exports = ({ env }) => ({
 });
 ```
 
-:::
+::::
 
-::: tab MongoDB
+:::: tab MongoDB
 
 ```js
 module.exports = ({ env }) => ({
@@ -216,9 +239,9 @@ module.exports = ({ env }) => ({
 });
 ```
 
-:::
-
 ::::
+
+:::::
 
 ::: tip
 Take a look at the [database's guide](/developer-docs/latest/setup-deployment-guides/configurations.md#databases-installation-guides) for more details.

--- a/docs/developer-docs/latest/setup-deployment-guides/configurations.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/configurations.md
@@ -114,7 +114,9 @@ module.exports = ({ env }) => ({
         username: env('DATABASE_USERNAME', 'strapi'),
         password: env('DATABASE_PASSWORD', 'strapi'),
         schema: env('DATABASE_SCHEMA', 'public'), // Not Required
-        ssl: env.bool('DATABASE_SSL', false),
+        ssl: {
+          rejectUnauthorized: env.bool('DATABASE_SSL_SELF', false), // For self-signed certificates
+        },
       },
     },
   },
@@ -135,9 +137,6 @@ module.exports = ({ env }) => ({
         ssl: {
           ca: fs.readFileSync(`${__dirname}/path/to/your/ca-certificate.crt`).toString(),
         },
-      },
-      options: {
-        ssl: true
       },
     },
   },


### PR DESCRIPTION
### What does it do?

It change the default configuration example for PostgreSQL database since it's wrong regarding SSL

### Why is it needed?

Lot of people were in trouble trying to make strapi works with PostgreSQL on several Hosting platform (Qovery/Heroku...)
The default configuration was not right regarding the SSL configuration for knex

### Related issue(s)/PR(s)

#281 
