### PR TITLE
Remove populateCreatorFields from models

### DIFF
--- a/docs/developer-docs/latest/development/backend-customization/models.md
+++ b/docs/developer-docs/latest/development/backend-customization/models.md
@@ -540,7 +540,6 @@ The `options` key is used to define specific behaviors and accepts the following
 | Parameter                     | Type                        | Description                                                                                                                                                                                                                                                                                                                                  |
 | ----------------------- | --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `privateAttributes`     | Array of strings            | Allows treating a set of attributes as private, even if they're not actually defined as attributes in the model. It could be used to remove them from API responses timestamps.<br><br>The set of `privateAttributes` defined in the model are merged with the `privateAttributes` defined in the global Strapi configuration. |
-| `populateCreatorFields` | Boolean                     | Toggles including the `created_by` and `updated_by` fields in the API response.<br><br>Default value: `false`                                                                                                                                                                                                                 |
 | `draftAndPublish`       | Boolean                     | Enables the draft and publish feature.<br><br>Default value: `false`                                                                                                                                                                                                                                                                          |
 
 ```json
@@ -549,7 +548,6 @@ The `options` key is used to define specific behaviors and accepts the following
 {
   "options": {
     "privateAttributes": ["id", "created_at"],
-    "populateCreatorFields": true,
     "draftAndPublish": false
   }
 }


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

removes legacy v3 populateCreatorFields from the models documentation. 

### Why is it needed?

accurate v4 documentation 

### Related issue(s)/PR(s)

#762 