### PR TITLE
Add example of customizing internal middleware

### DIFF
--- a/docs/developer-docs/latest/setup-deployment-guides/configurations/required/middlewares.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/configurations/required/middlewares.md
@@ -131,6 +131,23 @@ This security middleware is about cross-origin resource sharing (CORS) and is ba
 | `headers`       | Configure the `Access-Control-Allow-Headers` CORS header<br/><br/>If not specified, defaults to reflecting the headers specified in the request's `Access-Control-Request-Headers` header | `Array` or `String`       | `['Content-Type', 'Authorization', 'Origin', 'Accept']`                                                                    |
 | `keepHeaderOnError`      | Add set headers to `err.header` if an error is thrown     | `Boolean`                                                                            | `false`                                                                          |                                                                 |
 
+Example:
+
+```js
+// path: ./config/middlewares.js
+
+module.exports = [
+  ...,
+  {
+    name: 'strapi::cors',
+    config: {
+      origin: '*',
+      headers: '*'
+    }
+  }
+];
+```
+
 ### `errors`
 
 The errors middleware handles [errors](/developer-docs/latest/developer-resources/error-handling.md) thrown by the code. Based on the type of error it sets the appropriate HTTP status to the response. By default, any error not supposed to be exposed to the end-user will result in a 500 HTTP response.


### PR DESCRIPTION
### What does it do?

Adds an example for how to configure an internal middleware.

### Why is it needed?

The documentation lacks clear examples in a lot of cases and assumes the user knows how to do things. In this case it's not clear how someone is supposed to add configurations to a built in middleware. The only information is regarding the resolve and config keys for custom middleware.

### Related issue(s)/PR(s)

NA