### PR TITLE
Update backend-customization.md

### DIFF
--- a/docs/developer-docs/latest/development/backend-customization.md
+++ b/docs/developer-docs/latest/development/backend-customization.md
@@ -981,13 +981,15 @@ module.exports = {
    *
    * @return {Promise}
    */
-  async find(populate) {
-    const results = await strapi.query('restaurant').find({ _limit: 1 }, populate);
+  async find(params, populate) {
+    const results = await strapi.query('restaurant').find({ ...params, _limit: 1 }, populate);
     return _.first(results) || null;
   },
 };
 ```
 
+- `params` (object): this represent filters for your find request.<br>
+  The object follow the URL query format, [refer to this documentation.](/developer-docs/latest/developer-resources/content-api/content-api.md#api-parameters).
 - `populate` (array): you have to mention data you want populate `["author", "author.name", "comment", "comment.content"]`
 
 :::


### PR DESCRIPTION
### What does it do?

Update the single-type `find` service example, as it wasn't correct.

### Why is it needed?

To allow correct custom populating of a single-type request.
Looking at this code the function still has an `params` parameter as like the collection type `find` service : 

https://github.com/strapi/strapi/blob/df832fafd1705266d65bae22d8dd3a0fe37964cf/packages/strapi/lib/services/entity-service.js#L68-L71

