### PR TITLE
Fix broken links to iso-locales.json

### DIFF
--- a/docs/developer-docs/latest/development/admin-customization.md
+++ b/docs/developer-docs/latest/development/admin-customization.md
@@ -173,7 +173,7 @@ export default {
 ::: note NOTES
 
 * The `en` locale cannot be removed from the build as it is both the fallback (i.e. if a translation is not found in a locale, the `en` will be used) and the default locale (i.e. used when a user opens the administration panel for the first time).
-* The full list of available locales is accessible on [Strapi's Github repo](https://github.com/strapi/strapi/blob/releases/v4/packages/plugins/i18n/server/constants/iso-locales.json).
+* The full list of available locales is accessible on [Strapi's Github repo](https://github.com/strapi/strapi/blob/v4.0.0/packages/plugins/i18n/server/constants/iso-locales.json).
 :::
 
 ##### Extending translations

--- a/docs/developer-docs/latest/plugins/i18n.md
+++ b/docs/developer-docs/latest/plugins/i18n.md
@@ -55,7 +55,7 @@ The i18n plugin adds new features to the [REST API](/developer-docs/latest/devel
 
 ### Getting localized entries with the `locale` parameter
 
-The `locale` [API parameter](/developer-docs/latest/developer-resources/database-apis-reference/rest-api.md#api-parameters) can be used to fetch entries only for a specified locale. It takes a locale code as value (see [full list of available locales](https://github.com/strapi/strapi/blob/master/packages/plugins/i18n/server/constants/iso-locales.json)).
+The `locale` [API parameter](/developer-docs/latest/developer-resources/database-apis-reference/rest-api.md#api-parameters) can be used to fetch entries only for a specified locale. It takes a locale code as value (see [full list of available locales](https://github.com/strapi/strapi/blob/v4.0.0/packages/plugins/i18n/server/constants/iso-locales.json)).
 
 :::tip
 To fetch content for a locale, make sure it has been already [added to Strapi in the admin panel](/user-docs/latest/settings/managing-global-settings.md#configuring-internationalization-locales).
@@ -700,6 +700,6 @@ The response returns the entry that has just been deleted.
 
 ## Configuration in production environments
 
-A `STRAPI_PLUGIN_I18N_INIT_LOCALE_CODE` [environment variable](/developer-docs/latest/setup-deployment-guides/configurations/optional/environment.md#strapi-s-environment-variables) can be configured to set the initialization locale for your environment. The value used for this variable should be a string (see [full list of available locales](https://github.com/strapi/strapi/blob/releases/v4/packages/plugins/i18n/server/constants/iso-locales.json)).
+A `STRAPI_PLUGIN_I18N_INIT_LOCALE_CODE` [environment variable](/developer-docs/latest/setup-deployment-guides/configurations/optional/environment.md#strapi-s-environment-variables) can be configured to set the initialization locale for your environment. The value used for this variable should be a string (see [full list of available locales](https://github.com/strapi/strapi/blob/v4.0.0/packages/plugins/i18n/server/constants/iso-locales.json)).
 
 This is useful when a Strapi app is deployed in production, with the i18n plugin installed and enabled on your content types for the first time. On a fresh i18n plugin installation, `en` is the default locale. So if the database does not contain any locale, and no `STRAPI_PLUGIN_I18N_INIT_LOCALE_CODE` is set for the environment, the content of the content types with i18n enabled will be automatically migrated to the `en` locale. But if the `STRAPI_PLUGIN_I18N_INIT_LOCALE_CODE` is defined, then the content will be migrated to this locale. Using this environment variable saves you from having to manually update the locale for existing content entries.

--- a/docs/user-docs/latest/settings/managing-global-settings.md
+++ b/docs/user-docs/latest/settings/managing-global-settings.md
@@ -44,7 +44,7 @@ For each locale, the table displays the default ISO code of the locale, its opti
 Administrators can add and manage as many locales as they want. There can however only be one locale set as the default one for the whole Strapi application.
 
 ::: note
-It is not possible to create custom locales. Locales can only be created based on [the 500+ pre-created list of locales](https://github.com/strapi/strapi/blob/releases/v4/packages/plugins/i18n/server/constants/iso-locales.json) set by Strapi.
+It is not possible to create custom locales. Locales can only be created based on [the 500+ pre-created list of locales](https://github.com/strapi/strapi/blob/v4.0.0/packages/plugins/i18n/server/constants/iso-locales.json) set by Strapi.
 :::
 
 To add a new locale:


### PR DESCRIPTION
### What does it do?

`iso-locales.json` was linked multiple times as `https://github.com/strapi/strapi/blob/releases/v4/packages/plugins/i18n/server/constants/iso-locales.json` (returns 404 now) and once as `https://github.com/strapi/strapi/blob/master/packages/plugins/i18n/server/constants/iso-locales.json` (this link can possibly break in the future if the repo is reorganized e.g. renaming "master" branch to "main"). I have changed these links to `https://github.com/strapi/strapi/blob/v4.0.0/packages/plugins/i18n/server/constants/iso-locales.json` which would consistently be found as long as v4.0.0 tag is there.

### Why is it needed?

Fixing some broken links, also keeping all links to the same file consistent. Please, let me know if there's some convention how the files in should be referenced and if I have broken it.

### Related issue(s)/PR(s)

#171 maybe? Probably not.
