### PR TITLE
Fix Application Error for Deploying Strapi v4 To Heroku

### DIFF
--- a/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/heroku.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/heroku.md
@@ -242,8 +242,6 @@ module.exports = ({ env }) => ({
 
 You will also need at least two of the `APP_KEYS` found in the default `.env` environment variable. Each key is seperated by a comma.
 
-`Path: ./my-project/`
-
 Add this `APP_KEYS` and a `proxy: true` as well to the newly created `server.js`
 
 ```js

--- a/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/heroku.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/heroku.md
@@ -230,28 +230,30 @@ heroku config:set NODE_ENV=production
 
 ### 5. Create your Strapi server config for production
 
-Create a new `server.js` in a new [env](/developer-docs/latest/setup-deployment-guides/configurations/optional/environment.md) folder. In this file you only need one key, the `url`, to notify Strapi what our public Heroku domain is. All other settings will automatically be pulled from the default `./config/server.js`. 
-
-`Path: ./config/env/production/server.js`
+Create a new `server.js` in the [env](/developer-docs/latest/setup-deployment-guides/configurations/optional/environment.md) folder created before. In this file you need, the `url` key, to notify Strapi what our public Heroku domain is. All other settings will automatically be pulled from the default `./config/server.js`. 
 
 ```js
+//Path: ./config/env/production/server.js
+
 module.exports = ({ env }) => ({
   url: env('MY_HEROKU_URL'),
 });
 ```
 
-You will also need at least two of the `API_KEYS` found in the `.env` environment variable. Each key is seperated by comma.
-`Path: ./my-project/`. 
+You will also need at least two of the `APP_KEYS` found in the default `.env` environment variable. Each key is seperated by a comma.
 
-Add this `API_KEYS` and a `proxy: true` as well to the newly created `server.js`
-`Path: ./config/env/production/server.js`
+`Path: ./my-project/`
+
+Add this `APP_KEYS` and a `proxy: true` as well to the newly created `server.js`
 
 ```js
+// Path: ./config/env/production/server.js
+
 module.exports = ({ env }) => ({
   proxy: true,
   url: env('MY_HEROKU_URL'),
   app: { 
-    keys: env.array('APP_KEYS', ['app_key_one', 'app_key-two']
+    keys: env.array('APP_KEYS', ['app_key_one', 'app_key-two'])
   },
 });
 ```

--- a/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/heroku.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/heroku.md
@@ -230,13 +230,29 @@ heroku config:set NODE_ENV=production
 
 ### 5. Create your Strapi server config for production
 
-Create a new `server.js` in a new [env](/developer-docs/latest/setup-deployment-guides/configurations/optional/environment.md) folder. In this file you only need one key, the `url`, to notify Strapi what our public Heroku domain is. All other settings will automatically be pulled from the default `./config/server.js`.
+Create a new `server.js` in a new [env](/developer-docs/latest/setup-deployment-guides/configurations/optional/environment.md) folder. In this file you only need one key, the `url`, to notify Strapi what our public Heroku domain is. All other settings will automatically be pulled from the default `./config/server.js`. 
 
 `Path: ./config/env/production/server.js`
 
 ```js
 module.exports = ({ env }) => ({
   url: env('MY_HEROKU_URL'),
+});
+```
+
+You will also need at least two of the `API_KEYS` found in the `.env` environment variable. Each key is seperated by comma.
+`Path: ./my-project/`. 
+
+Add this `API_KEYS` and a `proxy: true` as well to the newly created `server.js`
+`Path: ./config/env/production/server.js`
+
+```js
+module.exports = ({ env }) => ({
+  proxy: true,
+  url: env('MY_HEROKU_URL'),
+  app: { 
+    keys: env.array('APP_KEYS', ['app_key_one', 'app_key-two']
+  },
 });
 ```
 


### PR DESCRIPTION
Pushing Strapi v4 to Heroku following the previous guide result in an Application Error(H10). This update provides a fix for that and allows Strapi v4 to be deployed to Heroku without any issues

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

Describe the technical changes you did.

### Why is it needed?

Describe the issue you are solving.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
