### PR TITLE
Fixed content type export object & missing commas

### DIFF
--- a/docs/developer-docs/latest/developer-resources/plugin-api-reference/server.md
+++ b/docs/developer-docs/latest/developer-resources/plugin-api-reference/server.md
@@ -141,8 +141,8 @@ const contentTypeA = require('./content-type-a');
 const contentTypeB = require('./content-type-b');
 
 module.exports = {
-  'content-type-a': contentTypeA, // should re-use the singularName of the content-type
-  'content-type-b': contentTypeB, 
+  'content-type-a': { schema: contentTypeA }, // should re-use the singularName of the content-type
+  'content-type-b': { schema: contentTypeB }, 
 };
 ```
 
@@ -155,18 +155,18 @@ module.exports = {
     singularName: 'content-type-a', // kebab-case mandatory
     pluralName: 'content-type-as', // kebab-case mandatory
     displayName: 'Content Type A',
-    description: 'A regular content type'
-    kind: 'collectionType'
+    description: 'A regular content type',
+    kind: 'collectionType',
   },
   options: {
     draftAndPublish: true,
   },
   pluginOptions: {
     'content-manager': {
-      visible: false
+      visible: false,
     },
     'content-type-builder': {
-      visible: false
+      visible: false,
     }
   },
   attributes: {
@@ -174,7 +174,7 @@ module.exports = {
       type: 'string',
       min: 1,
       max: 50,
-      configurable: false
+      configurable: false,
     },
   }
 };
@@ -195,7 +195,7 @@ const routes = require('./routes');
 
 module.exports = () => ({
   routes,
-  type: 'content-api' // can also be 'admin-api' depending on the type of route
+  type: 'content-api', // can also be 'admin-api' depending on the type of route
 });
 ```
 


### PR DESCRIPTION
Without { schema } don`t work( I use v4.0.2
In another plugin:
https://github.com/strapi/strapi/blob/master/packages/plugins/users-permissions/server/content-types/index.js
