### PR TITLE
Add prerequisites for admin panel customization

### DIFF
--- a/docs/developer-docs/latest/development/admin-customization.md
+++ b/docs/developer-docs/latest/development/admin-customization.md
@@ -82,7 +82,7 @@ module.exports = ({ env }) => ({
 ::: prerequisites
 Before configuring any admin panel customization option, make sure to:
 - rename the default `app.example.js` file into `app.js`,
-- and create a new `extensions` folder in `./src/admin/`. Strapi projects already contain by default another `extensions` folder in `./src/` but it is for plugins extensions only (see [Plugins extention](/developer-docs/latest/development/plugins-extention.md)).
+- and create a new `extensions` folder in `./src/admin/`. Strapi projects already contain by default another `extensions` folder in `./src/` but it is for plugins extensions only (see [Plugins extension](/developer-docs/latest/development/plugins-extension.md)).
 :::
 
 The `config` object found at `./src/admin/app.js` stores the admin panel configuration.

--- a/docs/developer-docs/latest/development/admin-customization.md
+++ b/docs/developer-docs/latest/development/admin-customization.md
@@ -79,9 +79,15 @@ module.exports = ({ env }) => ({
 
 ### Configuration options
 
+::: prerequisites
+Before configuring any admin panel customization option, make sure to:
+- rename the default `app.example.js` file into `app.js`,
+- and create a new `extensions` folder in `./src/admin/`. Strapi projects already contain by default another `extensions` folder in `./src/` but it is for plugins extensions only (see [Plugins extention](/developer-docs/latest/development/plugins-extention.md)).
+:::
+
 The `config` object found at `./src/admin/app.js` stores the admin panel configuration.
 
-Any file used by the `config` object (e.g. a custom logo) should be placed in the `./src/admin/extensions/` folder and imported inside `./src/admin/app.js`.
+Any file used by the `config` object (e.g. a custom logo) should be placed in a `./src/admin/extensions/` folder and imported inside `./src/admin/app.js`.
 
 The `config` object accepts the following parameters:
 
@@ -287,6 +293,10 @@ module.exports = {
 ```
 
 ### Webpack configuration
+
+::: prerequisites
+Make sure to rename the default `webpack.config.example.js` file into `webpack.config.js` before customizing webpack.
+:::
 
 In order to extend the usage of webpack v5, define a function that extends its configuration inside `./my-app/src/admin/webpack.config.js`:
 


### PR DESCRIPTION
Add prerequisites in Admin Panel customisation:
- example files renaming (`app.example.js`, `webpack.config.example.js`)
- `extensions` folder creation (+ explanations about the 2 different extensions folders)