### PR TITLE
remove TypeScript from v4.0.6->v4.1.8 migration guide

### DIFF
--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/v4/migration-guide-4.0.6-to-4.1.8.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/v4/migration-guide-4.0.6-to-4.1.8.md
@@ -52,10 +52,6 @@ If the operation doesn't work, try removing your `yarn.lock` or `package-lock.js
 - add the apiToken object,
 - remove the comma and default value from the `ADMIN_JWT_SECRET` parenthetical.
 
-<code-group>
-
-<code-block title="JAVASCRIPT">
-
 ```jsx
 
 //path: config/admin.js
@@ -71,34 +67,7 @@ module.exports = ({ env }) => ({
 
 ```
 
-</code-block>
-
-<code-block title="TYPESCRIPT">
-
-```jsx
-//path: config/admin.ts
-
-export default ({ env }) => ({
-  auth: {
-    secret: env('ADMIN_JWT_SECRET'),
-  },
-  apiToken: {
-    salt: env('API_TOKEN_SALT'),
-  },
-});
-
-
-```
-
-</code-block>
-
-</code-group>
-
 2. Configure`JWT_SECRET`. `JWT_SECRET` is used by the Users and Permissions plugin, and populated in `/.env`. The property should be stored in `config/plugins.js` (or `config/plugins.ts` for a TypeScript project). The `plugins` file is not created by default in a Strapi application. If the file does not exist, users should create the file and add the following code snippet.
-
-<code-group>
-
-<code-block title="JAVASCRIPT">
 
 ```jsx
 //  path: config/plugins.js
@@ -114,29 +83,6 @@ module.exports = ({ env }) => ({
 });
 
 ```
-
-</code-block>
-
-<code-block title="TYPESCRIPT">
-
-```jsx
-//  path: config/plugins.ts
-
-export default ({ env }) => ({
-  // ...
-  'users-permissions': {
-    config: {
-    jwtSecret: env('JWT_SECRET')
-  },
-  },
-  // ...
-});
-
-```
-
-</code-block>
-
-</code-group>
 
 ## Setting secrets for non-development environments
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged


Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

Remove TypeScript code blocks from pre-v4.3 migration guide.

### Why is it needed?

Remove unnecessary code blocks. 

### Related issue(s)/PR(s)

#980 To be merged for the TypeScript documentation stable release. 