### PR TITLE
Canonical URL additions for SEO

### DIFF
--- a/docs/developer-docs/latest/concepts/draft-and-publish.md
+++ b/docs/developer-docs/latest/concepts/draft-and-publish.md
@@ -1,6 +1,7 @@
 ---
 title: Draft and publish - Strapi Developer Documentation
 description: The draft and publish feature allows you to save your content as a draft, to publish it later.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/concepts/draft-and-publish.html
 ---
 
 # Draft and publish

--- a/docs/developer-docs/latest/developer-resources/cli/CLI.md
+++ b/docs/developer-docs/latest/developer-resources/cli/CLI.md
@@ -1,6 +1,7 @@
 ---
 title: CLI - Strapi Developer Documentation
 description: Strapi comes with a full featured Command Line Interface (CLI) which lets you scaffold and manage your project in seconds.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/developer-resources/cli.html
 ---
 
 # Command Line Interface (CLI)

--- a/docs/developer-docs/latest/developer-resources/content-api/integrations.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations.md
@@ -1,6 +1,7 @@
 ---
 title: Integrations - Strapi Developer Documentation
 description: Integrate Strapi with a multitude of frameworks, frontend or backend programming languages.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/developer-resources/content-api/integrations.html
 ---
 
 # Integrations

--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/11ty.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/11ty.md
@@ -1,6 +1,7 @@
 ---
 title: Get started with 11ty - Strapi Developer Documentation
 description: Build powerful applications using Strapi, the leading open-source headless CMS and 11ty.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/developer-resources/content-api/integrations/11ty.html
 ---
 
 # Getting Started with 11ty

--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/angular.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/angular.md
@@ -1,6 +1,7 @@
 ---
 title: Get started with Angular - Strapi Developer Documentation
 description: Build powerful applications using Strapi, the leading open-source headless cms and Angular.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/developer-resources/content-api/integrations/angular.html
 ---
 
 # Getting Started with Angular

--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/dart.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/dart.md
@@ -1,6 +1,7 @@
 ---
 title: Get started with Dart - Strapi Developer Documentation
 description: Build powerful applications using Strapi, the leading open-source headless cms and Dart.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/developer-resources/content-api/integrations/dart.html
 ---
 
 # Getting Started with Dart

--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/flutter.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/flutter.md
@@ -1,6 +1,7 @@
 ---
 title: Get started with Flutter - Strapi Developer Documentation
 description: Build powerful applications using Strapi, the leading open-source headless cms and Flutter.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/developer-resources/content-api/integrations/flutter.html
 ---
 
 # Getting Started with Flutter

--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/gatsby.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/gatsby.md
@@ -1,6 +1,7 @@
 ---
 title: Get started with Gatsby - Strapi Developer Documentation
-description: Build powerful applications using Strapi, the leading open-source headless cms and Gatsby.
+description: Build powerful applications using Strapi, the leading open-source headless CMS and Gatsby.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/developer-resources/content-api/integrations/gatsby.html
 ---
 
 # Getting Started with Gatsby

--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/go.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/go.md
@@ -1,6 +1,7 @@
 ---
 title: Get started with Go - Strapi Developer Documentation
 description: Build powerful applications using Strapi, the leading open-source headless cms and Go.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/developer-resources/content-api/integrations/go.html
 ---
 
 # Getting Started with GO

--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/graphql.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/graphql.md
@@ -1,6 +1,7 @@
 ---
 title: Get started with GraphQL - Strapi Developer Documentation
 description: Build powerful applications using Strapi, the leading open-source headless cms and GraphQL.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/developer-resources/content-api/integrations/graphql.html
 ---
 
 # Getting Started with GraphQL

--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/gridsome.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/gridsome.md
@@ -1,6 +1,7 @@
 ---
 title: Get started with Gridsome - Strapi Developer Documentation
 description: Build powerful applications using Strapi, the leading open-source headless cms and Gridsome.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/developer-resources/content-api/integrations/gridsome.html
 ---
 
 # Getting Started with Gridsome

--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/jekyll.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/jekyll.md
@@ -1,6 +1,7 @@
 ---
 title: Get started with Jekyll - Strapi Developer Documentation
 description: Build powerful applications using Strapi, the leading open-source headless cms and Jekyll.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/developer-resources/content-api/integrations/jekyll.html
 ---
 
 # Getting Started with Jekyll

--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/laravel.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/laravel.md
@@ -1,6 +1,7 @@
 ---
 title: Get started with Laravel - Strapi Developer Documentation
 description: Build powerful applications using Strapi, the leading open-source headless cms and Laravel.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/developer-resources/content-api/integrations/laravel.html
 ---
 
 # Getting Started with Laravel

--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/next-js.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/next-js.md
@@ -1,6 +1,7 @@
 ---
 title: Get started with Next.js - Strapi Developer Documentation
 description: Build powerful applications using Strapi, the leading open-source headless cms and Next.js.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/developer-resources/content-api/integrations/next-js.html
 ---
 
 # Getting Started with Next.js

--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/nuxt-js.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/nuxt-js.md
@@ -1,6 +1,7 @@
 ---
 title: Get started with Nuxt.js - Strapi Developer Documentation
 description: Build powerful applications using Strapi, the leading open-source headless cms and Nuxt.js.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/developer-resources/content-api/integrations/nuxt-js.html
 ---
 
 # Getting Started with Nuxt.js

--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/php.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/php.md
@@ -1,6 +1,7 @@
 ---
 title: Get started with PHP - Strapi Developer Documentation
 description: Build powerful applications using Strapi, the leading open-source headless cms and PHP.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/developer-resources/content-api/integrations/php.html
 ---
 
 # Getting Started with PHP

--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/python.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/python.md
@@ -1,6 +1,7 @@
 ---
 title: Get started with Python - Strapi Developer Documentation
 description: Build powerful applications using Strapi, the leading open-source headless cms and Python.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/developer-resources/content-api/integrations/python.html
 ---
 
 # Getting Started with Python

--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/react.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/react.md
@@ -1,6 +1,7 @@
 ---
 title: Get started with React - Strapi Developer Documentation
 description: Build powerful applications using Strapi, the leading open-source headless cms and React.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/developer-resources/content-api/integrations/react.html
 ---
 
 # Getting Started with React

--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/ruby.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/ruby.md
@@ -1,6 +1,7 @@
 ---
 title: Get started with Ruby - Strapi Developer Documentation
 description: Build powerful applications using Strapi, the leading open-source headless cms and Ruby.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/developer-resources/content-api/integrations/ruby.html
 ---
 
 # Getting Started with Ruby

--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/sapper.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/sapper.md
@@ -1,6 +1,7 @@
 ---
 title: Get started with Sapper - Strapi Developer Documentation
 description: Build powerful applications using Strapi, the leading open-source headless cms and Sapper.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/developer-resources/content-api/integrations/sapper.html
 ---
 
 # Getting Started with Sapper

--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/svelte.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/svelte.md
@@ -1,6 +1,7 @@
 ---
 title: Get started with Svelte - Strapi Developer Documentation
 description: Build powerful applications using Strapi, the leading open-source headless cms and Svelte.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/developer-resources/content-api/integrations/svelte.html
 ---
 
 # Getting Started with Svelte

--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/vue-js.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/vue-js.md
@@ -1,6 +1,7 @@
 ---
 title: Get started with Vue.js - Strapi Developer Documentation
 description: Build powerful applications using Strapi, the leading open-source headless cms and Vue.js.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/developer-resources/content-api/integrations/vue-js.html
 ---
 
 # Getting Started with Vue.js

--- a/docs/developer-docs/latest/developer-resources/database-apis-reference/entity-service-api.md
+++ b/docs/developer-docs/latest/developer-resources/database-apis-reference/entity-service-api.md
@@ -1,6 +1,7 @@
 ---
 title: Entity Service API - Strapi Developer Documentation
 description: The Entity Service is the layer that handles Strapi's complex data structures like components and dynamic zones, and uses the Query Engine API under the hood to execute database queries.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/entity-service-api.html
 ---
 
 # Entity Service API

--- a/docs/developer-docs/latest/developer-resources/database-apis-reference/entity-service/components-dynamic-zones.md
+++ b/docs/developer-docs/latest/developer-resources/database-apis-reference/entity-service/components-dynamic-zones.md
@@ -1,6 +1,7 @@
 ---
 title: Components and Dynamic Zones with Entity Service API - Strapi Developer Documentation
 description: Use Strapi's Entity Service to create and update components and dynamic zones.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/entity-service/components-dynamic-zones.html
 ---
 
 # Entity Service API: Components and dynamic zones

--- a/docs/developer-docs/latest/developer-resources/database-apis-reference/entity-service/crud.md
+++ b/docs/developer-docs/latest/developer-resources/database-apis-reference/entity-service/crud.md
@@ -1,6 +1,7 @@
 ---
 title: CRUD operations with Entity Service API - Strapi Developer Docs
 description: Use Strapi's Entity Service API to perform CRUD (create, read, update, delete) operations on your content.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/entity-service/crud.html
 ---
 
 # Entity Service API: CRUD operations

--- a/docs/developer-docs/latest/developer-resources/database-apis-reference/entity-service/filter.md
+++ b/docs/developer-docs/latest/developer-resources/database-apis-reference/entity-service/filter.md
@@ -2,6 +2,7 @@
 title: Filtering with Entity Service API - Strapi Developer Documentation
 description: Use Strapi's Entity Service API to filter your queries results.
 sidebarDepth: 3
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/entity-service/filter.html
 ---
 
 # Entity Service API: Filtering

