### PR TITLE
Update amazon-aws.md

### DIFF
--- a/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/amazon-aws.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/amazon-aws.md
@@ -105,7 +105,14 @@ In the top menu, near your IAM Account User name, select, from the dropdown, the
     :::
   - After downloading the file, click the blue `Launch Instances` button.
 
-Your instance is now running. Continue to the next steps.
+Your instance is now running. 
+
+Before we continue, we need to add `default` security group to the EC2 instance we've just created.
+- Click on **Instances** in the left hand pane.
+- Select your new instance in the list and click on the **Actions** dropdown in the top right corner > **Security** > **Change security groups**.
+- Under **Associated security groups** search for "default" and click `Add security group` and then `Save`
+
+Continue to the next steps.
 
 ### Install a PostgreSQL database on AWS RDS
 
@@ -641,7 +648,7 @@ After=network.target
 Environment=PATH=/PASTE-PATH_HERE #path from echo $PATH (as above)
 Type=simple
 User=ubuntu #replace with your name, if changed from default ubuntu user
-ExecStart=/usr/bin/nodejs /home/ubuntu/NodeWebHooks/webhook.js #replace with your name, if changed from default ubuntu user
+ExecStart=/usr/bin/node /home/ubuntu/NodeWebHooks/webhook.js #replace with your name, if changed from default ubuntu user
 Restart=on-failure
 
 [Install]


### PR DESCRIPTION
### What does it do?

Updates the documentation for AWS deployment.

### Why is it needed?

1. The node package installed on ubuntu is no longer called `nodejs` - just `node`.
![Screenshot 2021-10-02 at 11 07 24](https://user-images.githubusercontent.com/52371939/135711431-94f4bc05-375f-43d2-a5dc-b816db5e92b3.png)

2. Creating a custom security group will leave out `default` thus isolating the EC2 from the RDS. Therefore we need to add a step to add the `default` security group as well to the EC2 instance.


### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
