### PR TITLE
Adds strapi parameter to controller

### DIFF
--- a/docs/developer-docs/latest/developer-resources/plugin-api-reference/server.md
+++ b/docs/developer-docs/latest/developer-resources/plugin-api-reference/server.md
@@ -247,11 +247,11 @@ module.exports = {
 ```js
 // path: ./controllers/controller-a.js
 
-module.exports = {
+module.exports = ({ strapi }) => ({
   doSomething(ctx) {
     ctx.body = { message: 'HelloWorld' };
   },
-};
+});
 ```
 
 ### Services


### PR DESCRIPTION
### What does it do?

Add the strapi parameter to the controller. 
Even if the previous example worked it was not clear that the controller can return both an object and a function. 
Since it is very likely that the user would want to access the services in the controller I think showing an example where you can access the `strapi` API without having to rely on the global `strapi` variable is better. 

### Why is it needed?

More relevant example

### Related issue(s)/PR(s)

/