### PR TITLE
Fix wrong parameter name in connection.connection documentation

### DIFF
--- a/docs/developer-docs/latest/setup-deployment-guides/configurations/required/databases.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/configurations/required/databases.md
@@ -38,7 +38,7 @@ The `connection.connection` object found in `./config/database.js` is used to pa
 | `host`     | Database host name. Default value: `localhost`.                                                                               | `String`              |
 | `port`     | Database port                                                                                                                 | `Integer`             |
 | `database` | Database name.                                                                                                                | `String`              |
-| `username` | Username used to establish the connection                                                                                     | `String`              |
+| `user` | Username used to establish the connection                                                                                     | `String`              |
 | `password` | Password used to establish the connection                                                                                     | `String`              |
 | `timezone` | Set the default behavior for local time. Default value: `utc` [Timezone options](https://www.php.net/manual/en/timezones.php) | `String`              |
 | `schema`   | Set the default database schema. **Used only for Postgres DB.**                                                               | `String`              |


### PR DESCRIPTION
In the documentation about the connection parameters, the `username` parameter does not actually exist. This is probably a typo and should be replaced by the `user` parameter as per the example given below on the same page.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

Update the database documentation page to fix the wrongly named `connection.connection.username` key (updated to `connection.connection.user`)

### Why is it needed?

Otherwise configuring the app without using the example leads to errors that are difficult to troubleshoot.

### Related issue(s)/PR(s)

None
