### PR TITLE
Small typo in Quick Start Guide, word "Next" occurs twice unnecessarily

### DIFF
--- a/docs/developer-docs/latest/getting-started/quick-start.md
+++ b/docs/developer-docs/latest/getting-started/quick-start.md
@@ -314,7 +314,7 @@ Now that you know the basics of creating and publishing content with Strapi, we 
 
 ## 🚀 Part A: Create a new project with Strapi starters
 
-Strapi [starters](https://strapi.io/starters) are the fastest way to kickstart your project. They cover many use cases (blog, e-commerce solution, corporate website, portfolio) and integrate with various technologies (Next, Gridsome, Next, Nuxt).
+Strapi [starters](https://strapi.io/starters) are the fastest way to kickstart your project. They cover many use cases (blog, e-commerce solution, corporate website, portfolio) and integrate with various technologies (Next, Gridsome, Nuxt).
 
 This quick start guide has been specifically tailored to use the [Next blog starter](https://strapi.io/starters/strapi-starter-next-js-blog). We highly recommend you to follow along with this starter. Once you get a better understanding of Strapi, you will be able to play with other starters on your own.
 


### PR DESCRIPTION
Removed one of the occurrences.