### PR TITLE
Fix broken feature request link in DO notice

### DIFF
--- a/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/digitalocean-app-platform.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/digitalocean-app-platform.md
@@ -8,7 +8,7 @@ description: Learn in this guide how to deploy your Strapi application on Digita
 This is a step-by-step guide for deploying a Strapi project to [DigitalOcean's App Platform](https://digitalocean.com). App Platform is DigitalOcean's Platform as a Service (PaaS) that will handle deploying, networking, SSL, and more for your app. It is the easiest way to deploy Strapi to DigitalOcean.
 
 ::: warning
-Please note that as of June 18th, 2021 we were made aware that there is a critical security issue when using DigitalOcean Managed databases with the DigitalOcean App platform. We do not currently recommend using this combination and if you require a managed database, you should use a DigitalOcean Droplet instead. More information can be found on the DigitalOcean [forum thread](https://www.digitalocean.com/community/questions/how-to-add-my-digitalocean-app-as-a-trusted-resource-for-my-managed-database) and [feature request](https://ideas.digitalocean.com/ideas/APPX-I-73) pages.
+Please note that as of June 18th, 2021 we were made aware that there is a critical security issue when using DigitalOcean Managed databases with the DigitalOcean App platform. We do not currently recommend using this combination and if you require a managed database, you should use a DigitalOcean Droplet instead. More information can be found on the DigitalOcean [forum thread](https://www.digitalocean.com/community/questions/how-to-add-my-digitalocean-app-as-a-trusted-resource-for-my-managed-database) and [feature request](https://ideas.digitalocean.com/app-framework-services/p/allow-managed-databases-trusted-sources-to-be-used-with-app-platform) pages.
 :::
 
 Databases can be created using DigitalOcean's [Managed Databases](https://www.digitalocean.com/products/managed-databases/).


### PR DESCRIPTION
### What does it do?

Fixes a broken link to DO's feature request, it appears they changed to using Canny.io instead of whatever they were on before.

### Why is it needed?

Broken link

### Related issue(s)/PR(s)

N/A
