### PR TITLE
Change decrypted to decoded

### DIFF
--- a/docs/developer-docs/latest/guides/api-token.md
+++ b/docs/developer-docs/latest/guides/api-token.md
@@ -80,12 +80,12 @@ module.exports = async (ctx, next) => {
         delete ctx.request.query.token;
       } else if (ctx.request && ctx.request.header && ctx.request.header.authorization) {
         // use the current system with JWT in the header
-        const decrypted = await strapi.plugins[
+        const decoded = await strapi.plugins[
           'users-permissions'
         ].services.jwt.getToken(ctx);
 
-        id = decrypted.id;
-        isAdmin = decrypted.isAdmin || false;
+        id = decoded.id;
+        isAdmin = decoded.isAdmin || false;
       }
 
       // this is the line that already exist in the code


### PR DESCRIPTION
### What does it do?

The word decrypted gives the sense of this token to be encrypted, but in reality it is only encoded, not encrypted. Changing the wording to avoid confusion

### Why is it needed?

As above

Describe the issue you are solving.

As above

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
