### PR TITLE
update link to public roadmap

### DIFF
--- a/docs/developer-docs/latest/getting-started/troubleshooting.md
+++ b/docs/developer-docs/latest/getting-started/troubleshooting.md
@@ -103,6 +103,6 @@ Due to these two issues, it is recommended you use a proxy application such as [
 
 ## Is X feature available yet?
 
-You can see our [Public roadmap](https://feedback.strapi.io/) to see which feature requests are currently being worked on and which have not been started yet.
+You can see the [Public roadmap](https://feedback.strapi.io/) to see which feature requests are currently being worked on and which have not been started yet.
 
 <!-- TODO: This will be changed to Canny eventually, leave this note here for Derrick please -->

--- a/docs/developer-docs/latest/getting-started/troubleshooting.md
+++ b/docs/developer-docs/latest/getting-started/troubleshooting.md
@@ -103,6 +103,6 @@ Due to these two issues, it is recommended you use a proxy application such as [
 
 ## Is X feature available yet?
 
-You can see the [ProductBoard roadmap](https://portal.productboard.com/strapi) to see which feature requests are currently being worked on and which have not been started yet.
+You can see our [Public roadmap](https://feedback.strapi.io/) to see which feature requests are currently being worked on and which have not been started yet.
 
 <!-- TODO: This will be changed to Canny eventually, leave this note here for Derrick please -->


### PR DESCRIPTION
### What does it do?

Update link to public roadmap from Product Board to Canny


### Why is it needed?

We no longer user product board. 

### Related issue(s)/PR(s)

NA