### PR TITLE
Add in unstable attribute db options

### DIFF
--- a/docs/developer-docs/latest/development/backend-customization/models.md
+++ b/docs/developer-docs/latest/development/backend-customization/models.md
@@ -135,7 +135,7 @@ Basic validations can be applied to attributes using the following parameters:
 // ./src/api/[api-name]/content-types/restaurant/schema.json
 
 {
-  ...
+  // ...
   "attributes": {
     "title": {
       "type": "string",
@@ -152,7 +152,65 @@ Basic validations can be applied to attributes using the following parameters:
       "type": "uid",
       "targetField": "title"
     }
-    ...
+    // ...
+  }
+}
+```
+
+#### Database validations and settings
+
+:::caution 🚧 This API is considered unstable for now.
+<br>
+:::
+
+Database validations and settings are custom options passed directly onto the `tableBuilder` Knex.js function during schema migrations. They allow for a much more advanced degree of control for setting custom column settings. This is a very advanced and unstable API that is subject to change at any moment, please use it at your own risk! These options are set in a `column: {}` object per attribute.
+
+| Parameter     | Type    | Description                                                                                   | Default |
+| ------------- | ------- | --------------------------------------------------------------------------------------------- | ------- |
+| `name`        | string  | Changes the name of the column in the database                                                | -       |
+| `defaultTo`   | string  | Sets the database `defaultTo`, typically used with `notNullable`                              | -       |
+| `notNullable` | boolean | Sets the database `notNullable`, ensures that columns cannot be null                          | `false` |
+| `unsigned`    | boolean | Only applies to number columns, removes the ability to go negative but doubles maximum length | `false` |
+| `unique`      | boolean | Enforces database level unique, caution when using with draft & publish feature               | `false` |
+| `type`        | string  | Changes the database type, if `type` has arguments, you should pass them in `args`            | -       |
+| `args`        | array   | Arguments passed into the Knex.js function that changes things like `type`                    | `[]`    |
+
+```json
+// ./src/api/[api-name]/content-types/restaurant/schema.json
+
+{
+  // ...
+  "attributes": {
+    "title": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 99,
+      "unique": true,
+      "column": {
+        "unique": true // enforce database unique also
+      }
+    },
+    "description": {
+      "default": "My description",
+      "type": "text",
+      "required": true,
+      "column": {
+        "defaultTo": "My description", // set database level default
+        "notNullable": true // enforce required at database level, even for drafts
+      }
+    },
+    "rating": {
+      "type": "decimal",
+      "default": 0,
+      "column": {
+        "defaultTo": 0,
+        "type": "decimal", // using the native decimal type but allowing for custom precision
+        "args": [
+          6,1 // using custom precision and scale
+        ]
+      }
+    }
+    // ...
   }
 }
 ```


### PR DESCRIPTION
There are certainly previously undocumented attribute settings that weren't documented because they are unstable.

Ideally these could be useful for the community so I'm adding them to the documentation under an unstable header just like RBAC Conditionals