--- a/docs/developer-docs/latest/developer-resources/database-apis-reference/entity-service/order-pagination.md
+++ b/docs/developer-docs/latest/developer-resources/database-apis-reference/entity-service/order-pagination.md
@@ -1,6 +1,7 @@
 ---
 title: Ordering & Pagination with Entity Service API - Strapi Developer Documentation
 description: Use Strapi's Entity Service API to order and paginate queries results.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/entity-service/order-pagination.html
 ---
 
 # Entity Service API: Ordering & Pagination

--- a/docs/developer-docs/latest/developer-resources/database-apis-reference/entity-service/populate.md
+++ b/docs/developer-docs/latest/developer-resources/database-apis-reference/entity-service/populate.md
@@ -1,6 +1,7 @@
 ---
 title: Entity Service API - Populating - Strapi Developer Documentation
 description: Use Strapi's Entity Service API to populate relations in your queries.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/entity-service/populate.html
 ---
 
 # Entity Service API: Populating

--- a/docs/developer-docs/latest/developer-resources/database-apis-reference/graphql-api.md
+++ b/docs/developer-docs/latest/developer-resources/database-apis-reference/graphql-api.md
@@ -2,6 +2,7 @@
 title: GraphQL API - Strapi Developer Documentation
 description: Use a GraphQL endpoint in your Strapi project to fetch and mutate your content.
 sidebarDepth: 3
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/graphql-api.html
 ---
 
 # GraphQL API

--- a/docs/developer-docs/latest/developer-resources/database-apis-reference/query-engine-api.md
+++ b/docs/developer-docs/latest/developer-resources/database-apis-reference/query-engine-api.md
@@ -1,6 +1,7 @@
 ---
 title: Query Engine API - Strapi Developer Documentation
 description: Strapi provides a Query Engine API to give unrestricted internal access to the database layer at a lower level.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/query-engine-api.html
 ---
 
 # Query Engine API

--- a/docs/developer-docs/latest/developer-resources/database-apis-reference/query-engine/bulk-operations.md
+++ b/docs/developer-docs/latest/developer-resources/database-apis-reference/query-engine/bulk-operations.md
@@ -1,6 +1,7 @@
 ---
 title: Bulk Operations for Query Engine API - Strapi Developer Documentation
 description: Use Strapi's Query Engine API to perform operations on multiple entries.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/query-engine/bulk-operations.html
 ---
 
 # Query Engine API: Bulk Operations

--- a/docs/developer-docs/latest/developer-resources/database-apis-reference/query-engine/filtering.md
+++ b/docs/developer-docs/latest/developer-resources/database-apis-reference/query-engine/filtering.md
@@ -2,6 +2,7 @@
 title: Filtering Operations for Query Engine API - Strapi Developer Documentation
 description: Use Strapi's Query Engine API to filter the results of your queries.
 sidebarDepth: 3
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/query-engine/filtering.html
 ---
 
 # Query Engine API: Filtering

--- a/docs/developer-docs/latest/developer-resources/database-apis-reference/query-engine/order-pagination.md
+++ b/docs/developer-docs/latest/developer-resources/database-apis-reference/query-engine/order-pagination.md
@@ -1,6 +1,7 @@
 ---
 title: Ordering & Pagination for Query Engine API - Strapi Developer Documentation
 description: Use Strapi's Query Engine API to order and paginate the results of your queries.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/query-engine/order-pagination.html
 ---
 
 # Query Engine API: Ordering & Paginating

--- a/docs/developer-docs/latest/developer-resources/database-apis-reference/query-engine/populating.md
+++ b/docs/developer-docs/latest/developer-resources/database-apis-reference/query-engine/populating.md
@@ -1,6 +1,7 @@
 ---
 title: Populating for Query Engine API - Strapi Developer Documentation
 description: Use Strapi's Query Engine API to populate relations when querying your content.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/query-engine/populating.html
 ---
 
 # Query Engine API: Populating

--- a/docs/developer-docs/latest/developer-resources/database-apis-reference/query-engine/single-operations.md
+++ b/docs/developer-docs/latest/developer-resources/database-apis-reference/query-engine/single-operations.md
@@ -1,6 +1,7 @@
 ---
 title: Single Operations for Query Engine API - Strapi Developer Documentation
 description: Use Strapi's Query Engine API to perform operations on single entries.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/query-engine/single-operations.html
 ---
 
 # Query Engine API: Single Operations

--- a/docs/developer-docs/latest/developer-resources/database-apis-reference/rest-api.md
+++ b/docs/developer-docs/latest/developer-resources/database-apis-reference/rest-api.md
@@ -2,6 +2,7 @@
 title: REST API - Strapi Developer Documentation
 description: Interact with your Content-Types using the REST API endpoints Strapi generates for you.
 sidebarDepth: 3
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/rest-api.html
 ---
 
 # REST API

--- a/docs/developer-docs/latest/developer-resources/error-handling.md
+++ b/docs/developer-docs/latest/developer-resources/error-handling.md
@@ -1,6 +1,7 @@
 ---
 title: Error handling - Strapi Developer Documentation
 description: With Strapi's error handling feature it's easy to send and receive errors in your application.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/developer-resources/error-handling.html
 ---
 
 # Error handling

--- a/docs/developer-docs/latest/developer-resources/global-strapi/api-reference.md
+++ b/docs/developer-docs/latest/developer-resources/global-strapi/api-reference.md
@@ -1,6 +1,7 @@
 ---
 title: API Reference - Strapi Developer Documentation
-description: Discover our concise reference documentation containing all the information to work with your Strapi API
+description: Discover our concise reference documentation containing all the information to work with your Strapi API.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/developer-resources/global-strapi/api-reference.html
 ---
 
 # Global strapi API reference

--- a/docs/developer-docs/latest/developer-resources/plugin-api-reference/admin-panel.md
+++ b/docs/developer-docs/latest/developer-resources/plugin-api-reference/admin-panel.md
@@ -2,6 +2,7 @@
 title: Admin Panel API - Strapi Developer Documentation
 description: Strapi's Admin Panel API for plugins allows a Strapi plugin to customize the front end part (i.e. the admin panel) of your application.
 sidebarDepth: 3
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/developer-resources/plugin-api-reference/admin-panel.html
 ---
 
 # Admin Panel API for plugins

--- a/docs/developer-docs/latest/developer-resources/plugin-api-reference/server.md
+++ b/docs/developer-docs/latest/developer-resources/plugin-api-reference/server.md
@@ -2,6 +2,7 @@
 title: Server API - Strapi Developer Documentation
 description: Strapi's Server API for plugins allows a Strapi plugin to customize the back end part (i.e. the server) of your application.
 sidebarDepth: 3
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/developer-resources/plugin-api-reference/server.html
 ---
 
 # Server API for plugins

--- a/docs/developer-docs/latest/development/admin-customization.md
+++ b/docs/developer-docs/latest/development/admin-customization.md
@@ -2,6 +2,7 @@
 title: Admin panel customization - Strapi Developer Documentation
 description: The administration panel of Strapi can be customized according to your needs, so you can make it reflect your identity.
 sidebarDepth: 3
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/development/admin-customization.html
 ---
 
 # Admin panel customization

--- a/docs/developer-docs/latest/development/backend-customization.md
+++ b/docs/developer-docs/latest/development/backend-customization.md
@@ -1,6 +1,7 @@
 ---
 title: Back-end customization - Strapi Developer Documentation
 description: All elements of Strapi's back end, like routes, policies, middlewares, controllers, services, models, requests, responses, and webhooks, can be customized.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/development/backend-customization.html
 ---
 
 # Back-end customization

--- a/docs/developer-docs/latest/development/backend-customization/controllers.md
+++ b/docs/developer-docs/latest/development/backend-customization/controllers.md
@@ -2,6 +2,7 @@
 title: Backend customization - Controllers - Strapi Developer Docs
 description: Strapi controllers are JavaScript files that contain a set of methods, called actions, reached by the client according to the requested route. Controllers can be customized according to your needs.
 sidebarDepth: 3
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/development/backend-customization/controllers.html
 ---
 
 # Controllers

--- a/docs/developer-docs/latest/development/backend-customization/middlewares.md
+++ b/docs/developer-docs/latest/development/backend-customization/middlewares.md
@@ -1,6 +1,7 @@
 ---
 title: Backend customization - Middlewares - Strapi Developer Documentation
 description : Strapi middlewares are configured and enabled for the entire Strapi server application. Middlewares can be customized according to your needs.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/development/backend-customization/middlewares.html
 ---
 
 # Middlewares customization

--- a/docs/developer-docs/latest/development/backend-customization/models.md
+++ b/docs/developer-docs/latest/development/backend-customization/models.md
@@ -2,6 +2,7 @@
 title: Models - Strapi Developer Documentation
 description: As Strapi is a headless Content Management System (CMS), creating a data structure for the content is one of the most important aspects of using the software. Strapi models (i.e. content-types, components, and dynamic zones) define a representation of the data structure.
 sidebarDepth: 3
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/development/backend-customization/models.html
 ---
 
 # Models

--- a/docs/developer-docs/latest/development/backend-customization/policies.md
+++ b/docs/developer-docs/latest/development/backend-customization/policies.md
@@ -2,6 +2,7 @@
 title: Policies - Backend customization - Strapi Developer Documentation
 description: Strapi policies are functions that execute specific logic on each request before it reaches the controller. Policies can be customized according to your needs.
 sidebarDepth: 3
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/development/backend-customization/policies.html
 ---
 
 # Policies

