### PR TITLE
Remove em object from lifecycle arguments

### DIFF
--- a/docs/developer-docs/latest/development/backend-customization/models.md
+++ b/docs/developer-docs/latest/development/backend-customization/models.md
@@ -598,7 +598,6 @@ Lifecycle hooks are functions that take an `event` parameter, an object with the
 | -------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `action` | String            | Lifecycle event that has been triggered (see [list](#available-lifecycle-events))                                                                                |
 | `model`  | Object            | Model object                                                                                                                                                       |
-| `em`     | EntityManagerObject           | EntityManager |                                                                                                                                                    |
 | `params` | Object            | Accepts the following parameters:<ul><li>`data`</li><li>`select`</li><li>`where`</li><li>`orderBy`</li><li>`limit`</li><li>`offset`</li><li>`populate`</li></ul> |
 | `result` | Object            | _Optional, only available with `afterXXX` events_<br><br>Contains the result of the action.                                                                      |
 | `state`  | Object            | Query state, can be used to share state between `beforeXXX` and `afterXXX` events of a query.                                                               |


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

It removes the `em` object from the list of arguments passed to lifecycle functions.

### Why is it needed?

There is no such thing as an `em` object and thus the argument is always undefined
I have discussed this with @derrickmehaffy, who confirmed the object does not exist at the moment and it's not WIP either.
