### PR TITLE
Add caution callout above custom routes config

### DIFF
--- a/docs/developer-docs/latest/development/backend-customization/routes.md
+++ b/docs/developer-docs/latest/development/backend-customization/routes.md
@@ -105,19 +105,15 @@ Creating custom routers consists in creating a file that exports an array of obj
 Dynamic routes can be created using parameters and regular expressions. These parameters will be exposed in the `ctx.params` object. For more details, please refer to the [PathToRegex](https://github.com/pillarjs/path-to-regexp) documentation.
 
 ::: caution
-
-Routes files are loaded in alphabetical order, keep that in mind if you plan to add custom routes that could conflict with core routes.
-
-In the example below, the custom routes would never be hit if the name of their file comes after the one exporting core routes.
-
-An easy solution for this problem would be to prefix the name of your routes files to enforce the expected order (e.g.: `01-custom-routes.js` and `02-core-routes.js`).
-
+Routes files are loaded in alphabetical order. To load custom routes before core routes, make sure to name custom routes appropriately (e.g. `01-custom-routes.js` and `02-core-routes.js`).
 :::
 
 ::: details Example of a custom router using URL parameters and regular expressions for routes
 
+In the following example, the custom routes file name is prefixed with `01-` to make sure the route is reached before the core routes.
+
 ```js
-// path: ./src/api/restaurant/routes/custom-restaurant.js
+// path: ./src/api/restaurant/routes/01-custom-restaurant.js
 
 module.exports = {
   routes: [

--- a/docs/developer-docs/latest/development/backend-customization/routes.md
+++ b/docs/developer-docs/latest/development/backend-customization/routes.md
@@ -104,21 +104,32 @@ Creating custom routers consists in creating a file that exports an array of obj
 
 Dynamic routes can be created using parameters and regular expressions. These parameters will be exposed in the `ctx.params` object. For more details, please refer to the [PathToRegex](https://github.com/pillarjs/path-to-regexp) documentation.
 
+::: caution
+
+Routes files are loaded in alphabetical order, keep that in mind if you plan to add custom routes that could conflict with core routes.
+
+In the example below, the custom routes would never be hit if the name of their file comes after the one exporting core routes.
+
+An easy solution for this problem would be to prefix the name of your routes files to enforce the expected order (e.g.: `01-custom-routes.js` and `02-core-routes.js`).
+
+:::
+
 ::: details Example of a custom router using URL parameters and regular expressions for routes
+
 ```js
 // path: ./src/api/restaurant/routes/custom-restaurant.js
 
 module.exports = {
   routes: [
-    { // Path defined with a URL parameter
-      method: 'GET',
-      path: '/restaurants/:category/:id',
-      handler: 'Restaurant.findOneByCategory',
+    { // Path defined with an URL parameter
+      method: 'POST',
+      path: '/restaurants/:id/review', 
+      handler: 'restaurant.review',
     },
     { // Path defined with a regular expression
       method: 'GET',
-      path: '/restaurants/:region(\\d{2}|\\d{3})/:id', // Only match when the first parameter contains 2 or 3 digits.
-      handler: 'Restaurant.findOneByRegion',
+      path: "/restaurants/:category([a-z]+)", // Only match when the URL parameter is composed of lowercase letters
+      handler: 'restaurant.findByCategory',
     }
   ]
 }


### PR DESCRIPTION
### What does it do?

I added a caution callout just before showing a custom routes example to highlight the fact that routes order matters and Strapi is loading routes file alphabetically, meaning file naming matter.

I also updated the example provided because:
- Handlers' definitions were using a capital `R` which is incorrect
- The logic behind `/restaurants/:category/:id` I think is off, having both `category` AND `id` as URL parameters is counter-intuitive, if you have the `id` why would you pass the `category` as well? For the region, there's a similar problem.
So I updated both examples and tried to make them easier to understand.

### Why is it needed?

Without this callout, I think it's easy to add custom routes that will never get hit because they come after core routes.

### Remarks

If we update the `createCoreRouter` factory function to allow custom routes directly there, this callout will be less necessary as by default we'll make sure the custom routes would come before core routes.
