### PR TITLE
Test neutral version of rebranding

### DIFF
--- a/docs/.vuepress/styles/branding--neutral.styl
+++ b/docs/.vuepress/styles/branding--neutral.styl
@@ -1,0 +1,95 @@
+body
+  font-family system-ui
+  color $neutral800
+
+a
+  color $primary600
+  font-weight 600
+.theme-default-content:not(.custom)
+  a.header-anchor
+    text-decoration none
+.dropdown-title
+  font-weight 600 !important
+
+h1, h2, h3, h4, h5, h6
+  color: $neutral900
+
+h2
+  border-bottom-color $neutral150
+
+.theme-default-content:not(.custom)
+  max-width 840px
+
+.theme-default-content code
+  border-radius 4px
+  background-color: $neutral100
+  color: $neutral700
+
+.sidebar-links a:hover
+.sidebar-heading.router-link-active
+.nav-link.router-link-active
+.sidebar-heading.clickable.active
+  color: $primary600 !important
+.sidebar-heading.clickable.active
+  border-left-color $primary600 !important
+.dropdown-wrapper .nav-dropdown .dropdown-item a.router-link-active::after
+  border-left-color $primary600 !important
+
+.nav-links a
+.nav-links a.router-link-active
+  font-weight 600
+  color: $neutral700
+
+.nav-links a:hover
+.nav-links a.active
+.sidebar-link.active
+  color: $primary600 !important
+  // TODO: override NavLinks.vue to avoid !important
+
+/**
+ * Tables
+ */
+table > tbody > tr:nth-child(2n) // disable alternating row colors
+  background-color: white
+table > tr, th, td
+  border-color $neutral200
+
+/**
+ * Code blocks
+ */
+[class^="language-"]
+  background-color $neutral900 !important
+[class^="language-"]::after
+  background-color $neutral900 !important
+  border-right-color: $neutral900 !important
+
+.line-number
+  color $neutral600
+
+code
+  .token
+    &.comment
+      color $neutral400
+
+/**
+ * Update code group styles
+ */
+.theme-code-group__nav
+  background-color $neutral900 !important
+  // TODO: override CodeGroup.vue to avoid !important
+
+.theme-code-group
+.el-tabs__content
+  .theme-code-group__li
+    .theme-code-group__nav-tab.theme-code-group__nav-tab-active
+      border-bottom-color $primary500 !important
+
+/**
+ * Update "tabs card" styles
+ */
+.el-tabs__header
+  .el-tabs__item.is-active
+  .el-tabs__item:not(.is-disabled):hover
+    color $primary600
+  .el-tabs__active-bar
+    background-color $primary600 !important

--- a/docs/.vuepress/styles/branding.styl
+++ b/docs/.vuepress/styles/branding.styl
@@ -21,12 +21,9 @@ h2
   max-width 840px
 
 .theme-default-content code
+  border-radius 4px
   background-color $primary100
   color $primary600
-  border-radius 4px
-  // more neutral version 👇
-  // background-color: $primary100
-  // color: $neutral700
 
 .sidebar-links a:hover
 .sidebar-heading.router-link-active

--- a/docs/.vuepress/styles/index.styl
+++ b/docs/.vuepress/styles/index.styl
@@ -2,5 +2,5 @@
   opacity: 1 !important
 
 @import "palette.styl"
-@import "branding.styl"
-@import "strapi-custom-blocks.styl"
+@import "branding--neutral.styl"
+@import "strapi-custom-blocks--neutral.styl"

