### PR TITLE
Make plugin resolve config option mandatory

### DIFF
--- a/docs/developer-docs/latest/setup-deployment-guides/configurations/optional/plugins.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/configurations/optional/plugins.md
@@ -8,11 +8,11 @@ canonicalUrl: https://docs.strapi.io/developer-docs/latest/setup-deployment-guid
 
 The configurations for all plugins are stored in `./config/plugins.js` (see [project structure](/developer-docs/latest/setup-deployment-guides/file-structure.md)). Each plugin can be configured with the following available parameters:
 
-| Parameter                   | Description                                                                                                                                                            | Type    |
-| --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `enabled`                   | Enable (`true`) or disable (`false`) an installed plugin                                                                                                               | Boolean |
-| `config`<br><br>_Optional_  | Used to override default plugin configuration ([defined in strapi-server.js](/developer-docs/latest/developer-resources/plugin-api-reference/server.md#configuration)) | Object  |
-| `resolve`<br><br>_Optional_ | Path to the plugin's folder                                                                                                                                            | String  |
+| Parameter                  | Description                                                                                                                                                            | Type    |
+| -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `enabled`                  | Enable (`true`) or disable (`false`) an installed plugin                                                                                                               | Boolean |
+| `config`<br><br>_Optional_ | Used to override default plugin configuration ([defined in strapi-server.js](/developer-docs/latest/developer-resources/plugin-api-reference/server.md#configuration)) | Object  |
+| `resolve`<br>              | Path to the plugin's folder                                                                                                                                            | String  |
 
 ```js
 // path: ./config/plugins.js
@@ -46,8 +46,8 @@ If no specific configuration is required, a plugin can also be declared with the
 
 The [GraphQL plugin](/developer-docs/latest/plugins/graphql.md) has the following specific configuration options:
 
-| Parameter      | Description                                                                                                                                                                     | Type    | 
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- | ------------- |
+| Parameter      | Description                                                                                                                                                                     | Type      |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- |
 | `defaultLimit` | Default value for [the `pagination[limit]` parameter](/developer-docs/latest/developer-resources/database-apis-reference/graphql-api.md#pagination-by-offset) used in API calls | `Integer` |
 | `maxLimit`     | Maximum value for [the `pagination[limit]` parameter](/developer-docs/latest/developer-resources/database-apis-reference/graphql-api.md#pagination-by-offset) used in API calls | `Integer` |
 

--- a/docs/developer-docs/latest/setup-deployment-guides/configurations/optional/plugins.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/configurations/optional/plugins.md
@@ -12,7 +12,7 @@ The configurations for all plugins are stored in `./config/plugins.js` (see [pro
 | -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
 | `enabled`                  | Enable (`true`) or disable (`false`) an installed plugin                                                                                                               | Boolean |
 | `config`<br><br>_Optional_ | Used to override default plugin configuration ([defined in strapi-server.js](/developer-docs/latest/developer-resources/plugin-api-reference/server.md#configuration)) | Object  |
-| `resolve`<br>              | Path to the plugin's folder                                                                                                                                            | String  |
+| `resolve`<br> _Optional, only required for local plugins_             | Path to the plugin's folder                                                                                                                                            | String  |
 
 ```js
 // path: ./config/plugins.js


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

This PR removes the Optional designation on the resolve field of plugin configuration. This field, is currently required in v4.

### Why is it needed?

Without it, the Strapi application is unable to start and throws the error seen below:
```bash
[2022-01-27 16:05:06.185] debug: ⛔️ Server wasn't able to start properly.
[2022-01-27 16:05:06.185] error: The "path" argument must be of type string. Received undefined
TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined
    at validateString (internal/validators.js:124:11)
    at join (path.js:1148:7)
    at Object.loadPlugins (/Users/app/node_modules/@strapi/strapi/lib/core/loaders/plugins/index.js:89:34)
    at async Strapi.loadPlugins (/Users/app/node_modules/@strapi/strapi/lib/Strapi.js:279:5)
    at async Promise.all (index 1)
    at async Strapi.register (/Users/app/node_modules/@strapi/strapi/lib/Strapi.js:311:5)
    at async Strapi.load (/Users/app/node_modules/@strapi/strapi/lib/Strapi.js:409:5)
    at async Strapi.start (/Users/app/node_modules/@strapi/strapi/lib/Strapi.js:161:9)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

