### PR TITLE
[For discussion] Streamlining documentation

### DIFF
--- a/docs/developer-docs/latest/getting-started/introduction.md
+++ b/docs/developer-docs/latest/getting-started/introduction.md
@@ -6,38 +6,38 @@ canonicalUrl: https://docs.strapi.io/developer-docs/latest/getting-started/intro
 
 # Welcome to the Strapi v4 developer documentation!
 
-This documentation contains all technical documentation related to the setup, deployment, update and customization of your Strapi application.
+This documentation contains all technical documentation related to the setup, deployment, update and customization of a Strapi application.
 
 ::: strapi Can't wait to start using Strapi?
 You can directly head to the [Quick Start](quick-start.md)! <br> If demos are more your thing, we have a [video demo](https://youtu.be/zd0_S_FPzKg), or you can request a [live demo](https://strapi.io/demo)!
 :::
 
-The original purpose of the project was to help Boot**strap** your **API**: that's how Strapi was created. Now, Strapi is an open-source headless CMS that gives developers the freedom to choose their favorite tools and frameworks and allows editors to manage and distribute their content using their application's admin panel. Based on a plugin system, Strapi is a flexible CMS whose admin panel and API are extensible - and which every part is customizable to match any use case. Strapi also has a built-in user system to manage in detail what the administrators and end users have access to.
+The original purpose of the project was to help Boot**strap** an **API**: that's how Strapi was created. Now, Strapi is an open-source headless CMS that gives developers the freedom to choose their favorite tools and frameworks and allows editors to manage and distribute their content using their application's admin panel. Based on a plugin system, Strapi is a flexible CMS whose admin panel and API are extensible – and every part of which is customizable to match any use case. Strapi also has a built-in user system that allows to create fine-grained access controls for administrators as well as end users.
 
 ## Open-source & Contribution
 
-Strapi is an open-source project (see [LICENSE](https://github.com/strapi/strapi/blob/master/LICENSE) file for more information). The core project, as well as the documentation and any related tool can be found in the [Strapi](https://github.com/strapi) GitHub organization.
+Strapi is an open-source project (see [LICENSE](https://github.com/strapi/strapi/blob/master/LICENSE) file for more information). The core project as well as the documentation and any related tool can be found in the [Strapi](https://github.com/strapi) GitHub organization.
 
-As it goes hand in hand with the open-source ecosystem, Strapi is open to contributions. The Strapi team appreciates every contribution, be it a feature request, bug report, or pull request. The following GitHub repositories are open-source and contributions-friendly:
+As it goes hand in hand with the open-source ecosystem, Strapi is open to contributions. The Strapi team appreciates every contribution, be it a feature request, bug report, or pull request. The following GitHub repositories are open-source and contribution-friendly:
 
-- [`strapi/strapi`](https://github.com/strapi/strapi): main repository of Strapi, which contains the core of the project. You can find the admin panel, core plugins, plugin providers, and the whole code that runs your Strapi application. Please read the [`CONTRIBUTING.md`](https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md) file to have more information about contributions to the main repository.
-- [`strapi/documentation`](https://github.com/strapi/documentation): contains the whole documentation of Strapi. Please read the [contribution guide](https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md) to have more information about contributions to the Strapi documentation.
-- [`strapi/design-system`](https://github.com/strapi/design-system): is the design system that is used in the admin panel. It brings consistency between the different admin plugins.
-- [`strapi/strapi-docker`](https://github.com/strapi/strapi-docker): contains the code used to generate the official Docker images for Strapi (available through our [Docker Hub](https://hub.docker.com/r/strapi/strapi)).
-- [`strapi/awesome-strapi`](https://github.com/strapi/awesome-strapi): contains everything the community built and all managed plugins. It is used as a central place to find and submit new packages such as plugins, middlewares, hooks, and general enhancements to the core of Strapi.
+- [`strapi/strapi`](https://github.com/strapi/strapi): the main repository of Strapi, which contains the core of the project. You can find the admin panel, core plugins, plugin providers, and the complete code that runs your Strapi application. Please read the [Contribute to Strapi](https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md) guide for more information about contributing to the main repository.
+- [`strapi/documentation`](https://github.com/strapi/documentation): the complete documentation of Strapi. Please read the [Contribute to the Strapi documentation](https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md) guide for more information about contributing to the Strapi documentation.
+- [`strapi/design-system`](https://github.com/strapi/design-system): the design system that is used in the admin panel. It establishes consistency among the various admin plugins.
+- [`strapi/strapi-docker`](https://github.com/strapi/strapi-docker): the code used to generate the official Docker images for Strapi (available through our [Docker Hub](https://hub.docker.com/r/strapi/strapi)).
+- [`strapi/awesome-strapi`](https://github.com/strapi/awesome-strapi): all plugins managed by the core team as well as contributions built by the community. It is used as a central place to find and submit new packages such as plugins, middlewares, hooks, and general enhancements to the core of Strapi.
 
 ## Strapi Community
 
-Strapi is a community-oriented project with an emphasis on transparency. The Strapi team has at heart to share their vision and build the future of Strapi with the Strapi community. This is why the [roadmap](https://portal.productboard.com/strapi) is open: as all insights are very important and will help steer the project in the right direction, any community member is most welcome to share ideas and opinions there.
+Strapi is a community-oriented project with an emphasis on transparency. The Strapi team has at heart to share their vision and build the future of Strapi with the Strapi community. This is why the [roadmap](https://portal.productboard.com/strapi) is open: as all insights are very important and help steer the project in the right direction, any community member is most welcome to share ideas and opinions there.
 
-Community members also take great part in providing the whole community a plethora of resources about Strapi. You can find [tutorials](https://strapi.io/tutorials/) on the Strapi website, where you can also create your own. Also, as an open-source project, the technical documentation of Strapi is open to contributions (see [Open-source & Contribution](#open-source-contribution)).
+Community members also take great part in providing the a plethora of resources about Strapi. You can find [tutorials](https://strapi.io/tutorials/) on the Strapi website, where you can even create your own. Also, as an open-source project, the technical documentation of Strapi is open to contributions (see [Open-source & Contribution](#open-source-contribution)).
 
 ::: strapi Want to join the community?
-You can join [GitHub](https://github.com/strapi/strapi), the [Forum](https://forum.strapi.io/), and the [Discord](https://discord.strapi.io) to share your ideas and opinions with other community members and members of the Strapi team. If you're looking for news and updates about Strapi, [Twitter](https://twitter.com/strapijs) and the [blog](https://strapi.io/blog) are pretty good places to start!
+You can join [GitHub](https://github.com/strapi/strapi), the [Forum](https://forum.strapi.io/), and the [Discord](https://discord.strapi.io) to share your ideas and opinions with other community members and members of the Strapi team. If you are looking for news and updates about Strapi, [Twitter](https://twitter.com/strapijs) and the [blog](https://strapi.io/blog) are pretty good places to start!
 :::
 
 ## Support
 
-Strapi is offered as free and open-source for users who wish to self-host the software. When having an issue or a question, the [forum](https://forum.strapi.io) is great first place to reach out for help. Both the Strapi community and core developers often check this platform and answer posts.
+Strapi is open-source and free and is therefore ideal for self-hosting, if a user wishes to do so. When having an issue or a question, the [forum](https://forum.strapi.io) is a great place to reach out for help. Both the Strapi community and core developers often check this platform and answer posts. [Stackoverflow](https://www.stackoverflow.com/) is another good place for getting answers to problems, too.
 
-For enterprise support, please see our [Enterprise Support platform](https://support.strapi.io/support/home), please note that you will need to have an active enterprise license to place tickets.
+For enterprise support, please have a look at our [Enterprise Support platform](https://support.strapi.io/support/home). You need to have an active enterprise license to place tickets.


### PR DESCRIPTION
Based on a feedback by @pwilzla stating that the internal rules for technical writing are very strict and that the documentation needs improvement concerning that matter, I propose these changes:

- Continuations after colons in a list should be unified: either they all start with a verb, or they all formulate a complete sentence, or they all shortly state what their content/purpose is (incomplete sentence; chosen here)
- Removal of "you" and the like in non-callout sections (even though this page is not really a technical documentation yet; but I would like to know, why you would NOT remove those 2 examples given, if you decide against their removal)
- Smooth out some formulations that seem to be "not so English". (I know, this is quite arrogant from my side, because I am not a native English speaker; but I am convinced that my formulations are better to read; and if not, a collaboration would eventually nevertheless improve the wording. So I kindly ask to set aside my arrogance and instead address the formulation problem, which it still is - at least to me as a reader of the documentation and a user of Strapi) :-)
- Use the headline of the document linked to as text for the URL ("Contribute to Strapi" and "Contribute to the Strapi documentation", which had rather arbitrary link titles, one using the name of the document, the other some text that nowhere is used. It remains to be discussed whether these texts should be treated as a title, because that would have an impact on the capitalisations of their words.)

Things that are not really clear at the moment:
- "Strapi is open source and free" is true, but there are differences to the commercial version. This should be made clear somehow, e.g. by clarifying, which Strapi is meant. "The 'Strapi Community Edition' is open source and free [...]"
- This brings up the question: what are the differences between the community and the commercial edition? IMO a link should be provided to such a page.

And simply just out of interest: What is the thinking behind the idea that "Enterprise support" is only available to those, who have an active enterprise licence? What about providing "paid support" in general? I know of a project that finances its OSS development that way (at least partly, but it is an important part; if you wish to know more, I can share a link).
