### PR TITLE
Corrected: Database.js Structure and key variable

### DIFF
--- a/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/amazon-aws.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/amazon-aws.md
@@ -311,22 +311,16 @@ Copy/paste the following:
 
 ```js
 module.exports = ({ env }) => ({
-  defaultConnection: 'default',
-  connections: {
-    default: {
-      connector: 'bookshelf',
-      settings: {
-        client: 'postgres',
-        host: env('DATABASE_HOST', '127.0.0.1'),
-        port: env.int('DATABASE_PORT', 5432),
-        database: env('DATABASE_NAME', 'strapi'),
-        username: env('DATABASE_USERNAME', ''),
-        password: env('DATABASE_PASSWORD', ''),
-      },
-      options: {
-        ssl: false,
-      },
+  connection: {
+    client: "postgres",
+    connection: {
+      host: env("DATABASE_HOST", "127.0.0.1"),
+      port: env.int("DATABASE_PORT", 5432),
+      database: env("DATABASE_NAME", "strapi"),
+      user: env("DATABASE_USERNAME", ""),
+      password: env("DATABASE_PASSWORD", ""),
     },
+    useNullAsDefault: true,
   },
 });
 ```


### PR DESCRIPTION
The default structure provided in the doc doesn't work on AWS. The provided syntax which has a connection object within the connection object which consists of configurations seems to work.

username key is being replaced with user

