### PR TITLE
FIx typos and correct naming conventions

### DIFF
--- a/docs/developer-docs/latest/development/backend-customization/models.md
+++ b/docs/developer-docs/latest/development/backend-customization/models.md
@@ -614,7 +614,7 @@ Each event listener is called sequentially. They can be synchronous or asynchron
 <code-block title=JAVASCRIPT>
 
 ```js
-// ./src/api/[api-name]/content-types/restaurant/lifecycles.js
+// ./src/api/[api-name]/content-types/[api-name]/lifecycles.js
 
 module.exports = {
   beforeCreate(event) {
@@ -639,7 +639,7 @@ module.exports = {
 <code-block title=TYPESCRIPT>
 
 ```js
-// ./src/api/[api-name]/content-types/restaurant/lifecycles.ts
+// ./src/api/[api-name]/content-types/[api-name]/lifecycles.ts
 
 export default {
   beforeCreate(event) {
@@ -663,7 +663,7 @@ export default {
 Using the database layer API, it's also possible to register a subscriber and listen to events programmatically:
 
 ```js
-// ./src/api/[api-name]/content-types/restaurant/lifecycles.js
+// ./src/api/[api-name]/content-types/[api-name]/lifecycles.js
 
 // registering a subscriber
 strapi.db.lifecycles.subscribe({


### PR DESCRIPTION


### What does it do?

FIx typos and correct naming conventions.

### Why is it needed?

It is difficult for the document reader to understand `./src/api/[api-name]/content-types/restaurant/lifecycles.js` because he might be working on a local codebase and having `restaurant` in the documentation make it confusing. I replaced it with the `[api-name]` so, the reader would know how to define and name that file correctly.

### Related issue(s)/PR(s)

None
