### PR TITLE
Fix next landing page meta refresh

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,5 @@
 ---
 meta:
   - http-equiv: refresh
-    content: 0;url=/documentation/developer-docs/latest/getting-started/introduction.html
+    content: 0;url=/developer-docs/latest/getting-started/introduction.html
 ---


### PR DESCRIPTION
Removes the /documentation path from the main landing readme.md for the meta-refresh