### PR TITLE
Fix typo in i18n.md docs

### DIFF
--- a/docs/developer-docs/latest/plugins/i18n.md
+++ b/docs/developer-docs/latest/plugins/i18n.md
@@ -53,9 +53,9 @@ The i18n plugin adds new features to the [REST API](/developer-docs/latest/devel
 - a new [`locale`](#getting-localized-entries-with-the-locale-parameter) parameter to fetch content only for a specified locale
 - the ability to create a localized entry, either [from scratch](#creating-a-new-localized-entry) or [for an existing localized entry](#creating-a-localization-for-an-existing-entry)
 
-### Getting localized entries with the `locale` parameter
+### Getting localized entries with the `_locale` parameter
 
-The `locale` [API parameter](/developer-docs/latest/developer-resources/database-apis-reference/rest-api.md#api-parameters) can be used to fetch entries only for a specified locale. It takes a locale code as value (see [full list of available locales](https://github.com/strapi/strapi/blob/master/packages/plugins/i18n/server/constants/iso-locales.json)).
+The `_locale` [API parameter](/developer-docs/latest/developer-resources/database-apis-reference/rest-api.md#api-parameters) can be used to fetch entries only for a specified locale. It takes a locale code as value (see [full list of available locales](https://github.com/strapi/strapi/blob/master/packages/plugins/i18n/server/constants/iso-locales.json)).
 
 :::tip
  To fetch content for a locale, make sure it has been already [added to Strapi in the admin panel](/user-docs/latest/settings/managing-global-settings.md#configuring-internationalization-locales).
@@ -64,12 +64,12 @@ The `locale` [API parameter](/developer-docs/latest/developer-resources/database
 The format for a GET request is the following:
 
 :::request
-`GET /api/{content-type}?locale={locale-code}`
+`GET /api/{content-type}?_locale={locale-code}`
 :::
 
-Use `all` as a value for the locale code, as in `http://localhost:1337/api/restaurants?locale=all`, to fetch entries for all locales that have been configured in the admin panel.
+Use `all` as a value for the locale code, as in `http://localhost:1337/api/restaurants?_locale=all`, to fetch entries for all locales that have been configured in the admin panel.
 
-If the `locale` parameter isn't defined, it will be set to the default locale. `en` is the default locale when the i18n plugin is installed, so by default a GET request to `http://localhost:1337/api/restaurants` will return the same response as a request to `http://localhost:1337/api/restaurants?locale=en`.
+If the `_locale` parameter isn't defined, it will be set to the default locale. `en` is the default locale when the i18n plugin is installed, so by default a GET request to `http://localhost:1337/api/restaurants` will return the same response as a request to `http://localhost:1337/api/restaurants?_locale=en`.
 
 ::: tip
 Another locale can be [set as the default locale](/user-docs/latest/settings/managing-global-settings.md#adding-a-new-locale) in the admin panel.
@@ -85,7 +85,7 @@ When the i18n plugin is installed, the response to requests can include fields t
 
 ::: request Example request
 
-`GET http://localhost:1337/api/restaurants?locale=fr`
+`GET http://localhost:1337/api/restaurants?_locale=fr`
 
 :::
 


### PR DESCRIPTION
### What does it do?

Fix typo in documentation

### Why is it needed?

I spent ages trying to work out why my API calls were failing. I finally stumbled upon [this](https://forum.strapi.io/t/i18n-and-slug-system/4428/3) community answer which says that the query param should be `_locale`, not `locale` and suddenly everything works as expected.

### Related issue(s)/PR(s)


N/A