### PR TITLE
Update amazon-aws.md: Wrong package mentioned

### DIFF
--- a/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/amazon-aws.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/amazon-aws.md
@@ -330,7 +330,7 @@ module.exports = ({ env }) => ({
 Path: `./my-project/`.
 
 ```bash
-npm install strapi-provider-upload-aws-s3
+npm install @strapi/provider-upload-aws-s3
 ```
 
 To enable and configure the provider, create or edit the file at `./config/plugins.js`.


### PR DESCRIPTION
Line 333 mentioned to run "npm install strapi-provider-upload-aws-s3".
Above package is not working.
New working package is "@strapi/provider-upload-aws-s3"

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

Describe the technical changes you did.

### Why is it needed?

Describe the issue you are solving.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
