### PR TITLE
fix typo isAuthenticated for plugin

### DIFF
--- a/docs/developer-docs/latest/development/backend-customization.md
+++ b/docs/developer-docs/latest/development/backend-customization.md
@@ -198,14 +198,14 @@ Plugins can add and expose policies into your app. For example, the plugin **Use
       "path": "/restaurants",
       "handler": "Restaurant.find",
       "config": {
-        "policies": ["plugins::users-permissions.is-authenticated"]
+        "policies": ["plugins::users-permissions.isAuthenticated"]
       }
     }
   ]
 }
 ```
 
-The policy `is-authenticated` located in the `users-permissions` plugin will be executed before the `find` action in the `Restaurant.js` controller.
+The policy `isAuthenticated` located in the `users-permissions` plugin will be executed before the `find` action in the `Restaurant.js` controller.
 
 #### API policies
 


### PR DESCRIPTION
### What does it do?

The file is named `isAuthenticated.js`, so it should be ``plugins::users-permissions.isAuthenticated``, see https://github.com/strapi/strapi/tree/master/packages/strapi-plugin-users-permissions/config/policies

### Why is it needed?

copy/paste of current code in documentation will fail:
````
Error creating endpoint: Could not find policy "plugins::users-permissions.is-authenticated"
````

### Related issue(s)/PR(s)

n/a
