### PR TITLE
Fix template docs for v4

### DIFF
--- a/docs/developer-docs/latest/setup-deployment-guides/installation/templates.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/installation/templates.md
@@ -18,7 +18,7 @@ Here are some things a template may configure for you:
 Templates and starters are not the same thing:
 
 - A _template_ is a pre-made Strapi configuration. Note that it's only a configuration, not a configured application. That's because it cannot be run on its own, since it lacks many files, like database configs or the `package.json`. A template is only useful once applied on top of a default Strapi app via the CLI.
-- A _starter_ is a pre-made frontend application that consumes a Strapi API
+- A _starter_ is a pre-made frontend application that consumes a Strapi API.
 
 :::
 
@@ -31,7 +31,7 @@ You can use a template when creating a project with `create-strapi-app`.
 ::: tab yarn
 
 ```bash
-yarn create strapi-app my-project --template <template-github-name>
+yarn create strapi-app my-project --template <template-package>
 ```
 
 :::
@@ -39,32 +39,24 @@ yarn create strapi-app my-project --template <template-github-name>
 ::: tab npx
 
 ```bash
-npx create-strapi-app@latest my-project --template <template-github-name>
+npx create-strapi-app@latest my-project --template <template-package>
 ```
 
 :::
 
 ::::
 
-In these examples, the `template-github-name` argument can have different forms:
-
-- A shorthand. If a Github user named `paul` has a repository called `strapi-template-restaurant`, then the shorthand would be `paul/restaurant`. It only works if the repository's name starts with `strapi-template-`.
-- A URL. Just paste the URL of your GitHub repository. It works even if the repository is not prefixed by `strapi-template-`.
+Because we use npm to install template packages, `<template-package>` can match [any format](https://docs.npmjs.com/cli/v8/commands/npm-install) that you would give to `npm install`. This includes npm packages, scoped packages, packages with a precise version or tag, as well as local directories for development.
 
 ::: tip
-When using a shorthand, if the username is omitted, the CLI assumes it's `strapi`.
-
-So the following commands are equivalent:
+For convenience, official Strapi templates also have a shorthand. It lets you omit the `@strapi/template-` prefix from the template npm package name. So the following commands are equivalent:
 
 ```bash
 # Shorthand
-yarn create strapi-app my-project --template strapi/blog
-
-# Shorthand with username omitted since it defaults to strapi
 yarn create strapi-app my-project --template blog
 
-# Full GitHub URL
-yarn create strapi-app my-project --template https://github.com/strapi/strapi-template-blog
+# npm package name
+yarn create strapi-app my-project --template @strapi/template-blog
 ```
 
 :::
@@ -73,7 +65,7 @@ You can use the `--template` option in combination with all other `create-strapi
 
 ## Creating a template
 
-To create a Strapi template, you need to publish a public GitHub repository that follows some rules.
+To create a Strapi template, you need to publish a package that follows some rules.
 
 First, a template's only concern should be to adapt Strapi to a use case. It should not deal with environment-specific configs, like databases, or upload and email providers. This is to make sure that templates stay maintainable, and to avoid conflicts with other CLI options like `--quickstart`.
 
@@ -103,7 +95,7 @@ npx strapi templates:generate <path>
 
 ### File structure
 
-You can add as many files as you want to the root of your template repository. But it must at least have `template` directory, and either a `template.json` or a `template.js` file.
+You can add as many files as you want to the root of your template repository. But it must at least have `template` directory, a `package.json`, and a `template.json` file.
 
 The `template.json` is used to extend the Strapi app's default `package.json`. You can put all the properties that should overwrite the default `package.json` in a root `package` property. For example, a `template.json` might look like this:
 
@@ -111,7 +103,7 @@ The `template.json` is used to extend the Strapi app's default `package.json`. Y
 {
   "package": {
     "dependencies": {
-      "strapi-plugin-graphql": "latest"
+      "strapi-plugin-graphql": "^4.0.0"
     },
     "scripts": {
       "custom": "node ./scripts/custom.js"
@@ -120,31 +112,14 @@ The `template.json` is used to extend the Strapi app's default `package.json`. Y
 }
 ```
 
-You can also use a `template.js` file instead of the `template.json` file. It should export a function that returns an object with the same properties. It's useful when our properties need to have dynamic values. For example, we can use it to make sure that a template requires the latest version of a Strapi plugin:
-
-```js
-module.exports = function(scope) {
-  return {
-    package: {
-      dependencies: {
-        'strapi-plugin-graphql': scope.strapiVersion,
-      },
-    },
-  };
-};
-```
-
 The `template` directory is where you can extend the file contents of a Strapi project. All the children are optional, you should only include the files that will overwrite the default Strapi app.
 
 Only the following contents are allowed inside the `template` directory:
 
 - `README.md`: the readme of an app made with this template
 - `.env.example`: to specify required environment variables
-- `api/`: for collections and single types
-- `components/` for components
-- `config/` can only include the `functions` directory (things like `bootstrap.js` or `404.js`), because other config files are environment-specific.
+- `src/`
 - `data/` to store the data imported by a seed script
-- `plugins/` for custom Strapi plugins
 - `public/` to serve files
 - `scripts/` for custom scripts
 
@@ -159,4 +134,4 @@ After reading the above rules, follow these steps to create your template:
 3. Generate your template using the [CLI](/developer-docs/latest/developer-resources/cli/CLI.md#strapi-templates-generate) by running `strapi templates:generate <path>`
 4. Navigate to this path to see your generated template
 5. If you have modified your app's `package.json`, include these changes (and _only_ these changes) in `template.json` in a `package` property. Otherwise, leave it as an empty object.
-6. Publish the root template project on GitHub. Make sure that the repository is public, and that the code is on the `master` branch.
+6. Enter `npm publish` to make your template available on the npm package registry.


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### Why is it needed?

v4 handles templates differently than v3. On v3, we used Github to host them. Now they are published as npm packages.

Some features were also removed on v4:

- The shorthand feature was removed. npm package names are much shorter than Github URLs, so it was less useful. It also added some complexity to the docs. Now, only Strapi's official templates have a shorthand.
- The dynamic `template.js` config feature was also removed. That's because templates can now be versioned with npm. So there's no need to dynamically generate the config, users should instead create a new template version instead.