### PR TITLE
Include APP_KEYS in Heroku Deployment Guide - fix #807

### DIFF
--- a/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/heroku.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/heroku.md
@@ -236,15 +236,21 @@ Create a new `server.js` in a new [env](/developer-docs/latest/setup-deployment-
 
 ```js
 module.exports = ({ env }) => ({
-  url: env('MY_HEROKU_URL'),
-});
+    proxy: true,
+    url: env('MY_HEROKU_URL'),
+    app: { 
+      keys: env.array('APP_KEYS')
+    },
+  })
 ```
 
-You will also need to set the environment variable in Heroku for the `MY_HEROKU_URL`. This will populate the variable with something like `https://your-app.herokuapp.com`.
+You will also need to set the environment variable in Heroku for the `MY_HEROKU_URL` and `APP_KEYS`. This will populate the variables with something like `https://your-app.herokuapp.com/` and `dsfhasbvvfwfcerterzer+n1w==,afjdsagfsauzuwzref6==,kjdbgjerhgh6wireg==,jkssdhgjaksdgkjbsdg==` respectively.
 
 ```bash
 heroku config:set MY_HEROKU_URL=$(heroku info -s | grep web_url | cut -d= -f2)
+heroku config:set APP_KEYS=$(cat .env | grep APP_KEYS | cut -d= -f2-)
 ```
+
 
 ### 6. Install the `pg` node module
 


### PR DESCRIPTION
### What does it do?
### Describe the technical changes you did.
Under title 5. Create your Strapi server config for production
Update env/production/server.js to include app -> keys object
Include bash command to set APP_KEYS environment variable on Heroku

### Why is it needed?
Solves the error:
Error: Middleware "strapi::session": App keys are required. Please set app.keys in config/server.js (ex: keys: ['myKeyA', 'myKeyB'])

### Related issue(s)/PR(s)
The Issue is here https://github.com/strapi/documentation/issues/807

### - Specify if the PR is in WIP (work in progress) state or ready to be merged
The fix is ready to be merged
