### PR TITLE
fix(api configuration): add missing API prefix option for rest

### DIFF
--- a/docs/developer-docs/latest/setup-deployment-guides/configurations/optional/api.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/configurations/optional/api.md
@@ -13,6 +13,7 @@ General settings for API calls can be set in the `./config/api.js` file:
 | `responses`                   | Global API response configuration                                                                                                                                                                                                                    | Object       | -       |
 | `responses.privateAttributes` | Set of globally defined attributes to be treated as private.                                                                                                                                                                                         | String array | `[]`    |
 | `rest`                        | REST API configuration                                                                                                                                                                                                                               | Object       | -       |
+| `rest.prefix`                 | The API prefix                       | String      | `/api`   |
 | `rest.defaultLimit`           | Default `limit` parameter used in API calls (see [REST API documentation](/developer-docs/latest/developer-resources/database-apis-reference/rest/sort-pagination.md#pagination-by-offset))                                                                      | Integer      | `25`    |
 | `rest.maxLimit`               | Maximum allowed number that can be requested as `limit` (see [REST API documentation](/developer-docs/latest/developer-resources/database-apis-reference/rest/sort-pagination.md#pagination-by-offset)).<br/><br/>Defaults to `null`, which fetches all results. | Integer      | `100`   |
 
@@ -26,6 +27,7 @@ module.exports = ({ env }) => ({
     privateAttributes: ['_v', 'id', 'created_at'],
   },
   rest: {
+    prefix: '/v1',
     defaultLimit: 100,
     maxLimit: 250,
   },


### PR DESCRIPTION
### What does it do?

Adds the missing `rest.prefix` option to the [API configuration section](https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/configurations/optional/api.html) of the developer docs.

### Why is it needed?

It provides the information necessary for a developer to easily set a custom prefix for the REST API without needed to find the correct configuration themselves.

### Related issue(s)/PR(s)

N/A