### PR TITLE
Update admin-customization.md for plugin translation

### DIFF
--- a/docs/developer-docs/latest/development/admin-customization.md
+++ b/docs/developer-docs/latest/development/admin-customization.md
@@ -388,7 +388,7 @@ export default {
 </code-block>
 </code-group>
 
-To extend a plugin's key/value pair (which are declared independently in the plugin's files at `./admin/src/translations/[language-name].json`), you can similarly extend these in the `config.translations` key by prefixing the key with the plugin's name `[plugin name].[key]: 'value'` :
+A plugin's key/value pairs are declared independently in the plugin's files at `./admin/src/translations/[language-name].json`. These key/value pairs can similarly be extended in the `config.translations` key by prefixing the key with the plugin's name (i.e. `[plugin name].[key]: 'value'`) as in the following example:
 
 <code-group>
 <code-block title="JAVASCRIPT">

--- a/docs/developer-docs/latest/development/admin-customization.md
+++ b/docs/developer-docs/latest/development/admin-customization.md
@@ -388,6 +388,56 @@ export default {
 </code-block>
 </code-group>
 
+To extend a plugin's key/value pair (which are declared independently in the plugin's files at `./admin/src/translations/[language-name].json`), you can similarly extend these in the `config.translations` key by prefixing the key with the plugin's name `[plugin name].[key]: 'value'` :
+
+<code-group>
+<code-block title="JAVASCRIPT">
+
+```js
+// path: ./my-app/src/admin/app.js
+
+export default {
+  config: {
+    locales: ['fr'],
+    translations: {
+      fr: {
+        'Auth.form.email.label': 'test',
+        // Translate a plugin's key/value pair by adding the plugin's name as a prefix
+        // In this case, we translate the "plugin.name" key of plugin "content-type-builder"
+        "content-type-builder.plugin.name": "Constructeur de Type-Contenu",
+      },
+    },
+  },
+  bootstrap() {},
+};
+```
+
+</code-block>
+
+<code-block title="TYPESCRIPT">
+
+
+```js
+// path: ./my-app/src/admin/app.ts
+
+export default {
+  config: {
+    locales: ['fr'],
+    translations: {
+      fr: {
+        'Auth.form.email.label': 'test',
+        // Translate a plugin's key/value pair by adding the plugin's name as a prefix
+        // In this case, we translate the "plugin.name" key of plugin "content-type-builder"
+        "content-type-builder.plugin.name": "Constructeur de Type-Contenu",
+      },
+    },
+  },
+  bootstrap() {},
+};
+```
+
+</code-block>
+</code-group>
 
 
 If more translations files should be added, place them in `./src/admin/extensions/translations` folder.


### PR DESCRIPTION
### What does it do?

Add instructions to admin-customization.md for extending a plugin's translations, which requires prefixing the key/value pair (declared in the plugin's translation file) with the plugin's name, for example `"content-type-builder.plugin.name": "Constructeur de Type-Contenu"` in order to translate the `plugin.name` key declared in `content-type-builder` plugin.

### Why is it needed?

This wasn't made clear by the documentation previously, since even for default plugins (such as content-type-builder) some fields are not translatable with the default method because they are declared independently in the plugin's files. I couldn't find any reference in the docs to the fact the plugin's name needed to be added as a prefix in order to extend a plugin's key.

### Related issue(s)/PR(s)

None that i'm aware of.
