### PR TITLE
Add information about uid and remove model name for upload ref

### DIFF
--- a/docs/developer-docs/latest/plugins/upload.md
+++ b/docs/developer-docs/latest/plugins/upload.md
@@ -150,7 +150,7 @@ To upload files that will be linked to a specific entry.
 - `files`: The file(s) to upload. The value(s) can be a Buffer or Stream.
 - `path` (optional): The folder where the file(s) will be uploaded to (only supported on strapi-provider-upload-aws-s3).
 - `refId`: The ID of the entry which the file(s) will be linked to.
-- `ref`: The name of the model which the file(s) will be linked to (see more below).
+- `ref`: The unique ID (uid) of the model which the file(s) will be linked to (see more below).
 - `source` (optional): The name of the plugin where the model is located.
 - `field`: The field of the entry which the file(s) will be precisely linked to.
 
@@ -182,7 +182,7 @@ Code
 <form>
   <!-- Can be multiple files if you setup "collection" instead of "model" -->
   <input type="file" name="files" />
-  <input type="text" name="ref" value="restaurant" />
+  <input type="text" name="ref" value="api::restaurant.restaurant" />
   <input type="text" name="refId" value="5c126648c7415f0c0ef1bccd" />
   <input type="text" name="field" value="cover" />
   <input type="submit" value="Submit" />


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

This PR correctly states the parameters required to link an upload to a related entity, specifically by stating that the `ref` key in the form data must be the `uid` of the content type and not the name of the model.

### Why is it needed?

Without this, users attempting to upload with the content API are not able to link their uploads to related entities.

### Related issue(s)/PR(s)

Related to [#11919](https://github.com/strapi/strapi/issues/11919)
