### PR TITLE
Callout for unsupported v4 Docker image 

### DIFF
--- a/docs/developer-docs/latest/setup-deployment-guides/installation/docker.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/installation/docker.md
@@ -8,7 +8,7 @@ canonicalUrl: https://docs.strapi.io/developer-docs/latest/setup-deployment-guid
 
 :::caution
 This Docker image is only for Strapi v3. For now, Strapi will not update the image for v4.
-However, to build an image compatible with Strapi v4, we recommend following this guide by Simen Daehlin, Community Star at Strapi, <https://blog.dehlin.dev/docker-with-strapi-v4>.
+However, to build an image compatible with Strapi v4, we recommend following [this guide](https://blog.dehlin.dev/docker-with-strapi-v4) by Simen Daehlin, Community Star at Strapi.
 
 If you would like an official v4 image, please share it on the [roadmap](https://feedback.strapi.io/developer-experience).
 

--- a/docs/developer-docs/latest/setup-deployment-guides/installation/docker.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/installation/docker.md
@@ -6,6 +6,14 @@ canonicalUrl: https://docs.strapi.io/developer-docs/latest/setup-deployment-guid
 
 # Installing using Docker
 
+:::caution
+This Docker image is only for Strapi v3. For now, Strapi will not update the image for v4.
+However, to build an image compatible with Strapi v4, we recommend following this guide by Simen Daehlin, Community Star at Strapi, <https://blog.dehlin.dev/docker-with-strapi-v4>.
+
+If you would like an official v4 image, please share it on the [roadmap](https://feedback.strapi.io/developer-experience).
+
+:::
+
 The following documentation will guide you through the installation of a new Strapi project using [Docker](https://www.docker.com/).
 
 Docker is an open platform that allows to develop, ship and run applications by using containers (i.e. packages containing all the parts an application needs to function, such as libraries and dependencies).


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

Added callout to clarify that Strapi is not currently providing a Docker image for v4 and a link to a Community solution. 

### Why is it needed?

Describe the issue you are solving.

### Related issue(s)/PR(s)

#826 