### PR TITLE
Move Query API to the bottom to promote ES

### DIFF
--- a/docs/.vuepress/config/sidebar-developer.js
+++ b/docs/.vuepress/config/sidebar-developer.js
@@ -272,35 +272,6 @@ const developer = [
             'GraphQL API',
           ],
           {
-            title: 'Query Engine API',
-            path:
-              '/developer-docs/latest/developer-resources/database-apis-reference/query-engine-api.html',
-            collapsable: true,
-            // sidebarDepth: 3,
-            children: [
-              [
-                '/developer-docs/latest/developer-resources/database-apis-reference/query-engine/single-operations.md',
-                'Single Operations',
-              ],
-              [
-                '/developer-docs/latest/developer-resources/database-apis-reference/query-engine/bulk-operations.md',
-                'Bulk Operations',
-              ],
-              [
-                '/developer-docs/latest/developer-resources/database-apis-reference/query-engine/filtering.md',
-                'Filtering',
-              ],
-              [
-                '/developer-docs/latest/developer-resources/database-apis-reference/query-engine/populating.md',
-                'Populating',
-              ],
-              [
-                '/developer-docs/latest/developer-resources/database-apis-reference/query-engine/order-pagination.md',
-                'Ordering & pagination',
-              ],
-            ],
-          },
-          {
             title: 'Entity Service API',
             path:
               '/developer-docs/latest/developer-resources/database-apis-reference/entity-service-api',
@@ -339,6 +310,35 @@ const developer = [
               [
                 '/developer-docs/latest/developer-resources/plugin-api-reference/admin-panel.md',
                 'Admin Panel API for plugins',
+              ],
+            ],
+          },
+          {
+            title: 'Query Engine API',
+            path:
+              '/developer-docs/latest/developer-resources/database-apis-reference/query-engine-api.html',
+            collapsable: true,
+            // sidebarDepth: 3,
+            children: [
+              [
+                '/developer-docs/latest/developer-resources/database-apis-reference/query-engine/single-operations.md',
+                'Single Operations',
+              ],
+              [
+                '/developer-docs/latest/developer-resources/database-apis-reference/query-engine/bulk-operations.md',
+                'Bulk Operations',
+              ],
+              [
+                '/developer-docs/latest/developer-resources/database-apis-reference/query-engine/filtering.md',
+                'Filtering',
+              ],
+              [
+                '/developer-docs/latest/developer-resources/database-apis-reference/query-engine/populating.md',
+                'Populating',
+              ],
+              [
+                '/developer-docs/latest/developer-resources/database-apis-reference/query-engine/order-pagination.md',
+                'Ordering & pagination',
               ],
             ],
           },

--- a/docs/.vuepress/config/sidebar-developer.js
+++ b/docs/.vuepress/config/sidebar-developer.js
@@ -272,6 +272,35 @@ const developer = [
             'GraphQL API',
           ],
           {
+            title: 'Query Engine API',
+            path:
+              '/developer-docs/latest/developer-resources/database-apis-reference/query-engine-api.html',
+            collapsable: true,
+            // sidebarDepth: 3,
+            children: [
+              [
+                '/developer-docs/latest/developer-resources/database-apis-reference/query-engine/single-operations.md',
+                'Single Operations',
+              ],
+              [
+                '/developer-docs/latest/developer-resources/database-apis-reference/query-engine/bulk-operations.md',
+                'Bulk Operations',
+              ],
+              [
+                '/developer-docs/latest/developer-resources/database-apis-reference/query-engine/filtering.md',
+                'Filtering',
+              ],
+              [
+                '/developer-docs/latest/developer-resources/database-apis-reference/query-engine/populating.md',
+                'Populating',
+              ],
+              [
+                '/developer-docs/latest/developer-resources/database-apis-reference/query-engine/order-pagination.md',
+                'Ordering & pagination',
+              ],
+            ],
+          },
+          {
             title: 'Entity Service API',
             path:
               '/developer-docs/latest/developer-resources/database-apis-reference/entity-service-api',
@@ -310,35 +339,6 @@ const developer = [
               [
                 '/developer-docs/latest/developer-resources/plugin-api-reference/admin-panel.md',
                 'Admin Panel API for plugins',
-              ],
-            ],
-          },
-          {
-            title: 'Query Engine API',
-            path:
-              '/developer-docs/latest/developer-resources/database-apis-reference/query-engine-api.html',
-            collapsable: true,
-            // sidebarDepth: 3,
-            children: [
-              [
-                '/developer-docs/latest/developer-resources/database-apis-reference/query-engine/single-operations.md',
-                'Single Operations',
-              ],
-              [
-                '/developer-docs/latest/developer-resources/database-apis-reference/query-engine/bulk-operations.md',
-                'Bulk Operations',
-              ],
-              [
-                '/developer-docs/latest/developer-resources/database-apis-reference/query-engine/filtering.md',
-                'Filtering',
-              ],
-              [
-                '/developer-docs/latest/developer-resources/database-apis-reference/query-engine/populating.md',
-                'Populating',
-              ],
-              [
-                '/developer-docs/latest/developer-resources/database-apis-reference/query-engine/order-pagination.md',
-                'Ordering & pagination',
               ],
             ],
           },

