### PR TITLE
Fix wrong strapi module name for server.js

### DIFF
--- a/docs/developer-docs/latest/guides/process-manager.md
+++ b/docs/developer-docs/latest/guides/process-manager.md
@@ -50,7 +50,7 @@ So first let's create a `server.js` file that will let you run the `pm2` command
 **Path —** `./server.js`
 
 ```js
-const strapi = require('strapi');
+const strapi = require('@strapi/strapi');
 strapi().start();
 ```
 

--- a/docs/developer-docs/latest/guides/secure-your-app.md
+++ b/docs/developer-docs/latest/guides/secure-your-app.md
@@ -47,7 +47,7 @@ To do so you will have to create a `server.js` file to be able to start our appl
 **Path —** `./server.js`
 
 ```js
-const strapi = require('strapi');
+const strapi = require('@strapi/strapi');
 strapi().start();
 ```
 
@@ -66,7 +66,7 @@ To do so, you will have to update this file.
 
 ```js
 require('sqreen');
-const strapi = require('strapi');
+const strapi = require('@strapi/strapi');
 strapi().start();
 ```
 

--- a/docs/developer-docs/latest/setup-deployment-guides/deployment.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment.md
@@ -157,7 +157,7 @@ We highly recommend using [pm2](https://github.com/Unitech/pm2/) to manage your 
 If you need a server.js file to be able to run `node server.js` instead of `npm run start` then create a `./server.js` file as follows:
 
 ```js
-const strapi = require('strapi');
+const strapi = require('@strapi/strapi');
 
 strapi(/* {...} */).start();
 ```


### PR DESCRIPTION
Signed-off-by: harimkims <harimkims@gmail.com>

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

- I changed `require('strapi')` to `require('@strapi/strapi')`

### Why is it needed?

- To fix `Error: Cannot find module 'strapi'` error
- To correct right module name

### Related issue(s)/PR(s)

X
