### PR TITLE
Bump version number to 4.2.1

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-docs",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "main": "index.js",
   "scripts": {
     "dev": "yarn create:config-file && vuepress dev",


### PR DESCRIPTION
Bumps documentation version number to 4.2.1 to sync with the product release.