--- a/docs/developer-docs/latest/development/backend-customization/requests-responses.md
+++ b/docs/developer-docs/latest/development/backend-customization/requests-responses.md
@@ -1,3 +1,9 @@
+---
+title: Requests and Responses - Strapi Developer Documentation 
+description: Learn more about requests and responses for Strapi, the most popular headless CMS.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/development/backend-customization/requests-responses.html
+---
+
 # Requests & Responses
 
 ## Requests

--- a/docs/developer-docs/latest/development/backend-customization/routes.md
+++ b/docs/developer-docs/latest/development/backend-customization/routes.md
@@ -2,6 +2,7 @@
 title: Routes - Strapi Developer Documentation
 description: Strapi routes handle requests to your content and are auto-generated for your content-types. Routes can be customized according to your needs.
 sidebarDepth: 3
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/development/backend-customization/routes.html
 ---
 
 # Routes

--- a/docs/developer-docs/latest/development/backend-customization/services.md
+++ b/docs/developer-docs/latest/development/backend-customization/services.md
@@ -2,6 +2,7 @@
 title: Services - Strapi Developer Documentation
 description: Strapi services are a set of reusable functions, useful to simplify controllers logic.
 sidebarDepth: 3
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/development/backend-customization/services.html
 ---
 
 # Services

--- a/docs/developer-docs/latest/development/backend-customization/webhooks.md
+++ b/docs/developer-docs/latest/development/backend-customization/webhooks.md
@@ -1,6 +1,7 @@
 ---
 title: Webhooks - Strapi Developer Documentation 
 description: Strapi webhooks are user-defined HTTP callbacks used by an application to notify other applications that an event occurred.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/development/backend-customization/webhooks.html
 ---
 
 # Webhooks

--- a/docs/developer-docs/latest/development/plugins-development.md
+++ b/docs/developer-docs/latest/development/plugins-development.md
@@ -1,6 +1,7 @@
 ---
 title: Plugins development - Strapi Developer Documentation
 description: Strapi allows you to create your own custom local plugins that will work exactly the same as external ones.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/development/plugins-development.html
 ---
 
 # Plugins development

--- a/docs/developer-docs/latest/development/plugins-extension.md
+++ b/docs/developer-docs/latest/development/plugins-extension.md
@@ -2,6 +2,7 @@
 title: Plugins extension - Strapi Developer Docs
 description: Strapi plugins can be extended by extending the content-types or the plugin's interface.
 sidebarDepth: 2
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/development/plugins-extension.html
 ---
 
 # Plugins extension

--- a/docs/developer-docs/latest/getting-started/introduction.md
+++ b/docs/developer-docs/latest/getting-started/introduction.md
@@ -1,6 +1,7 @@
 ---
 title: Strapi Developer Documentation
 description: This documentation contains all technical documentation related to the setup, deployment, update and customization of your Strapi application.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/getting-started/introduction.html
 ---
 
 # Welcome to the Strapi v4 developer documentation!

--- a/docs/developer-docs/latest/getting-started/quick-start.md
+++ b/docs/developer-docs/latest/getting-started/quick-start.md
@@ -3,6 +3,7 @@ title: Quick Start Guide - Strapi Developer Documentation
 description: Get ready to get Strapi, your favorite open-source headless cms up and running in less than 3 minutes.
 sidebarDepth: 0
 next: ./troubleshooting
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/getting-started/quick-start.html
 ---
 
 # Quick Start Guide

--- a/docs/developer-docs/latest/getting-started/troubleshooting.md
+++ b/docs/developer-docs/latest/getting-started/troubleshooting.md
@@ -2,6 +2,7 @@
 title: Troubleshooting - Strapi Developer Documentation
 description: Find some answers and solutions to most common issues that you may experience when working with Strapi.
 sidebarDepth: 0
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/getting-started/troubleshooting.html
 ---
 
 # Frequently Asked Questions

--- a/docs/developer-docs/latest/getting-started/usage-information.md
+++ b/docs/developer-docs/latest/getting-started/usage-information.md
@@ -2,6 +2,7 @@
 title: Usage information - Strapi Developer Documentation
 description: We are committed to providing a solution, with Strapi, that exceeds the expectations of the users and community. We are also committed to continuing to develop and make Strapi even better than it is today.
 sidebarDepth: 0
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/getting-started/usage-information.html
 ---
 
 # Collected Usage Information

--- a/docs/developer-docs/latest/guides/auth-request.md
+++ b/docs/developer-docs/latest/guides/auth-request.md
@@ -1,6 +1,7 @@
 ---
 title: Authenticated request - Strapi Developer Documentation
 description: Learn in this guide how you can request the API of your Strapi project as an authenticated user.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/guides/auth-request.html
 ---
 
 # Authenticated request

--- a/docs/developer-docs/latest/guides/client.md
+++ b/docs/developer-docs/latest/guides/client.md
@@ -1,6 +1,7 @@
 ---
 title: Client - Strapi Developer Documentation
 description: Learn in this guide how to setup a connection with a third party client and use it everywhere in your code.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/guides/client.html
 ---
 # Setup a third party client
 

--- a/docs/developer-docs/latest/guides/count-graphql.md
+++ b/docs/developer-docs/latest/guides/count-graphql.md
@@ -1,6 +1,7 @@
 ---
 title: Count with GraphQL - Strapi Developer Documentation
 description: Learn in this guide how to count data with a GraphQL query.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/guides/count-graphql.html
 ---
 
 # Count with GraphQL

--- a/docs/developer-docs/latest/guides/custom-admin.md
+++ b/docs/developer-docs/latest/guides/custom-admin.md
@@ -1,6 +1,7 @@
 ---
 title: Custom Admin - Strapi Developer Documentation
 description: Learn in this guide how you can customize the admin panel of your Strapi project.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/guides/custom-admin.html
 ---
 
 # Custom admin

--- a/docs/developer-docs/latest/guides/custom-data-response.md
+++ b/docs/developer-docs/latest/guides/custom-data-response.md
@@ -1,6 +1,7 @@
 ---
 title: Custom Data Response - Strapi Developer Documentation
 description: Learn in this guide how you can customize your Strapi project API's response.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/guides/custom-date-response.html
 ---
 
 # Custom data response

--- a/docs/developer-docs/latest/guides/draft.md
+++ b/docs/developer-docs/latest/guides/draft.md
@@ -1,6 +1,7 @@
 ---
 title: Draft System - Strapi Developer Documentation
 description: Learn in this guide how to create a draft system that will allow you to manage draft, published, and archive status inside your Strapi project.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/guides/draft.html
 ---
 
 # Draft system

--- a/docs/developer-docs/latest/guides/error-catching.md
+++ b/docs/developer-docs/latest/guides/error-catching.md
@@ -1,6 +1,7 @@
 ---
 title: Error Catching - Strapi Developer Documentation
 description: Learn in this guide how you can catch errors and send them to the Application Monitoring / Error Tracking Software you want.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/guides/error-catching.html
 ---
 
 # Error catching

--- a/docs/developer-docs/latest/guides/external-data.md
+++ b/docs/developer-docs/latest/guides/external-data.md
@@ -1,6 +1,7 @@
 ---
 title: External Data - Strapi Developer Documentation
 description: Learn in this guide how to fetch data from an external service to use it in your Strapi project.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/guides/external-data.html
 ---
 
 # Fetching external data

--- a/docs/developer-docs/latest/guides/is-owner.md
+++ b/docs/developer-docs/latest/guides/is-owner.md
@@ -1,6 +1,7 @@
 ---
 title: Is Owner - Strapi Developer Documentation
 description: Learn in this guide how to restrict content editing to content authors only.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/guides/is-owner.html
 ---
 
 # Create is owner policy

--- a/docs/developer-docs/latest/guides/jwt-validation.md
+++ b/docs/developer-docs/latest/guides/jwt-validation.md
@@ -1,6 +1,7 @@
 ---
 title: JWT validation - Strapi Developer Documentation
 description: Learn in this guide how to validate a JWT (JSON Web Token) with a third party service.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/guides/jwt-validation.html
 ---
 
 # JWT validation

--- a/docs/developer-docs/latest/guides/process-manager.md
+++ b/docs/developer-docs/latest/guides/process-manager.md
@@ -2,6 +2,7 @@
 title: Process Manager - Strapi Developer Documentation
 description: Learn in this guide how you can start a Strapi application using a process manager.
 sidebarDepth: 2
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/guides/process-manager.html
 ---
 
 # Process manager

--- a/docs/developer-docs/latest/guides/registering-a-field-in-admin.md
+++ b/docs/developer-docs/latest/guides/registering-a-field-in-admin.md
@@ -1,6 +1,7 @@
 ---
 title: Field Registering - Strapi Developer Documentation
 description: Learn in this guide how you can create a new Field for your administration panel.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/guides/registering-a-field-in-admin.html
 ---
 
 # Creating a new Field in the administration panel

--- a/docs/developer-docs/latest/guides/scheduled-publication.md
+++ b/docs/developer-docs/latest/guides/scheduled-publication.md
@@ -1,6 +1,7 @@
 ---
 title: Scheduled Publication - Strapi Developer Documentation
 description: Learn in this guide how to create an article schedule system.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/guides/scheduled-publication.html
 ---
 
 # Scheduled publication

--- a/docs/developer-docs/latest/guides/secure-your-app.md
+++ b/docs/developer-docs/latest/guides/secure-your-app.md
@@ -1,6 +1,7 @@
 ---
 title: Secure your application - Strapi Developer Documentation
 description: Learn in this guide how you can secure your Strapi application by using a third party provider.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/guides/secure-your-app.html
 ---
 
 # Secure your application

