### PR TITLE
Update gatsby-source-plugin guide for v1.0.0

### DIFF
--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/gatsby.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/gatsby.md
@@ -32,7 +32,7 @@ yarn add gatsby-source-strapi
   resolve: "gatsby-source-strapi",
   options: {
     apiURL: "http://localhost:1337",
-    contentTypes: [
+    collectionTypes: [
       "restaurant",
       "category",
     ],


### PR DESCRIPTION
### What does it do?

contentTypes was renamed to collectionTypes in the Gatsby example

### Why is it needed?

Because gatsby-source-strapi v1.0.0 includes this as a breaking change

Let's wait for the release to be done before we merge this :)
