### PR TITLE
Add the ability to insert re-usable snippets into Markdown files

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -637,4 +637,10 @@ module.exports = {
       '/user-docs/latest/': sidebar.user,
     },
   },
+  markdown: {
+    extendMarkdown: md => {
+      // use more markdown-it plugins!
+      md.use(require('markdown-it-include'))
+    }
+  }
 };

--- a/docs/developer-docs/latest/setup-deployment-guides/configurations/databases/mongodb.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/configurations/databases/mongodb.md
@@ -5,8 +5,8 @@ description: Learn how to install MongoDB on your computer and using it for your
 
 # MongoDB Installation
 
-::: warning WARNING
-Starting from the release of Strapi v4, MongoDB is not supported natively anymore and no connector is available. For more information, please refer to [the official communication on the topic](https://strapi.io/blog/mongo-db-support-in-strapi-past-present-and-future).
+::: warning
+!!!include(developer-docs/latest/snippets/mongodb-warning.md)!!!
 :::
 
 ## Install MongoDB locally

--- a/docs/developer-docs/latest/setup-deployment-guides/installation/cli.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/installation/cli.md
@@ -56,9 +56,7 @@ The CLI installation guide requires at least two software prerequisites to be al
 
 A database is also required for any Strapi project. Strapi currently supports the following databases:
 
-::: warning WARNING
-Starting from the release of Strapi v4, MongoDB is not supported natively anymore and no connector is available. For more information, please refer to [the official communication on the topic](https://strapi.io/blog/mongo-db-support-in-strapi-past-present-and-future).
-:::
+!!!include(developer-docs/latest/snippets/mongodb-warning.md)!!!
 
 | Database   | Minimum version |
 | ---------- | --------------- |

--- a/docs/developer-docs/latest/setup-deployment-guides/installation/docker.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/installation/docker.md
@@ -70,9 +70,8 @@ You can find the official Docker image for Strapi in the [Docker Hub](https://hu
 
     :::: tab MongoDB
 
-
-      ::: warning WARNING
-      Starting from the release of Strapi v4, MongoDB is not supported natively anymore and no connector is available. For more information, please refer to [the official communication on the topic](https://strapi.io/blog/mongo-db-support-in-strapi-past-present-and-future).
+      ::: warning
+      !!!include(developer-docs/latest/snippets/mongodb-warning.md)!!!
       :::
 
     ```yaml

--- a/docs/developer-docs/latest/snippets/mongodb-warning.md
+++ b/docs/developer-docs/latest/snippets/mongodb-warning.md
@@ -1,0 +1,2 @@
+<!-- The ::: warning markup is not included as it causes some render issues within tabs -->
+Starting from the release of Strapi v4, MongoDB is not supported natively anymore and no connector is available. For more information, please refer to [the official communication on the topic](https://strapi.io/blog/mongo-db-support-in-strapi-past-present-and-future).

--- a/docs/package.json
+++ b/docs/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@vuepress/plugin-google-analytics": "^1.7.1",
     "@vuepress/plugin-medium-zoom": "^1.7.1",
+    "markdown-it-include": "^2.0.0",
     "vuepress": "^1.7.1",
     "vuepress-plugin-code-copy": "^1.0.6",
     "vuepress-plugin-element-tabs": "^0.2.8",

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -5079,6 +5079,11 @@ markdown-it-emoji@^1.4.0:
   resolved "https://registry.yarnpkg.com/markdown-it-emoji/-/markdown-it-emoji-1.4.0.tgz#9bee0e9a990a963ba96df6980c4fddb05dfb4dcc"
   integrity sha1-m+4OmpkKljupbfaYDE/dsF37Tcw=
 
+markdown-it-include@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/markdown-it-include/-/markdown-it-include-2.0.0.tgz#e86e3b3c68c8f0e0437e179ba919ffd28443127a"
+  integrity sha512-wfgIX92ZEYahYWiCk6Jx36XmHvAimeHN420csOWgfyZjpf171Y0xREqZWcm/Rwjzyd0RLYryY+cbNmrkYW2MDw==
+
 markdown-it-table-of-contents@^0.4.0:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/markdown-it-table-of-contents/-/markdown-it-table-of-contents-0.4.4.tgz#3dc7ce8b8fc17e5981c77cc398d1782319f37fbc"


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

* Adds the [markdown-it-include](https://www.npmjs.com/package/markdown-it-include) package and configures it
* Creates a `snippets` folder in `developer-docs` to store snippet files
* Use the MongoDB warning as an example to insert the same content in several files

### Why is it needed?

To keep things [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) 🙂 

***

### Notes

Its usage is documented [in Notion](https://www.notion.so/strapi/VuePress-snippets-01126d2a9af1410baa2ed90b7aabe13d) and we'll make it public once we update the contributing guide.