### PR TITLE
fix(CONTRIBUTING): incorrect dev docs launch command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,7 +91,7 @@ The core team will review your pull request and will either merge it, request ch
     yarn dev
 
     # Launch only the developer docs
-    yarn dev:developer
+    yarn dev:dev
 
     # Launch only the user docs
     yarn dev:user


### PR DESCRIPTION
### What does it do?

Updates the dev docs launch command mentioned in `CONTRIBUTING.md` to the correct one defined in the `package.json`.

### Why is it needed?

The current command `yarn dev:developer` results in an error which can cause confusion for first time contributers.

### Related issue(s)/PR(s)

N/A
