### PR TITLE
Improve typescript documentation

### DIFF
--- a/docs/developer-docs/latest/development/typescript.md
+++ b/docs/developer-docs/latest/development/typescript.md
@@ -64,6 +64,32 @@ To experience TypeScript-based autocomplete while developing Strapi applications
 4. When the `strapi.runLifecyclesFunctions` method is added, a list of available lifecycle types (i.e. `register`, `bootstrap` and `destroy`) are returned by the code editor. Use keyboard arrows to choose one of the lifecycles and the code will autocomplete.
 
 
+:::details You can also create a helper function to automaticaly type strapi parameter:
+
+```ts
+// path: ./src/utils.ts
+
+import { Strapi } from '@strapi/strapi';
+
+export function withStrapi<T>(fn: (ctx: { strapi: Strapi }) => T) {
+  return fn;
+}
+```
+
+```js
+// path: ./src/index.ts
+
+import { withStrapi } from './utils';
+
+export default {
+  register: withStrapi({ strapi } => {
+    // ...
+  }),
+};
+```
+:::
+
+
 ## Generate typings for project schemas
 
 To generate typings for your project schemas use the [`ts:generate-types` CLI command](/developer-docs/latest/developer-resources/cli/CLI.md#strapi-ts-generate-types). The `ts:generate-types` command creates the file `schemas.d.ts`, at the project root, which stores the schema typings. The optional `--verbose` flag returns a detailed table of the generated schemas.

--- a/docs/developer-docs/latest/development/typescript.md
+++ b/docs/developer-docs/latest/development/typescript.md
@@ -21,6 +21,10 @@ Starting the development environment for a TypeScript-enabled project requires b
 <code-block title="NPM">
 
 ```sh
+# create a project
+npx create-strapi-app@latest my-typescript-strapi --ts
+
+# run build before first develop
 npm run build
 npm run develop
 ```
@@ -30,6 +34,10 @@ npm run develop
  <code-block title="YARN">
 
 ```sh
+# create a project
+yarn create strapi-app --ts my-typescript-strapi
+
+# run build before first develop
 yarn build
 yarn develop
 ```

--- a/docs/developer-docs/latest/development/typescript.md
+++ b/docs/developer-docs/latest/development/typescript.md
@@ -144,119 +144,120 @@ TypeScript support can be added to an existing Strapi project using the followin
 
 1. Add a `tsconfig.json` file at the project root and copy the following code, with the `allowJs` flag, to the file:
 
-```json
-// path: ./tsconfig.json
-
-{
-    "extends": "@strapi/typescript-utils/tsconfigs/server",
-    "compilerOptions": {
-      "outDir": "dist",
-      "rootDir": ".",
-      "allowJs": true, // copy *.js files in outDir
-      "checkJs": false, // do not validate *.js files for now
-      "paths": {
-        "~": [
-          "."
+    ```json
+    // path: ./tsconfig.json
+    
+    {
+        "extends": "@strapi/typescript-utils/tsconfigs/server",
+        "compilerOptions": {
+          "outDir": "dist",
+          "rootDir": ".",
+          "allowJs": true, // copy *.js files in outDir
+          "checkJs": false, // do not validate *.js files for now
+          "paths": {
+            "~": [
+              "."
+            ],
+            "~/*": [
+              "./*"
+            ]
+          }
+        },
+        "include": [
+          "./",
+          "src/**/*.json"
         ],
-        "~/*": [
-          "./*"
+        "exclude": [
+          "node_modules/",
+          "build/",
+          "dist/",
+          ".cache/",
+          ".tmp/",
+          "src/admin/",
+          "**/*.test.ts"
         ]
+       
       }
-    },
-    "include": [
-      "./",
-      "src/**/*.json"
-    ],
-    "exclude": [
-      "node_modules/",
-      "build/",
-      "dist/",
-      ".cache/",
-      ".tmp/",
-      "src/admin/",
-      "**/*.test.ts"
-    ]
-   
-  }
-  
-```
+      
+    ```
 
