### PR TITLE
npm build command doesn't work. Use npm run build

### DIFF
--- a/docs/developer-docs/latest/development/admin-customization.md
+++ b/docs/developer-docs/latest/development/admin-customization.md
@@ -196,7 +196,7 @@ To build the administration, run the following command from the root directory o
 
 <code-block title="NPM">
 ```sh
-npm  build
+npm run build
 ```
 </code-block>
 


### PR DESCRIPTION
See: 
https://stackoverflow.com/questions/29939697/npm-build-doesnt-run-the-script-named-build-in-package-json

This should also be updated across the docs wherever its found. Maybe I'll go hunting soon if this one gets merged (first time contributor here 😊)