### PR TITLE
Removed Slack from the Navbar Community dropdown

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -48,8 +48,7 @@ const sidebar = {
           children: [
             {
               title: 'Hosting Provider Guides',
-              path:
-                '/developer-docs/latest/setup-deployment-guides/deployment.html#hosting-provider-guides',
+              path: '/developer-docs/latest/setup-deployment-guides/deployment.html#hosting-provider-guides',
               collapsable: true,
               children: [
                 [
@@ -93,8 +92,7 @@ const sidebar = {
             },
             {
               title: 'Optional Software Guides',
-              path:
-                '/developer-docs/latest/setup-deployment-guides/deployment.html#optional-software-guides',
+              path: '/developer-docs/latest/setup-deployment-guides/deployment.html#optional-software-guides',
               collapsable: true,
               children: [
                 [
@@ -401,7 +399,7 @@ module.exports = {
     },
     seo: {
       siteTitle: (_, $site) => $site.title,
-      title: $page => $page.title,
+      title: ($page) => $page.title,
     },
     'vuepress-plugin-code-copy': {
       color: '#ffffff',
@@ -556,13 +554,11 @@ module.exports = {
               },
               {
                 text: 'Content-Types Builder',
-                link:
-                  '/user-docs/latest/content-types-builder/introduction-to-content-types-builder.html',
+                link: '/user-docs/latest/content-types-builder/introduction-to-content-types-builder.html',
               },
               {
                 text: 'Users, Roles, and Permissions',
-                link:
-                  '/user-docs/latest/users-roles-permissions/introduction-to-users-roles-permissions.html',
+                link: '/user-docs/latest/users-roles-permissions/introduction-to-users-roles-permissions.html',
               },
               {
                 text: 'Plugins',
@@ -604,8 +600,8 @@ module.exports = {
                 link: 'https://forum.strapi.io',
               },
               {
-                text: 'Slack',
-                link: 'https://slack.strapi.io',
+                text: 'Discord',
+                link: 'https://discord.strapi.io',
               },
               {
                 text: 'Awesome-Strapi',


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

This PR removes the 'Slack' link from the community tab on the nav bar.

### Why is it needed?

To continue redirecting users to the active community and not the discontinued Slack one.
