### PR TITLE
Change strapi.api example from function to array

### DIFF
--- a/docs/developer-docs/latest/developer-resources/plugin-api-reference/server.md
+++ b/docs/developer-docs/latest/developer-resources/plugin-api-reference/server.md
@@ -390,7 +390,7 @@ While top-level getters imply chaining functions, global getters are syntactic s
 
 ```js
 // Access an API or a plugin controller using a top-level getter 
-strapi.api('api-name').controller('controller-name')
+strapi.api['api-name'].controller('controller-name')
 strapi.plugin('plugin-name').controller('controller-name')
 
 // Access an API or a plugin controller using a global getter


### PR DESCRIPTION
### What does it do?

Changes the type of `strapi.api`


### Why is it needed?

`strapi.api` is an object not a function

### Related issue(s)/PR(s)

/