--- a/docs/developer-docs/latest/guides/send-email.md
+++ b/docs/developer-docs/latest/guides/send-email.md
@@ -1,6 +1,7 @@
 ---
 title: Send Email - Strapi Developer Documentation
 description: Learn in this guide how to use the Email plugin to send email where you want in your Strapi app.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/guides/send-email.html
 ---
 
 # Send email programmatically

--- a/docs/developer-docs/latest/guides/slug.md
+++ b/docs/developer-docs/latest/guides/slug.md
@@ -1,6 +1,7 @@
 ---
 title: Slug System - Strapi Developer Documentation
 description: Learn in this guide how to create a slug system for a Post, Article or any Content Type you want in your Strapi project.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/guides/slug.html
 ---
 
 # Create a slug system

--- a/docs/developer-docs/latest/guides/unit-testing.md
+++ b/docs/developer-docs/latest/guides/unit-testing.md
@@ -2,6 +2,7 @@
 title: Unit Testing - Strapi Developer Documentation
 description: Learn in this guide how you can run basic unit tests for a Strapi application using a testing framework.
 sidebarDepth: 2
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/guides/unit-testing.html
 ---
 
 # Unit testing

--- a/docs/developer-docs/latest/plugins/documentation.md
+++ b/docs/developer-docs/latest/plugins/documentation.md
@@ -1,6 +1,7 @@
 ---
 title: API Documentation - Strapi Developer Documentation
 description: By using Swagger UI, the API documentation plugin takes out most of your pain to generate your documentation.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/plugins/documentation.html
 ---
 
 # API Documentation

--- a/docs/developer-docs/latest/plugins/email.md
+++ b/docs/developer-docs/latest/plugins/email.md
@@ -1,6 +1,7 @@
 ---
 title: Email - Strapi Developer Documentation
 description: Send email from your server or externals providers.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/plugins/email.html
 ---
 
 # Email

--- a/docs/developer-docs/latest/plugins/graphql.md
+++ b/docs/developer-docs/latest/plugins/graphql.md
@@ -2,6 +2,7 @@
 title: GraphQL - Strapi Developer Documentation
 description: Use a GraphQL endpoint in your Strapi project to fetch and mutate your content.
 sidebarDepth: 3
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/plugins/graphql.html
 ---
 
 # GraphQL

--- a/docs/developer-docs/latest/plugins/i18n.md
+++ b/docs/developer-docs/latest/plugins/i18n.md
@@ -2,6 +2,7 @@
 title: Internationalization (i18n) - Strapi Developer Documentation
 description: Instructions on how to use Strapi Content API with the Internationalization (i18n) optional plugin
 sidebarDepth: 3
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/plugins/i18n.html
 ---
 
 # 🌍  Internationalization (i18n)

--- a/docs/developer-docs/latest/plugins/plugins-intro.md
+++ b/docs/developer-docs/latest/plugins/plugins-intro.md
@@ -1,6 +1,7 @@
 ---
 title: Strapi plugins - Strapi Developer Documentation
 description: Strapi comes with built-in plugins (i18n, GraphQL, Users & Permissions, Upload, API documentation, and Email) and you can install plugins as npm packages.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/plugins/plugins-intro.html
 ---
 
 # Strapi plugins

--- a/docs/developer-docs/latest/plugins/upload.md
+++ b/docs/developer-docs/latest/plugins/upload.md
@@ -1,6 +1,7 @@
 ---
 title: Upload - Strapi Developer Documentation
 description: Upload any kind of file on your server or external providers.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/plugins/upload.html
 ---
 
 # Upload

--- a/docs/developer-docs/latest/plugins/users-permissions.md
+++ b/docs/developer-docs/latest/plugins/users-permissions.md
@@ -2,6 +2,7 @@
 title: Roles & Permissions - Strapi Developer Documentation
 description: Protect your API with a full authentication process based on JWT and manage the permissions between the groups of users.
 sidebarDepth: 2
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/plugins/users-permissions.html
 ---
 
 # Roles & Permissions

--- a/docs/developer-docs/latest/setup-deployment-guides/configurations.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/configurations.md
@@ -2,6 +2,7 @@
 title: Configurations - Strapi Developer Documentation
 description: Learn how you can manage and customize the configuration of your Strapi application.
 sidebarDepth: auto
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/configurations.html
 ---
 
 # Configurations

--- a/docs/developer-docs/latest/setup-deployment-guides/configurations/databases/sqlite.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/configurations/databases/sqlite.md
@@ -1,6 +1,7 @@
 ---
 title: SQLite - Strapi Developer Documentation
 description: Learn how you can use SQLite for your Strapi application.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/configurations/databases/sqlite.html
 ---
 
 # SQLite Installation

--- a/docs/developer-docs/latest/setup-deployment-guides/configurations/optional/api.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/configurations/optional/api.md
@@ -1,6 +1,7 @@
 ---
 title: API configuration - Strapi Developer Documentation
 description: Strapi's default API parameters can be configured.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/configurations/optional/api.html
 ---
 
 # API configuration

--- a/docs/developer-docs/latest/setup-deployment-guides/configurations/optional/cronjobs.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/configurations/optional/cronjobs.md
@@ -1,6 +1,7 @@
 ---
 title: Cron jobs - Strapi Developer Documentation
 description: Strapi allows you to configure cron jobs for execution at specific dates and times, with optional reccurence rules.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/configurations/optional/cronjobs.html
 ---
 
 # Cron jobs

--- a/docs/developer-docs/latest/setup-deployment-guides/configurations/optional/environment.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/configurations/optional/environment.md
@@ -2,6 +2,7 @@
 title: Environment configuration and variables - Strapi Developer Documentation
 description: In case you need specific static configurations for specific environments, and using environment variables becomes tedious, Strapi configurations can be created per environment.
 sidebarDepth: 3
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/configurations/optional/environment.html
 ---
 
 # Environment configuration and variables

--- a/docs/developer-docs/latest/setup-deployment-guides/configurations/optional/functions.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/configurations/optional/functions.md
@@ -1,6 +1,7 @@
 ---
 title: Functions - Strapi Developer Documentation
 description: Strapi includes life cycle functions (e.g. register, bootstrap and destroy) that control the flow of your application.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/configurations/optional/functions.html
 ---
 
 # Functions

--- a/docs/developer-docs/latest/setup-deployment-guides/configurations/optional/plugins.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/configurations/optional/plugins.md
@@ -1,6 +1,7 @@
 ---
 title: Plugins configuration - Strapi Developer Docs
 description: Strapi plugins have a single entry point file to define their configurations.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/configurations/optional/plugins.html
 ---
 
 # Plugins configuration

--- a/docs/developer-docs/latest/setup-deployment-guides/configurations/optional/public-assets.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/configurations/optional/public-assets.md
@@ -1,6 +1,7 @@
 ---
 title: Public assets configuration - Strapi Developer Documentation
 description: The public folder of Strapi is used for static files that you want to make accesible to the outside world.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/configurations/optional/public-assets.html
 ---
 
 # Public assets configuration

--- a/docs/developer-docs/latest/setup-deployment-guides/configurations/optional/rbac.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/configurations/optional/rbac.md
@@ -1,6 +1,7 @@
 ---
 title: Role-Based Access Control (RBAC) - Strapi Developer Documentation
 description: In Strapi, Role-Based Access Control (RBAC) is an approach to restricting access to some features of the admin panel to some users. The Community Edition of Strapi offers 3 default roles. To go further, creating custom conditions for any type of permission is also possible and requires an Enterprise Edition.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/configurations/optional/rbac.html
 ---
 
 # Role-Based Access Control <BronzeBadge link="https://strapi.io/pricing-self-hosted"/> <SilverBadge link="https://strapi.io/pricing-self-hosted"/> <GoldBadge link="https://strapi.io/pricing-self-hosted" withLinkIcon/>

--- a/docs/developer-docs/latest/setup-deployment-guides/configurations/optional/sso.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/configurations/optional/sso.md
@@ -2,6 +2,7 @@
 title: Single Sign-On (SSO) - Strapi Developer Documentation
 description: Strapi's Single Sign-On allows you to configure additional sign-in and sign-up methods for your administration panel. It requires an Entreprise Edition with a Gold plan.
 sidebarDepth: 3
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/configurations/optional/sso.html
 ---
 
 # Single Sign-On <GoldBadge link="https://strapi.io/pricing-self-hosted/" withLinkIcon />

--- a/docs/developer-docs/latest/setup-deployment-guides/configurations/required/admin-panel.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/configurations/required/admin-panel.md
@@ -1,6 +1,7 @@
 ---
 title: Admin panel configuration - Strapi Developer Documentation
 description: Strapi's admin panel offers a single entry point file for its configuration.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/configurations/required/admin-panel.html
 ---
 
 # Admin panel configuration

--- a/docs/developer-docs/latest/setup-deployment-guides/configurations/required/databases.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/configurations/required/databases.md
@@ -1,6 +1,7 @@
 ---
 title: Database configuration - Strapi Developer Documentation
 description: Strapi offers a single entry point file to configure its databases.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/configurations/required/databases.html
 ---
 
 # Database configuration

--- a/docs/developer-docs/latest/setup-deployment-guides/configurations/required/middlewares.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/configurations/required/middlewares.md
@@ -1,6 +1,7 @@
 ---
 title: Middlewares configuration - Strapi Developer Documentation
 description: Strapi offers a single entry point file for its middlewares configurations.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/configurations/required/middlewares.html
 ---
 
 # Middlewares configuration

