### PR TITLE
Fixed config object example code

### DIFF
--- a/docs/developer-docs/latest/development/backend-customization/policies.md
+++ b/docs/developer-docs/latest/development/backend-customization/policies.md
@@ -54,7 +54,6 @@ module.exports = (policyContext, config, { strapi }) => {
     }
 
     return false; // If you return nothing, Strapi considers you didn't want to block the request and will let it pass
-  }
 };
 ```
 


### PR DESCRIPTION
There was a } that wasn't needed in the code example. 
As the fix is as silly as that, I didn't bother to open an issue just to relate the PR to it, and I hope it's OK
