### PR TITLE
add manual installation sqlite

### DIFF
--- a/docs/developer-docs/latest/setup-deployment-guides/configurations/databases/sqlite.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/configurations/databases/sqlite.md
@@ -10,7 +10,7 @@ SQLite is the default ([Quick Start](/developer-docs/latest/getting-started/quic
 
 ## Install SQLite using starter
 
-Simply use one of the following commands.
+Use one of the following commands:
 
 <code-group>
 

--- a/docs/developer-docs/latest/setup-deployment-guides/configurations/databases/sqlite.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/configurations/databases/sqlite.md
@@ -48,7 +48,7 @@ npm install better-sqlite3
 
 <code-block title="YARN">
 ```sh
-yarn install better-sqlite3
+yarn add better-sqlite3
 ```
 </code-block>
 

--- a/docs/developer-docs/latest/setup-deployment-guides/configurations/databases/sqlite.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/configurations/databases/sqlite.md
@@ -8,7 +8,7 @@ canonicalUrl: https://docs.strapi.io/developer-docs/latest/setup-deployment-guid
 
 SQLite is the default ([Quick Start](/developer-docs/latest/getting-started/quick-start.md)) and recommended database to quickly create an app locally.
 
-## Install SQLite locally
+## Install SQLite using starter
 
 Simply use one of the following commands.
 
@@ -33,6 +33,40 @@ This will create a new project and launch it in the browser.
 ::: tip
 The [Quick Start Guide](/developer-docs/latest/getting-started/quick-start.md) is a complete step-by-step tutorial.
 :::
+
+## Install SQLite manually
+
+In terminal, run the following command:
+
+<code-group>
+
+<code-block title="NPM">
+```sh
+npm install better-sqlite3
+```
+</code-block>
+
+<code-block title="YARN">
+```sh
+yarn install better-sqlite3
+```
+</code-block>
+
+</code-group>
+
+Add the following to your `./config/database.js` file:
+
+```js
+module.exports = ({ env }) => ({
+  connection: {
+    client: 'sqlite',
+    connection: {
+      filename: path.join(__dirname, '..', env('DATABASE_FILENAME', '.tmp/data.db')),
+    },
+    useNullAsDefault: true,
+  },
+});
+```
 
 ## Other SQL Databases (PostgreSQL, MySQL)
 


### PR DESCRIPTION
### What does it do?

Fixes the `error: knex: Required configuration option 'client' is missing.` error, When using SQLite as database and mentioned dependency doesn't exist.

### Why is it needed?

I noticed that for some starters/templates. If the developer wants to switch back to the SQLite database and the dependency I mentioned is not available, it will return with an error message saying the client doesn't exist. 

### Related issue(s)/PR(s)

None