### PR TITLE
Add GraphQL Plugin config to TypeScript example similar to JavaScript

### DIFF
--- a/docs/developer-docs/latest/setup-deployment-guides/configurations/optional/plugins.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/configurations/optional/plugins.md
@@ -129,8 +129,12 @@ export default () => ({
   graphql: {
     enabled: true,
     config: {
+      playgroundAlways: false,
       defaultLimit: 10,
-      maxLimit: 20
+      maxLimit: 20,
+      apolloServer: {
+        tracing: true,
+      },
     }
   }
 })


### PR DESCRIPTION
### What does it do?

Synchronized the examples of GraphQL Plugin configuration in TypeScript and JavaScript.

### Why is it needed?

For some reason, TypeScript configuration was lacking options present in JavaScript configuration.
