### PR TITLE
Added missing curly brace

### DIFF
--- a/docs/developer-docs/latest/setup-deployment-guides/configurations/optional/plugins.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/configurations/optional/plugins.md
@@ -61,5 +61,6 @@ module.exports = () => ({
       defaultLimit: 10,
       maxLimit: 20
     }
+  }
 })
 ```


### PR DESCRIPTION
In the GraphQL configuration example a closing curly brace is missing.