--- a/docs/developer-docs/latest/setup-deployment-guides/configurations/required/server.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/configurations/required/server.md
@@ -1,6 +1,7 @@
 ---
 title: Server configuration - Strapi Developer Documentation
 description: Strapi offers a single entry point file for its server configuration.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/configurations/required/server.html
 ---
 
 # Server configuration

--- a/docs/developer-docs/latest/setup-deployment-guides/deployment.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment.md
@@ -1,6 +1,7 @@
 ---
 title: Deployment - Strapi Developer Documentation
 description: Learn how to develop locally with Strapi and deploy Strapi with various hosting options.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/deployment.html
 ---
 
 # Deployment

--- a/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/21yunbox.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/21yunbox.md
@@ -1,6 +1,7 @@
 ---
 title: 21YunBox Deployment - Strapi Developer Documentation
 description: Learn in this guide how to update an existing Strapi project so it can be deployed on 21YunBox.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/21yunbox.html
 ---
 
 # 21YunBox

--- a/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/amazon-aws.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/amazon-aws.md
@@ -1,6 +1,7 @@
 ---
 title: AWS Deployment - Strapi Developer Documentation
 description: Learn in this guide how to deploy your Strapi application on AWS EC2, host your database on AWS RDS and upload your assets on AWS S3.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/amazon-aws.html
 ---
 
 # Amazon AWS

--- a/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/azure.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/azure.md
@@ -1,6 +1,7 @@
 ---
 title: Azure Deployment - Strapi Developer Documentation
 description: Learn in this guide how to deploy your Strapi application on Microsoft Azure.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/azure.html
 ---
 
 # Azure

--- a/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/digitalocean-app-platform.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/digitalocean-app-platform.md
@@ -1,6 +1,7 @@
 ---
 title: DigitalOcean App Platform Deployment - Strapi Developer Documentation
 description: Learn in this guide how to deploy your Strapi application on DigitalOcean App Platform.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/digitalocean-app-platform.html
 ---
 
 # DigitalOcean App Platform

--- a/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/digitalocean.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/digitalocean.md
@@ -1,6 +1,7 @@
 ---
 title: DigitalOcean Droplet Deployment - Strapi Developer Documentation
 description: Learn in this guide how to deploy your Strapi application on DigitalOcean Droplets.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/digitalocean.html
 ---
 
 # DigitalOcean Droplets

--- a/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/google-app-engine.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/google-app-engine.md
@@ -1,6 +1,7 @@
 ---
 title: Google App Engine Deployment - Strapi Developer Documentation
 description: Learn in this guide how to deploy your Strapi application on Google App Engine and how to upload your assets on Google Cloud Storage.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/google-app-engine.html
 ---
 
 # Google App Engine

--- a/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/heroku.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/heroku.md
@@ -1,6 +1,7 @@
 ---
 title: Heroku Deployment - Strapi Developer Documentation
 description: Learn in this guide how to deploy your Strapi application on Heroku.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/heroku.html
 ---
 
 # Heroku

--- a/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/qovery.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/qovery.md
@@ -1,6 +1,7 @@
 ---
 title: Qovery Deployment - Strapi Developer Documentation
 description: Learn in this guide how to deploy your Strapi application on Qovery.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/qovery.html
 ---
 
 # Qovery

--- a/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/render.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/render.md
@@ -1,6 +1,7 @@
 ---
 title: Render Deployment - Strapi Developer Documentation
 description: Learn in this guide how to deploy your Strapi application on Render.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/render.html
 ---
 
 # Render

--- a/docs/developer-docs/latest/setup-deployment-guides/deployment/optional-software/caddy-proxy.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment/optional-software/caddy-proxy.md
@@ -1,6 +1,7 @@
 ---
 title: Caddy Proxying - Strapi Developer Documentation
 description: Learn how you can use a proxy application like Caddy to secure your Strapi application.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/deployment/optional-software/caddy-proxy.html
 ---
 
 # Caddy Proxying

--- a/docs/developer-docs/latest/setup-deployment-guides/deployment/optional-software/haproxy-proxy.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment/optional-software/haproxy-proxy.md
@@ -1,6 +1,7 @@
 ---
 title: HAProxy Proxying - Strapi Developer Documentation
 description: Learn how you can use a proxy application like HAProxy to secure your Strapi application.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/deployment/optional-software/haproxy-proxy.html
 ---
 
 # HAProxy Proxying

--- a/docs/developer-docs/latest/setup-deployment-guides/deployment/optional-software/nginx-proxy.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment/optional-software/nginx-proxy.md
@@ -1,6 +1,7 @@
 ---
 title: Nginx Proxying - Strapi Developer Documentation
 description: Learn how you can use a proxy application like Nginx to secure your Strapi application.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/deployment/optional-software/nginx-proxy.html
 ---
 
 # Nginx Proxying

--- a/docs/developer-docs/latest/setup-deployment-guides/file-structure.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/file-structure.md
@@ -1,6 +1,7 @@
 ---
 title: Project Structure - Strapi Developer Documentation
 description: Discover the project structure of any default Strapi application.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/file-structure.html
 ---
 
 <style lang="scss" scoped>

--- a/docs/developer-docs/latest/setup-deployment-guides/installation.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/installation.md
@@ -1,6 +1,7 @@
 ---
 title: Installation - Strapi Developer Documentation
 description: Learn many different options to install Strapi and getting started on using it.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/installation.html
 ---
 
 # Installation

--- a/docs/developer-docs/latest/setup-deployment-guides/installation/cli.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/installation/cli.md
@@ -1,6 +1,7 @@
 ---
 title: Installing from CLI - Strapi Developer Documentation
 description: Fast-track local install for getting Strapi running on your computer in less than a minute.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/installation/cli.html
 ---
 
 # Installing from CLI

--- a/docs/developer-docs/latest/setup-deployment-guides/installation/digitalocean-one-click.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/installation/digitalocean-one-click.md
@@ -1,6 +1,7 @@
 ---
 title: DigitalOcean One-click - Strapi Developer Documentation
 description: Quickly deploy a Strapi application on DigitalOcean by simply using their One-click button.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/installation/digitalocean-one-click.html
 ---
 
 # DigitalOcean One-click

--- a/docs/developer-docs/latest/setup-deployment-guides/installation/docker.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/installation/docker.md
@@ -1,6 +1,7 @@
 ---
 title: Install from Docker - Strapi Developer Documentation
 description: Quickly create a Strapi application using our official Strapi Docker images.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/installation/docker.html
 ---
 
 # Installing using Docker

--- a/docs/developer-docs/latest/setup-deployment-guides/installation/platformsh.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/installation/platformsh.md
@@ -1,6 +1,7 @@
 ---
 title: Install using Platform.sh - Strapi Developer Documentation
 description: Quickly deploy a Strapi application using the official Platform.sh Strapi template.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/installation/platformsh.html
 sidebarDepth: 1
 ---
 

--- a/docs/developer-docs/latest/setup-deployment-guides/installation/render.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/installation/render.md
@@ -1,6 +1,7 @@
 ---
 title: Render One-Click - Strapi Developer Documentation
 description: Quickly deploy a Strapi application on Render by simply using their One-click button.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/installation/render.html
 ---
 
 # Render One-Click

