### PR TITLE
Update test documentation

### DIFF
--- a/docs/developer-docs/latest/guides/unit-testing.md
+++ b/docs/developer-docs/latest/guides/unit-testing.md
@@ -143,13 +143,12 @@ const fs = require('fs');
 const { setupStrapi } = require('./helpers/strapi');
 
 /** this code is called once before any test is called */
-beforeAll(async done => {
+beforeAll(async () => {
   await setupStrapi(); // singleton so it can be called many times
-  done();
 });
 
 /** this code is called once before all the tested are finished */
-afterAll(async done => {
+afterAll(async () => {
   const dbSettings = strapi.config.get('database.connections.default.settings');
   
   //close server to release the db-file
@@ -162,7 +161,6 @@ afterAll(async done => {
       fs.unlinkSync(tmpDbFile);
     }
   }
-  done();
 });
 
 it('strapi is defined', () => {
@@ -206,14 +204,13 @@ Let's create a separate test file where `supertest` will be used to check if end
 ```js
 const request = require('supertest');
 
-it('should return hello world', async done => {
+it('should return hello world', async () => {
   await request(strapi.server) // app server is an instance of Class: http.Server
     .get('/hello')
     .expect(200) // Expect response http code 200
     .then(data => {
       expect(data.text).toBe('Hello World!'); // expect the response text
     });
-  done();
 });
 ```
 
@@ -242,6 +239,8 @@ Ran all test suites.
 ✨  Done in 9.09s.
 ```
 
+> Note: if you receive an error `Jest has detected the following 1 open handles potentially keeping Jest from exiting` check `jest` version as `26.6.3` works without an issue.
+
 ### Testing `auth` endpoint controller.
 
 In this scenario we'll test authentication login endpoint with two tests
@@ -264,7 +263,7 @@ const mockUserData = {
   blocked: null,
 };
 
-it('should login user and return jwt token', async done => {
+it('should login user and return jwt token', async () => {
   /** Creates a new user and save it to the database */
   await strapi.plugins['users-permissions'].services.user.add({
     ...mockUserData,
@@ -283,11 +282,9 @@ it('should login user and return jwt token', async done => {
     .then(data => {
       expect(data.body.jwt).toBeDefined();
     });
-
-  done();
 });
 
-it('should return users data for authenticated user', async done => {
+it('should return users data for authenticated user', async () => {
   /** Gets the default user role */
   const defaultRole = await strapi.query('role', 'users-permissions').findOne({}, []);
 
@@ -318,8 +315,6 @@ it('should return users data for authenticated user', async done => {
       expect(data.body.username).toBe(user.username);
       expect(data.body.email).toBe(user.email);
     });
-
-  done();
 });
 ```
 


### PR DESCRIPTION
### What does it do?

Update test code snippets to work with latest test libraries versions.
```
    Test functions cannot both take a 'done' callback and return something. Either use a 'done' callback, or return a promise.
    Returned value: Promise {}

      3 |
      4 | /** this code is called once before any test is called */
    > 5 | beforeAll(async done => {
        | ^
      6 |   await setupStrapi(); // singleton so it can be called many times
      7 |   done();
      8 | });
```
After updating code snippets those errors are gone.

I also added comment which helps to resolve issue with latest release of `jest` library. This is an error which I was getting when working with `jest` version `27.x`
```
Jest has detected the following 3 open handles potentially keeping Jest from exiting
```
Also does not appear when using previous major release.

### Why is it needed?

Maintain documentation quality and provide useful hints for users.

### Related issue(s)/PR(s)

N/A
