### PR TITLE
[v4 migration] Controllers migration

### DIFF
--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/v4/code/backend/controllers.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/v4/code/backend/controllers.md
@@ -1,0 +1,87 @@
+---
+title: v4 code migration - Controllers - Strapi Developer Docs
+description: Migrate controllers of a Strapi application from v3.6.8 to v4.0.x
+canonicalUrl:  Used by Google to index page, should start with https://docs.strapi.io/ — delete this comment when done [paste final URL here]
+---
+
+<!-- TODO: update SEO -->
+
+# v4 code migration: Updating controllers
+
+!!!include(developer-docs/latest/update-migration-guides/migration-guides/v4/snippets/code-migration-intro.md)!!!
+
+::: strapi v3/v4 comparison
+In both Strapi v3 and v4, creating content-types automatically generates core API controllers. Controllers are JavaScript files that contain a list of methods, called actions.
+
+In Strapi v3, controllers export an object containing actions  that are merged with the existing actions of core API controllers, allowing customization.
+
+In Strapi v4, controllers export the result of a call to the [`createCoreController` factory function](/developer-docs/latest/development/backend-customization/controllers.md#implementation), with or without further customization.
+:::
+
+Migrating a controller to Strapi v4 consists in making sure that each controller is located in the proper folder and uses the `createCoreController` factory function introduced in v4.
+
+Due to the differences between controllers implementation in Strapi v3 and v4, it's recommended to create a new controller file, then optionally bring existing v3 customizations into the new file and adapt them when necessary.
+
+A new controller can be created:
+
+- manually, starting at step 1 of the following procedure,
+- or automatically, using the [`strapi generate` interactive CLI](/developer-docs/latest/developer-resources/cli/CLI.md#strapi-generate) then jumping directly to step 4 of the following procedure if controller customizations are required.
+
+To create a v4 controller:
+
+1. Create a `api/<api-name>/controllers/<controller-name>.js` file inside the `./src` folder (see [project structure](/developer-docs/latest/setup-deployment-guides/file-structure.md)).
+
+2. Copy and paste the following code at the top of the `./src/api/<api-name>/controllers/<controller-name>.js` file. The code imports the `createCoreController` factory function from the factories included with the core of Strapi:
+
+    ```js
+    const { createCoreController } = require('@strapi/strapi').factories;
+    ```
+
+3. Copy and paste the following code, replacing `api-name` and `content-type-name` with appropriate names. The code exports the result of a call to the `createCoreController` factory function, passing the unique identifier of the content-type (e.g. `api::api-name.content-type-name`) as an argument:
+
+    ```js
+    module.exports = createCoreController('api::api-name.content-type-name')
+    ```
+
+4. (_optional_) To customize controller actions, pass a second argument to the `createCoreController` factory function. This argument is an object containing methods, which can either be entirely new actions or replace or extend existing actions of core API controllers (see [controllers implementation documentation](/developer-docs/latest/development/backend-customization/controllers.md#adding-a-new-controller)).
+
+::: details Example of a v4 controller without customization
+
+  ```jsx
+  // path: ./src/api/<content-type-name>/controllers/<controller-name>.js
+
+  const { createCoreController } = require('@strapi/strapi').factories;
+
+  module.exports = createCoreController('api::api-name.content-type-name');
+  ```
+
+:::
+
+::: details Example of a v4 controller with customization
+
+  ```jsx
+  // path: ./src/api/<content-type-name>/controllers/<controller-name>.js
+
+  const { createCoreController } = require('@strapi/strapi').factories;
+    
+  module.exports = createCoreController('api::api-name.content-type-name', {
+    // replace the find() action of the core API controller
+    async find(ctx) {
+      const { results } = await strapi.service('api::address.address').find();
+  
+      ctx.body = await this.sanitizeOutput(results);
+    },
+  });
+  ```
+
+:::
+
+:::tip Customization tips
+
+* The `sanitizeInput` and `sanitizeOutput` utilities can be used in Strapi v4 and replace the `sanitizeEntity` utility from v3.
+* The original controller’s CRUD actions can be called using `super` (e.g. `super.find()`).
+
+More examples can be found in the [controllers implementation documentation](/developer-docs/latest/development/backend-customization/controllers.md#implementation).
+:::
+
+<!-- TODO: add a conclusion or links for other steps -->

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/v4/code/backend/controllers.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/v4/code/backend/controllers.md
@@ -25,7 +25,8 @@ Due to the differences between controllers implementation in Strapi v3 and v4, i
 A new controller can be created:
 
 - manually, starting at step 1 of the following procedure,
-- or automatically, using the [`strapi generate` interactive CLI](/developer-docs/latest/developer-resources/cli/CLI.md#strapi-generate) then jumping directly to step 4 of the following procedure if controller customizations are required.
+- or automatically, using the [`strapi generate` interactive CLI](/developer-docs/latest/developer-resources/cli/CLI.md#strapi-generate) then jumping to step 2 of the following procedure.
+<!-- ? I noticed the strapi generate CLI generates an empty controller and not a call to createCoreController, is it intended ? -->
 
 To create a v4 controller:
 

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/v4/code/backend/controllers.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/v4/code/backend/controllers.md
@@ -86,8 +86,8 @@ To create a v4 controller:
 
 :::tip Customization tips
 
-* The `sanitizeInput` and `sanitizeOutput` utilities can be used in Strapi v4 and replace the `sanitizeEntity` utility from v3.
-* The original controller’s CRUD actions can be called using `super` (e.g. `super.find()`).
+- The `sanitizeInput` and `sanitizeOutput` utilities can be used in Strapi v4 and replace the `sanitizeEntity` utility from v3.
+- The original controller’s CRUD actions can be called using `super` (e.g. `super.find()`).
 
 More examples can be found in the [controllers implementation documentation](/developer-docs/latest/development/backend-customization/controllers.md#implementation).
 :::

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/v4/code/backend/controllers.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/v4/code/backend/controllers.md
@@ -18,7 +18,7 @@ In Strapi v3, controllers export an object containing actions  that are merged w
 In Strapi v4, controllers export the result of a call to the [`createCoreController` factory function](/developer-docs/latest/development/backend-customization/controllers.md#implementation), with or without further customization.
 :::
 
-Migrating a controller to Strapi v4 consists in making sure that each controller is located in the proper folder and uses the `createCoreController` factory function introduced in v4.
+Migrating [controllers](/developer-docs/latest/development/backend-customization/controllers.md) to Strapi v4 consists in making sure that each controller is located in the proper folder and uses the `createCoreController` factory function introduced in v4.
 
 Due to the differences between controllers implementation in Strapi v3 and v4, it's recommended to create a new controller file, then optionally bring existing v3 customizations into the new file and adapt them when necessary.
 
@@ -86,8 +86,8 @@ To create a v4 controller:
 
 :::tip Customization tips
 
-- The `sanitizeInput` and `sanitizeOutput` utilities can be used in Strapi v4 and replace the `sanitizeEntity` utility from v3.
 - The original controller’s CRUD actions can be called using `super` (e.g. `super.find()`).
+- The `sanitizeInput` and `sanitizeOutput` utilities can be used in Strapi v4 and replace the `sanitizeEntity` utility from v3.
 
 More examples can be found in the [controllers implementation documentation](/developer-docs/latest/development/backend-customization/controllers.md#implementation).
 :::

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/v4/code/backend/controllers.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/v4/code/backend/controllers.md
@@ -43,7 +43,7 @@ To create a v4 controller:
     module.exports = createCoreController('api::api-name.content-type-name')
     ```
 
-4. (_optional_) To customize controller actions, pass a second argument to the `createCoreController` factory function. This argument is an object containing methods, which can either be entirely new actions or replace or extend existing actions of core API controllers (see [controllers implementation documentation](/developer-docs/latest/development/backend-customization/controllers.md#adding-a-new-controller)).
+4. (_optional_) To customize controller actions, pass a second argument to the `createCoreController` factory function. This argument can be either an object or a function returning an object. The object contains methods, which can either be entirely new actions or replace or extend existing actions of core API controllers (see [controllers implementation documentation](/developer-docs/latest/development/backend-customization/controllers.md#adding-a-new-controller)).
 
 ::: details Example of a v4 controller without customization
 

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/v4/code/backend/controllers.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/v4/code/backend/controllers.md
@@ -1,10 +1,8 @@
 ---
 title: v4 code migration - Controllers - Strapi Developer Docs
 description: Migrate controllers of a Strapi application from v3.6.8 to v4.0.x
-canonicalUrl:  Used by Google to index page, should start with https://docs.strapi.io/ — delete this comment when done [paste final URL here]
+canonicalUrl:  http://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/v4/code/backend/controllers.html
 ---
-
-<!-- TODO: update SEO -->
 
 # v4 code migration: Updating controllers
 

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/v4/code/backend/controllers.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/v4/code/backend/controllers.md
@@ -63,15 +63,23 @@ To create a v4 controller:
   // path: ./src/api/<content-type-name>/controllers/<controller-name>.js
 
   const { createCoreController } = require('@strapi/strapi').factories;
-    
-  module.exports = createCoreController('api::api-name.content-type-name', {
-    // replace the find() action of the core API controller
+
+  module.exports = createCoreController('api::api-name.content-type-name', ({ strapi }) => ({
+  // wrap a core action, leaving core logic in place
     async find(ctx) {
-      const { results } = await strapi.service('api::address.address').find();
-  
-      ctx.body = await this.sanitizeOutput(results);
+      // some custom logic here
+      ctx.query = { ...ctx.query, local: 'en' }
+
+      // calling the default core action with super
+      const { data, meta } = await super.find(ctx);
+
+      // some more custom logic
+      meta.date = Date.now()
+
+      return { data, meta };
     },
-  });
+  }));
+
   ```
 
 :::


### PR DESCRIPTION
This adds documentation on how to migrate controllers from v3 to v4.

Look out for a lot more upcoming PRs in the following weeks — their title will be prefixed by [v4 migration].

_Please note: This branch targets the `dev/code-migration` branch which will be used as a main entry branch for all code migration guide PRs. Please do not review #712 yet._
