### PR TITLE
default route user register in v4

### DIFF
--- a/docs/developer-docs/latest/plugins/users-permissions.md
+++ b/docs/developer-docs/latest/plugins/users-permissions.md
@@ -41,7 +41,7 @@ On the right sidebar you will be able to see the URL related to this function.
 
 ### Update the default role
 
-When you create a user without a role or if you use the `/auth/local/register` route, the `authenticated` role is given to the user.
+When you create a user without a role or if you use the `/api/auth/local/register` route, the `authenticated` role is given to the user.
 
 To change the default role, go to the `Advanced settings` tab and update the `Default role for authenticated users` option.
 
@@ -113,7 +113,7 @@ import axios from 'axios';
 // Request API.
 // Add your own code here to customize or restrict how the public can register new users.
 axios
-  .post('http://localhost:1337/auth/local/register', {
+  .post('http://localhost:1337/api/auth/local/register', {
     username: 'Strapi user',
     email: 'user@strapi.io',
     password: 'strapiPassword',
@@ -143,7 +143,7 @@ import axios from 'axios';
 
 // Request API.
 axios
-  .post('http://localhost:1337/auth/local', {
+  .post('http://localhost:1337/api/auth/local', {
     identifier: 'user@strapi.io',
     password: 'strapiPassword',
   })


### PR DESCRIPTION
I found that default route user register in v4 is `api/auth/local/register`

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

just found that default route user register in v4 
`/api/auth/local/register`

### Why is it needed?

update default route should be prefixed with `/api`

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
