### PR TITLE
Fix entityService references to sort instead of orderBy

### DIFF
--- a/docs/developer-docs/latest/developer-resources/database-apis-reference/entity-service/order-pagination.md
+++ b/docs/developer-docs/latest/developer-resources/database-apis-reference/entity-service/order-pagination.md
@@ -10,41 +10,41 @@ The [Entity Service API](/developer-docs/latest/developer-resources/database-api
 
 ## Ordering
 
-To order results returned by the Entity Service API, use the `orderBy` parameter. Results can be ordered based on a [single](#single) or on [multiple](#multiple) attribute(s) and can also use [relational ordering](#relational-ordering).
+To order results returned by the Entity Service API, use the `sort` parameter. Results can be ordered based on a [single](#single) or on [multiple](#multiple) attribute(s) and can also use [relational ordering](#relational-ordering).
 
 ### Single
 
-To order results by a single field, just pass it to the `orderBy` parameter: 
+To order results by a single field, just pass it to the `sort` parameter:
 
 - either as a string to sort with the default ascending order
 - or as an object to define both the field name and the order (i.e. `'asc'` for ascending order or `'desc'` for descending order)
 
 ```js
 strapi.entityService('api::article.article').findMany({
-  orderBy: 'id',
+  sort: 'id',
 });
 
 // single with direction
 strapi.entityService('api::article.article').findMany({
-  orderBy: { id: 'desc' },
+  sort: { id: 'desc' },
 });
 ```
 
 ### Multiple
 
-To order results by multiple fields, pass the fields as an array to the `orderBy` parameter:
+To order results by multiple fields, pass the fields as an array to the `sort` parameter:
 
 - either as an array of strings to sort multiple fields using the default ascending order
 - or as an array of objects to define both the field name and the order (i.e. `'asc'` for ascending order or `'desc'` for descending order)
 
 ```js
 strapi.entityService('api::article.article').findMany({
-  orderBy: ['publishDate', 'name'],
+  sort: ['publishDate', 'name'],
 });
 
 // multiple with direction
 strapi.entityService('api::article.article').findMany({
-  orderBy: [{ title: 'asc' }, { publishedAt: 'desc' }],
+  sort: [{ title: 'asc' }, { publishedAt: 'desc' }],
 });
 ```
 
@@ -54,7 +54,7 @@ Fields can also be sorted based on fields from relations:
 
 ```js
 strapi.entityService('api::article.article').findMany({
-  orderBy: {
+  sort: {
     author: {
       name: 'asc',
     },

--- a/docs/developer-docs/latest/developer-resources/database-apis-reference/entity-service/populate.md
+++ b/docs/developer-docs/latest/developer-resources/database-apis-reference/entity-service/populate.md
@@ -60,7 +60,7 @@ const entries = await strapi.entityService.findMany('api::article.article', {
 
     repeatableComponent: {
       fields: ['someAttributeName'],
-      orderBy: ['someAttributeName'],
+      sort: ['someAttributeName'],
       populate: {
         componentRelationA: true,
       },


### PR DESCRIPTION
Signed-off-by: Derrick Mehaffy <derrickmehaffy@gmail.com>

fixes: #731

replaces `orderBy` with `sort` for the entityService. Not sure how we want to adjust all the grammer on this page or if we should just keep using the "order" instead of "sort" but this fixes the technical information