### PR TITLE
Update node LTS versions

### DIFF
--- a/docs/developer-docs/latest/setup-deployment-guides/deployment.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment.md
@@ -17,7 +17,7 @@ Deploying databases along with Strapi is covered in the [databases guide](/devel
 ::: prerequisites
 To provide the best possible environment for Strapi there are a few requirements, these apply in both a development (local) as well as a staging and production workflow.
 
-- Node LTS (v12 or V14) **Note that odd-number releases of Node will never be supported (e.g. v13, v15).**
+- Node LTS (v12, v14 or v16) **Note that odd-number releases of Node will never be supported (e.g. v13, v15, v17).**
 - NPM v6 or whatever ships with the LTS Node versions
 - Typical standard build tools for your OS (the `build-essentials` package on most Debian-based systems)
 - At least 1 CPU core (Highly recommended at least 2)


### PR DESCRIPTION
### What does it do?

Update node LTS versions according https://nodejs.org/en/about/releases/

### Why is it needed?

It's good to know that Strapi works with latest LTS
