### PR TITLE
Missing installation step in the documentation

### DIFF
--- a/docs/developer-docs/latest/setup-deployment-guides/installation/cli.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/installation/cli.md
@@ -70,6 +70,27 @@ yarn create strapi-app my-project
 
 6. (Custom installation type only) Name your project's database.
 
+## Install Strapi dependencies with npm or yarn
+
+First, you should install npm packages using the following command
+
+<code-group>
+
+<code-block title="NPM">
+```bash
+npm install
+```
+</code-block>
+
+<code-block title="YARN">
+```sh
+yarn
+```
+</code-block>
+
+</code-group>
+
+
 ## Running Strapi
 
 To start the Strapi application, run the following command in the project folder:


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

Describe how to install starpi using npm packages 

### Why is it needed?

You cannot run the following command in the documentation, unless you install the required npm packages