### PR TITLE
Add "Last updated" mention at the bottom of each page

### DIFF
--- a/docs/.vuepress/config/plugins.js
+++ b/docs/.vuepress/config/plugins.js
@@ -21,6 +21,15 @@ const checklinksIgnoredFiles = [
 
 const plugins = [
   ['vuepress-plugin-element-tabs', {}],
+  ['@vuepress/last-updated',
+    {
+      transformer: (timestamp, lang) => {
+        const date = new Date(timestamp);
+        const options = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' };
+        return date.toLocaleDateString('en-US', options)
+      }
+    }
+  ],
   [
     'check-md',
     {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

It configures the built-in [@vuepress/last-updated-plugin](https://vuepress.vuejs.org/plugin/official/plugin-last-updated.html) plugin to display the last updated date at the bottom of each page.

I used the plugin and not the default [theme.lastUpdated](https://vuepress.vuejs.org/theme/default-theme-config.html#last-updated) theme configuration option as the latter does not seem to allow configuring the output.

![Screenshot 2022-05-20 at 13 57 12](https://user-images.githubusercontent.com/4233866/169523422-ea4f6971-a0f8-4f12-85d3-af38eb729d73.png)

