### PR TITLE
Custom fields - Dev docs: Minor updates and cross-links

### DIFF
--- a/docs/developer-docs/latest/developer-resources/plugin-api-reference/admin-panel.md
+++ b/docs/developer-docs/latest/developer-resources/plugin-api-reference/admin-panel.md
@@ -181,6 +181,7 @@ The Admin Panel API allows a plugin to take advantage of several small APIs to p
 | Declare an injection zone                | [Injection Zones API](#injection-zones-api) | [`registerPlugin()`](#registerplugin)             | [`register()`](#register)   |
 | Add a reducer                            | [Reducers API](#reducers-api)                                       | [`addReducers()`](#reducers-api)                      | [`register()`](#register)   |
 | Create a hook                          | [Hooks API](#hooks-api)                 | [`createHook()`](#hooks-api)                    | [`register()`](#register)   |
+| Register the admin panel part of a custom field | APIs for custom fields (see [custom fields documentation](/developer-docs/latest/development/custom-fields.md)) | `app.customFields.register()` | `register()` |
 | Add a single link to a settings section  | [Settings API](#settings-api)           | [`addSettingsLink()`](#addsettingslink)             | [`bootstrap()`](#bootstrap) |
 | Add multiple links to a settings section | [Settings API](#settings-api)           | [`addSettingsLinks()`](#addsettingslinks)           | [`bootstrap()`](#bootstrap) |
 | Inject a Component in an injection zone  | [Injection Zones API](#injection-zones-api) | [`injectComponent()`](#injection-zones-api)           | [`bootstrap()`](#register)  |

--- a/docs/developer-docs/latest/developer-resources/plugin-api-reference/admin-panel.md
+++ b/docs/developer-docs/latest/developer-resources/plugin-api-reference/admin-panel.md
@@ -49,6 +49,7 @@ Within the register function, a plugin can:
 * [create a new settings section](#createsettingsection)
 * define [injection zones](#injection-zones-api)
 * [add reducers](#reducers-api)
+* register the admin panel part of [custom fields](/developer-docs/latest/development/custom-fields.md#registering-a-custom-field-in-the-admin-panel)
 
 #### registerPlugin()
 
@@ -112,7 +113,6 @@ Within the bootstrap function, a plugin can:
 * extend another plugin, using `getPlugin('plugin-name')`,
 * register hooks (see [Hooks API](#hooks-api))
 * [add links to a settings section](#settings-api)
-* register the admin panel part of [custom fields](/developer-docs/latest/development/custom-fields.md#registering-a-custom-field-in-the-admin-panel)
 
 **Example:**
 

--- a/docs/developer-docs/latest/developer-resources/plugin-api-reference/admin-panel.md
+++ b/docs/developer-docs/latest/developer-resources/plugin-api-reference/admin-panel.md
@@ -112,6 +112,7 @@ Within the bootstrap function, a plugin can:
 * extend another plugin, using `getPlugin('plugin-name')`,
 * register hooks (see [Hooks API](#hooks-api))
 * [add links to a settings section](#settings-api)
+* register the admin panel part of [custom fields](/developer-docs/latest/development/custom-fields.md#registering-a-custom-field-in-the-admin-panel)
 
 **Example:**
 

--- a/docs/developer-docs/latest/developer-resources/plugin-api-reference/server.md
+++ b/docs/developer-docs/latest/developer-resources/plugin-api-reference/server.md
@@ -28,7 +28,7 @@ To tap into the Server API, create a `strapi-server.js` file at the root of the 
 
 ### register()
 
-This function is called to load the plugin, even before the application is actually [bootstrapped](#bootstrap), in order to register [permissions](/developer-docs/latest/plugins/users-permissions.md) or database migrations.
+This function is called to load the plugin, even before the application is actually [bootstrapped](#bootstrap), in order to register [permissions](/developer-docs/latest/plugins/users-permissions.md), the server part of [custom fields](/developer-docs/latest/development/custom-fields.md#registering-a-custom-field-on-the-server), or database migrations.
 
 **Type**: `Function`
 

--- a/docs/developer-docs/latest/developer-resources/plugin-api-reference/server.md
+++ b/docs/developer-docs/latest/developer-resources/plugin-api-reference/server.md
@@ -28,7 +28,7 @@ To tap into the Server API, create a `strapi-server.js` file at the root of the 
 
 ### register()
 
-This function is called to load the plugin, even before the application is actually [bootstrapped](#bootstrap), in order to register [permissions](/developer-docs/latest/plugins/users-permissions.md), the server part of [custom fields](/developer-docs/latest/development/custom-fields.md#registering-a-custom-field-on-the-server), or database migrations.
+This function is called to load the plugin, before the application is [bootstrapped](#bootstrap), in order to register [permissions](/developer-docs/latest/plugins/users-permissions.md), the server part of [custom fields](/developer-docs/latest/development/custom-fields.md#registering-a-custom-field-on-the-server), or database migrations.
 
 **Type**: `Function`
 

--- a/docs/developer-docs/latest/development/plugins-development.md
+++ b/docs/developer-docs/latest/development/plugins-development.md
@@ -72,3 +72,7 @@ Strapi provides programmatic APIs for plugins to hook into some of Strapi's feat
 Plugins can register with the server and/or the admin panel, by looking for entry point files at the root of the package:
   - `strapi-server.js` for the Server (see [Server API](/developer-docs/latest/developer-resources/plugin-api-reference/server.md)),
   - `strapi-admin.js` for the admin panel (see [Admin Panel API](/developer-docs/latest/developer-resources/plugin-api-reference/admin-panel.md)).
+
+::: strapi Custom fields plugins
+Plugins can also be used to add [custom fields](/developer-docs/latest/development/custom-fields/reference.md) to Strapi.
+:::

--- a/docs/developer-docs/latest/setup-deployment-guides/configurations/optional/functions.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/configurations/optional/functions.md
@@ -15,7 +15,8 @@ It can be used to:
 
 - [extend plugins](/developer-docs/latest/development/plugins-extension.md#extending-a-plugin-s-interface)
 - extend [content-types](/developer-docs/latest/development/backend-customization/models.md) programmatically
-- load some [environment variables](/developer-docs/latest/setup-deployment-guides/configurations/optional/environment.md).
+- load some [environment variables](/developer-docs/latest/setup-deployment-guides/configurations/optional/environment.md)
+- register the server part of [custom fields](/developer-docs/latest/development/custom-fields.md) that would be used only by the current Strapi application.
 
 ## Bootstrap
 
@@ -26,6 +27,7 @@ It can be used to:
 - create an admin user if there isn't one
 - fill the database with some necessary data
 - declare custom conditions for the [Role-Based Access Control (RBAC)](/developer-docs/latest/setup-deployment-guides/configurations/optional/rbac.md) feature
+- register the admin panel part of [custom fields](/developer-docs/latest/development/custom-fields.md) that would be used only by the current Strapi application.
 
 The bootstrap function can be synchronous, asynchronous, or return a promise:
 

--- a/docs/developer-docs/latest/setup-deployment-guides/configurations/optional/functions.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/configurations/optional/functions.md
@@ -16,7 +16,7 @@ It can be used to:
 - [extend plugins](/developer-docs/latest/development/plugins-extension.md#extending-a-plugin-s-interface)
 - extend [content-types](/developer-docs/latest/development/backend-customization/models.md) programmatically
 - load some [environment variables](/developer-docs/latest/setup-deployment-guides/configurations/optional/environment.md)
-- register the server part of [custom fields](/developer-docs/latest/development/custom-fields.md) that would be used only by the current Strapi application.
+- register a [custom field](/developer-docs/latest/development/custom-fields.md) that would be used only by the current Strapi application.
 
 ## Bootstrap
 
@@ -27,7 +27,6 @@ It can be used to:
 - create an admin user if there isn't one
 - fill the database with some necessary data
 - declare custom conditions for the [Role-Based Access Control (RBAC)](/developer-docs/latest/setup-deployment-guides/configurations/optional/rbac.md) feature
-- register the admin panel part of [custom fields](/developer-docs/latest/development/custom-fields.md) that would be used only by the current Strapi application.
 
 The bootstrap function can be synchronous, asynchronous, or return a promise:
 


### PR DESCRIPTION
This PR mentions custom fields in the following existing sections:
- the Server and Admin Panel APIs for plugins
- the global `register()` lifecycle function
- the Plugins development page

Doing so, it adds cross-reference links back to the Development > Custom fields page created in PR #1035.

***
(Note: If you read this content from any VuePress preview, links to the new page will appear as broken and will only work when both PRs are merged into dev/custom-fields (see PR #1036)) 