### PR TITLE
Bump dependencies version

### DIFF
--- a/docs/developer-docs/latest/update-migration-guides/update-version.md
+++ b/docs/developer-docs/latest/update-migration-guides/update-version.md
@@ -31,7 +31,7 @@ Strapi periodically releases code improvements through upgrades. Upgrades contai
     "@strapi/strapi": "4.4.0",
     "@strapi/plugin-users-permissions": "4.3.9",
     "@strapi/plugin-i18n": "4.4.0",
-    "sqlite3": "5.0.2"
+    "better-sqlite3": "7.4.6"
     // ...
   }
 }

--- a/docs/developer-docs/latest/update-migration-guides/update-version.md
+++ b/docs/developer-docs/latest/update-migration-guides/update-version.md
@@ -30,7 +30,7 @@ Strapi periodically releases code improvements through upgrades. Upgrades contai
   "dependencies": {
     "@strapi/strapi": "4.4.0",
     "@strapi/plugin-users-permissions": "4.3.9",
-    "@strapi/plugin-i18n": "4.3.9",
+    "@strapi/plugin-i18n": "4.4.0",
     "sqlite3": "5.0.2"
     // ...
   }

--- a/docs/developer-docs/latest/update-migration-guides/update-version.md
+++ b/docs/developer-docs/latest/update-migration-guides/update-version.md
@@ -28,7 +28,7 @@ Strapi periodically releases code improvements through upgrades. Upgrades contai
 {
   // ...
   "dependencies": {
-    "@strapi/strapi": "4.3.9",
+    "@strapi/strapi": "4.4.0",
     "@strapi/plugin-users-permissions": "4.3.9",
     "@strapi/plugin-i18n": "4.3.9",
     "sqlite3": "5.0.2"

--- a/docs/developer-docs/latest/update-migration-guides/update-version.md
+++ b/docs/developer-docs/latest/update-migration-guides/update-version.md
@@ -28,9 +28,9 @@ Strapi periodically releases code improvements through upgrades. Upgrades contai
 {
   // ...
   "dependencies": {
-    "@strapi/strapi": "4.0.7",
-    "@strapi/plugin-users-permissions": "4.0.7",
-    "@strapi/plugin-i18n": "4.0.7",
+    "@strapi/strapi": "4.3.9",
+    "@strapi/plugin-users-permissions": "4.3.9",
+    "@strapi/plugin-i18n": "4.3.9",
     "sqlite3": "5.0.2"
     // ...
   }


### PR DESCRIPTION
### What does it do?

Bump dependencies version inside upgrade strapi version file

### Why is it needed?

To help people to upgrade to last version

### Question

sqlite3 version is correct?
