### PR TITLE
Update templates.md

### DIFF
--- a/docs/developer-docs/latest/setup-deployment-guides/installation/templates.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/installation/templates.md
@@ -86,7 +86,7 @@ You can create this file structure by hand or generate it via the [CLI](/develop
 ::: tab yarn
 
 ```bash
-yarn strapi templates:generate <path>
+yarn strapi generate:template <path>
 ```
 
 :::
@@ -94,7 +94,7 @@ yarn strapi templates:generate <path>
 ::: tab npx
 
 ```bash
-npx strapi templates:generate <path>
+npx strapi generate:template <path>
 ```
 
 :::


### PR DESCRIPTION
### What does it do?
Updating this example with the correct syntax for creating a template.
- wrong
```
yarn strapi templates:generate:template path-here
```
- correct
```
yarn strapi generate:template path-here
```

### Why is it needed?

The command will error, the syntax is wrong
