### PR TITLE
Update migration-guide-4.3.6-to-4.3.7.md

### DIFF
--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/v4/migration-guide-4.3.6-to-4.3.7.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/v4/migration-guide-4.3.6-to-4.3.7.md
@@ -1,12 +1,12 @@
 ---
-title: Migrate from 4.3.6 to 4.3.7 - Strapi Developer Docs
-description: Learn how you can migrate your Strapi application from 4.3.6 to 4.3.7.
-canonicalUrl: https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/v4/migration-guide-4.3.6-to-4.3.7.html
+title: Migrate from 4.3.6 to 4.3.8 - Strapi Developer Docs
+description: Learn how you can migrate your Strapi application from 4.3.6 to 4.3.8.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/v4/migration-guide-4.3.6-to-4.3.8.html
 ---
 
-# v4.3.6 to v4.3.7 migration guide
+# v4.3.6 to v4.3.8 migration guide
 
-The Strapi v4.3.6 to v4.3.7 migration guide upgrades v4.3.6 to v4.3.7. The migration changes the SQLite database package from `sqlite3`  to `better-sqlite3`. The migration guide consists of:
+The Strapi v4.3.6 to v4.3.8 migration guide upgrades v4.3.6 to v4.3.8. The migration changes the SQLite database package from `sqlite3`  to `better-sqlite3`. The migration guide consists of:
 
 - upgrading the application dependencies,
 - changing the `sqlite3` package to `better-sqlite3`,
@@ -22,7 +22,7 @@ The Strapi v4.3.6 to v4.3.7 migration guide upgrades v4.3.6 to v4.3.7. The migra
 Stop the server before starting the upgrade.
 :::
 
-1. Upgrade all of the Strapi packages in `package.json` to `4.3.7`:
+1. Upgrade all of the Strapi packages in `package.json` to `4.3.8`:
 
 ```json
 // path: package.json
@@ -30,9 +30,9 @@ Stop the server before starting the upgrade.
 {
   // ...
   "dependencies": {
-    "@strapi/strapi": "4.3.7",
-    "@strapi/plugin-users-permissions": "4.3.7",
-    "@strapi/plugin-i18n": "4.3.7",
+    "@strapi/strapi": "4.3.8",
+    "@strapi/plugin-users-permissions": "4.3.8",
+    "@strapi/plugin-i18n": "4.3.8",
     // ...
   }
 }
@@ -46,9 +46,9 @@ Stop the server before starting the upgrade.
 {
   // ...
   "dependencies": {
-    "@strapi/strapi": "4.3.7",
-    "@strapi/plugin-users-permissions": "4.3.7",
-    "@strapi/plugin-i18n": "4.3.7",
+    "@strapi/strapi": "4.3.8",
+    "@strapi/plugin-users-permissions": "4.3.8",
+    "@strapi/plugin-i18n": "4.3.8",
     "better-sqlite3": "7.4.6"
     // ...
   }

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/v4/migration-guide-4.3.6-to-4.3.7.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/v4/migration-guide-4.3.6-to-4.3.7.md
@@ -13,9 +13,9 @@ The Strapi v4.3.6 to v4.3.8 migration guide upgrades v4.3.6 to v4.3.8. The migra
 - reinitializing the application.
 
 :::caution
- This migration guide skips v4.3.7, which introduced an error in the SQLite database.
+ - This migration guide skips v4.3.7, which introduced an error in the SQLite database.
  
-[Plugins extension](/developer-docs/latest/plugins/users-permissions.md) that create custom code or modify existing code, will need to be updated and compared to the changes in the repository. Not updating the plugin extensions could break the application.
+- [Plugins extension](/developer-docs/latest/plugins/users-permissions.md) that create custom code or modify existing code, will need to be updated and compared to the changes in the repository. Not updating the plugin extensions could break the application.
 :::
 
 ## Upgrading the application dependencies

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/v4/migration-guide-4.3.6-to-4.3.7.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/v4/migration-guide-4.3.6-to-4.3.7.md
@@ -13,7 +13,9 @@ The Strapi v4.3.6 to v4.3.8 migration guide upgrades v4.3.6 to v4.3.8. The migra
 - reinitializing the application.
 
 :::caution
- [Plugins extension](/developer-docs/latest/plugins/users-permissions.md) that create custom code or modify existing code, will need to be updated and compared to the changes in the repository. Not updating the plugin extensions could break the application.
+ This migration guide skips v4.3.7, which introduced an error in the SQLite database.
+ 
+[Plugins extension](/developer-docs/latest/plugins/users-permissions.md) that create custom code or modify existing code, will need to be updated and compared to the changes in the repository. Not updating the plugin extensions could break the application.
 :::
 
 ## Upgrading the application dependencies


### PR DESCRIPTION
### What does it do?

Updated the strapi version in the doc.

### Why is it needed?

I've spent a lot of time figuring out the error that was fixed in this PR - https://github.com/strapi/strapi/pull/14342, while I've been migrating to the 4.3.7 version. I think it's worth updating the version in the migration doc at least to 4.3.8.

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/pull/14342
