### PR TITLE
fix: url on email-templates

### DIFF
--- a/docs/developer-docs/latest/development/plugins/email.md
+++ b/docs/developer-docs/latest/development/plugins/email.md
@@ -139,7 +139,7 @@ Only one email provider will be active at all time. If the email provider settin
 
 ::: tip
 When testing the new email provider with those two email templates created during strapi setup, the _shipper email_ on the template, with default no-reply@strapi.io need to be updated in according to your email provider, otherwise it will fail the test.
-More info here: [Configure templates Locally](http://localhost:1337/admin/plugins/users-permissions/email-templates)
+More info here: [Configure templates Locally](/user-docs/latest/settings/configuring-users-permissions-plugin-settings.html#configuring-email-templates)
 :::
 
 ## Create new provider


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

Fix url on email plugins "More info here: Configure templates Locally"

### Why is it needed?

a bit misleading for localhost url when visiting the site

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
