### PR TITLE
Quality-of-life improvements for new build scripts

### DIFF
--- a/docs/.vuepress/config/metas.js
+++ b/docs/.vuepress/config/metas.js
@@ -101,4 +101,8 @@ const metas = {
       `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src= 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f); })(window,document,'script','dataLayer','GTM-KN9JRWG');`,
     ],
   ],
+  extraWatchFiles: [
+    '.vuepress/config/sidebar-developer.js',
+    '.vuepress/config/sidebar-user.js',
+  ]
 };

--- a/docs/package.json
+++ b/docs/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "scripts": {
     "dev": "yarn create:config-file && vuepress dev",
-    "dev:developer": "yarn create:dev-config-file && vuepress dev",
+    "dev:dev": "yarn create:dev-config-file && vuepress dev",
     "dev:user": "yarn create:user-config-file && vuepress dev",
     "build": "yarn create:config-file && vuepress build",
     "check-links": "vuepress check-md",


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

* Make sure that updating `config/sidebar-developer.js` and `config/sidebar-user.js` triggers a VuePress reload
* Shorten the name of the script that loads only the developer docs:  `yarn dev:developer` → `yarn dev:dev`

**Note: Known bug:** 
Even if VuePress rebuilds when you update sidebar-user or sidebar-developer, changes are not reflected in the config.js as it does not trigger another run of our files found in the `scripts` folder.
Temp. workaround is to directly update the config.js file — make sure changes are then reported to the dedicated file in the `config` folder.
(FYI @soupette — maybe could we play with [`chainWebpack`](https://vuepress.vuejs.org/config/#chainwebpack) or `configureWebpack` in VuePress config to fix this)