### PR TITLE
Add temp workaround for legacy domain

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -131,9 +131,9 @@ const sidebar = {
             ['/developer-docs/latest/development/plugins/documentation', 'API Documentation'],
             ['/developer-docs/latest/development/plugins/email', 'Email'],
             ['/developer-docs/latest/development/plugins/graphql', 'GraphQL'],
-['/developer-docs/latest/development/plugins/i18n', 'Internationalization (i18n)'],
+            ['/developer-docs/latest/development/plugins/i18n', 'Internationalization (i18n)'],
             ['/developer-docs/latest/development/plugins/upload', 'Upload'],
-            ['/developer-docs/latest/development/plugins/users-permissions', 'Users & Permissions']
+            ['/developer-docs/latest/development/plugins/users-permissions', 'Users & Permissions'],
           ],
           sidebarDepth: 1,
         },
@@ -327,18 +327,12 @@ const sidebar = {
       collapsable: false,
       title: 'Plugins',
       children: [
-        [
-          '/user-docs/latest/plugins/introduction-to-plugins',
-          'Introduction to plugins',
-        ],
+        ['/user-docs/latest/plugins/introduction-to-plugins', 'Introduction to plugins'],
         [
           '/user-docs/latest/plugins/installing-plugins-via-marketplace',
           'Installing plugins via the Marketplace',
         ],
-        [
-          '/user-docs/latest/plugins/strapi-plugins',
-          'List of Strapi plugins',
-        ],
+        ['/user-docs/latest/plugins/strapi-plugins', 'List of Strapi plugins'],
       ],
     },
     {
@@ -370,11 +364,19 @@ const checklinksIgnoredFiles = [
   './developer-docs/latest/update-migration-guides/migration-guides/migration-guide-beta.20-to-3.0.0.md', // line 93
 ];
 
+const checkLegacy = () => {
+  if (process.env.NODE_ENV == 'legacy') {
+    return '/documentation/';
+  } else {
+    return '/';
+  }
+};
+
 module.exports = {
   title: '',
   port: 8080,
   description: 'The headless CMS developers love.',
-  base: '/documentation/',
+  base: checkLegacy(),
   plugins: {
     '@vuepress/medium-zoom': {},
     'vuepress-plugin-element-tabs': {},

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,5 @@
 ---
 meta:
-    - http-equiv: refresh
-      content: 0;url=/documentation/developer-docs/latest/getting-started/introduction.html
+  - http-equiv: refresh
+    content: 0;url=https://strapi.io/resource-center
 ---


### PR DESCRIPTION
Adds a function that checks for node_env and if it's legacy it sets the base key to `/documentation/` else it just sets the base to the vuepress default `/`

Also added a replacement for the landing meta-refresh

---

@pwizla / @Mcastres The new landing meta-refresh might make testing locally a lot harder as the vuepress default link it provides in the terminal when you use `yarn dev` is the base link; meaning when you click it locally you are going to be redirected to the resource center.

We have a few choices here:

- We create a simple landing page (which would make @Mcastres happy since it gets rid of the legacy meta-refresh)
- We modify whatever core vuepress package that provides that link and inject some different ones (this is the most complex as I have no idea where it comes from, probably webpack)
- We keep the existing meta-refresh but that will make it impossible to deploy in one of the two "versions"


The issue here and why all the vercel links are broken right now unless you are on a specific set of branches is because of that `base` key. Right now we have to set the base as `/documentation/` because we are using the https://strapi.io/documentation but with the new URL structure https://docs.strapi.io/ there is no suffix so the base is just simply `/`

---

I've set this as a draft til we figure out what we want to do or unless someone can find a hacky way to read the `NODE_ENV` in the landing `README.md` file and adjust the meta-refresh link.