### PR TITLE
lifecycles.js file is not generated automatically

### DIFF
--- a/docs/developer-docs/latest/development/backend-customization/models.md
+++ b/docs/developer-docs/latest/development/backend-customization/models.md
@@ -30,7 +30,7 @@ Content-types in Strapi can be created:
 The content-types has the following models files:
 
 - `schema.json` for the model's [schema](#model-schema) definition. (generated automatically, when creating content-type with either method)
-- `lifecycles.js` for [lifecycle hooks](#lifecycle-hooks). (must be created manually)
+- `lifecycles.js` for [lifecycle hooks](#lifecycle-hooks). This file must be created manually.
 
 These models files are stored in `./src/api/[api-name]/content-types/[content-type-name]/`, and any JavaScript or JSON file found in these folders will be loaded as a content-type's model (see [project structure](/developer-docs/latest/setup-deployment-guides/file-structure.md)).
 

--- a/docs/developer-docs/latest/development/backend-customization/models.md
+++ b/docs/developer-docs/latest/development/backend-customization/models.md
@@ -30,7 +30,7 @@ Content-types in Strapi can be created:
 The content-types has the following models files:
 
 - `schema.json` for the model's [schema](#model-schema) definition. (generated automatically, when creating content-type with either method)
-- `lifecycles.js` for [lifecycle hooks](#lifecycle-hooks). (can be generated manually)
+- `lifecycles.js` for [lifecycle hooks](#lifecycle-hooks). (must be created manually)
 
 These models files are stored in `./src/api/[api-name]/content-types/[content-type-name]/`, and any JavaScript or JSON file found in these folders will be loaded as a content-type's model (see [project structure](/developer-docs/latest/setup-deployment-guides/file-structure.md)).
 

--- a/docs/developer-docs/latest/development/backend-customization/models.md
+++ b/docs/developer-docs/latest/development/backend-customization/models.md
@@ -27,10 +27,10 @@ Content-types in Strapi can be created:
 - with the [Content-Type Builder in the admin panel](/user-docs/latest/content-types-builder/introduction-to-content-types-builder.md),
 - or with [Strapi's interactive CLI `strapi generate`](/developer-docs/latest/developer-resources/cli/CLI.md#strapi-generate) command.
 
-Creating a content-type with either method generates 2 files:
+The content-types has the following models files:
 
-- `schema.json` for the model's [schema](#model-schema) definition,
-- `lifecycles.js` for [lifecycle hooks](#lifecycle-hooks).
+- `schema.json` for the model's [schema](#model-schema) definition. (generated automatically, when creating content-type with either method)
+- `lifecycles.js` for [lifecycle hooks](#lifecycle-hooks). (can be generated manually)
 
 These models files are stored in `./src/api/[api-name]/content-types/[content-type-name]/`, and any JavaScript or JSON file found in these folders will be loaded as a content-type's model (see [project structure](/developer-docs/latest/setup-deployment-guides/file-structure.md)).
 


### PR DESCRIPTION
I think since version 4, the lifecycles.js file is not created automatically but needs to be created manually if needed.

Postscript
Correct me if I'm wrong.
You can also rephrase this change if it is relevant and true.
Thanks

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->
