### PR TITLE
CTB: Add new time interval option for datetime and time fields

### DIFF
--- a/docs/user-docs/latest/content-types-builder/configuring-fields-content-type.md
+++ b/docs/user-docs/latest/content-types-builder/configuring-fields-content-type.md
@@ -141,6 +141,7 @@ The Date field can display a date (year, month, day), time (hour, minute, second
 | Enable localization for this field | (if the [Internationalization plugin](/user-docs/latest/plugins/strapi-plugins.md#internationalization-plugin) is installed and localization is enabled for the content-type) Allow the field to have a different value per locale. |
 | Required field | Tick to prevent creating or saving an entry if the field is not filled in.  |
 | Unique field   | Tick to prevent another field to be identical to this one.                  |
+| Time interval  | The interval (in minutes) the timepicker will allow to select (for fields of type datetime and time). |
 
 :::
 


### PR DESCRIPTION
### What does it do?

Adds a new display option "Time interval" for datetime and time fields to the user docs.

### Why is it needed?

To document all available options.

### Related issue(s)/PR(s)

- https://github.com/strapi/strapi/pull/13597
