### PR TITLE
Fix typo in dev configuration options

### DIFF
--- a/docs/developer-docs/latest/development/admin-customization.md
+++ b/docs/developer-docs/latest/development/admin-customization.md
@@ -93,8 +93,8 @@ The `config` object accepts the following parameters:
 | `translations`  | Object           | [Extends the translations](#extending-translations)                                                                                                                       |
 | `menu`          | Object           | Accepts the `logo` key to change the [logo](#logos) in the main navigation                                                           |
 | `theme`         | Object           | Overrides or [extends the theme](#theme-extension)                                                                                          |
-| `tutorial`      | Boolean          | Toggles [displaying the video tutorials](#tutorial-videos)                                                            |
-| `notifications` | Object           | Accepts the `release` key (Boolean) to toggle [displaying notifications about new releases](#releases-notifications)          |
+| `tutorials`     | Boolean          | Toggles [displaying the video tutorials](#tutorial-videos)                                                            |
+| `notifications` | Object           | Accepts the `releases` key (Boolean) to toggle [displaying notifications about new releases](#releases-notifications)          |
 
 ::: details Example of a custom configuration for the admin panel:
 


### PR DESCRIPTION
### What does it do?
Configuration options for toggling tutorials on or off and notifying about new releases contained a typo referencing `tutorial` key instead of `tutorials` and `notification.release` instead of `notification.releases`

As defined in
https://github.com/strapi/strapi/blob/3e4de3d5acd2d16e451d4db759f3482128dcdf49/packages/core/admin/admin/src/StrapiApp.js#L36-L39