### PR TITLE
typo in Collection by Field section

### DIFF
--- a/docs/developer-docs/latest/developer-resources/content-api/integrations/laravel.md
+++ b/docs/developer-docs/latest/developer-resources/content-api/integrations/laravel.md
@@ -111,7 +111,7 @@ $homepageItem = $strapi->single('homepage', 'content');
 
 ```php
 $strapi = new Dbfx\LaravelStrapi();
-$entries = $strapi->entriesByField('restaurants', 'slug', 'test-restuarant-name');
+$entries = $strapi->entriesByField('restaurants', 'slug', 'test-restaurant-name');
 ```
 
 ## Single item from collection


### PR DESCRIPTION
### What does it do?

Fixes small typo 

### Why is it needed?

To not have small typo anymore

