### PR TITLE
Remove incorrect API limit default

### DIFF
--- a/docs/developer-docs/latest/setup-deployment-guides/configurations/optional/api.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/configurations/optional/api.md
@@ -15,7 +15,7 @@ General settings for API calls can be set in the `./config/api.js` file:
 | `rest`                        | REST API configuration                                                                                                                                                                                                                               | Object       | -       |
 | `rest.prefix`                 | The API prefix                       | String      | `/api`   |
 | `rest.defaultLimit`           | Default `limit` parameter used in API calls (see [REST API documentation](/developer-docs/latest/developer-resources/database-apis-reference/rest/sort-pagination.md#pagination-by-offset))                                                                      | Integer      | `25`    |
-| `rest.maxLimit`               | Maximum allowed number that can be requested as `limit` (see [REST API documentation](/developer-docs/latest/developer-resources/database-apis-reference/rest/sort-pagination.md#pagination-by-offset)).<br/><br/>Defaults to `null`, which fetches all results. | Integer      | `100`   |
+| `rest.maxLimit`               | Maximum allowed number that can be requested as `limit` (see [REST API documentation](/developer-docs/latest/developer-resources/database-apis-reference/rest/sort-pagination.md#pagination-by-offset)). | Integer      | `100`   |
 
 **Example:**
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

Removes an incorrect line on [this page](https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/configurations/optional/api.html).

### Why is it needed?

As per the table, the default limit is `100` and not `null`.