### PR TITLE
Remove TypeScript typings from lifecycles examples

### DIFF
--- a/docs/developer-docs/latest/development/backend-customization/models.md
+++ b/docs/developer-docs/latest/development/backend-customization/models.md
@@ -554,14 +554,14 @@ Each event listener is called sequentially. They can be synchronous or asynchron
 // ./src/api/[api-name]/content-types/restaurant/lifecycles.js
 
 module.exports = {
-  beforeCreate(event: Event) {
+  beforeCreate(event) {
     const { data, where, select, populate } = event.params;
 
     // let's do a 20% discount everytime
     event.params.data.price = event.params.data.price * 0.8;
   },
 
-  afterCreate(event: Event) {
+  afterCreate(event) {
     const { result, params } = event;
 
     // do something to the result;
@@ -578,13 +578,13 @@ Using the database layer API, it's also possible to register a subscriber and li
 strapi.db.lifecycles.subscribe({
   models: [], // optional;
 
-  beforeCreate(event: Event) {
+  beforeCreate(event) {
     const { data, where, select, populate } = event.params;
 
     event.state = 'doStuffAfterWards';
   },
 
-  afterCreate(event: Event) {
+  afterCreate(event) {
     if (event.state === 'doStuffAfterWards') {
     }
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

Removes parameter types from lifecycle functions provided as examples.

### Why is it needed?

Although Strapi does define some types, it still runs JavaScript, so the example functions will not work because typing parameters is exclusive to TypeScript.