--- a/docs/developer-docs/latest/setup-deployment-guides/installation/templates.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/installation/templates.md
@@ -1,6 +1,7 @@
 ---
 title: Templates - Strapi Developer Documentation
 description: Quickly create a pre-made Strapi application designed for a specific use case. It allows you to quickly bootstrap a custom Strapi app.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/installation/templates.html
 ---
 
 # Templates

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides.md
@@ -1,6 +1,7 @@
 ---
 title: Migrate Guides - Strapi Developer Documentation
 description: All the migration guides for a Strapi application.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides.html
 ---
 
 # Migrations guides

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-1-to-3.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-1-to-3.md
@@ -1,6 +1,7 @@
 ---
 title: Migrate from v1 to v3 - Strapi Developer Documentation
 description: Learn how you can migrate your Strapi application from v1 to v3.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-1-to-3.html
 ---
 
 # Migrating from v1 to v3

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-3.0.x-to-3.1.x.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-3.0.x-to-3.1.x.md
@@ -1,6 +1,7 @@
 ---
 title: Migrate from 3.0.x to 3.1.x - Strapi Developer Documentation
 description: Learn how you can migrate your Strapi application from 3.0.x to 3.1.x.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-3.0.x-to-3.1.x.html
 ---
 
 # Migration guide from 3.0.x to 3.1.x

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-3.1.x-to-3.2.x.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-3.1.x-to-3.2.x.md
@@ -1,6 +1,7 @@
 ---
 title: Migrate from 3.1.x to 3.2.3 - Strapi Developer Documentation
 description: Learn how you can migrate your Strapi application from 3.1.x to 3.2.3.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-3.1.x-to-3.2.x.html
 ---
 
 # Migration guide from 3.1.x to 3.2.3

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-3.2.3-to-3.2.4.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-3.2.3-to-3.2.4.md
@@ -1,6 +1,7 @@
 ---
 title: Migrate from 3.2.3 to 3.2.4 - Strapi Developer Documentation
 description: Learn how you can migrate your Strapi application from 3.2.3 to 3.2.4.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-3.2.3-to-3.2.4.html
 ---
 
 # Migration guide from 3.2.3 to 3.2.4

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-3.2.5-to-3.3.0.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-3.2.5-to-3.3.0.md
@@ -1,6 +1,7 @@
 ---
 title: Migrate from 3.2.5 to 3.3.0 - Strapi Developer Documentation
 description: Learn how you can migrate your Strapi application from 3.2.5 to 3.3.0.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-3.2.5-to-3.3.0.html
 ---
 
 # Migration guide from 3.2.5 to 3.3.0

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-3.3.x-to-3.4.0.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-3.3.x-to-3.4.0.md
@@ -1,6 +1,7 @@
 ---
 title: Migrate from 3.3.x to 3.4.0 - Strapi Developer Documentation
 description: Learn how you can migrate your Strapi application from 3.3.x to 3.4.0.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-3.3.x-to-3.4.0.html
 ---
 
 # Migration guide from 3.3.x to 3.4.0

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-3.4.x-to-3.4.4.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-3.4.x-to-3.4.4.md
@@ -1,6 +1,7 @@
 ---
 title: Migrate from 3.4.x to 3.4.4 - Strapi Developer Documentation
 description: Learn how you can migrate your Strapi application from 3.4.x to 3.4.4.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-3.4.x-to-3.4.4.html
 ---
 
 # Migration guide from 3.4.x to 3.4.4

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.10-to-alpha.11.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.10-to-alpha.11.md
@@ -1,6 +1,7 @@
 ---
 title: Migrate from alpha.10 to alpha.11 - Strapi Developer Documentation
 description: Learn how you can migrate your Strapi application from alpha.10 to alpha.11.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.10-to-alpha.11.html
 ---
 
 # Migration guide from alpha.10 to alpha.11

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.11-to-alpha.12.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.11-to-alpha.12.md
@@ -1,6 +1,7 @@
 ---
 title: Migrate from alpha.11 to alpha.12 - Strapi Developer Documentation
 description: Learn how you can migrate your Strapi application from alpha.11 to alpha.12.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.11-to-alpha.12.html
 ---
 
 # Migration guide from alpha.11 to alpha.12

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.12.1-to-alpha.12.2.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.12.1-to-alpha.12.2.md
@@ -1,6 +1,7 @@
 ---
 title: Migrate from alpha.12.1 to alpha.12.2 - Strapi Developer Documentation
 description: Learn how you can migrate your Strapi application from alpha.12.1 to alpha.12.2.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.12.1-to-alpha.12.2.html
 ---
 
 # Migration guide from alpha.12.1 to alpha.12.2

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.12.2-to-alpha.12.3.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.12.2-to-alpha.12.3.md
@@ -1,6 +1,7 @@
 ---
 title: Migrate from alpha.12.2 to alpha.12.3 - Strapi Developer Documentation
 description: Learn how you can migrate your Strapi application from alpha.12.2 to alpha.12.3.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.12.2-to-alpha.12.3.html
 ---
 
 # Migration guide from alpha.12.2 to alpha.12.3

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.12.3-to-alpha.12.4.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.12.3-to-alpha.12.4.md
@@ -1,6 +1,7 @@
 ---
 title: Migrate from alpha.12.3 to alpha.12.4 - Strapi Developer Documentation
 description: Learn how you can migrate your Strapi application from alpha.12.3 to alpha.12.4.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.12.3-to-alpha.12.4.html
 ---
 
 # Migration guide from alpha.12.3 to alpha.12.4

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.12.4-to-alpha.12.5.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.12.4-to-alpha.12.5.md
@@ -1,6 +1,7 @@
 ---
 title: Migrate from alpha.12.4 to alpha.12.5 - Strapi Developer Documentation
 description: Learn how you can migrate your Strapi application from alpha.12.4 to alpha.12.5.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.12.4-to-alpha.12.5.html
 ---
 
 # Migration guide from alpha.12.4 to alpha.12.5

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.12.5-to-alpha.12.6.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.12.5-to-alpha.12.6.md
@@ -1,6 +1,7 @@
 ---
 title: Migrate from alpha.12.5 to alpha.12.6 - Strapi Developer Documentation
 description: Learn how you can migrate your Strapi application from alpha.12.5 to alpha.12.6.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.12.5-to-alpha.12.6.html
 ---
 
 # Migration guide from alpha.12.5 to alpha.12.6

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.12.6-to-alpha.12.7.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.12.6-to-alpha.12.7.md
@@ -1,6 +1,7 @@
 ---
 title: Migrate from alpha.12.6 to alpha.12.7 - Strapi Developer Documentation
 description: Learn how you can migrate your Strapi application from alpha.12.6 to alpha.12.7.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.12.6-to-alpha.12.7.html
 ---
 
 # Migration guide from alpha.12.6 to alpha.12.7

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.12.7-to-alpha.13.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.12.7-to-alpha.13.md
@@ -1,6 +1,7 @@
 ---
 title: Migrate from alpha.12.7 to alpha.13 - Strapi Developer Documentation
 description: Learn how you can migrate your Strapi application from alpha.12.7 to alpha.13.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.12.7-to-alpha.13.html
 ---
 
 # Migration guide from alpha.12.7 to alpha.13

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.13-to-alpha.13.1.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.13-to-alpha.13.1.md
@@ -1,6 +1,7 @@
 ---
 title: Migrate from alpha.13 to alpha.13.1 - Strapi Developer Documentation
 description: Learn how you can migrate your Strapi application from alpha.13 to alpha.13.1.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.13-to-alpha.13.1.html
 ---
 
 # Migration guide from alpha.13 to alpha.13.1

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.13.1-to-alpha.14.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.13.1-to-alpha.14.md
@@ -1,6 +1,7 @@
 ---
 title: Migrate from alpha.13.1 to alpha.14 - Strapi Developer Documentation
 description: Learn how you can migrate your Strapi application from alpha.13.1 to alpha.14.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.13.1-to-alpha.14.html
 ---
 
 # Migration guide from alpha.13.1 to alpha.14

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.14-to-alpha.14.1.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.14-to-alpha.14.1.md
@@ -1,6 +1,7 @@
 ---
 title: Migrate from alpha.14 to alpha.14.1 - Strapi Developer Documentation
 description: Learn how you can migrate your Strapi application from alpha.14 to alpha.14.1.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.14-to-alpha.14.1.html
 ---
 
 # Migration guide from alpha.14 to alpha.14.1

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.14.1-to-alpha.14.2.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.14.1-to-alpha.14.2.md
@@ -1,6 +1,7 @@
 ---
 title: Migrate from alpha.14.1 to alpha.14.2 - Strapi Developer Documentation
 description: Learn how you can migrate your Strapi application from alpha.14.1 to alpha.14.2.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.14.1-to-alpha.14.2.html
 ---
 
 # Migration guide from alpha.14.1 to alpha.14.2

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.14.2-to-alpha.14.3.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.14.2-to-alpha.14.3.md
@@ -1,6 +1,7 @@
 ---
 title: Migrate from alpha.14.2 to alpha.14.3 - Strapi Developer Documentation
 description: Learn how you can migrate your Strapi application from alpha.14.2 to alpha.14.3.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.14.2-to-alpha.14.3.html
 ---
 
 # Migration guide from alpha.14.2 to alpha.14.3

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.14.3-to-alpha.14.4.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.14.3-to-alpha.14.4.md
@@ -1,6 +1,7 @@
 ---
 title: Migrate from alpha.14.3 to alpha.14.4 - Strapi Developer Documentation
 description: Learn how you can migrate your Strapi application from alpha.14.3 to alpha.14.4.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.14.3-to-alpha.14.4.html
 ---
 
 # Migration guide from alpha.14.3 to alpha.14.4

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.14.4-to-alpha.14.5.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.14.4-to-alpha.14.5.md
@@ -1,6 +1,7 @@
 ---
 title: Migrate from alpha.14.4 to alpha.14.5 - Strapi Developer Documentation
 description: Learn how you can migrate your Strapi application from alpha.14.4 to alpha.14.5.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.14.4-to-alpha.14.5.html
 ---
 
 # Migration guide from alpha.14.4 to alpha.14.5

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.14.5-to-alpha.15.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.14.5-to-alpha.15.md
@@ -1,6 +1,7 @@
 ---
 title: Migrate from alpha.14.5 to alpha.15 - Strapi Developer Documentation
 description: Learn how you can migrate your Strapi application from alpha.14.5 to alpha.15.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.14.5-to-alpha.15.html
 ---
 
 # Migration guide from alpha.14.5 to alpha.15

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.15-to-alpha.16.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.15-to-alpha.16.md
@@ -1,6 +1,7 @@
 ---
 title: Migrate from alpha.15 to alpha.16 - Strapi Developer Documentation
 description: Learn how you can migrate your Strapi application from alpha.15 to alpha.16.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.15-to-alpha.16.html
 ---
 
 # Migration guide from alpha.15 to alpha.16

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.16-to-alpha.17.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.16-to-alpha.17.md
@@ -1,6 +1,7 @@
 ---
 title: Migrate from alpha.16 to alpha.17 - Strapi Developer Documentation
 description: Learn how you can migrate your Strapi application from alpha.16 to alpha.17.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.16-to-alpha.17.html
 ---
 
 # Migration guide from alpha.16 to alpha.17

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.17-to-alpha.18.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.17-to-alpha.18.md
@@ -1,6 +1,7 @@
 ---
 title: Migrate from alpha.17 to alpha.18 - Strapi Developer Documentation
 description: Learn how you can migrate your Strapi application from alpha.17 to alpha.18.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.17-to-alpha.18.html
 ---
 
 # Migration guide from alpha.17 to alpha.18

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.18-to-alpha.19.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.18-to-alpha.19.md
@@ -1,6 +1,7 @@
 ---
 title: Migrate from alpha.18 to alpha.19 - Strapi Developer Documentation
 description: Learn how you can migrate your Strapi application from alpha.18 to alpha.19.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.18-to-alpha.19.html
 ---
 
 # Migration guide from alpha.18 to alpha.19

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.19-to-alpha.20.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.19-to-alpha.20.md
@@ -1,6 +1,7 @@
 ---
 title: Migrate from alpha.19 to alpha.20 - Strapi Developer Documentation
 description: Learn how you can migrate your Strapi application from alpha.19 to alpha.20.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.19-to-alpha.20.html
 ---
 
 # Migration guide from alpha.19 to alpha.20

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.20-to-alpha.21.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.20-to-alpha.21.md
@@ -1,6 +1,7 @@
 ---
 title: Migrate from alpha.20 to alpha.21 - Strapi Developer Documentation
 description: Learn how you can migrate your Strapi application from alpha.20 to alpha.21.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.20-to-alpha.21.html
 ---
 
 # Migration guide from alpha.20 to alpha.21

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.21-to-alpha.22.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.21-to-alpha.22.md
@@ -1,6 +1,7 @@
 ---
 title: Migrate from alpha.21 to alpha.22 - Strapi Developer Documentation
 description: Learn how you can migrate your Strapi application from alpha.21 to alpha.22.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.21-to-alpha.22.html
 ---
 
 # Migration guide from alpha.21 to alpha.22

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.22-to-alpha.23.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.22-to-alpha.23.md
@@ -1,6 +1,7 @@
 ---
 title: Migrate from alpha.22 to alpha.23 - Strapi Developer Documentation
 description: Learn how you can migrate your Strapi application from alpha.22 to alpha.23.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.22-to-alpha.23.html
 ---
 
 # Migration guide from alpha.22 to alpha.23

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.23-to-alpha.24.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.23-to-alpha.24.md
@@ -1,6 +1,7 @@
 ---
 title: Migrate from alpha.23 to alpha.24 - Strapi Developer Documentation
 description: Learn how you can migrate your Strapi application from alpha.23 to alpha.24.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.23-to-alpha.24.html
 ---
 
 # Migration guide from alpha.23 to alpha.24

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.24-to-alpha.25.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.24-to-alpha.25.md
@@ -1,6 +1,7 @@
 ---
 title: Migrate from alpha.24 to alpha.25.2 - Strapi Developer Documentation
