### PR TITLE
More appropriate async-await example

### DIFF
--- a/docs/developer-docs/latest/guides/scheduled-publication.md
+++ b/docs/developer-docs/latest/guides/scheduled-publication.md
@@ -66,12 +66,12 @@ module.exports = {
     });
 
     // update published_at of articles
-    draftArticleToPublish.forEach(async article => {
-      await strapi.api.article.services.article.update(
+    await Promise.all(draftArticleToPublish.map(article => {
+      return strapi.api.article.services.article.update(
         { id: article.id },
         { published_at: new Date() }
       );
-    });
+    }));
   },
 };
 ```


### PR DESCRIPTION
The previous implementation works but in my opinion that is more appropriate. It's a common misconception when we have a forEach method with async-await, so we could fix that with a better example.
