### PR TITLE
Mention python prerequisite in installation guides

### DIFF
--- a/docs/developer-docs/latest/developer-resources/cli/snippets/installation-prerequisites.md
+++ b/docs/developer-docs/latest/developer-resources/cli/snippets/installation-prerequisites.md
@@ -1,0 +1,5 @@
+The installation requires the following software to be already installed on your computer:
+
+- [Node.js](https://nodejs.org): only LTS versions are supported (v14 and v16). Other versions of Node.js may not be compatible with the latest release of Strapi. The 14.x version is most recommended by Strapi.
+- [npm](https://docs.npmjs.com/cli/v6/commands/npm-install) (v6 only) or [yarn](https://yarnpkg.com/getting-started/install) to run the CLI installation scripts.
+- [Python](https://www.python.org/downloads/) when using a SQLite database

--- a/docs/developer-docs/latest/getting-started/quick-start.md
+++ b/docs/developer-docs/latest/getting-started/quick-start.md
@@ -87,8 +87,14 @@ canonicalUrl: https://docs.strapi.io/developer-docs/latest/getting-started/quick
 Strapi offers a lot of flexibility. Whether you want to go fast and quickly see the final result, or would rather dive deeper into the product, we got you covered.
 
 ::: prerequisites
-Make sure [Node.js and npm are properly installed](/developer-docs/latest/setup-deployment-guides/installation/cli.md#preparing-the-installation) on your machine. It is also possible to use Yarn instead of npm (see [install the Yarn package](https://yarnpkg.com/en/)).
+
+The installation requires the following software to be already installed on your computer:
+
+- [Node.js](https://nodejs.org): only LTS versions are supported (v14 and v16). Other versions of Node.js may not be compatible with the latest release of Strapi. The 14.x version is most recommended by Strapi.
+- [npm](https://docs.npmjs.com/cli/v6/commands/npm-install) (v6 only) or [yarn](https://yarnpkg.com/getting-started/install) to run the CLI installation scripts.
+- [Python](https://www.python.org/downloads/) when using a SQLite database
 :::
+
 
 👇 Let's get started! Using the big buttons below, please choose between:
 

--- a/docs/developer-docs/latest/getting-started/quick-start.md
+++ b/docs/developer-docs/latest/getting-started/quick-start.md
@@ -88,11 +88,8 @@ Strapi offers a lot of flexibility. Whether you want to go fast and quickly see 
 
 ::: prerequisites
 
-The installation requires the following software to be already installed on your computer:
+!!!include(developer-docs/latest/developer-resources/cli/snippets/installation-prerequisites.md)!!!
 
-- [Node.js](https://nodejs.org): only LTS versions are supported (v14 and v16). Other versions of Node.js may not be compatible with the latest release of Strapi. The 14.x version is most recommended by Strapi.
-- [npm](https://docs.npmjs.com/cli/v6/commands/npm-install) (v6 only) or [yarn](https://yarnpkg.com/getting-started/install) to run the CLI installation scripts.
-- [Python](https://www.python.org/downloads/) when using a SQLite database
 :::
 
 

--- a/docs/developer-docs/latest/setup-deployment-guides/installation/cli.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/installation/cli.md
@@ -10,11 +10,7 @@ Strapi CLI (Command Line Interface) installation scripts are the fastest way to 
 
 ## Preparing the installation
 
-The installation requires the following software to be already installed on your computer:
-
-- [Node.js](https://nodejs.org): only LTS versions are supported (v14 and v16). Other versions of Node.js may not be compatible with the latest release of Strapi. The 14.x version is most recommended by Strapi.
-- [npm](https://docs.npmjs.com/cli/v6/commands/npm-install) (v6 only) or [yarn](https://yarnpkg.com/getting-started/install) to run the CLI installation scripts.
-- [Python](https://www.python.org/downloads/) when using a SQLite database
+!!!include(developer-docs/latest/developer-resources/cli/snippets/installation-prerequisites.md)!!!
 
 A database is also required for any Strapi project. Strapi currently supports the following databases:
 

--- a/docs/developer-docs/latest/setup-deployment-guides/installation/cli.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/installation/cli.md
@@ -10,10 +10,11 @@ Strapi CLI (Command Line Interface) installation scripts are the fastest way to 
 
 ## Preparing the installation
 
-The CLI installation guide requires at least two software prerequisites to be already installed on your computer:
+The installation requires the following software to be already installed on your computer:
 
 - [Node.js](https://nodejs.org): only LTS versions are supported (v14 and v16). Other versions of Node.js may not be compatible with the latest release of Strapi. The 14.x version is most recommended by Strapi.
 - [npm](https://docs.npmjs.com/cli/v6/commands/npm-install) (v6 only) or [yarn](https://yarnpkg.com/getting-started/install) to run the CLI installation scripts.
+- [Python](https://www.python.org/downloads/) when using a SQLite database
 
 A database is also required for any Strapi project. Strapi currently supports the following databases:
 


### PR DESCRIPTION
### What does it do?

@soupette made me aware again that `ptyhon` is a hard dependency when installing Strapi. Usually python will be installed on users systems, but in recent MacOS / ARM based setup this is not the case any longer. This PR adds python as prerequisite to the setup instructions.

### Why is it needed?

To avoid cryptic node-gyp errors.

