### PR TITLE
Update i18n docs, fix locale filter typo + autoformat

### DIFF
--- a/docs/developer-docs/latest/plugins/i18n.md
+++ b/docs/developer-docs/latest/plugins/i18n.md
@@ -5,7 +5,7 @@ sidebarDepth: 3
 canonicalUrl: https://docs.strapi.io/developer-docs/latest/plugins/i18n.html
 ---
 
-# 🌍  Internationalization (i18n)
+# 🌍 Internationalization (i18n)
 
 The Internationalization (i18n) plugin allows Strapi users to create, manage and distribute localized content in different languages, called "locales". For more information about the concept of internationalization, please refer to the
 [W3C definition](https://www.w3.org/International/questions/qa-i18n.en#i18n).
@@ -53,23 +53,23 @@ The i18n plugin adds new features to the [REST API](/developer-docs/latest/devel
 - a new [`locale`](#getting-localized-entries-with-the-locale-parameter) parameter to fetch content only for a specified locale
 - the ability to create a localized entry, either [from scratch](#creating-a-new-localized-entry) or [for an existing localized entry](#creating-a-localization-for-an-existing-entry)
 
-### Getting localized entries with the `_locale` parameter
+### Getting localized entries with the `locale` parameter
 
-The `_locale` [API parameter](/developer-docs/latest/developer-resources/database-apis-reference/rest-api.md#api-parameters) can be used to fetch entries only for a specified locale. It takes a locale code as value (see [full list of available locales](https://github.com/strapi/strapi/blob/master/packages/plugins/i18n/server/constants/iso-locales.json)).
+The `locale` [API parameter](/developer-docs/latest/developer-resources/database-apis-reference/rest-api.md#api-parameters) can be used to fetch entries only for a specified locale. It takes a locale code as value (see [full list of available locales](https://github.com/strapi/strapi/blob/master/packages/plugins/i18n/server/constants/iso-locales.json)).
 
 :::tip
- To fetch content for a locale, make sure it has been already [added to Strapi in the admin panel](/user-docs/latest/settings/managing-global-settings.md#configuring-internationalization-locales).
+To fetch content for a locale, make sure it has been already [added to Strapi in the admin panel](/user-docs/latest/settings/managing-global-settings.md#configuring-internationalization-locales).
 :::
 
 The format for a GET request is the following:
 
 :::request
-`GET /api/{content-type}?_locale={locale-code}`
+`GET /api/{content-type}?locale={locale-code}`
 :::
 
-Use `all` as a value for the locale code, as in `http://localhost:1337/api/restaurants?_locale=all`, to fetch entries for all locales that have been configured in the admin panel.
+Use `all` as a value for the locale code, as in `http://localhost:1337/api/restaurants?locale=all`, to fetch entries for all locales that have been configured in the admin panel.
 
-If the `_locale` parameter isn't defined, it will be set to the default locale. `en` is the default locale when the i18n plugin is installed, so by default a GET request to `http://localhost:1337/api/restaurants` will return the same response as a request to `http://localhost:1337/api/restaurants?_locale=en`.
+If the `locale` parameter isn't defined, it will be set to the default locale. `en` is the default locale when the i18n plugin is installed, so by default a GET request to `http://localhost:1337/api/restaurants` will return the same response as a request to `http://localhost:1337/api/restaurants?locale=en`.
 
 ::: tip
 Another locale can be [set as the default locale](/user-docs/latest/settings/managing-global-settings.md#adding-a-new-locale) in the admin panel.
@@ -77,7 +77,7 @@ Another locale can be [set as the default locale](/user-docs/latest/settings/man
 
 When the i18n plugin is installed, the response to requests can include fields that are specific to internationalization:
 
-- The  `locale` (string) field is always included, it's the locale code for the content entry.
+- The `locale` (string) field is always included, it's the locale code for the content entry.
 
 - The `localizations` (object) can be included if specifically requested by appending `?populate=localizations` to the URL (see [relations population documentation](/developer-docs/latest/developer-resources/database-apis-reference/rest/populating-fields.md#population). It includes a `data` array with a list of objects, each of them including the `id` and `attributes` of the localization.
 
@@ -85,7 +85,7 @@ When the i18n plugin is installed, the response to requests can include fields t
 
 ::: request Example request
 
-`GET http://localhost:1337/api/restaurants?_locale=fr`
+`GET http://localhost:1337/api/restaurants?locale=fr`
 
 :::
 
@@ -101,7 +101,7 @@ When the i18n plugin is installed, the response to requests can include fields t
         "description": "description in French",
         "locale": "fr",
         "createdAt": "2021-10-28T15:24:42.129Z",
-        "publishedAt": "2021-10-28T15:24:42.129Z",
+        "publishedAt": "2021-10-28T15:24:42.129Z"
       }
     },
     {
@@ -111,7 +111,7 @@ When the i18n plugin is installed, the response to requests can include fields t
         "description": "description in French",
         "locale": "fr",
         "createdAt": "2021-10-28T16:17:42.129Z",
-        "publishedAt": "2021-10-28T16:18:24.126Z",
+        "publishedAt": "2021-10-28T16:18:24.126Z"
       }
     }
   ],
@@ -260,7 +260,7 @@ This request:
 1. creates a new entry in `en`
 2. links the created entry with `restaurant:8` (they will share the same `localizations` object)
 3. copies every non-localized fields from `restaurant:8` into the new entry and keeps the localized fields from the request's body
-:::
+   :::
 
 ::: response Example response
 
@@ -302,7 +302,7 @@ This request:
 ```json
 {
   "title": "Bienvenue sur FoodAdvisor !",
-  "locale": "fr",
+  "locale": "fr"
 }
 ```
 
@@ -319,7 +319,7 @@ This request:
   "localizations": [
     {
       "id": 1,
-      "locale": "en",
+      "locale": "en"
       // ...
     }
   ]
@@ -353,6 +353,7 @@ Queries can use the `locale` argument to fetch entries only for a specified loca
 ::: tip
 To fetch entries for all locales, use `locale: "all"` in the query.
 :::
+
 #### Fetching a collection type
 
 :::: api-call
@@ -373,7 +374,7 @@ query {
             attributes {
               name
               description
-          	}
+            }
           }
         }
       }
@@ -423,6 +424,7 @@ query {
 :::
 
 ::::
+
 #### Fetching a single type
 
 :::: api-call
@@ -453,7 +455,7 @@ query {
       "data": {
         "id": "1",
         "attributes": {
-          "title": "Welcome on FoodAdvisor!",
+          "title": "Welcome on FoodAdvisor!"
         }
       }
     }
@@ -480,10 +482,7 @@ mutation {
   createRestaurantLocalization(
     id: 8
     locale: "en"
-    data: {
-      name: "She's Cake"
-      description: "description in english"
-    }
+    data: { name: "She's Cake", description: "description in english" }
   ) {
     data {
       id
@@ -557,7 +556,7 @@ mutation {
     }
   }
 }
-      
+
 ```
 
 :::
@@ -572,12 +571,7 @@ mutation {
 
 ```graphql
 mutation {
-  createHomepageLocalization(
-    locale: "fr"
-    data: {
-      title: "Bienvenue sur FoodAdvisor !"
-    }
-  ) {
+  createHomepageLocalization(locale: "fr", data: { title: "Bienvenue sur FoodAdvisor !" }) {
     data {
       id
       attributes {
@@ -607,7 +601,6 @@ mutation {
     }
   }
 }
-
 ```
 
 :::
@@ -626,10 +619,7 @@ Currently, it is not possible to change the locale of an existing localized entr
 
 ```graphql
 mutation {
-  updateHomepage(
-    locale: "fr"
-    data: { title: "Bienvenue sur l'annuaire FoodAdvisor !" }
-  ) {
+  updateHomepage(locale: "fr", data: { title: "Bienvenue sur l'annuaire FoodAdvisor !" }) {
     data {
       id
       attributes {
@@ -638,7 +628,6 @@ mutation {
     }
   }
 }
-
 ```
 
 :::


### PR DESCRIPTION
### What does it do?

Update the locale filter mentions with the correct wording
-`_locale`
+`locale`

Autoformat of the `JSON` snippets (removed comma for last attributes in objects)

### Why is it needed?

Describe the issue you are solving.

https://github.com/strapi/strapi/issues/11953
https://github.com/strapi/strapi/pull/11961