-description: Learn how you can migrate your Strapi application from alpha.24 to alpha.25.2.
+description: Learn how you can migrate your Strapi application from alpha.24 to alpha.25.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.24-to-alpha.25.html
 ---
 
 # Migration guide from alpha.24 to alpha.25.2

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.25-to-alpha.26.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.25-to-alpha.26.md
@@ -1,6 +1,7 @@
 ---
 title: Migrate from alpha.25 to alpha.26.2s - Strapi Developer Documentation
-description: Learn how you can migrate your Strapi application from alpha.25 to alpha.26.2s.
+description: Learn how you can migrate your Strapi application from alpha.25 to alpha.26.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.25-to-alpha.26.html
 ---
 
 # Migration guide from alpha.25 to alpha.26.2

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.26-to-beta.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.26-to-beta.md
@@ -1,6 +1,7 @@
 ---
 title: Migrate to v3.0.0-beta.x - Strapi Developer Documentation
-description: Learn how you can migrate your Strapi application to v3.0.0-beta.x.
+description: Learn how you can migrate your Strapi application to from aplha.26 to beta.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.26-to-beta.html
 ---
 
 # Migration Guide

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.7.4-to-alpha.8.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.7.4-to-alpha.8.md
@@ -1,6 +1,7 @@
 ---
 title: Migrate from alpha.7.4 to alpha.8 - Strapi Developer Documentation
 description: Learn how you can migrate your Strapi application from alpha.7.4 to alpha.8.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.7.4-to-alpha.8.html
 ---
 
 # Migration guide from alpha.7.4 to alpha.8

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.8-to-alpha.9.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.8-to-alpha.9.md
@@ -1,6 +1,7 @@
 ---
 title: Migrate from alpha.8 to alpha.9 - Strapi Developer Documentation
 description: Learn how you can migrate your Strapi application from alpha.8 to alpha.9.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.8-to-alpha.9.html
 ---
 
 # Migration guide from alpha.8 to alpha.9

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.9-to-alpha.10.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.9-to-alpha.10.md
@@ -1,6 +1,7 @@
 ---
 title: Migrate from alpha.9 to alpha.10 - Strapi Developer Documentation
 description: Learn how you can migrate your Strapi application from alpha.9 to alpha.10.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-alpha.9-to-alpha.10.html
 ---
 
 # Migration guide from alpha.9 to alpha.10

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-beta.15-to-beta.16.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-beta.15-to-beta.16.md
@@ -1,6 +1,7 @@
 ---
 title: Migrate from beta.15 to beta.16 - Strapi Developer Documentation
 description: Learn how you can migrate your Strapi application from beta.15 to beta.16.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-beta.15-to-beta.16.html
 ---
 
 # Migration guide from beta.15 to beta.16

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-beta.16-to-beta.17.4.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-beta.16-to-beta.17.4.md
@@ -1,6 +1,7 @@
 ---
 title: Migrate to beta.17.4 - Strapi Developer Documentation
 description: Learn how you can migrate your Strapi application to beta.17.4.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-beta.16-to-beta.17.4.html
 ---
 
 # Migration guide from beta.16.8 through beta.17.3 to beta.17.4

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-beta.17-to-beta.18.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-beta.17-to-beta.18.md
@@ -1,6 +1,7 @@
 ---
 title: Migrate to beta.18 - Strapi Developer Documentation
 description: Learn how you can migrate your Strapi application to beta.18.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-beta.17-to-beta.18.html
 ---
 
 # Migration guide from beta.17.4 through beta.17.8 to beta.18

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-beta.18-to-beta.19.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-beta.18-to-beta.19.md
@@ -1,6 +1,7 @@
 ---
 title: Migrate from beta.18.x to beta.19 - Strapi Developer Documentation
 description: Learn how you can migrate your Strapi application from beta.18.x to beta.19.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-beta.18-to-beta.19.html
 ---
 
 # Migration guide from beta.18.x to beta.19

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-beta.19-to-beta.19.4.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-beta.19-to-beta.19.4.md
@@ -1,6 +1,7 @@
 ---
 title: Migrate from beta.19.x to beta.19.4 - Strapi Developer Documentation
 description: Learn how you can migrate your Strapi application from beta.19.x to beta.19.4.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-beta.19-to-beta.19.4.html
 ---
 
 # Migration guide from beta.19.x to beta.19.4

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-beta.19-to-beta.20.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-beta.19-to-beta.20.md
@@ -1,6 +1,7 @@
 ---
 title: Migrate from beta.19.x to beta.20 - Strapi Developer Documentation
 description: Learn how you can migrate your Strapi application from beta.19.x to beta.20.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-beta.19-to-beta.20.html
 ---
 
 # Migration guide from beta.19.x to beta.20

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-beta.20-to-3.0.0.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-beta.20-to-3.0.0.md
@@ -1,6 +1,7 @@
 ---
 title: Migrate from 3.0.0-beta.20 to 3.0.0 - Strapi Developer Documentation
-description: Learn how you can migrate your Strapi application from 3.0.0-beta.20 to 3.0.0.
+description: Learn how you can migrate your Strapi application from beta.20 to 3.0.0.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/migration-guide-beta.20-to-3.0.0.html
 ---
 
 # Migration guide from 3.0.0-beta.20 to 3.0.0

--- a/docs/developer-docs/latest/update-migration-guides/update-version.md
+++ b/docs/developer-docs/latest/update-migration-guides/update-version.md
@@ -1,6 +1,7 @@
 ---
 title: Update Strapi version - Strapi Developer Documentation
 description: The following documentation covers how to upgrade your application to the latest version of Strapi.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/update-migration-guides/update-version.html
 ---
 
 # Update Strapi version

--- a/docs/user-docs/latest/content-manager/configuring-view-of-content-type.md
+++ b/docs/user-docs/latest/content-manager/configuring-view-of-content-type.md
@@ -1,6 +1,7 @@
 ---
 title: Configuring views of a content type - Strapi User Guide
 description: Instructions to configure the edit view and list view of a content type in a Strapi application.
+canonicalUrl: https://docs.strapi.io/user-docs/latest/content-manager/configuring-view-of-content-type.html
 ---
 
 # Configuring the views of a content type

--- a/docs/user-docs/latest/content-manager/introduction-to-content-manager.md
+++ b/docs/user-docs/latest/content-manager/introduction-to-content-manager.md
@@ -1,6 +1,7 @@
 ---
 title: Content Manager - Strapi User Guide
 description: Introduction to the Content Manager which allows to write content for collection types and single types.
+canonicalUrl: https://docs.strapi.io/user-docs/latest/content-manager/introduction-to-content-manager.html
 ---
 
 # Introduction to the Content Manager

--- a/docs/user-docs/latest/content-manager/managing-relational-fields.md
+++ b/docs/user-docs/latest/content-manager/managing-relational-fields.md
@@ -1,6 +1,7 @@
 ---
 title: Managing Relational Fields - Strapi User Guide
 description: Instructions to manage relation-type fields, called "relational fields", which establish a relation between two content-types.
+canonicalUrl: https://docs.strapi.io/user-docs/latest/content-manager/managing-relational-fields.html
 ---
 
 # Managing relational fields

