### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Strapi is a free and open-source headless CMS delivering your content anywhere y
 
 The following are required if you are submitting pull requests to the documentation. For more information on how to contribute please see our [contribution guide](./CONTRIBUTING.md)
 
-- NodeJS >= 10.16 <=12
+- NodeJS >=12.x <=14.x
 - NPM >= 6.x
 - Yarn >= 1.22.x
 


### PR DESCRIPTION
Update Node version: https://strapi.io/documentation/developer-docs/latest/setup-deployment-guides/installation/cli.html#preparing-the-installation
`Node.js: only LTS versions are supported (version 12.x minimum). Other versions of Node.js may not be compatible with the latest release of Strapi. The 14.x version is most recommended by Strapi.`
