### PR TITLE
fix: can't find property name with dot notation

### DIFF
--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/angular.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/angular.md
@@ -209,7 +209,7 @@ export class AppComponent implements OnInit {
 </div>
 
 <ul>
-  <li *ngFor="let restaurant of restaurants">{{ restaurant.name }}</li>
+  <li *ngFor="let restaurant of restaurants">{{ restaurant['name'] }}</li>
 </ul>
 ```
 


### PR DESCRIPTION

### What does it do?

changing way of accessing the property
### Why is it needed?

While trying out the docs we ran into the issue, that restaurant.name was not found

### Related issue(s)/PR(s)

none
