### PR TITLE
Update note in v3 migration guides

### DIFF
--- a/docs/developer-docs/latest/update-migration-guides/migration-guides.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides.md
@@ -39,6 +39,7 @@ If you were to upgrade your version from `3.2.3` to `3.6.1`, you would have to f
 ::: warning
 
 The Strapi Beta version is no longer supported, you should upgrade to the V3 Stable.
+If you have issues upgrading, it's our general recommendation to create a new project.
 
 :::
 


### PR DESCRIPTION
### What does it do?

Changes note in migration guides that we don't support beta and users should just try creating a new project

### Why is it needed?

Issues migrating from old v3-beta versions to v3-stable

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/11277
