### PR TITLE
Update nav-links class to prevent overlap on mobile

### DIFF
--- a/docs/.vuepress/theme/components/Sidebar.vue
+++ b/docs/.vuepress/theme/components/Sidebar.vue
@@ -59,7 +59,7 @@ export default {
   a
     display inline-block
   .nav-links
-    position: absolute
+    position: relative
     left: 0
     top: 0
     display none


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

I changed the `nav-links` class positioning to `position: relative` from `position: absolute`.

### Why is it needed?

The positioning is causing the `nav-links` content to overlap on mobile.

If the changes seem okay, it's ready to be merged.
