### PR TITLE
Make the default populating behavior change in Strapi v4 more visible

### DIFF
--- a/docs/developer-docs/latest/developer-resources/database-apis-reference/rest-api.md
+++ b/docs/developer-docs/latest/developer-resources/database-apis-reference/rest-api.md
@@ -9,10 +9,9 @@ canonicalUrl: https://docs.strapi.io/developer-docs/latest/developer-resources/d
 
 The REST API allows accessing the [content-types](/developer-docs/latest/development/backend-customization/models.md) through API endpoints. Strapi automatically creates [API endpoints](#endpoints) when a content-type is created. [API parameters](/developer-docs/latest/developer-resources/database-apis-reference/rest/api-parameters.md) can be used when querying API endpoints to refine the results.
 
-:::note
-[Components](/developer-docs/latest/development/backend-customization/models.md#components) don't have API endpoints.
+::: note
+The REST API by default does not populate any relations, media fields, components, or dynamic zones. Use the [`populate` parameter](/developer-docs/latest/developer-resources/database-apis-reference/rest/populating-fields.md) to populate specific fields.
 :::
-
 ## Endpoints
 
 For each Content-Type, the following endpoints are automatically generated:
@@ -114,6 +113,10 @@ For each Content-Type, the following endpoints are automatically generated:
 :::
 ::::
 :::::
+
+::: note
+[Components](/developer-docs/latest/development/backend-customization/models.md#components) don't have API endpoints.
+:::
 
 ## Requests
 

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/v4/code-migration.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/v4/code-migration.md
@@ -31,7 +31,7 @@ The following topics are covered by this guide, and you can either click on a sp
 The following topics are not extensively covered in this code migration guide, but Strapi v4 also introduces:
 
 - a new [file structure](/developer-docs/latest/setup-deployment-guides/file-structure.md) for the project, which can be migrated with the help of [Strapi codemods](https://github.com/strapi/codemods/),
-- fully rewritten [REST](/developer-docs/latest/developer-resources/database-apis-reference/rest-api.md) and [GraphQL](/developer-docs/latest/developer-resources/database-apis-reference/graphql-api.md) APIs,
+- fully rewritten [REST](/developer-docs/latest/developer-resources/database-apis-reference/rest-api.md) and [GraphQL](/developer-docs/latest/developer-resources/database-apis-reference/graphql-api.md) APIs, with the REST API not [populating](/developer-docs/latest/developer-resources/database-apis-reference/rest/populating-fields.md) by default any relations, components, dynamic zones, and medias,
 - the new [Entity Service](/developer-docs/latest/developer-resources/database-apis-reference/entity-service-api.md) and [Query Engine](/developer-docs/latest/developer-resources/database-apis-reference/query-engine-api.md) APIs,
 - and the [Strapi Design System](https://design-system.strapi.io/) which is used to build the new user interface of Strapi v4.
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

* Mentions populating behavior change directly in the code migration guide introduction
* Adds a note callout about populating in the REST API introduction

### Why is it needed?

This is big change between v3 and v4 and some people missed the change.

