### PR TITLE
Add warning to set JWT secret key for production.

### DIFF
--- a/docs/developer-docs/latest/setup-deployment-guides/deployment.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment.md
@@ -78,6 +78,9 @@ Then you can create a `.env` file or directly use the deployment platform you us
 
 **Path —** `.env`.
 
+::: danger When deploying to production please ensure you set your JWT secret in your ENV. Read more [here](https://strapi.io/documentation/developer-docs/latest/setup-deployment-guides/configurations.html#server)
+:::
+
 ```
 APP_HOST=10.0.0.1
 NODE_PORT=1338


### PR DESCRIPTION
On our first deploy of Strapi we didn't realize we had to set this. I guess we assumed it was in the DB or something. Just wanted to add this note in order to help make more production environments secure

### What does it do?

Doc Update

### Why is it needed?

Help with security

### Related issue(s)/PR(s)

None
