### PR TITLE
show npm-yarn tabs on Hands-on

### DIFF
--- a/docs/developer-docs/latest/getting-started/quick-start.md
+++ b/docs/developer-docs/latest/getting-started/quick-start.md
@@ -107,21 +107,21 @@ Make sure [Node.js and npm are properly installed](/developer-docs/latest/setup-
 
 Run the following command in a terminal:
 
-<code-group>
+:::: tabs card
+::: tab npm
 
-<code-block title="NPM">
 ```bash
-npx create-strapi-app@latest my-project --quickstart
+  npx create-strapi-app@latest my-project --quickstart
 ```
-</code-block>
 
-<code-block title="YARN">
+:::
+::: tab yarn
+
 ```bash
-yarn create strapi-app my-project --quickstart
+  yarn create strapi-app my-project --quickstart
 ```
-</code-block>
 
-</code-group>
+::::
 
 ### Step 2: Register the first administrator user
 


### PR DESCRIPTION
Ready to be merged!

### What does it do?

![image](https://user-images.githubusercontent.com/32805147/144487268-415319e0-6eec-4754-b093-7630f6f9e4f1.png)

In the following page (Hands-on tab) don't show the command to create a new app. I just created a similar structure from Starters tab.

https://docs.strapi.io/developer-docs/latest/getting-started/quick-start.html