### PR TITLE
:book: :arrow_up:  bump Mysql/MariaDB minimum verison

### DIFF
--- a/docs/developer-docs/latest/setup-deployment-guides/deployment.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment.md
@@ -24,8 +24,8 @@ To provide the best possible environment for Strapi there are a few requirements
 - At least 2 GB of RAM (Moderately recommended 4)
 - Minimum required storage space recommended by your OS or 32 GB of **free** space
 - A supported database version
-  - MySQL >= 5.6
-  - MariaDB >= 10.1
+  - MySQL >= 5.7.8
+  - MariaDB >= 10.2.7
   - PostgreSQL >= 10
   - SQLite >= 3
 - A supported operating system

--- a/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/azure.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/azure.md
@@ -194,8 +194,8 @@ For Azure managed databases you can use the following:
 
 Likewise you can use any of the following installed locally on the virtual machine:
 
-- MySQL >= 5.6
-- MariaDB >= 10.1
+- MySQL >= 5.7.8
+- MariaDB >= 10.2.7
 - PostgreSQL >= 10
 - SQLite >= 3
 

--- a/docs/developer-docs/latest/setup-deployment-guides/installation/cli.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/installation/cli.md
@@ -21,8 +21,8 @@ A database is also required for any Strapi project. Strapi currently supports th
 | ---------- | --------------- |
 | SQLite     | 3               |
 | PostgreSQL | 10              |
-| MySQL      | 5.6             |
-| MariaDB    | 10.1            |
+| MySQL      | 5.7.8           |
+| MariaDB    | 10.2.7          |
 
 ## Creating a Strapi project
 


### PR DESCRIPTION
  - bump MyQL/MariaDB Minimum Version for `JSON` datatype support


### What does it do?

From Strapi V4 [database Storage](https://github.com/strapi/strapi/blob/f80b89fe69a95c597aa9a879d39a1ac1a9ba6a4f/packages/core/database/lib/schema/storage.js#L13) use `t.json` for a column with `json` datatype.  And, with [MariaDB V10.2.7](https://mariadb.com/kb/en/json-data-type/) / [MySQL V5.7.8](https://dev.mysql.com/doc/refman/5.7/en/json.html)  `json` was added. So, I think, Documents about minimum database version should be update.

For Myself, I use V4 and MariaDB V10.2.6, I got an error with `sql syntax `
``` sql
 create table `strapi_database_schema` (`id` int unsigned not null auto_increment primary key, `schema` json, `time` datetime, `hash` varchar(255)) - ER_PARSE_ERROR: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'json, `time` datetime, `hash` varchar(255))' at line 1

```

### Why is it needed?

Update minimum Version to make  V4  work  normally.

### Related issue(s)/PR(s)

None.
