### PR TITLE
fix: the youtube link for video demo is outdated

### DIFF
--- a/docs/developer-docs/latest/getting-started/introduction.md
+++ b/docs/developer-docs/latest/getting-started/introduction.md
@@ -9,7 +9,7 @@ canonicalUrl: https://docs.strapi.io/developer-docs/latest/getting-started/intro
 This documentation contains all technical documentation related to the setup, deployment, update and customization of your Strapi application.
 
 ::: strapi Can't wait to start using Strapi?
-You can directly head to the [Quick Start](quick-start.md)! <br> If demos are more your thing, we have a [video demo](https://youtu.be/zd0_S_FPzKg), or you can request a [live demo](https://strapi.io/demo)!
+You can directly head to the [Quick Start](quick-start.md)! <br> If demos are more your thing, we have a [video demo](https://www.youtube.com/watch?v=h9vETeRiulY), or you can request a [live demo](https://strapi.io/demo)!
 :::
 
 The original purpose of the project was to help Boot**strap** your **API**: that's how Strapi was created. Now, Strapi is an open-source headless CMS that gives developers the freedom to choose their favorite tools and frameworks and allows editors to manage and distribute their content using their application's admin panel. Based on a plugin system, Strapi is a flexible CMS whose admin panel and API are extensible - and which every part is customizable to match any use case. Strapi also has a built-in user system to manage in detail what the administrators and end users have access to.

--- a/docs/developer-docs/latest/getting-started/introduction.md
+++ b/docs/developer-docs/latest/getting-started/introduction.md
@@ -9,7 +9,7 @@ canonicalUrl: https://docs.strapi.io/developer-docs/latest/getting-started/intro
 This documentation contains all technical documentation related to the setup, deployment, update and customization of your Strapi application.
 
 ::: strapi Can't wait to start using Strapi?
-You can directly head to the [Quick Start](quick-start.md)! <br> If demos are more your thing, we have a [video demo](https://www.youtube.com/watch?v=h9vETeRiulY), or you can request a [live demo](https://strapi.io/demo)!
+You can directly head to the [Quick Start](quick-start.md)! <br> If demos are more your thing, we have a [video demo](https://youtu.be/h9vETeRiulY), or you can request a [live demo](https://strapi.io/demo)!
 :::
 
 The original purpose of the project was to help Boot**strap** your **API**: that's how Strapi was created. Now, Strapi is an open-source headless CMS that gives developers the freedom to choose their favorite tools and frameworks and allows editors to manage and distribute their content using their application's admin panel. Based on a plugin system, Strapi is a flexible CMS whose admin panel and API are extensible - and which every part is customizable to match any use case. Strapi also has a built-in user system to manage in detail what the administrators and end users have access to.


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

the original link for the video demo is for v3, and I updated it with the one for v4.

### Why is it needed?

Because the Youtube link is outdated

### Related issue(s)/PR(s)

NA.