--- a/docs/.vuepress/styles/strapi-custom-blocks--neutral.styl
+++ b/docs/.vuepress/styles/strapi-custom-blocks--neutral.styl
@@ -1,0 +1,298 @@
+.el-tabs__active-bar
+  background-color: #007eff !important
+
+.custom-block
+  /**
+   * CALLOUTS
+   */
+  .custom-block-title
+    font-weight 600
+    margin-bottom -0.4rem
+  &.callout
+  &.callout-alt
+  &.strapi
+  &.prerequisites
+  &.note
+  &.tip
+  &.warning
+  &.danger
+  &.caution
+    padding .1rem 1.5rem
+    margin-top 2rem
+    margin-bottom 2rem
+    border-left-width: .25rem
+    border-left-style solid
+    color: $neutral800
+    .custom-block-title
+      font-weight 600
+
+  &.callout
+  &.callout-alt
+  &.prerequisites
+    background-color $neutral100
+    border-color $neutral500
+    .custom-block-title
+      color: $neutral800
+    a
+      color $primary600
+  &.callout-alt
+    border-radius: 10px
+    background-color: #eff5f7
+    border: none
+  &.strapi
+    background-color $primary100
+    border-color $primary600
+    .custom-block-title
+      color $primary700
+    a
+      color $primary600
+  &.warning
+    background-color $danger100
+    border-color $danger600
+    .custom-block-title
+      color $danger700
+    a
+      color $danger600
+  &.caution
+    background-color $warning100
+    border-color $warning600
+    .custom-block-title
+      color $warning700
+    a
+      color $warning600
+  &.tip
+    background-color $success100
+    border-color $success600
+    .custom-block-title
+      color $success700
+    a
+      color $success600
+  &.note
+    background-color $secondary100
+    border-color $secondary600
+    .custom-block-title
+      color $secondary700
+    a
+      color $secondary600
+  &.details
+    background-color $neutral150
+    border-radius 6px
+  /**
+   * API CALLS
+  */
+  &.api-call
+    padding: 0
+    border-radius: 12px
+    // margin: 2rem 0 2rem
+    @media (min-width: 1536px)
+      display: flex
+      margin: 0 -12rem 2rem 0
+      align-items: stretch
+  &.request
+    background-color: $neutral700
+    padding: 0 1rem 1rem
+    border-radius: 12px
+    font-size: 100%
+    color:#F6F6F9
+    .custom-block-title
+      margin-left: -1rem
+      margin-right: -1rem
+      margin-top: 0
+      border-radius: 12px 12px 0 0
+      padding: .5rem 1rem
+      font-weight: 700
+      background-color: $neutral600
+      color: #F6F6F9
+      font-size: 90%;
+    .custom-block-title+p
+      padding-top: 1rem
+    p, ul, ol
+      color: #2c3e50
+      color: rgba(241,251,255,.8)
+    p
+      padding-left: 1rem
+      code
+      /* Chrome version 29 and above */
+        @media screen and (-webkit-min-device-pixel-ratio:0) and (min-resolution:.001dpcm)
+          word-break: break-word
+    ul, ol
+      padding-left: 3rem
+    [class^="language-"]
+      background-color $neutral700 !important
+      font-size: 100%
+      &::before
+        color: #EAEAEF
+      &::after
+        background-color $neutral700 !important
+        border-right-color $neutral700 !important
+    .line-number
+      color $neutral500
+    pre
+      padding: 1rem 0 0 1rem
+    code
+      color: #F6F6F9
+      background-color: #212134
+      .token
+        color: #F6F6F9 // catch-all for undefined colors
+        &.punctuation
+          color: #d3d3d3
+        &.operator
+        &.property
+          color: #F6F6F9
+        &.string
+        &.attr-name
+        &.function
+          color: #B6FFB5
+        &.number
+        &.keyword
+          color: #FDED9B
+        &.comment
+          color: #d9d9d9
+  &.response
+    background-color: $neutral900
+    margin-top: 2rem
+    padding: 0 1rem 1rem
+    border-radius: 12px
+    font-size: 100%
+    color: $neutral200
+    .extra-class::before
+      color: $neutral200
+    .custom-block-title
+      background-color: $neutral800
+      color: $neutral0
+      border-radius: 12px 12px 0 0
+      margin-left: -1rem
+      margin-right: -1rem
+      padding: .5rem 1rem
+      margin-top: 0
+      font-weight: 700
+      font-size: 90%;
+      margin-bottom: .5rem
+    [class^="language-"]
+      background-color: transparent
+      font-size: 100%
+      &::before
+        color: $neutral200
+    pre
+      padding: 1rem 0 0 1rem
+    code
+      color: $neutral200 !important
+      .token
+        color: $neutral200 // catch-all for undefined colors
+        &.punctuation
+        &.operator
+        &.property
+          color: $neutral200
+        &.string
+          color: $success500
+        &.number
+          color: $danger500
+        &.comment
+          color: #8585b2
+  &.request
+  &.response
+    margin-top: 2rem
+    .extra-class
+      font-size: 90%
+      border-radius: 6px 0 6px 0
+      pre
+        // white-space: pre-wrap
+        word-break: break-word
+        margin-bottom: 0
+
+  &.api-call
+    > .request
+    > .response
+      @media (min-width: 1536px)
+          flex: 0 0 42%
+          max-width: 42%
+    > .request
+      @media (min-width: 1536px)
+        border-radius: 12px 0 0 12px
+        .custom-block-title
+          border-radius: 12px 0 0 0
+    .response
+      @media (min-width: 1536px)
+        border-radius: 0 12px 12px 0
+        .custom-block-title
+          border-radius: 0 12px 0 0
+
+  &.columns
+    @media (min-width: 1200px)
+      display: flex
+      justify-content: space-between
+
+    > .column-left
+    > .column-right
+      @media (min-width: 1200px)
+        flex: 0 0 40%
+        max-width: 40%
+
+  &.grid
+    @media (min-width: 1200px)
+      display: grid
+      grid-template: 1fr 50% / 1fr 50%
+      grid-column-gap: 40px
+      margin-bottom: 20px
+
+    > .custom-block-title
+      grid-row: 1
+      grid-column: 1 / 3
+
+  &.grid-top-left
+    @media (min-width: 1200px)
+      grid-row: 2
+      grid-column: 1
+
+  &.grid-top-right
+    @media (min-width: 1200px)
+      grid-row: 2
+      grid-column: 2
+
+  &.grid-bottom-left
+    @media (min-width: 1200px)
+      grid-row: 3
+      grid-column: 1
+
+  &.grid-bottom-right
+    @media (min-width: 1200px)
+      grid-row: 3
+      grid-column: 2
+
+.custom-block.details
+  color rgb(44, 62, 80)
+
+.install-link
+  // text-decoration: none
+  background-color: #4945FF
+  border-radius: 6px
+  padding: 20px
+  color: $primary100
+  justify-content: space-between
+
+  .text
+    flex-grow: 1
+
+  .title
+    color: $neutral0
+
+  .description
+    color: $primary100
+
+  .arrow
+    width: 24px
+    height: 24px
+    transform: translateX(-8px)
+    transition: all .2s ease-in-out
+
+  &:hover
+    .title
+      color: $neutral0
+      text-decoration: underline
+    .description
+      color: $neutral0
+      // text-decoration: none
+    .arrow
+      transform: translateX(0)
+
+


### PR DESCRIPTION
Mostly uses a toned-down version of the inline code style.

Please don't merge, as this PR was created only as a way to deploy to Vercel and see a live demo.

Comparing the Database configuration page between what's deployed [on docs-next](https://docs-next.strapi.io/developer-docs/latest/setup-deployment-guides/configurations/required/databases.html#configuration-structure) and the present version would give an excellent overview of the differences, as exemplified by the screenshot:


![comparison](https://user-images.githubusercontent.com/4233866/186714544-4b4aaa3f-05e9-46bd-963c-04707296437d.png)




