### PR TITLE
Update 'Database Access' location

### DIFF
--- a/docs/developer-docs/latest/setup-deployment-guides/configurations/databases/mongodb.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/configurations/databases/mongodb.md
@@ -229,7 +229,7 @@ Follow these steps to configure a local Strapi project to use a [MongoDB Atlas](
   - In **Cluster Name**, name your cluster.
 - Click the green `Create Cluster` button. You will get a message that says, "_Your cluster is being created..._"
 
-### 2. Next, click on the `Database Access` in the left menu (under `Overview`):
+### 2. Next, click on the `Database Access` in the left menu (under `Security`):
 
 - Click the green `+ ADD NEW USER` button:
   - Enter a `username`.


### PR DESCRIPTION
The mongodb dashboard does not have an 'Overview' section anymore as implied in the strapi mongodb docs. Currently, it has a 'Deployment' section and 'Database Access' has been moved to the 'Security' section.

This PR fixes that. Subsequent users won't have to start searching for an 'Overview' section.

Thanks

