### PR TITLE
yarn install dependencies on both plugin and root directories

### DIFF
--- a/docs/developer-docs/latest/guides/registering-a-field-in-admin.md
+++ b/docs/developer-docs/latest/guides/registering-a-field-in-admin.md
@@ -81,6 +81,8 @@ strapi generate:plugin wysiwyg
 ```
 cd plugins/wysiwyg
 yarn add @ckeditor/ckeditor5-react @ckeditor/ckeditor5-build-classic
+cd ../
+yarn add @ckeditor/ckeditor5-react @ckeditor/ckeditor5-build-classic
 ```
 
 :::
@@ -89,7 +91,9 @@ yarn add @ckeditor/ckeditor5-react @ckeditor/ckeditor5-build-classic
 
 ```
 cd plugins/wysiwyg
-npm install @ckeditor/ckeditor5-react @ckeditor/ckeditor5-build-classic
+yarn add @ckeditor/ckeditor5-react @ckeditor/ckeditor5-build-classic
+cd ../
+yarn add @ckeditor/ckeditor5-react @ckeditor/ckeditor5-build-classic
 ```
 
 :::


### PR DESCRIPTION
I was getting a build error in Heroku when following the instructions and deploying. Heroku showed me that it did not find the dependency `import { CKEditor } from '@ckeditor/ckeditor5-react'; ` in `components/CKEditor/index.js`

After `yarn add @ckeditor/ckeditor5-react @ckeditor/ckeditor5-build-classic` in Root I was able to successfully deploy

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

Describe the technical changes you did.
Just updated the readme to install dependencies on both plugins and root directories following Heroku deployment error

### Why is it needed?

Describe the issue you are solving.
following [https://strapi.io/documentation/developer-docs/latest/guides/registering-a-field-in-admin.html#setup](this tutorial) ad being able to deploy on heroku

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
