### PR TITLE
Update graphql.md middleware example

### DIFF
--- a/docs/developer-docs/latest/plugins/graphql.md
+++ b/docs/developer-docs/latest/plugins/graphql.md
@@ -489,7 +489,7 @@ module.exports = {
 
 The `middlewares` key is an array accepting a list of middlewares, each item in this list being either a reference to an already registered policy or an implementation that is passed directly (see [middlewares configuration documentation](/developer-docs/latest/development/backend-customization/routes.md#middlewares)).
 
-Middlewares directly implemented in `resolversConfig` can take the GraphQL resolver's `parent`, `args`, `context` and `info` objects as arguments.
+Middlewares directly implemented in `resolversConfig` can take the GraphQL resolver's [`parent`, `args`, `context` and `info` objects](https://www.apollographql.com/docs/apollo-server/data/resolvers/#resolver-arguments) as arguments.
 
 :::tip
 Middlewares with GraphQL can even act on nested resolvers, which offer a more granular control than with REST.
@@ -513,14 +513,26 @@ module.exports = {
              * Basic middleware example #1
              * Log resolving time in console
              */
-            async (next, parent, args, context, info ) => {
-              console.time('Start resolving categories');
-              console.timeEnd('Stop resolving categories');
+            async (next, parent, args, context, info) => {
+              console.time('Resolving categories');
+              
+              // call the next resolver
+              const res = await next(parent, args, context, info);
+              
+              console.timeEnd('Resolving categories');
 
               return res;
             },
             /**
              * Basic middleware example #2
+             * Enable server-side shared caching
+             */
+            async (next, parent, args, context, info) => {
+              info.cacheControl.setCacheHint({ maxAge: 60, scope: "PUBLIC" });
+              return next(parent, args, context, info);
+            },
+            /**
+             * Basic middleware example #3
              * change the 'name' attribute of parent with id 1 to 'foobar'
              */
             (resolve, parent, ...rest) => {


### PR DESCRIPTION
### What does it do?

- Fix the first graphql middleware example by calling `next` method
- Add server-side shared cache example middleware

### Why is it needed?

The added sample can be useful to improve response time on this kind of queries

