### PR TITLE
Highlight active tab in blue (instead of default VuePress green)

### DIFF
--- a/docs/.vuepress/styles/strapi-custom-blocks.styl
+++ b/docs/.vuepress/styles/strapi-custom-blocks.styl
@@ -1,3 +1,6 @@
+.el-tabs__active-bar
+  background-color: #007eff !important
+
 .custom-block
   /**
    * CALLOUTS


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

Just make the active tab highlighting blue instead of the default VuePress green color :-) 
![Screenshot 2021-08-25 at 17 04 01](https://user-images.githubusercontent.com/4233866/130816705-171eaeea-084d-4219-90df-ac67656364a5.png)


### Why is it needed?

Because [blue](https://www.youtube.com/watch?v=8vBKI3ya-l0) is cool 😄 
