### PR TITLE
Fix order and pagination docs

### DIFF
--- a/docs/developer-docs/latest/developer-resources/database-apis-reference/entity-service/order-pagination.md
+++ b/docs/developer-docs/latest/developer-resources/database-apis-reference/entity-service/order-pagination.md
@@ -20,13 +20,13 @@ To order results by a single field, just pass it to the `orderBy` parameter:
 - or as an object to define both the field name and the order (i.e. `'asc'` for ascending order or `'desc'` for descending order)
 
 ```js
-strapi.entityService('api::article.article').findMany({
-  orderBy: 'id',
+strapi.entityService.findMany('api::article.article',{
+  sort: 'id',
 });
 
 // single with direction
-strapi.entityService('api::article.article').findMany({
-  orderBy: { id: 'desc' },
+strapi.entityService.findMany('api::article.article',{
+  sort: { id: 'desc' },
 });
 ```
 
@@ -38,13 +38,13 @@ To order results by multiple fields, pass the fields as an array to the `orderBy
 - or as an array of objects to define both the field name and the order (i.e. `'asc'` for ascending order or `'desc'` for descending order)
 
 ```js
-strapi.entityService('api::article.article').findMany({
-  orderBy: ['publishDate', 'name'],
+strapi.entityService.findMany('api::article.article',{
+  sort: ['publishDate', 'name'],
 });
 
 // multiple with direction
-strapi.entityService('api::article.article').findMany({
-  orderBy: [{ title: 'asc' }, { publishedAt: 'desc' }],
+strapi.entityService.findMany('api::article.article',{
+  sort: [{ title: 'asc' }, { publishedAt: 'desc' }],
 });
 ```
 
@@ -53,8 +53,8 @@ strapi.entityService('api::article.article').findMany({
 Fields can also be sorted based on fields from relations:
 
 ```js
-strapi.entityService('api::article.article').findMany({
-  orderBy: {
+strapi.entityService.findMany('api::article.article',{
+  sort: {
     author: {
       name: 'asc',
     },
@@ -67,7 +67,7 @@ strapi.entityService('api::article.article').findMany({
 To paginate results returned by the Entity Service API, use the `start` and `limit` parameters:
 
 ```js
-strapi.entityService('api::article.article').findMany({
+strapi.entityService.findMany('api::article.article',{
   start: 10,
   limit: 15,
 });


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?
It fixes the currently broken developer [docs for order and pagination](https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/entity-service/order-pagination.html).
`orderBy` parameter is now replaced by `sort`.
`strapi.entityService('api::article.article').findMany({})` is now replaced by `strapi.entityService.findMany('api::article.article',{})`

### Why is it needed?

The currently provided examples are not working.

### Related issue(s)/PR(s)

