### PR TITLE
Add explanation on populating with true

### DIFF
--- a/docs/developer-docs/latest/developer-resources/database-apis-reference/rest/populating-fields.md
+++ b/docs/developer-docs/latest/developer-resources/database-apis-reference/rest/populating-fields.md
@@ -174,12 +174,16 @@ await request(`/api/articles?${query}`);
 
 #### Populate 1 level
 
-To populate only specific relations one-level deep, use the relation name (e.g. `categories`) in combination with the `populate` parameter.
+To populate only specific relations one-level deep, use one of the following method:
+- Use the populate parameter as an array and put the relation name inside.
+- Use the populate parameter as an object (using LHS bracket notation) and put the relation name as a key with one of the following values: `true, false, t, f, 1, 0`.
 
 ::::api-call
 :::request Example request: populate categories
 
 `GET /api/articles?populate[0]=categories`
+
+`GET /api/articles?populate[categories]=true`
 
 :::
 
@@ -221,10 +225,22 @@ To populate only specific relations one-level deep, use the relation name (e.g. 
 !!!include(developer-docs/latest/developer-resources/database-apis-reference/rest/snippets/qs-for-query-body.md)!!!
 
 ```js
+// Array method
 const qs = require('qs');
 const query = qs.stringify({
   populate: ['categories'],
 }, {
+  encodeValuesOnly: true, // prettify URL
+});
+await request(`/api/articles?${query}`);
+```
+```js
+// Object method
+const qs = require('qs');
+const query = qs.stringify({
+  populate: {
+    categories: true,
+  }, {
   encodeValuesOnly: true, // prettify URL
 });
 
@@ -241,6 +257,8 @@ To populate specific relations, one or several levels deep, use the LHS bracket 
 :::request Example request: populate author and author.company
 
 `GET /api/articles?populate[author][populate][0]=company`
+
+`GET /api/articles?populate[author][populate][company]=true`
 
 :::
 
@@ -289,11 +307,29 @@ To populate specific relations, one or several levels deep, use the LHS bracket 
 !!!include(developer-docs/latest/developer-resources/database-apis-reference/rest/snippets/qs-for-query-body.md)!!!
 
 ```js
+// Array method
 const qs = require('qs');
 const query = qs.stringify({
   populate: {
     author: {
       populate: ['company'],
+    }
+  }
+}, {
+  encodeValuesOnly: true, // prettify URL
+});
+await request(`/api/articles?${query}`);
+```
+
+```js
+// Object method
+const qs = require('qs');
+const query = qs.stringify({
+  populate: {
+    author: {
+      populate: {
+        company: true
+      },
     }
   }
 }, {


### PR DESCRIPTION
### What does it do?

Add that we can populate a field by using `true`.
Remove the mention of `'*'`.

### Why is it needed?

Because `*` is replace with `true`.

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/pull/14124
