### PR TITLE
fix: use correct key parameter for azure deploy

### DIFF
--- a/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/azure.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/azure.md
@@ -144,7 +144,7 @@ In this section, we'll use the [Azure CLI](https://docs.microsoft.com/cli/azure/
 
    # Add a container to the storage account
    container=strapi-uploads
-   az storage container create --name $container --public-access blob --access-key $saKey --account-name $saName
+   az storage container create --name $container --public-access blob --account-key $saKey --account-name $saName
    ```
 
 5. Create a MySQL database.


### PR DESCRIPTION
Azure CLI uses `--account-key` rather than `--access-key` now



### What does it do?

Makes the Azure cli deploy commands work.

### Why is it needed?

Errors otherwise

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