-::: note
-The `@strapi/typescript-utils/tsconfigs/server` use node 14 as default target. You can override with your own, depending on your environment, more info in the [typescript wiki](https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping)
-:::
+    ::: note
+    The `@strapi/typescript-utils/tsconfigs/server` use node 14 as default target. You can override with your own, depending on your environment, more info in the         [typescript wiki](https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping)
+    :::
 
 2. Add a `tsconfig.json` file in the `./src/admin/` directory and copy the following code to the file:
 
-```json
-// path: ./src/admin/tsconfig.json
-
-{
-    "extends": "@strapi/typescript-utils/tsconfigs/admin",
-    "include": [
-      "../plugins/**/admin/src/**/*",
-      "./"
-    ],
-    "exclude": [
-      "node_modules/",
-      "build/",
-      "dist/",
-      "**/*.test.ts"
-    ]
-  }
-  
-```
+    ```json
+    // path: ./src/admin/tsconfig.json
+    
+    {
+        "extends": "@strapi/typescript-utils/tsconfigs/admin",
+        "include": [
+          "../plugins/**/admin/src/**/*",
+          "./"
+        ],
+        "exclude": [
+          "node_modules/",
+          "build/",
+          "dist/",
+          "**/*.test.ts"
+        ]
+      }
+      
+    ```
 
 3. (optional) Delete the `.eslintrc` and `.eslintignore` files from the project root. Alternatively, you can use [`@strapi-community`](https://github.com/strapi-community/eslint-config) configuration which allows both typescript and javascript.
 4. Add an additional `'..'` to the `filename` property in the `database.ts` configuration file (only required for SQLite databases):
 
-```js
-//path: ./config/database.ts
-
-const path = require('path');
-
-module.exports = ({ env }) => ({
-  connection: {
-    client: 'sqlite',
-    connection: {
-      filename: path.join(__dirname, '..','..', env('DATABASE_FILENAME', '.tmp/data.db')),
-    },
-    useNullAsDefault: true,
-  },
-});
-
-```
+    ```js
+    //path: ./config/database.ts
+    
+    const path = require('path');
+    
+    module.exports = ({ env }) => ({
+      connection: {
+        client: 'sqlite',
+        connection: {
+          filename: path.join(__dirname, '..','..', env('DATABASE_FILENAME', '.tmp/data.db')),
+        },
+        useNullAsDefault: true,
+      },
+    });
+    
+    ```
 
 5. Map your custom plugins server entrypoint to compiled typesript output `src/plugins/**/strapi-server.js`:
 
-```js
-'use strict';
-
-const { join } = require('node:path');
-module.exports = require(join(strapi.dirs.dist.src, 'plugins/<xxx>/server'));
-```
+    ```js
+    'use strict';
+    
+    const { join } = require('node:path');
+    module.exports = require(join(strapi.dirs.dist.src, 'plugins/<xxx>/server'));
+    ```
 
 
 6. Rebuild the admin panel and start the development server:
 
-<code-group>
-<code-block title='NPM'>
+    <code-group>
+    <code-block title='NPM'>
 
-```sh
-npm run build
-npm run develop
-```
+    ```sh
+    npm run build
+    npm run develop
+    ```
 
-</code-block>
+    </code-block>
 
-<code-block title='YARN'>
+    <code-block title='YARN'>
+    
+    ```sh
+    yarn build
+    yarn develop
+    ```
+    
+    </code-block>
+    </code-group>
 
-```sh
-yarn build
-yarn develop
-```
-
-</code-block>
-</code-group>
 
 After completing the preceding procedure a `dist` directory will be added at the project route and the project has access to the same TypeScript features as a new TypeScript-supported Strapi project.
 
@@ -292,8 +293,4 @@ Once you are ready, you can allow TypeScript compiler to check typing in  `*.js`
   }
 }
 ```
-
-
-
-
 


### PR DESCRIPTION
### What does it do?

- Add step to enable usage of typescript in user-defined plugins
- Add import alias `~/` to project root, so we can import generated `~/schemas` and other user-defined types
- Add note about tsconfig target and node version (when using node16, it enables usage of new EcmaScript features such as `String.prototype.replaceAll()`)
- Add [`@strapi-community`](https://github.com/strapi-community/eslint-config) as alternative to disabling linters
- Add tips to migrate existing JavaScript project to TypeScript
- Add note about declaration merging