### PR TITLE
Add another SSO prerequisites (enable in admin panel)

### DIFF
--- a/docs/developer-docs/latest/setup-deployment-guides/configurations/optional/sso.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/configurations/optional/sso.md
@@ -13,8 +13,9 @@ Single Sign-On on Strapi allows you to configure additional sign-in and sign-up 
 
 - A Strapi application running on version 3.5.0 or higher is required.
 - To configure SSO on your application, you will need an EE license with a [Gold plan](https://strapi.io/pricing-self-hosted).
+- Make sure the SSO feature is [enabled in the admin panel](/user-docs/latest/settings/managing-global-settings.md#configuring-single-sign-on).
 - Make sure Strapi is part of the applications you can access with your provider. For example, with Microsoft (Azure) Active Directory, you must first ask someone with the right permissions to add Strapi to the list of allowed applications. Please refer to your provider(s) documentation to learn more about that.
-  :::
+:::
 
 :::caution
 It is currently not possible to associate a unique SSO provider to an email address used for a Strapi account, meaning that the access to a Strapi account cannot be restricted to only one SSO provider. For more information and workarounds to solve this issue, [please refer to the dedicated GitHub issue](https://github.com/strapi/strapi/issues/9466#issuecomment-783587648).


### PR DESCRIPTION
It adds a prerequisite to make sure SSO is enabled in the admin panel.