### PR TITLE
Use a nodejs version supported by Strapi

### DIFF
--- a/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/google-app-engine.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/google-app-engine.md
@@ -105,7 +105,7 @@ The following is an example config for `Standard Environment` or `Flexible Envir
 ::: tab Standard Environment
 
 ```yaml
-runtime: nodejs10
+runtime: nodejs14
 
 instance_class: F2
 


### PR DESCRIPTION
Node v10 is not supported anymore. See https://strapi.io/documentation/developer-docs/latest/setup-deployment-guides/deployment.html

Use Node v14 in Standard Environment. See https://cloud.google.com/appengine/docs/standard/nodejs/runtime#node.js-14

Note about Flexible Environment: It will derive the right Node version from package.json. See https://cloud.google.com/appengine/docs/flexible/nodejs/runtime
