### PR TITLE
Fix plugins.md typo

### DIFF
--- a/docs/developer-docs/latest/setup-deployment-guides/configurations/optional/plugins.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/configurations/optional/plugins.md
@@ -67,7 +67,7 @@ module.exports = () => ({
     config: {
       playgroundAlways: false,
       defaultLimit: 10,
-      maxLimit: 20
+      maxLimit: 20,
       apolloServer: {
         tracing: true,
       },


### PR DESCRIPTION
### What does it do?

Adding comma to example config.

### Why is it needed?

Some people will copy and paste the example config, we want them to have a working example.