--- a/docs/user-docs/latest/content-manager/saving-and-publishing-content.md
+++ b/docs/user-docs/latest/content-manager/saving-and-publishing-content.md
@@ -1,6 +1,7 @@
 ---
 title: Saving & Publishishing content - Strapi User Guide
 description: Instructions to manage content throughout its whole lifecycle, from the draft version to the deletion of the obsolete content.
+canonicalUrl: https://docs.strapi.io/user-docs/latest/content-manager/saving-and-publishing-content.html
 ---
 
 # Saving, publishing and deleting content

--- a/docs/user-docs/latest/content-manager/translating-content.md
+++ b/docs/user-docs/latest/content-manager/translating-content.md
@@ -1,6 +1,7 @@
 ---
 title: Translating content - Strapi User Guide
-description: Instructions to translate content in various locales with i18n plugin
+description: Instructions to translate content in various locales with i18n plugin.
+canonicalUrl: https://docs.strapi.io/user-docs/latest/content-manager/translating-content.html
 ---
 
 # Translating content

--- a/docs/user-docs/latest/content-manager/writing-content.md
+++ b/docs/user-docs/latest/content-manager/writing-content.md
@@ -1,6 +1,7 @@
 ---
 title: Writing Content - Strapi User Guide
 description: Instructions to write content by filling up fields that are meant to contain specific content (e.g. text, numbers, media etc.).
+canonicalUrl: https://docs.strapi.io/user-docs/latest/content-manager/writing-content.html
 ---
 
 # Writing content

--- a/docs/user-docs/latest/content-types-builder/configuring-fields-content-type.md
+++ b/docs/user-docs/latest/content-types-builder/configuring-fields-content-type.md
@@ -2,6 +2,7 @@
 title: Fields for Content Types - Strapi User Guide
 description: Instructions to configure in the Content-Type Builder the fields that compose each content-type.
 sidebarDepth: 3
+canonicalUrl: https://docs.strapi.io/user-docs/latest/content-types-builder/configuring-fields-content-type.html
 ---
 
 # Configuring fields for content types

--- a/docs/user-docs/latest/content-types-builder/creating-new-content-type.md
+++ b/docs/user-docs/latest/content-types-builder/creating-new-content-type.md
@@ -1,6 +1,7 @@
 ---
 title: Creating Content-Types - Strapi User Guide
 description: The Content-Type Builder allows to create new content-types (single and collection types).
+canonicalUrl: https://docs.strapi.io/user-docs/latest/content-types-builder/creating-new-content-type.html
 ---
 
 # Creating content-types

--- a/docs/user-docs/latest/content-types-builder/introduction-to-content-types-builder.md
+++ b/docs/user-docs/latest/content-types-builder/introduction-to-content-types-builder.md
@@ -1,6 +1,7 @@
 ---
 title: Content-Type Builder - Strapi User Guide
 description: From the Content-Type Builder, administrators can create and manage content-types (collection types and single types but also components).
+canonicalUrl: https://docs.strapi.io/user-docs/latest/content-types-builder/introduction-to-content-types-builder.html
 ---
 
 # Introduction to the Content-Type Builder

--- a/docs/user-docs/latest/content-types-builder/managing-content-types.md
+++ b/docs/user-docs/latest/content-types-builder/managing-content-types.md
@@ -1,6 +1,7 @@
 ---
 title: Managing Content-types - Strapi User Guide
 description: The Content-Type Builder allows to manage any existing content-type or component, even if it is already being used in the Content Manager. They can only be managed one at a time.
+canonicalUrl: https://docs.strapi.io/user-docs/latest/content-types-builder/managing-content-types.html
 ---
 
 # Managing content-types

--- a/docs/user-docs/latest/getting-started/introduction.md
+++ b/docs/user-docs/latest/getting-started/introduction.md
@@ -1,6 +1,7 @@
 ---
 title: Strapi User Guide
 description: This user guide contains the functional documentation related to all features available in the admin panel of your Strapi application.
+canonicalUrl: https://docs.strapi.io/user-docs/latest/getting-started/introduction.html
 ---
 
 # Welcome to the Strapi user guide!

--- a/docs/user-docs/latest/plugins/installing-plugins-via-marketplace.md
+++ b/docs/user-docs/latest/plugins/installing-plugins-via-marketplace.md
@@ -1,6 +1,7 @@
 ---
 title: Installing plugins via the Marketplace - Strapi User Guide
-description: Instructions to install new plugins in a Strapi application via the Marketplace
+description: Instructions to install new plugins in a Strapi application via the Marketplace.
+canonicalUrl: https://docs.strapi.io/user-docs/latest/plugins/installing-plugins-via-marketplace.html
 ---
 
 # Installing plugins via the Marketplace

--- a/docs/user-docs/latest/plugins/introduction-to-plugins.md
+++ b/docs/user-docs/latest/plugins/introduction-to-plugins.md
@@ -1,6 +1,7 @@
 ---
 title: Plugins - Strapi User Guide
 description: Reference guide to all Strapi plugins and instructions to use these plugins.
+canonicalUrl: https://docs.strapi.io/user-docs/latest/plugins/introduction-to-plugins.html
 ---
 
 # Introduction to plugins

--- a/docs/user-docs/latest/plugins/strapi-plugins.md
+++ b/docs/user-docs/latest/plugins/strapi-plugins.md
@@ -1,6 +1,7 @@
 ---
 title: List of Strapi plugins - Strapi User Guide
-description: Reference guide to Strapi plugins explaining how they work and how they expand a Strapi application
+description: Reference guide to Strapi plugins explaining how they work and how they expand a Strapi application.
+canonicalUrl: https://docs.strapi.io/user-docs/latest/plugins/strapi-plugins.html
 ---
 
 # List of Strapi plugins

--- a/docs/user-docs/latest/settings/configuring-users-permissions-plugin-settings.md
+++ b/docs/user-docs/latest/settings/configuring-users-permissions-plugin-settings.md
@@ -1,6 +1,7 @@
 ---
 title: Users & Permissions plugin settings - Strapi User Guide
 description: Instructions to configure the Users & Permissions plugin
+canonicalUrl: https://docs.strapi.io/user-docs/latest/settings/configuring-users-permissions-plugin-settings.html
 ---
 
 # Configuring Users & Permissions plugin settings

--- a/docs/user-docs/latest/settings/managing-global-settings.md
+++ b/docs/user-docs/latest/settings/managing-global-settings.md
@@ -1,6 +1,7 @@
 ---
 title: Global Settings - Strapi User Guide
 description: Instructions to manage the global settings of a Strapi application in the admin panel.
+canonicalUrl: https://docs.strapi.io/user-docs/latest/settings/manageing-global-settings.html
 ---
 
 # Managing global settings

--- a/docs/user-docs/latest/users-roles-permissions/configuring-administrator-roles.md
+++ b/docs/user-docs/latest/users-roles-permissions/configuring-administrator-roles.md
@@ -1,6 +1,7 @@
 ---
 title: Configure Administrator Roles - Strapi User Guide
 description: Instructions to configure the administrator roles of a Strapi application with the Role-Based Access Control (RBAC) feature.
+canonicalUrl: https://docs.strapi.io/user-docs/latest/users-roles-permissions/configuring-administrator-roles.html
 ---
 
 # Configuring administrator roles

--- a/docs/user-docs/latest/users-roles-permissions/configuring-end-users-roles.md
+++ b/docs/user-docs/latest/users-roles-permissions/configuring-end-users-roles.md
@@ -1,6 +1,7 @@
 ---
 title: Configure End-users Roles - Strapi User Guide
 description: Instructions to configure the end-users roles for a front-end application using the Users & Permissions plugin
+canonicalUrl: https://docs.strapi.io/user-docs/latest/users-roles-permissions/configuring-end-users-roles.html
 ---
 
 # Configuring end-users roles

--- a/docs/user-docs/latest/users-roles-permissions/introduction-to-users-roles-permissions.md
+++ b/docs/user-docs/latest/users-roles-permissions/introduction-to-users-roles-permissions.md
@@ -1,6 +1,7 @@
 ---
 title: Users, Roles & Permissions - Strapi User Guide
 description: Introduction to the system of permissions of Strapi which gives access to features of the admin panel.
+canonicalUrl: https://docs.strapi.io/user-docs/latest/users-roles-permissions/introduction-to-users-roles-permissions.html
 ---
 
 # Introduction to users, roles & permissions

--- a/docs/user-docs/latest/users-roles-permissions/managing-administrators.md
+++ b/docs/user-docs/latest/users-roles-permissions/managing-administrators.md
@@ -1,6 +1,7 @@
 ---
 title: Managing Administrators - Strapi User Guide
 description: Instructions to manage the administrators of a Strapi application with the Role-Based Access Control (RBAC) feature.
+canonicalUrl: https://docs.strapi.io/user-docs/latest/users-roles-permissions/managing-administrators.html
 ---
 
 # Managing administrator accounts

--- a/docs/user-docs/latest/users-roles-permissions/managing-end-users.md
+++ b/docs/user-docs/latest/users-roles-permissions/managing-end-users.md
@@ -1,6 +1,7 @@
 ---
 title: Managing End-Users Accounts - Strapi User Guide
-description: Instructions to manage the end-users of a front-end application with the Users & Permissions plugin
+description: Instructions to manage the end-users of a front-end application with the Users & Permissions plugin.
+canonicalUrl: https://docs.strapi.io/user-docs/latest/users-roles-permissions/managing-end-users.html
 ---
 
 # Managing end-users accounts


### PR DESCRIPTION
### What does it do?

Added canonical tags in the front matter for all markdown files.

### Why is it needed?

To establish content ownership for SEO, especially for duplicate content across different versioning documentation.
