### PR TITLE
Remove breaking markdown on laravel page

### DIFF
--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/11ty.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/11ty.md
@@ -314,6 +314,8 @@ module.exports = async () => {
 ```
 :::
 
+::::
+
 ### Example
 
 `./src/_data/categories.js`

--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/angular.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/angular.md
@@ -604,7 +604,7 @@ fetch('http://localhost:1337/restaurants/2', {
   ]
 }
 ```
-
+:::
 
 ## Starter
 

--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/gridsome.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/gridsome.md
@@ -168,6 +168,8 @@ query {
 ```
 :::
 
+::::
+
 ### Example
 
 `./src/pages/Index.vue`

--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/laravel.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/laravel.md
@@ -32,7 +32,6 @@ Execute a `GET` request on the `restaurant` Collection Type in order to fetch al
 
 Be sure that you activated the `find` permission for the `restaurant` Collection Type.
 
-:::: api-call
 ::: request Example GET request
 
 ```php


### PR DESCRIPTION
There was a line that broke the layout of the entire page, making everything after the tag be placed inline. By removing this it will all be normal and readable again.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

It removes an unclosed block in order to fix the layout of the laravel page.

### Why is it needed?

On production it currently looks like this:
![image](https://user-images.githubusercontent.com/1311371/131158065-f77a16d5-9a1d-41b6-8cba-5c92c779f5d5.png)


### Related issue(s)/PR(s)

N.a.
