### PR TITLE
Update allowed node LTS versions for strapi V4

### DIFF
--- a/docs/developer-docs/latest/setup-deployment-guides/installation/cli.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/installation/cli.md
@@ -12,7 +12,7 @@ Strapi CLI (Command Line Interface) installation scripts are the fastest way to 
 
 The CLI installation guide requires at least two software prerequisites to be already installed on your computer:
 
-- [Node.js](https://nodejs.org): only LTS versions are supported (v12 and v14). Other versions of Node.js may not be compatible with the latest release of Strapi. The 14.x version is most recommended by Strapi.
+- [Node.js](https://nodejs.org): only LTS versions are supported (v12, v14 and v16). Other versions of Node.js may not be compatible with the latest release of Strapi. The 14.x version is most recommended by Strapi.
 - [npm](https://docs.npmjs.com/cli/v6/commands/npm-install) (v6 only) or [yarn](https://yarnpkg.com/getting-started/install) to run the CLI installation scripts.
 
 A database is also required for any Strapi project. Strapi currently supports the following databases:


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

Add node 16 lts as allowed option in the strapi V4 documentation

### Why is it needed?

Documentation is not reflecting that version 16  LTS is allowed
