### PR TITLE
Fixed service id in Typescript example

### DIFF
--- a/docs/developer-docs/latest/development/backend-customization/services.md
+++ b/docs/developer-docs/latest/development/backend-customization/services.md
@@ -170,7 +170,7 @@ const transporter = nodemailer.createTransport({
   },
 });
 
-export default factories.createCoreService('api::restaurant.restaurant', ({ strapi }) => ({
+export default factories.createCoreService('api::email.email', ({ strapi }) => ({
   send(from, to, subject, text) {
     // Setup e-mail data. 
     const options = {


### PR DESCRIPTION
The typescript example was using the wrong service id. 
Also, in the next code example, I'd say the createCoreController is also using the wrong id in both JS and TS, but I'm not sure, so I'm not modifying that.