### PR TITLE
improve instruction set for replacing the favicon

### DIFF
--- a/docs/developer-docs/latest/development/admin-customization.md
+++ b/docs/developer-docs/latest/development/admin-customization.md
@@ -252,7 +252,7 @@ export default {
 ```
 5. Rebuild, launch and revisit your Strapi app `yarn build && yarn develop`.
 
-:::note
+::: tip
 Make sure that the cached favicon is cleared. It can be cached in your web browser and also with your domain management tool like Cloudflare's CDN.
 :::
 

--- a/docs/developer-docs/latest/development/admin-customization.md
+++ b/docs/developer-docs/latest/development/admin-customization.md
@@ -227,7 +227,43 @@ Note also that the main navigation logo uploaded via the admin panel supersedes 
 
 #### Favicon
 
-To update the favicon, put a favicon file in the `./src/admin/extensions` folder and update the `config.head.favicon` key in the [admin panel configuration](#configuration-options).
+Replacing the Strapi favicon with a custom favicon.
+:::tip
+This same process may be used to replace the login logo `AuthLogo` and menu logo with `MenuLogo`. For more details, please visit Strapi [#logos](#)
+:::
+
+1. Create an extensions folder at:
+`src/admin/extensions/`
+
+2. Upload your favicon into:
+`src/admin/extensions/`
+
+3. Replace the **favicon.ico** at:
+`Strapi app root` with custom favicon.ico
+
+4. Update your `src/admin/app.js` with the following:
+
+```js
+// path: src/admin/app.js
+
+import favicon from './extensions/favicon.png';
+
+export default {
+  config: {
+         // replace favicon with custom icon
+         head: {
+                favicon: favicon,
+        },
+  }
+}
+```
+
+5. Rebuild, run & revisit your Strapi app
+ `yarn build && yarn develop`
+
+:::note
+Be certain that the cached favicon is cleared. It can be cached in your web browser and also with your domain management tool like Cloudflare's CDN
+:::
 
 #### Tutorial videos
 

--- a/docs/developer-docs/latest/development/admin-customization.md
+++ b/docs/developer-docs/latest/development/admin-customization.md
@@ -232,7 +232,7 @@ Replacing the Strapi favicon with a custom favicon.
 This same process may be used to replace the login logo `AuthLogo` and menu logo with `MenuLogo`. For more details, please visit Strapi [#logos](#)
 :::
 
-1. Create an extensions folder at:
+1. (_optional_) Create a `./src/admin/extensions/` folder if the folder does not already exist.
 
 2. Upload your favicon into `src/admin/extensions/`.
 `src/admin/extensions/`

--- a/docs/developer-docs/latest/development/admin-customization.md
+++ b/docs/developer-docs/latest/development/admin-customization.md
@@ -229,7 +229,7 @@ Note also that the main navigation logo uploaded via the admin panel supersedes 
 
 Replacing the Strapi favicon with a custom favicon.
 :::tip
-This same process may be used to replace the login logo `AuthLogo` and menu logo with `MenuLogo`. For more details, please visit Strapi [logos subsection](#logos)
+This same process may be used to replace the login logo (i.e. `AuthLogo`) and menu logo (i.e. `MenuLogo`) (see [logos customization documentation](#logos)).
 :::
 
 1. (_optional_) Create a `./src/admin/extensions/` folder if the folder does not already exist.

--- a/docs/developer-docs/latest/development/admin-customization.md
+++ b/docs/developer-docs/latest/development/admin-customization.md
@@ -253,7 +253,7 @@ export default {
 5. Rebuild, launch and revisit your Strapi app `yarn build && yarn develop`.
 
 :::note
-Be certain that the cached favicon is cleared. It can be cached in your web browser and also with your domain management tool like Cloudflare's CDN
+Make sure that the cached favicon is cleared. It can be cached in your web browser and also with your domain management tool like Cloudflare's CDN.
 :::
 
 #### Tutorial videos

--- a/docs/developer-docs/latest/development/admin-customization.md
+++ b/docs/developer-docs/latest/development/admin-customization.md
@@ -235,7 +235,7 @@ This same process may be used to replace the login logo `AuthLogo` and menu logo
 1. Create an extensions folder at:
 `src/admin/extensions/`
 
-2. Upload your favicon into:
+2. Upload your favicon into `src/admin/extensions/`.
 `src/admin/extensions/`
 
 3. Replace the **favicon.ico** at:

--- a/docs/developer-docs/latest/development/admin-customization.md
+++ b/docs/developer-docs/latest/development/admin-customization.md
@@ -229,19 +229,13 @@ Note also that the main navigation logo uploaded via the admin panel supersedes 
 
 Replacing the Strapi favicon with a custom favicon.
 :::tip
-This same process may be used to replace the login logo `AuthLogo` and menu logo with `MenuLogo`. For more details, please visit Strapi [#logos](#)
+This same process may be used to replace the login logo `AuthLogo` and menu logo with `MenuLogo`. For more details, please visit Strapi [logos subsection](#configuration-options)
 :::
 
 1. (_optional_) Create a `./src/admin/extensions/` folder if the folder does not already exist.
-
 2. Upload your favicon into `src/admin/extensions/`.
-`src/admin/extensions/`
-
-3. Replace the **favicon.ico** at:
-`Strapi app root` with custom favicon.ico
-
+3. Replace the **favicon.ico** at`Strapi app root` with custom favicon.ico
 4. Update your `src/admin/app.js` with the following:
-
 ```js
 // path: src/admin/app.js
 
@@ -256,7 +250,6 @@ export default {
   }
 }
 ```
-
 5. Rebuild, run & revisit your Strapi app
  `yarn build && yarn develop`
 

--- a/docs/developer-docs/latest/development/admin-customization.md
+++ b/docs/developer-docs/latest/development/admin-customization.md
@@ -229,7 +229,7 @@ Note also that the main navigation logo uploaded via the admin panel supersedes 
 
 Replacing the Strapi favicon with a custom favicon.
 :::tip
-This same process may be used to replace the login logo `AuthLogo` and menu logo with `MenuLogo`. For more details, please visit Strapi [logos subsection](#configuration-options)
+This same process may be used to replace the login logo `AuthLogo` and menu logo with `MenuLogo`. For more details, please visit Strapi [logos subsection](#logos)
 :::
 
 1. (_optional_) Create a `./src/admin/extensions/` folder if the folder does not already exist.
@@ -243,15 +243,14 @@ import favicon from './extensions/favicon.png';
 
 export default {
   config: {
-         // replace favicon with custom icon
+         // replace favicon with a custom icon
          head: {
                 favicon: favicon,
         },
   }
 }
 ```