--- a/docs/.vuepress/config/sidebar-developer.js
+++ b/docs/.vuepress/config/sidebar-developer.js
@@ -272,6 +272,34 @@ const developer = [
             'GraphQL API',
           ],
           {
+            title: 'Entity Service API',
+            path:
+              '/developer-docs/latest/developer-resources/database-apis-reference/entity-service-api',
+            collapsable: true,
+            children: [
+              [
+                '/developer-docs/latest/developer-resources/database-apis-reference/entity-service/crud.md',
+                'CRUD operations',
+              ],
+              [
+                '/developer-docs/latest/developer-resources/database-apis-reference/entity-service/filter.md',
+                'Filters',
+              ],
+              [
+                '/developer-docs/latest/developer-resources/database-apis-reference/entity-service/populate.md',
+                'Populate',
+              ],
+              [
+                '/developer-docs/latest/developer-resources/database-apis-reference/entity-service/order-pagination.md',
+                'Ordering & pagination',
+              ],
+              [
+                '/developer-docs/latest/developer-resources/database-apis-reference/entity-service/components-dynamic-zones.md',
+                'Components and dynamic zones',
+              ],
+            ],
+          },
+          {
             title: 'Query Engine API',
             path:
               '/developer-docs/latest/developer-resources/database-apis-reference/query-engine-api.html',
@@ -300,34 +328,7 @@ const developer = [
               ],
             ],
           },
-          {
-            title: 'Entity Service API',
-            path:
-              '/developer-docs/latest/developer-resources/database-apis-reference/entity-service-api',
-            collapsable: true,
-            children: [
-              [
-                '/developer-docs/latest/developer-resources/database-apis-reference/entity-service/crud.md',
-                'CRUD operations',
-              ],
-              [
-                '/developer-docs/latest/developer-resources/database-apis-reference/entity-service/filter.md',
-                'Filters',
-              ],
-              [
-                '/developer-docs/latest/developer-resources/database-apis-reference/entity-service/populate.md',
-                'Populate',
-              ],
-              [
-                '/developer-docs/latest/developer-resources/database-apis-reference/entity-service/order-pagination.md',
-                'Ordering & pagination',
-              ],
-              [
-                '/developer-docs/latest/developer-resources/database-apis-reference/entity-service/components-dynamic-zones.md',
-                'Components and dynamic zones',
-              ],
-            ],
-          },
+
           {
             title: 'Plugin APIs Reference',
             collapsable: true,


### PR DESCRIPTION
Feedback from a user in Discord, they chose to use the query layer over the entityService because it was higher in the list.

Moving this towards the bottom as it really shouldn't be used unless a user -really- needs to

![image](https://user-images.githubusercontent.com/8593673/158250297-e77f1828-14b1-4411-b400-dd807efe6086.png)
