### PR TITLE
Remove "/" in when setting env variable for url

### DIFF
--- a/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/heroku.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/heroku.md
@@ -255,7 +255,7 @@ module.exports = ({ env }) => ({
 });
 ```
 
-You will also need to set the environment variable in Heroku for the `MY_HEROKU_URL`. This will populate the variable with something like `https://your-app.herokuapp.com`.
+You will also need to set the environment variable in Heroku for the `MY_HEROKU_URL`. This will populate the variable with something like `www.your-app.herokuapp.com`.
 
 ```bash
 heroku config:set MY_HEROKU_URL=$(heroku info -s | grep web_url | cut -d= -f2)


### PR DESCRIPTION
The variable cannot contain the slash character. It will give you the error message "Name is invalid". The way to fix this is to change the url from:
https://your-app.herokuapp.com
to:
www.your-app.herokuapp.com

