### PR TITLE
Update link to ColorPicker input (again)

### DIFF
--- a/docs/developer-docs/latest/development/custom-fields.md
+++ b/docs/developer-docs/latest/development/custom-fields.md
@@ -199,7 +199,7 @@ register(app) {
 :::
 
 ::: tip
-The `Input` React component receives several props. The [`ColorPickerInput` file](https://github.com/strapi/strapi/blob/features/custom-fields/packages/plugins/color-picker/admin/src/components/ColorPicker/ColorPickerInput/index.js#L10-L21) in the Strapi codebase gives you an example of how they can be used.
+The `Input` React component receives several props. The [`ColorPickerInput` file](https://github.com/strapi/strapi/blob/main/packages/plugins/color-picker/admin/src/components/ColorPicker/ColorPickerInput/index.js#L71-L82) in the Strapi codebase gives you an example of how they can be used.
 :::
 
 


### PR DESCRIPTION
### What does it do?

Update old link

### Why is it needed?

custom-fields branch is now merged to main and deleted, so link in guide is not working again

### Related issue(s)/PR(s)

"again" because it was broken and fixed earlier in #1165
