### PR TITLE
fix: 🌍 wrong locale response when creating an entry with a locale dif…

### DIFF
--- a/docs/developer-docs/latest/plugins/i18n.md
+++ b/docs/developer-docs/latest/plugins/i18n.md
@@ -215,7 +215,7 @@ To create a localized entry for a locale different from the default one, add the
       "createdAt": "2021-10-28T17:01:47.089Z",
       "updatedAt": "2021-10-28T17:01:47.089Z",
       "publishedAt": "2021-10-28T17:01:47.082Z",
-      "locale": "en"
+      "locale": "fr"
     }
   },
   "meta": {}


### PR DESCRIPTION
…ferent than default one

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

Change fr to en.

### Why is it needed?

Entry was created with `fr` locale, so the response should also be `fr`, not `en.`

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