-5. Rebuild, run & revisit your Strapi app
- `yarn build && yarn develop`
+5. Rebuild, launch and revisit your Strapi app `yarn build && yarn develop`
 
 :::note
 Be certain that the cached favicon is cleared. It can be cached in your web browser and also with your domain management tool like Cloudflare's CDN

--- a/docs/developer-docs/latest/development/admin-customization.md
+++ b/docs/developer-docs/latest/development/admin-customization.md
@@ -250,7 +250,7 @@ export default {
   }
 }
 ```
-5. Rebuild, launch and revisit your Strapi app `yarn build && yarn develop`
+5. Rebuild, launch and revisit your Strapi app `yarn build && yarn develop`.
 
 :::note
 Be certain that the cached favicon is cleared. It can be cached in your web browser and also with your domain management tool like Cloudflare's CDN

--- a/docs/developer-docs/latest/development/admin-customization.md
+++ b/docs/developer-docs/latest/development/admin-customization.md
@@ -233,7 +233,6 @@ This same process may be used to replace the login logo `AuthLogo` and menu logo
 :::
 
 1. Create an extensions folder at:
-`src/admin/extensions/`
 
 2. Upload your favicon into `src/admin/extensions/`.
 `src/admin/extensions/`

--- a/docs/developer-docs/latest/development/admin-customization.md
+++ b/docs/developer-docs/latest/development/admin-customization.md
@@ -234,7 +234,7 @@ This same process may be used to replace the login logo `AuthLogo` and menu logo
 
 1. (_optional_) Create a `./src/admin/extensions/` folder if the folder does not already exist.
 2. Upload your favicon into `src/admin/extensions/`.
-3. Replace the **favicon.ico** at`Strapi app root` with custom favicon.ico
+3. Replace the **favicon.ico** at`Strapi app root` with custom favicon.ico.
 4. Update your `src/admin/app.js` with the following:
 ```js
 // path: src/admin/app.js


### PR DESCRIPTION
What does it do?

Improves instructions for updating the favicon

Why is it needed?
To update the app favicon

Related issue(s)/PR(s)
https://github.com/strapi/documentation/issues/987

Related PR that was closed: 
https://github.com/strapi/documentation/pull/995

Question: 

Do we have to use favicon.ico formatting? For example, replace the favicon.ico with favicon.png