### PR TITLE
Add a local node script for legacy

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -3,7 +3,8 @@
   "version": "3.0.0",
   "main": "index.js",
   "scripts": {
-    "dev": "vuepress dev",
+    "dev": "DEPLOY_ENV=legacy vuepress dev",
+    "dev:prod": "vuepress dev",
     "build": "vuepress build",
     "check-links": "vuepress check-md"
   },


### PR DESCRIPTION
Makes the main `yarn dev` command use the `DEPLOY_ENV=legacy` variable