### PR TITLE
Remove clean flag from build command

### DIFF
--- a/docs/developer-docs/latest/developer-resources/cli/CLI.md
+++ b/docs/developer-docs/latest/developer-resources/cli/CLI.md
@@ -90,8 +90,6 @@ options: [--no-optimization]
 ```
 
 - **strapi build**<br/>
-  Builds the administration panel and minimizing the assets
-- **strapi build --clean**<br/>
   Builds the administration panel and delete the previous build and .cache folders
 - **strapi build --no-optimization**<br/>
   Builds the administration panel without minimizing the assets. The build duration is faster.

--- a/docs/developer-docs/latest/update-migration-guides/update-version.md
+++ b/docs/developer-docs/latest/update-migration-guides/update-version.md
@@ -79,13 +79,13 @@ Rebuild the admin panel with one of the following commands:
 
 <code-block title="NPM">
 ```sh
-npm run build -- --clean
+npm run build
 ```
 </code-block>
 
 <code-block title="YARN">
 ```sh
-yarn build --clean
+yarn build
 ```
 </code-block>
 


### PR DESCRIPTION
Per: https://github.com/strapi/strapi/pull/12012 we are planning to remove the `--clean` flag from the build command and make all builds clean.

This PR is based on that upstream and shouldn't be merged and released until the upstream PR is merged and released.