### PR TITLE
Updates fetch by slug to use the filter system

### DIFF
--- a/docs/developer-docs/latest/guides/slug.md
+++ b/docs/developer-docs/latest/guides/slug.md
@@ -97,4 +97,4 @@ module.exports = {
 
 Then you will be able to fetch your **Articles** by this slug.
 
-You will be able to find your articles by slug with this request `GET /articles?slug=my-article-slug`
+You will be able to find your articles by slug with this request `GET /articles?filter[slug]=my-article-slug`

--- a/docs/developer-docs/latest/guides/slug.md
+++ b/docs/developer-docs/latest/guides/slug.md
@@ -97,4 +97,4 @@ module.exports = {
 
 Then you will be able to fetch your **Articles** by this slug.
 
-You will be able to find your articles by slug with this request `GET /articles?filter[slug]=my-article-slug`
+You will be able to find your articles by slug with this request `GET /articles?filters[slug]=my-article-slug`


### PR DESCRIPTION
In practice I had to add `filters[slug]` to query the backend and get the response I expected. 

This may be an error on my end, but in case it's not I wanted to propose this change.

### What does it do?

Updates [slug example](https://docs.strapi.io/developer-docs/latest/guides/slug.html) to use [filtering](https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/rest/filtering-locale-publication.html#filtering)

### Why is it needed?

In practice when I tried to fetch articles using the method described in the docs, it didn't work. The update does.

### Related issue(s)/PR(s)

Not sure if there are any
