### PR TITLE
privateAttributes values must be in camelCase - fix #1094

### DIFF
--- a/docs/developer-docs/latest/development/backend-customization/models.md
+++ b/docs/developer-docs/latest/development/backend-customization/models.md
@@ -551,7 +551,7 @@ The `options` key is used to define specific behaviors and accepts the following
 
 {
   "options": {
-    "privateAttributes": ["id", "created_at"],
+    "privateAttributes": ["id", "createdAt"],
     "draftAndPublish": true
   }
 }


### PR DESCRIPTION
Trying to make a field private setting the `privateAttributes` configuration values in snake case doesn't work, using camelCase it does.

Documentation: https://docs.strapi.io/developer-docs/latest/development/backend-customization/models.html#model-options

### What does it do?

Rename the `create_at` attribute to `createdAt` in the documentation

### Why is it needed?

Because the configuration does not work if we use snake_case

### Related issue(s)/PR(s)

#1094
