### PR TITLE
Update AWS deployment documentation

### DIFF
--- a/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/amazon-aws.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/amazon-aws.md
@@ -603,6 +603,12 @@ http
       - Port Range: `8080`
       - Source: `Custom` `0.0.0.0/0, ::/0`
     - Then `Save`
+  - If you have the `ufw` firewall enabled, as recommended by steps below, you will need to configure your settings to include `port 8080`:
+
+```bash
+sudo ufw allow 8080/tcp
+```
+  
 
 Earlier you setup `pm2` to start the services (your **Strapi project**) whenever the **EC2 instance** reboots or is started. You will now do the same for the `webhook` script.
 

--- a/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/amazon-aws.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/amazon-aws.md
@@ -603,7 +603,7 @@ http
       - Port Range: `8080`
       - Source: `Custom` `0.0.0.0/0, ::/0`
     - Then `Save`
-  - If you have the `ufw` firewall enabled, as recommended by steps below, you will need to configure your settings to include `port 8080`:
+  - If the `ufw` firewall is enabled, configure settings to include `port 8080` by running the following command:
 
 ```bash
 sudo ufw allow 8080/tcp


### PR DESCRIPTION
The added lines here are to make sure Webhooks work fine when `ufw` has enabled which is in the step below of installing Nginx, in other words, without this command Webhooks cannot connect to the host server due to firewall. 
Thanks!


