### PR TITLE
[Bug] Subtle grammar correction in documentation

### DIFF
--- a/docs/developer-docs/latest/development/backend-customization.md
+++ b/docs/developer-docs/latest/development/backend-customization.md
@@ -2171,7 +2171,7 @@ An `Image` model might belong to many `Article` models or `Product` models.
 
 ### Components
 
-Component fields let your create a relation between your Content Type and a Component structure.
+Component fields let you create a relation between your Content Type and a Component structure.
 
 ##### Example
 


### PR DESCRIPTION
Link to docs https://strapi.io/documentation/developer-docs/latest/development/backend-customization.html#components

### Describe the bug

"Component fields let your create a relation between your Content Type and a Component structure."

### Suggested improvements or fixes

should say:

"Component fields let you create a relation between your Content Type and a Component structure."

