### PR TITLE
Update heroku.md

### DIFF
--- a/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/heroku.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/heroku.md
@@ -237,6 +237,10 @@ Create a new `server.js` in a new [env](/developer-docs/latest/setup-deployment-
 ```js
 module.exports = ({ env }) => ({
   url: env('MY_HEROKU_URL'),
+  proxy: true,
+  app: {
+    keys: env.array("APP_KEYS", ["DATABASE_URL", "MY_HEROKU_URL", "NODE_ENV"]),
+  }
 });
 ```
 


### PR DESCRIPTION
Official tut fails to deliver - had to change this to work ?

`2022-03-23T13:20:53.779081+00:00 app[web.1]: [2022-03-23 13:20:53.778] error: Middleware "strapi::session": App keys are required. Please set app.keys in config/server.js (ex: keys: ['myKeyA', 'myKeyB'])
`
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

Fix the official strapi tutorial.

### Why is it needed?

Following the strapi tutorial for heroku fails with error above. 

### Related issue(s)/PR(s)

-
