### PR TITLE
fix: _locale params renamed to locale

### DIFF
--- a/docs/developer-docs/latest/plugins/i18n.md
+++ b/docs/developer-docs/latest/plugins/i18n.md
@@ -53,9 +53,9 @@ The i18n plugin adds new features to the [REST API](/developer-docs/latest/devel
 - a new [`locale`](#getting-localized-entries-with-the-locale-parameter) parameter to fetch content only for a specified locale
 - the ability to create a localized entry, either [from scratch](#creating-a-new-localized-entry) or [for an existing localized entry](#creating-a-localization-for-an-existing-entry)
 
-### Getting localized entries with the `_locale` parameter
+### Getting localized entries with the `locale` parameter
 
-The `_locale` [API parameter](/developer-docs/latest/developer-resources/database-apis-reference/rest-api.md#api-parameters) can be used to fetch entries only for a specified locale. It takes a locale code as value (see [full list of available locales](https://github.com/strapi/strapi/blob/master/packages/plugins/i18n/server/constants/iso-locales.json)).
+The `locale` [API parameter](/developer-docs/latest/developer-resources/database-apis-reference/rest-api.md#api-parameters) can be used to fetch entries only for a specified locale. It takes a locale code as value (see [full list of available locales](https://github.com/strapi/strapi/blob/master/packages/plugins/i18n/server/constants/iso-locales.json)).
 
 :::tip
 To fetch content for a locale, make sure it has been already [added to Strapi in the admin panel](/user-docs/latest/settings/managing-global-settings.md#configuring-internationalization-locales).
@@ -64,12 +64,12 @@ To fetch content for a locale, make sure it has been already [added to Strapi in
 The format for a GET request is the following:
 
 :::request
-`GET /api/{content-type}?_locale={locale-code}`
+`GET /api/{content-type}?locale={locale-code}`
 :::
 
-Use `all` as a value for the locale code, as in `http://localhost:1337/api/restaurants?_locale=all`, to fetch entries for all locales that have been configured in the admin panel.
+Use `all` as a value for the locale code, as in `http://localhost:1337/api/restaurants?locale=all`, to fetch entries for all locales that have been configured in the admin panel.
 
-If the `_locale` parameter isn't defined, it will be set to the default locale. `en` is the default locale when the i18n plugin is installed, so by default a GET request to `http://localhost:1337/api/restaurants` will return the same response as a request to `http://localhost:1337/api/restaurants?_locale=en`.
+If the `locale` parameter isn't defined, it will be set to the default locale. `en` is the default locale when the i18n plugin is installed, so by default a GET request to `http://localhost:1337/api/restaurants` will return the same response as a request to `http://localhost:1337/api/restaurants?locale=en`.
 
 ::: tip
 Another locale can be [set as the default locale](/user-docs/latest/settings/managing-global-settings.md#adding-a-new-locale) in the admin panel.
@@ -85,7 +85,7 @@ When the i18n plugin is installed, the response to requests can include fields t
 
 ::: request Example request
 
-`GET http://localhost:1337/api/restaurants?_locale=fr`
+`GET http://localhost:1337/api/restaurants?locale=fr`
 
 :::
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

As talked with @derrickmehaffy the query params `_locale` has been renamed by `locale`. Unfortunately it has not been changed on the `i18n` plugin page: https://docs.strapi.io/developer-docs/latest/plugins/i18n.html

### Why is it needed?

It can mislead people on the correct usage of `i18n` with strapi
