### PR TITLE
Upload: improve code examples

### DIFF
--- a/docs/developer-docs/latest/plugins/upload.md
+++ b/docs/developer-docs/latest/plugins/upload.md
@@ -113,9 +113,9 @@ To upload files to your application.
 
 - `files`: The file(s) to upload. The value(s) can be a Buffer or Stream.
 
-:::: tabs card
+<code-group>
 
-::: tab Browser
+<code-block title="BROWSER">
 
 ```html
 <form>
@@ -138,10 +138,9 @@ To upload files to your application.
 </script>
 ```
 
-:::
+</code-block>
 
-::: tab Node.js
-
+<code-block title="NODE.JS">
 
 ```js
 import { FormData, Blob } from "formdata-node"
@@ -164,7 +163,9 @@ await fetch('http://localhost:1337/api/upload', {
 });
 ```
 
-:::
+</code-block>
+
+</code-group>
 
 :::caution
 You have to send FormData in your request body.

--- a/docs/developer-docs/latest/plugins/upload.md
+++ b/docs/developer-docs/latest/plugins/upload.md
@@ -142,7 +142,6 @@ To upload files to your application.
 
 ::: tab Node.js
 
-### From Node.js
 
 ```js
 import { FormData, Blob } from "formdata-node"

--- a/docs/developer-docs/latest/plugins/upload.md
+++ b/docs/developer-docs/latest/plugins/upload.md
@@ -302,8 +302,7 @@ Code
 </script>
 ```
 
-Your entry data has to be contained in a `data` key and you need to `JSON.stringify` this object. The keys for files, need to
-be prefixed with `files` (example with a cover attribute: `files.cover`).
+Your entry data has to be contained in a `data` key and you need to `JSON.stringify` this object. The keys for files, need to be prefixed with `files` (example with a cover attribute: `files.cover`).
 
 ::: tip
 If you want to upload files for a component, you will have to specify the index of the item you want to add the file to.

--- a/docs/developer-docs/latest/plugins/upload.md
+++ b/docs/developer-docs/latest/plugins/upload.md
@@ -107,13 +107,15 @@ module.exports = ({ env }) => ({
 
 ## Upload files
 
-To upload files into your application.
+To upload files to your application.
 
 ### Parameters
 
 - `files`: The file(s) to upload. The value(s) can be a Buffer or Stream.
 
-### Code example
+:::: tabs card
+
+::: tab Browser
 
 ```html
 <form>
@@ -123,19 +125,47 @@ To upload files into your application.
 </form>
 
 <script type="text/javascript">
-  const formElement = document.querySelector('form');
+  const form = document.querySelector('form');
 
-  formElement.addEventListener('submit', (e) => {
+  form.addEventListener('submit', async (e) => {
     e.preventDefault();
 
-    const request = new XMLHttpRequest();
-
-    request.open('POST', '/upload');
-
-    request.send(new FormData(formElement));
+    await fetch('/api/upload', {
+      method: 'post',
+      body: new FormData(e.target)
+    });
   });
 </script>
 ```
+
+:::
+
+::: tab Node.js
+
+### From Node.js
+
+```js
+import { FormData, Blob } from "formdata-node"
+import { FormDataEncoder } from  "form-data-encoder"
+import { Readable } from "stream"
+import fetch from 'node-fetch';
+import fs from 'fs';
+
+const file = fs.createReadStream('path-to-your-file');
+const form = new FormData();
+
+form.append('files', file);
+
+const encoder = new FormDataEncoder(form);
+
+await fetch('http://localhost:1337/api/upload', {
+    method: "post",
+    headers: encoder.headers,
+    body: Readable.from(encoder)
+});
+```
+
+:::
 
 :::caution
 You have to send FormData in your request body.
@@ -189,16 +219,15 @@ Code
 </form>
 
 <script type="text/javascript">
-  const formElement = document.querySelector('form');
+  const form = document.querySelector('form');
 
-  formElement.addEventListener('submit', (e) => {
+  form.addEventListener('submit', async (e) => {
     e.preventDefault();
 
-    const request = new XMLHttpRequest();
-
-    request.open('POST', '/upload');
-
-    request.send(new FormData(formElement));
+    await fetch('/api/upload', {
+      method: 'post',
+      body: new FormData(e.target)
+    });
   });
 </script>
 ```
@@ -245,44 +274,37 @@ Code
 </form>
 
 <script type="text/javascript">
-  const formElement = document.querySelector('form');
+  const form = document.querySelector('form');
 
-  formElement.addEventListener('submit', (e) => {
+  form.addEventListener('submit', async (e) => {
     e.preventDefault();
 
-    const request = new XMLHttpRequest();
-
+    const data = {};
     const formData = new FormData();
 
-    const formElements = formElement.elements;
-
-    const data = {};
-
-    for (let i = 0; i < formElements.length; i++) {
-      const currentElement = formElements[i];
-      if (!['submit', 'file'].includes(currentElement.type)) {
-        data[currentElement.name] = currentElement.value;
-      } else if (currentElement.type === 'file') {
-        for (let i = 0; i < currentElement.files.length; i++) {
-          const file = currentElement.files[i];
-          formData.append(`files.${currentElement.name}`, file, file.name);
+    form.elements
+      .forEach(({ name, type, value, files, ...element }) => {
+        if (!['submit', 'file'].includes(type)) {
+          data[name] = value;
+        } else if (type === 'file') {
+          files.forEach((file) => {
+            formData.append(`files.${name}`, file, file.name);
+          });
         }
-      }
-    }
+      });
 
     formData.append('data', JSON.stringify(data));
 
-    request.open('POST', `${HOST}/restaurants`);
-
-    request.send(formData);
+    await fetch('/api/restaurants', {
+      method: 'post',
+      body: formData
+    });
   });
 </script>
 ```
 
-Your entry data has to be contained in a `data` key. You have to `JSON.stringify` your data object.
-
-And for your files, they have to be prefixed by `files`.
-Example here with cover attribute `files.cover`.
+Your entry data has to be contained in a `data` key and you need to `JSON.stringify` this object. The keys for files, need to
+be prefixed with `files` (example with a cover attribute: `files.cover`).
 
 ::: tip
 If you want to upload files for a component, you will have to specify the index of the item you want to add the file to.


### PR DESCRIPTION
### What does it do?

- modernizes the examples by using `fetch` instead of `XMLHttpRequest` which is widely supported
- add an example of how to upload a file from node.js

### Why is it needed?

To make the code easier to read.
