### PR TITLE
Improve visibility over v4 vs. v3 docs

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -676,7 +676,7 @@ module.exports = {
         link: 'https://strapi.io/resource-center',
       },
       {
-        text: 'Documentation',
+        text: 'v4 Documentation',
         items: [
           {
             text: 'Developer Docs',
@@ -736,16 +736,11 @@ module.exports = {
               },
             ],
           },
-          {
-            text: 'Older versions',
-            items: [
-              {
-                text: 'v3 Documentation',
-                link: 'https://docs-v3.strapi.io'
-              }
-            ],
-          },
         ],
+      },
+      {
+        text: 'v3 documentation',
+        link: 'https://docs-v3.strapi.io'
       },
       {
         text: 'Ecosystem',


### PR DESCRIPTION
Enhance visibility of v3 vs. v4 links as people were confused about it :-) 
