### PR TITLE
Telemetry: updates in "Usage Information" and CLI doc

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -1,7 +1,7 @@
 name: Documentation Bug Report
 description: Create a report to help us improve the Strapi documentation.
 title: "[Bug]: "
-labels: "type: bug, status: pending reproduction"
+labels: "type: bug"
 body:
   - type: input
     attributes:

--- a/docs/developer-docs/latest/developer-resources/cli/CLI.md
+++ b/docs/developer-docs/latest/developer-resources/cli/CLI.md
@@ -336,7 +336,7 @@ Some plugins have admin panel integrations, your admin panel might have to be re
 
 ## strapi telemetry:disable
 
-Disable data collection for the project.
+Disable data collection for the project (see [Usage Information](/developer-docs/latest/getting-started/usage-information.md)).
 
 ```bash
 strapi telemetry:disable
@@ -344,7 +344,7 @@ strapi telemetry:disable
 
 ## strapi telemetry:enable
 
-Re-enable data collection for the project after it was disabled.
+Re-enable data collection for the project after it was disabled (see [Usage Information](/developer-docs/latest/getting-started/usage-information.md)).
 
 ```bash
 strapi telemetry:enable

--- a/docs/developer-docs/latest/developer-resources/cli/CLI.md
+++ b/docs/developer-docs/latest/developer-resources/cli/CLI.md
@@ -334,6 +334,22 @@ options [--delete-files]
 Some plugins have admin panel integrations, your admin panel might have to be rebuilt. This can take some time.
 :::
 
+## strapi telemetry:disable
+
+Disable data collection for the project.
+
+```bash
+strapi telemetry:disable
+```
+
+## strapi telemetry:enable
+
+Re-enable data collection for the project after it was disabled.
+
+```bash
+strapi telemetry:enable
+```
+
 ## strapi console
 
 Start the server and eval commands in your application in real time.

--- a/docs/developer-docs/latest/getting-started/usage-information.md
+++ b/docs/developer-docs/latest/getting-started/usage-information.md
@@ -68,7 +68,9 @@ yarn strapi telemetry:disable
 
 </code-group>
 
-Alternatively, the `telemetryDisabled: true` flag in the project `package.json` file will also disable data collection. Deleting the flag or setting it to false will re-enable data collection.
+Alternatively, the `telemetryDisabled: true` flag in the project `package.json` file will also disable data collection.
+
+Data collection can later be re-enabled by deleting the flag or setting it to false, or by using the `telemetry:enable` command.
 
 ::: note
 If you have any questions or concerns regarding data collection, please contact us at the following email address [privacy@strapi.io](mailto:privacy@strapi.io).


### PR DESCRIPTION
- Addition of `telemetry:disable` and `telemetry:enable` in CLI documentation
- Update of Usage Information to mention `telemetry:enable`

Based on [PR #13233](https://github.com/strapi/strapi/pull/13233).