### PR TITLE
remove wrong config option for image upload plugin breakpoints

### DIFF
--- a/docs/developer-docs/latest/plugins/upload.md
+++ b/docs/developer-docs/latest/plugins/upload.md
@@ -52,14 +52,12 @@ These sizes can be overridden in `./config/plugins.js`:
 
 module.exports = ({ env }) => ({
   upload: {
-    config: {
-      breakpoints: {
-        xlarge: 1920,
-        large: 1000,
-        medium: 750,
-        small: 500,
-        xsmall: 64
-      },
+    breakpoints: {
+      xlarge: 1920,
+      large: 1000,
+      medium: 750,
+      small: 500,
+      xsmall: 64
     },
   },
 });


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?
removes wrong `config` config option for upload plugin `./config/plugins.js` options

Describe the technical changes you did.
corrected the documentation

### Why is it needed?
upload plugin doesn't create and upload a **large** image if `config` option is there.

Describe the issue you are solving.
Not able to create and upload **large** image following the documentation

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
