### PR TITLE
fixed typo "middlwares" in routes.md

### DIFF
--- a/docs/developer-docs/latest/development/backend-customization/routes.md
+++ b/docs/developer-docs/latest/development/backend-customization/routes.md
@@ -430,7 +430,7 @@ import { factories } from '@strapi/strapi';
 export default factories.createCoreRouter('api::restaurant.restaurant', {
   config: {
     find: {
-      middlwares: [
+      middlewares: [
         // point to a registered middleware
         'middleware-name', 
 


### PR DESCRIPTION
Fixed typo in backend customization docs.

### Related issue(s)/PR(s)

https://github.com/strapi/documentation/pull/1226#issuecomment-1290353600
