### PR TITLE
Fix entity service examples for ordering and pagination

### DIFF
--- a/docs/developer-docs/latest/developer-resources/database-apis-reference/entity-service/order-pagination.md
+++ b/docs/developer-docs/latest/developer-resources/database-apis-reference/entity-service/order-pagination.md
@@ -43,7 +43,7 @@ strapi.entityService.findMany('api::article.article', {
 });
 
 // multiple with direction
-strapi.entityService(.findMany('api::article.article', {
+strapi.entityService.findMany('api::article.article', {
   sort: [{ title: 'asc' }, { publishedAt: 'desc' }],
 });
 ```

--- a/docs/developer-docs/latest/developer-resources/database-apis-reference/entity-service/order-pagination.md
+++ b/docs/developer-docs/latest/developer-resources/database-apis-reference/entity-service/order-pagination.md
@@ -20,12 +20,12 @@ To order results by a single field, just pass it to the `sort` parameter:
 - or as an object to define both the field name and the order (i.e. `'asc'` for ascending order or `'desc'` for descending order)
 
 ```js
-strapi.entityService('api::article.article').findMany({
+strapi.entityService.findMany('api::article.article', {
   sort: 'id',
 });
 
 // single with direction
-strapi.entityService('api::article.article').findMany({
+strapi.entityService.findMany('api::article.article', {
   sort: { id: 'desc' },
 });
 ```
@@ -38,12 +38,12 @@ To order results by multiple fields, pass the fields as an array to the `sort` p
 - or as an array of objects to define both the field name and the order (i.e. `'asc'` for ascending order or `'desc'` for descending order)
 
 ```js
-strapi.entityService('api::article.article').findMany({
+strapi.entityService.findMany('api::article.article', {
   sort: ['publishDate', 'name'],
 });
 
 // multiple with direction
-strapi.entityService('api::article.article').findMany({
+strapi.entityService(.findMany('api::article.article', {
   sort: [{ title: 'asc' }, { publishedAt: 'desc' }],
 });
 ```
@@ -53,7 +53,7 @@ strapi.entityService('api::article.article').findMany({
 Fields can also be sorted based on fields from relations:
 
 ```js
-strapi.entityService('api::article.article').findMany({
+strapi.entityService.findMany('api::article.article', {
   sort: {
     author: {
       name: 'asc',
@@ -67,7 +67,7 @@ strapi.entityService('api::article.article').findMany({
 To paginate results returned by the Entity Service API, use the `start` and `limit` parameters:
 
 ```js
-strapi.entityService('api::article.article').findMany({
+strapi.entityService.findMany('api::article.article', {
   start: 10,
   limit: 15,
 });

--- a/docs/developer-docs/latest/setup-deployment-guides/configurations/optional/api.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/configurations/optional/api.md
@@ -15,7 +15,7 @@ General settings for API calls can be set in the `./config/api.js` file:
 | `rest`                        | REST API configuration                                                                                                                                                                                                                               | Object       | -       |
 | `rest.prefix`                 | The API prefix                       | String      | `/api`   |
 | `rest.defaultLimit`           | Default `limit` parameter used in API calls (see [REST API documentation](/developer-docs/latest/developer-resources/database-apis-reference/rest/sort-pagination.md#pagination-by-offset))                                                                      | Integer      | `25`    |
-| `rest.maxLimit`               | Maximum allowed number that can be requested as `limit` (see [REST API documentation](/developer-docs/latest/developer-resources/database-apis-reference/rest/sort-pagination.md#pagination-by-offset)).<br/><br/>Defaults to `null`, which fetches all results. | Integer      | `100`   |
+| `rest.maxLimit`               | Maximum allowed number that can be requested as `limit` (see [REST API documentation](/developer-docs/latest/developer-resources/database-apis-reference/rest/sort-pagination.md#pagination-by-offset)). | Integer      | `100`   |
 
 **Example:**
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

Fixes the example code on [this page](https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/entity-service/order-pagination.html).

### Why is it needed?

The entity service is called with UID `api::article.article`, but the UID is passed to `entityService` directly instead of being passed as a parameter of `findMany`.
