### PR TITLE
make render.com hosting guide work with strapi version >= v4.0.6

### DIFF
--- a/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/render.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/render.md
@@ -62,6 +62,8 @@ services:
         generateValue: true
       - key: APP_KEYS
         generateValue: true
+      - key: API_TOKEN_SALT
+        generateValue: true
 ```
 
 :::
@@ -97,6 +99,8 @@ services:
       - key: ADMIN_JWT_SECRET
         generateValue: true
       - key: APP_KEYS
+        generateValue: true
+      - key: API_TOKEN_SALT
         generateValue: true
 
 databases:
@@ -135,6 +139,8 @@ services:
       - key: ADMIN_JWT_SECRET
         generateValue: true
       - key: APP_KEYS
+        generateValue: true
+      - key: API_TOKEN_SALT
         generateValue: true
 
 databases:

--- a/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/render.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/render.md
@@ -6,8 +6,6 @@ canonicalUrl: https://docs.strapi.io/developer-docs/latest/setup-deployment-guid
 
 # Render
 
-!!!include(developer-docs/latest/setup-deployment-guides/deployment/snippets/deployment-guide-not-updated.md)!!!
-
 This guide explains how to update an existing Strapi project so it can be deployed on [Render](https://render.com).
 
 With persistent disks and managed PostgreSQL databases, Render gives you multiple different ways to store your content. Render services come with fully managed SSL, so it's no longer necessary to set up a proxy server to secure your Strapi app. Since Render services are automatically restarted if they become unresponsive, you don't need to use a process manager like `pm2` either.
@@ -53,7 +51,7 @@ services:
       sizeGB: 1
     envVars:
       - key: NODE_VERSION
-        value: 12.18.4
+        value: 12.22.0
       - key: NODE_ENV
         value: production
       - key: DATABASE_FILENAME
@@ -61,6 +59,8 @@ services:
       - key: JWT_SECRET
         generateValue: true
       - key: ADMIN_JWT_SECRET
+        generateValue: true
+      - key: APP_KEYS
         generateValue: true
 ```
 
@@ -79,7 +79,7 @@ services:
     healthCheckPath: /_health
     envVars:
       - key: NODE_VERSION
-        value: 12.18.4
+        value: 12.22.0
       - key: NODE_ENV
         value: production
       - key: CLOUDINARY_NAME
@@ -95,6 +95,8 @@ services:
       - key: JWT_SECRET
         generateValue: true
       - key: ADMIN_JWT_SECRET
+        generateValue: true
+      - key: APP_KEYS
         generateValue: true
 
 databases:
@@ -121,7 +123,7 @@ services:
       sizeGB: 1
     envVars:
       - key: NODE_VERSION
-        value: 12.18.4
+        value: 12.22.0
       - key: NODE_ENV
         value: production
       - key: DATABASE_URL
@@ -131,6 +133,8 @@ services:
       - key: JWT_SECRET
         generateValue: true
       - key: ADMIN_JWT_SECRET
+        generateValue: true
+      - key: APP_KEYS
         generateValue: true
 
 databases:


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

- set node version to 12.22.0 because install/build failed with 12.18.4 for i18n plugin.
- add APP_KEYS env variable because its required since v4.0.6

### Why is it needed?

make render hosting guide work with strapi version >= v4.0.6

### Related issue(s)/PR(s)

PR regarding to this conversation about updating hosting guides: https://github.com/strapi/documentation/issues/807#issuecomment-1089178575
