### PR TITLE
Azure updates

### DIFF
--- a/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/azure.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/azure.md
@@ -8,11 +8,11 @@ canonicalUrl: https://docs.strapi.io/developer-docs/latest/setup-deployment-guid
 
 !!!include(developer-docs/latest/setup-deployment-guides/deployment/snippets/deployment-guide-not-updated.md)!!!
 
-This is a step-by-step guide for deploying a Strapi project to [Azure](https://azure.microsoft.com/en-us/). Databases can be on a [Azure Virtual Machine](https://azure.microsoft.com/en-us/services/virtual-machines/), hosted externally as a service, or via the [Azure Managed Databases](https://azure.microsoft.com/en-us/services/postgresql/). Prior to starting this guide, you should have created a [Strapi project](/developer-docs/latest/getting-started/quick-start.md). And have read through the [configuration](/developer-docs/latest/setup-deployment-guides/deployment.md#application-configuration) section.
+This is a step-by-step guide for deploying a Strapi project to [Azure](https://azure.microsoft.com/). Databases can be on a [Azure Virtual Machine](https://azure.microsoft.com/services/virtual-machines/), hosted externally as a service, or via the [Azure Managed Databases](https://azure.microsoft.com/services/postgresql/). Prior to starting this guide, you should have created a [Strapi project](/developer-docs/latest/getting-started/quick-start.md). And have read through the [configuration](/developer-docs/latest/setup-deployment-guides/deployment.md#application-configuration) section.
 
 ### Azure Install Requirements
 
-- You must have an [Azure account](https://azure.microsoft.com/en-us/free/) before doing these steps.
+- You must have an [Azure account](https://azure.microsoft.com/free/) before doing these steps.
 - An SSH key to access the virtual machine
 
 ### Create a Virtual Machine

--- a/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/azure.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/azure.md
@@ -5,10 +5,196 @@ canonicalUrl: https://docs.strapi.io/developer-docs/latest/setup-deployment-guid
 ---
 
 # Azure
-
 !!!include(developer-docs/latest/setup-deployment-guides/deployment/snippets/deployment-guide-not-updated.md)!!!
 
-This is a step-by-step guide for deploying a Strapi project to [Azure](https://azure.microsoft.com/). Databases can be on a [Azure Virtual Machine](https://azure.microsoft.com/services/virtual-machines/), hosted externally as a service, or via the [Azure Managed Databases](https://azure.microsoft.com/services/postgresql/). Prior to starting this guide, you should have created a [Strapi project](/developer-docs/latest/getting-started/quick-start.md). And have read through the [configuration](/developer-docs/latest/setup-deployment-guides/deployment.md#application-configuration) section.
+This is a step-by-step guide for deploying a Strapi project to [Azure](https://azure.microsoft.com/) using Platform-as-a-Service (PaaS). If you're interested in using Infrastructre-as-a-Service (IaaS) refer to [IaaS deployment guide](#iaas-deployment-guide) further down. Prior to starting this guide, you should have created a [Strapi project](/developer-docs/latest/getting-started/quick-start.md) and have read through the [configuration](/developer-docs/latest/setup-deployment-guides/deployment.md#application-configuration) section.
+
+## Azure Install Requirements
+
+- You must have an [Azure account](https://azure.microsoft.com/free/) before doing these steps.
+
+## PaaS Deployment Guides
+
+There are three ways which you can deploy the Azure resources, via the [Azure Portal](#creating-resources-via-the-azure-portal), via the [Azure CLI](#creating-resources-via-the-azure-cli) or via an [Azure Resource Manager template](#deploy-with-an-azure-resource-manager-template).
+
+When Strapi is running in a PaaS hosting model, a custom storage provider will be required to avoid the transient disk of the PaaS model, [which is covered towards the end](#configure-strapi-for-azure-appservice).
+
+### Required Resources
+
+There are three resources in Azure that are required to run Strapi in a PaaS model, [AppService](https://azure.microsoft.com/services/app-service/?WT.mc_id=javascript-37811-aapowell) to host the Strapi web application, [Storage](https://azure.microsoft.com/product-categories/storage/?WT.mc_id=javascript-37811-aapowell) to store images/uploaded assets, and a database, Azure has managed MySQL and Postgres to choose from (for this tutorial, we'll use MySQL, but the steps are the same for MySQL).
+
+### Creating Resources via the Azure Portal
+
+In this section we'll use the Azure Portal to create the required resources to host Strapi.
+
+1. Navigate to the [Azure Portal](https://portal.azure.com/?WT.mc_id=javascript-37811-aapowell)
+
+1. Click **Create a resource** and search for _Resource group_ from the provided search box
+
+1. Provide a name for your Resource Group, `my-strapi-app`, and select a region
+
+1. Click **Review + create** then **Create**
+
+1. Navigate to the Resource Group once it's created, click **Create resources**
+   and search for _Web App_
+
+1. Ensure the _Subscription_ and _Resource Group_ are correct, then provide the following configuration for the app:
+
+   - _Name_ - `my-strapi-app`
+   - _Publish_ - `Code`
+   - _Runtime stack_ - `Node 14 LTS`
+   - _Operating System_ - `Linux`
+   - _Region_ - Select an appropriate region
+
+1. Use the _App Service Plan_ to select the appropriate Sku and size for the level fo scale your app will need (refer to [the Azure docs](https://azure.microsoft.com/pricing/details/app-service/windows/?WT.mc_id=javascript-37811-aapowell) for more information on the various Sku and sizes)
+
+1. Click **Review + create** then **Create**
+
+1. Navigate back to the Resource Group and click **Create** then search for _Storage account_ and click **Create**
+
+1. Ensure the _Subscription_ and _Resource Group_ are correct, then provide the following configuration for the storage account:
+
+   - _Name_ - `my-strapi-app`
+   - _Region_ - Select an appropriate region
+   - _Performance_ - `Standard`
+   - _Redundancy_ - Select the appropriate level of redundancy for your files
+
+1. Click **Review + create** then **Create**
+
+1. Navigate back to the Resource Group and click **Create** then search for _Azure Database for MySQL_ and click **Create**
+
+1. Select _Single server_ for the service type
+
+1. Ensure the _Subscription_ and _Resource Group_ are correct, then provide the following configuration for the storage account:
+
+   - _Name_ - `my-strapi-db`
+   - _Data source_ - `None` (unless you're wanting to import from a backup)
+   - _Location_ - Select an appropriate region
+   - _Version_ - `5.7`
+   - _Compute + storage_ - Select an appropriate scale for your requirements (Basic is adequate for many Strapi workloads)
+
+1. Enter a username and password for the _Administrator account_, click **Review + create** then **Create**
+
+#### Configuring the Resources
+
+Once all the resources are created, you will need to get the connection information for the MySQL and Storage account to the Web App, as well as configure the resources for use.
+
+##### Configure the Storage Account
+
+1. Navigate to the Storage Account resource, then **Data storage** - **Containers**
+1. Create a new Container, provide a _Name_, `strapi-uploads`, and set _Public access level_ to `Blob`, then click **Create**
+1. Navigate to **Security + networking** - **Access keys**, copy the _Storage account name_ and _key1_
+1. Navigate to the **Web App** you created and go to **Settings** - **Configuration**
+1. Create new application settings for the Storage account, storage account key and container name (these will become the environment variables available to Strapi) and click _Save_
+
+##### Configure MySQL
+
+1. Navigate to the MySQL resource then **Settings** - **Connection security**
+1. Set `Allow access to Azure services` to `Yes` and click **Save**
+1. Navigate to **Overview** and copy _Server name_ and _Server admin login name_
+1. Open the [Azure Cloud Shell](https://shell.azure.com?WT.mc_id=javascript-37811-aapowell) and log into the `mysql` cli:
+
+   - `mysql --host <server> --user <username> -p`
+
+1. Create a database for Strapi to use `CREATE DATABASE strapi;` then close the Cloud Shell
+   - Optional - create a separate non server admin user (see [this doc](https://docs.microsoft.com/azure/mysql/howto-create-users?tabs=single-server&WT.mc_id=javascript-37811-aapowell) for guidance)
+1. Navigate to the **Web App** you created and go to **Settings** - **Configuration**
+1. Create new application settings for the Database host, username and password (these will become the environment variables available to Strapi) and click _Save_
+
+### Creating Resources via the Azure CLI
+
+In this section, we'll use the [Azure CLI](https://docs.microsoft.com/cli/azure/?WT.mc_id=javascript-37811-aapowell) to create the required resources. This will assume you have some familiarity with the Azure CLI and how to find the right values.
+
+1. Create a new Resource Group
+
+   ```bash
+   rgName=my-strapi-app
+   location=westus
+   az group create --name $rgName --location $location
+   ```
+
+1. Create a new Linux App Service Plan (ensure you change the `number-of-workers` and `sku` to meet your scale requirements)
+
+   ```bash
+   appPlanName=strapi-app-service-plan
+   az appservice plan create --resource-group $rgName --name $appPlanName --is-linux --number-of-workers 4 --sku S1 --location $location
+   ```
+
+1. Create a Web App running Node.js 14
+
+   ```bash
+   webAppName=my-strapi-app
+   az webapp create --resource-group $rgName --name $webAppName --plan $appPlanName --runtime "node|10.14"
+   ```
+
+1. Create a Storage Account
+
+   ```bash
+   saName=mystrapiapp
+   az storage account create --resource-group $rgName --name $saName --location $location
+
+   # Get the access key
+   saKey=$(az storage account keys list --account-name $saName --query "[?keyName=='key1'].value" --output tsv)
+
+   # Add a container to the storage account
+   container=strapi-uploads
+   az storage container create --name $container --public-access blob --access-key $saKey --account-name $saName
+   ```
+
+1. Create a MySQL database
+
+   ```bash
+   serverName=my-strapi-db
+   dbName=strapi
+   username=strapi
+   password=...
+
+   # Create the server
+   az mysql server create --resource-group $rgName --name $serverName --location $location --admin-user $username --admin-password $password --version 5.7 --sku-name B_Gen5_1
+
+   # Create the database
+   az mysql db create --resource-group $rgName --name $dbName --server-name $serverName
+
+   # Allow Azure resources through the firewall
+   az mysql server firewall-rule create --resource-group $rgName --server-name $serverName --name AllowAllAzureIps --start-ip-range 0.0.0.0 --end-ip-range 0.0.0.0
+   ```
+
+1. Add configuration values to the Web App
+
+   ```bash
+   az webapp config appsettings set --resource-group $rgName --name $webAppName --setting STORAGE_ACCOUNT=$saName
+   az webapp config appsettings set --resource-group $rgName --name $webAppName --setting STORAGE_ACCOUNT_KEY=$saKey
+   az webapp config appsettings set --resource-group $rgName --name $webAppName --setting STORAGE_ACCOUNT_CONTAINER=$container
+   az webapp config appsettings set --resource-group $rgName --name $webAppName --setting DATABASE_HOST=$serverName.mysql.database.azure.com
+   az webapp config appsettings set --resource-group $rgName --name $webAppName --setting DATABASE_USERNAME=$username@$serverName
+   az webapp config appsettings set --resource-group $rgName --name $webAppName --setting DATABASE_PASSWORD=$password
+   ```
+
+### Deploy with an Azure Resource Manager template
+
+To deploy using an Azure Resource Manager template, use the botton below, or upload [this template](https://gist.githubusercontent.com/aaronpowell/f216f119ffe5ed52945b46d0bb55569b/raw/2490a9295ea25c905096dbaae57da6ef8edb0e43/azuredeploy.json) as a custom deployment in Azure.
+
+[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fgist.githubusercontent.com%2Faaronpowell%2Ff216f119ffe5ed52945b46d0bb55569b%2Fraw%2F2490a9295ea25c905096dbaae57da6ef8edb0e43%2Fazuredeploy.json)
+
+### Configure Strapi for Azure AppService
+
+Azure AppService can be deployed to using CI/CD pipelines or via FTPS, refer to the [Azure docs](https://docs.microsoft.com/azure/app-service/deploy-continuous-deployment?tabs=github&WT.mc_id=javascript-37811-aapowell) on how to do this for your preferred manner.
+
+As AppService is a PaaS hosting model, an upload provider will be required to save the uploaded assets to Azure Storage. Check out https://github.com/jakeFeldman/strapi-provider-upload-azure-storage for more details on using Azure Storage as an upload provider.
+
+_Note - for local development, you can either use the local disk upload provider, or the Azure Storage upload provider against the [Storage emulator](https://docs.microsoft.com/azure/storage/common/storage-use-azurite?toc=%2Fazure%2Fstorage%2Fblobs%2Ftoc.json&tabs=visual-studio&WT.mc_id=javascript-37811-aapowell)._
+
+To start the Node.js application, AppService will run the `npm start` command. As there is no guarantee that the symlinks created by `npm install` were preserved (in the case of an upload from a CI/CD pipeline) it is recommended that the `npm start` command directly references the Strapi entry point:
+
+```json
+"scripts": {
+    "start": "node node_modules/strapi/bin/strapi.js start"
+}
+```
+
+## IaaS Deployment Guide
+
+Databases can be on a [Azure Virtual Machine](https://azure.microsoft.com/services/virtual-machines/), hosted externally as a service, or via the [Azure Managed Databases](https://azure.microsoft.com/services/postgresql/).
 
 ### Azure Install Requirements
 


### PR DESCRIPTION
This is an overhaul of the Azure deployment guide which introduces instructions on how to run Strapi in a Platform-as-a-Service (PaaS) model and use a hosted DB, rather than a full IaaS model (which requires setup for VM's and such).

There's three new sections, to cater for the different ways in which someone would want to interact with Azure, using the portal, using the CLI or using a Resource Manager template.

I've also kept the IaaS docs for people that would still prefer that model.