### PR TITLE
Adjust parameter name for USER

### DIFF
--- a/docs/developer-docs/latest/setup-deployment-guides/configurations/required/databases.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/configurations/required/databases.md
@@ -38,7 +38,7 @@ The `connection.connection` object found in `./config/database.js` is used to pa
 | `host`     | Database host name. Default value: `localhost`.                                                                               | `String`              |
 | `port`     | Database port                                                                                                                 | `Integer`             |
 | `database` | Database name.                                                                                                                | `String`              |
-| `username` | Username used to establish the connection                                                                                     | `String`              |
+| `user` | Username used to establish the connection                                                                                     | `String`              |
 | `password` | Password used to establish the connection                                                                                     | `String`              |
 | `timezone` | Set the default behavior for local time. Default value: `utc` [Timezone options](https://www.php.net/manual/en/timezones.php) | `String`              |
 | `schema`   | Set the default database schema. **Used only for Postgres DB.**                                                               | `String`              |


### PR DESCRIPTION
### What does it do?

Documentation update.

### Why is it needed?

Starting with v4, the `username` field for a DB connection is now named `user`.
I've adjusted the table describing the accepted parameters for connection to reflect that.

### Related issue(s)/PR(s)

No issue raised for this problem as far as I'm aware.
