### PR TITLE
Fix middleware configuration

### DIFF
--- a/docs/developer-docs/latest/setup-deployment-guides/configurations/required/middlewares.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/configurations/required/middlewares.md
@@ -37,8 +37,8 @@ module.exports = [
   // ...
   'my-custom-node-module', // custom middleware that does not require any configuration
   {
-    // custom resolve to find a package or a path
-    resolve: 'my-custom-node-module',
+    // custom name to find a package or a path
+    name: 'my-custom-node-module',
     config: {
       foo: 'bar',
     },


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

On applying configuration to a middleware by name, we need to specify the name, not the resolve.

### Why is it needed?

If setting resolve when you want to do it by name:

```js
  {
    // custom resolve to find a package or a path
    resolve: 'my-custom-node-module',
    config: {
      foo: 'bar',
    },
  },
```

```bash
 Could not load middleware "strapi-dir/my-custom-node-module".
    at resolveCustomMiddleware strapi-dirnode_modules/@strapi/strapi/lib/services/server/middleware.js:124:11)
```    
    
```js
  {
    // custom resolve to find a package or a path
    resolve: 'global::my-custom-node-module',
    config: {
      foo: 'bar',
    },
  },
```

```bash
Error: Could not load middleware "strapi-dir/global::my-custom-node-module".
    at resolveCustomMiddleware (strapi-dir/node_modules/@strapi/strapi/lib/services/server/middleware.js:124:11)
``` 

If we set:
```js
{
    // custom resolve to find a package or a path
    name: 'global::my-custom-node-module',
    config: {
      foo: 'bar',
    },
  },
```   

Then, the middleware is loaded in the proper way
