### PR TITLE
Update hardware, DB, OS recommendations 

### DIFF
--- a/docs/developer-docs/latest/setup-deployment-guides/deployment.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment.md
@@ -14,28 +14,41 @@ Deploying databases along with Strapi is covered in the [databases guide](/devel
 
 ## General guidelines
 
-::: prerequisites
+### Prerequisites
+
 To provide the best possible environment for Strapi there are a few requirements, these apply in both a development (local) as well as a staging and production workflow.
 
 - Node LTS (v14 or v16) **Note that odd-number releases of Node will never be supported (e.g. v13, v15).**
 - NPM v6 or whatever ships with the LTS Node versions
 - Typical standard build tools for your OS (the `build-essentials` package on most Debian-based systems)
-- At least 1 CPU core (Highly recommended at least 2)
-- At least 2 GB of RAM (Moderately recommended 4)
-- Minimum required storage space recommended by your OS or 32 GB of **free** space
-- A supported database version
-  - MySQL >= 5.7.8
-  - MariaDB >= 10.2.7
-  - PostgreSQL >= 10
-  - SQLite >= 3
-- A supported operating system
-  - Ubuntu >= 18.04 (LTS-Only)
-  - Debian >= 9.x
-  - CentOS/RHEL >= 8
-  - macOS Mojave or newer (ARM not supported)
-  - Windows 10
-  - Docker - [docker repo](https://github.com/strapi/strapi-docker)
-:::
+- Hardware specifications for your server (CPU, RAM, storage):
+
+| Hardware | Minimum | Recommended |
+|----------|---------|-------------|
+| CPU      | 1 core  | 2+ cores    |
+| Memory   | 2GB     | 4GB+        |
+| Disk     | 8GB     | 32GB+       |
+
+- A supported database version:
+
+| Database   | Minimum | Recommended |
+|------------|---------|-------------|
+| MySQL      | 5.7.8   | 8.0         |
+| MariaDB    | 10.3    | 10.6        |
+| PostgreSQL | 11.0    | 14.0        |
+| SQLite     | 3       | 3           |
+
+- A supported operating system:
+
+| Operating System | Minimum | Recommended |
+|------------------|---------|-------------|
+| Ubuntu (LTS)     | 20.04   | 22.04       |
+| Debian           | 10.x    | 11.x        |
+| CentOS/RHEL      | 8.x     | 9.x         |
+| macOS            | 10.15   | 11.0        |
+| Windows Desktop  | 10      | 11          |
+| Windows Server   | 2019    | 2022        |
+
 ### Application Configuration
 
 #### 1. Configure

--- a/docs/developer-docs/latest/setup-deployment-guides/deployment.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment.md
@@ -14,7 +14,7 @@ Deploying databases along with Strapi is covered in the [databases guide](/devel
 
 ## General guidelines
 
-### Prerequisites
+### Hardware and software requirements
 
 To provide the best possible environment for Strapi there are a few requirements, these apply in both a development (local) as well as a staging and production workflow.
 

--- a/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/azure.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/azure.md
@@ -388,10 +388,12 @@ For Azure managed databases you can use the following:
 
 Likewise you can use any of the following installed locally on the virtual machine:
 
-- MySQL >= 5.7.8
-- MariaDB >= 10.2.7
-- PostgreSQL >= 10
-- SQLite >= 3
+| Database   | Minimum | Recommended |
+|------------|---------|-------------|
+| MySQL      | 5.7.8   | 8.0         |
+| MariaDB    | 10.3    | 10.6        |
+| PostgreSQL | 11.0    | 14.0        |
+| SQLite     | 3       | 3           |
 
 In our example we will be using MariaDB 10.4 LTS using the MariaDB apt repo. Per the [documentation](https://downloads.mariadb.org/mariadb/repositories/#distro=Ubuntu&distro_release=bionic--ubuntu_bionic&mirror=digitalocean-sfo&version=10.4) we will use the following commands:
 


### PR DESCRIPTION
I had to get rid of the `::: prerequisites` block s it didn't allow for tables but I think the tables make it much easier to read and quickly see at a glance the min vs recommended.

If you would prefer me to move back to the unordered list instead let me know and I can revert the tables.

Signed-off-by: Derrick Mehaffy <derrickmehaffy@gmail.com>
