### PR TITLE
Fixed user-permissions email templating guide likn

### DIFF
--- a/docs/user-docs/latest/settings/configuring-users-permissions-plugin-settings.md
+++ b/docs/user-docs/latest/settings/configuring-users-permissions-plugin-settings.md
@@ -54,7 +54,7 @@ To configure and edit email templates:
 | Response email | (optional) Indicate the email address to which responses emails from the end users will be sent. |
 | Subject        | Write the subject of the email. Variables can be used (see [Developer documentation](https://strapi.io/documentation/developer-docs/latest/development/plugins/users-permissions.html#templating-emails)).             |
 
-4. Edit the content of the email in the "Message" textbox. Email templates content is in HTML and uses variables (see [Developer documentation](https://strapi.io/documentation/developer-docs/latest/development/plugins/users-permissions.html#templating-emails)).
+4. Edit the content of the email in the "Message" textbox. Email templates content is in HTML and uses variables (see [Developer documentation](https://docs.strapi.io/developer-docs/latest/plugins/users-permissions.html#templating-emails)).
 5. Click on the **Save** button.
 
 ## Configuring advanced settings


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

Replaced [this link](https://strapi.io/documentation/developer-docs/latest/development/plugins/users-permissions.html#templating-emails) with [this link](https://docs.strapi.io/developer-docs/latest/plugins/users-permissions.html#templating-emails) on [this page](https://docs.strapi.io/user-docs/latest/settings/configuring-users-permissions-plugin-settings.html#configuring-email-templates).

### Why is it needed?

The link I replaced does not exist.
