### PR TITLE
auth route v4

### DIFF
--- a/docs/developer-docs/latest/guides/auth-request.md
+++ b/docs/developer-docs/latest/guides/auth-request.md
@@ -69,7 +69,7 @@ Finally create **2 users** with the following data.
 
 To login as a user your will have to follow the [login documentation](/developer-docs/latest/plugins/users-permissions.md#login).
 
-Here is the API route for the authentication `/auth/local`.
+Here is the API route for the authentication `/api/auth/local`.
 
 You have to request it in **POST**.
 
@@ -80,7 +80,7 @@ You have to request it in **POST**.
 ```js
 import axios from 'axios';
 
-const { data } = await axios.post('http://localhost:1337/auth/local', {
+const { data } = await axios.post('http://localhost:1337/api/auth/local', {
   identifier: 'reader@strapi.io',
   password: 'strapi',
 });


### PR DESCRIPTION
i found that default authentication route should be `/api/auth/local`

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

Update default route for authentication should be `/api/auth/local`

### Why is it needed?

Some article still refer to this route `/auth/local`

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
