### PR TITLE
strapi.server.close() instead of strapi.destroy()

### DIFF
--- a/docs/developer-docs/latest/guides/unit-testing.md
+++ b/docs/developer-docs/latest/guides/unit-testing.md
@@ -155,7 +155,7 @@ afterAll(async () => {
   const dbSettings = strapi.config.get('database.connections.default.settings');
   
   //close server to release the db-file
-  await strapi.destroy();
+  await strapi.server.close();
 
   //delete test database after all tests
   if (dbSettings && dbSettings.filename) {


### PR DESCRIPTION
Unit test throws error TypeError: this.admin.destroy is not a function

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

Describe the technical changes you did.

### Why is it needed?

Describe the issue you are solving.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
