### PR TITLE
I18n: Move env section into installation steps

### DIFF
--- a/docs/developer-docs/latest/plugins/i18n.md
+++ b/docs/developer-docs/latest/plugins/i18n.md
@@ -46,6 +46,12 @@ yarn strapi install i18n
 
 </code-group>
 
+### Configuration of the default locale
+
+A `STRAPI_PLUGIN_I18N_INIT_LOCALE_CODE` [environment variable](/developer-docs/latest/setup-deployment-guides/configurations/optional/environment.html#strapi-s-environment-variables) can be configured to set the default locale for your environment. The value used for this variable should be an ISO country code (see [full list of available locales](https://github.com/strapi/strapi/blob/v4.0.0/packages/plugins/i18n/server/constants/iso-locales.json)).
+
+This is useful when a Strapi app is deployed in production, with the i18n plugin installed and enabled for your content types the first time. On a fresh i18n plugin installation, `en` is set as default locale. If the database does not contain any locale, and no `STRAPI_PLUGIN_I18N_INIT_LOCALE_CODE` is set for the environment, all entities of the content types, which have localization enabled, will be automatically migrated to the `en` locale.
+
 ## Usage with the REST API
 
 The i18n plugin adds new features to the [REST API](/developer-docs/latest/developer-resources/database-apis-reference/rest-api.md):
@@ -698,8 +704,4 @@ The response returns the entry that has just been deleted.
 
 ::::
 
-## Configuration in production environments
 
-A `STRAPI_PLUGIN_I18N_INIT_LOCALE_CODE` [environment variable](/developer-docs/latest/setup-deployment-guides/configurations/optional/environment.md#strapi-s-environment-variables) can be configured to set the initialization locale for your environment. The value used for this variable should be a string (see [full list of available locales](https://github.com/strapi/strapi/blob/v4.0.0/packages/plugins/i18n/server/constants/iso-locales.json)).
-
-This is useful when a Strapi app is deployed in production, with the i18n plugin installed and enabled on your content-types for the first time. On a fresh i18n plugin installation, `en` is the default locale. So if the database does not contain any locale, and no `STRAPI_PLUGIN_I18N_INIT_LOCALE_CODE` is set for the environment, the content of the content-types with i18n enabled will be automatically migrated to the `en` locale. But if the `STRAPI_PLUGIN_I18N_INIT_LOCALE_CODE` is defined, then the content will be migrated to this locale. Using this environment variable saves you from having to manually update the locale for existing content entries.

--- a/docs/developer-docs/latest/plugins/i18n.md
+++ b/docs/developer-docs/latest/plugins/i18n.md
@@ -50,7 +50,7 @@ yarn strapi install i18n
 
 A `STRAPI_PLUGIN_I18N_INIT_LOCALE_CODE` [environment variable](/developer-docs/latest/setup-deployment-guides/configurations/optional/environment.html#strapi-s-environment-variables) can be configured to set the default locale for your environment. The value used for this variable should be an ISO country code (see [full list of available locales](https://github.com/strapi/strapi/blob/v4.0.0/packages/plugins/i18n/server/constants/iso-locales.json)).
 
-This is useful when a Strapi app is deployed in production, with the i18n plugin installed and enabled for your content types the first time. On a fresh i18n plugin installation, `en` is set as default locale. If the database does not contain any locale, and no `STRAPI_PLUGIN_I18N_INIT_LOCALE_CODE` is set for the environment, all entities of the content types, which have localization enabled, will be automatically migrated to the `en` locale.
+This is useful when a Strapi application is deployed in production, with the i18n plugin installed and enabled for your content types the first time. On a fresh i18n plugin installation, `en` is set as default locale. If the database does not contain any locale, and no `STRAPI_PLUGIN_I18N_INIT_LOCALE_CODE` is set for the environment, all entities of the content types, which have localization enabled, will be automatically migrated to the `en` locale.
 
 ## Usage with the REST API
 


### PR DESCRIPTION
### What does it do?

It moves the important section about setting the initial locale closer to the installation section, because imo it fits there much better than below the queries. I only know about it, because @petersg83 told me about it.

### Why is it needed?

To cover an important case when setting up the plugin.
