### PR TITLE
Create migration guide from 4.4.3 to 4.4.5

### DIFF
--- a/docs/developer-docs/latest/update-migration-guides/migration-guides.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides.md
@@ -20,6 +20,7 @@ Migrations are necessary when upgrades to Strapi include breaking changes. The m
 - [Migration guide from 4.1.8+ to 4.1.10](migration-guides/v4/migration-guide-4.1.8-to-4.1.10.md)
 - [Migration guide from 4.2.x to 4.3.x](migration-guides/v4/migration-guide-4.2.x-to-4.3.x.md)
 - [Migration guide from 4.3.6 to 4.3.8](migration-guides/v4/migration-guide-4.3.6-to-4.3.8.md)
+- [Migration guide from 4.4.3 to 4.4.5](migration-guides/v4/migration-guide-4.4.3-to-4.4.5.md)
 
 ## v3 to v4 migration guides
 

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/v4/migration-guide-4.4.3-to-4.4.5.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/v4/migration-guide-4.4.3-to-4.4.5.md
@@ -20,19 +20,19 @@ Stop the server before starting the upgrade.
 
 1. Upgrade all of the Strapi packages in `package.json` to `4.4.5`:
 
-```json
-// path: package.json
+    ```json
+    // path: package.json
 
-{
-  // ...
-  "dependencies": {
-    "@strapi/strapi": "4.4.5",
-    "@strapi/plugin-users-permissions": "4.4.5",
-    "@strapi/plugin-i18n": "4.4.5",
-    // ...
-  }
-}
-```
+    {
+      // ...
+      "dependencies": {
+        "@strapi/strapi": "4.4.5",
+        "@strapi/plugin-users-permissions": "4.4.5",
+        "@strapi/plugin-i18n": "4.4.5",
+        // ...
+      }
+    }
+    ```
 
 2. Save the edited `package.json` file.
 

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/v4/migration-guide-4.4.3-to-4.4.5.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/v4/migration-guide-4.4.3-to-4.4.5.md
@@ -6,9 +6,7 @@ canonicalUrl: https://docs.strapi.io/developer-docs/latest/update-migration-guid
 
 # v4.4.3 to v4.4.5 migration guide
 
-The Strapi v4.4.3 to v4.4.5 migration guide upgrades v4.4.3 to v4.4.5. The migration changes the name of the favicon. The migration guide consists of:
-
-- renaming the `favicon.ico` file to `favicon.png`.
+The Strapi v4.4.3 to v4.4.5 migration guide upgrades v4.4.3 to v4.4.5. The migration changes the name of the favicon from `favicon.ico` to `favicon.png`.
 
 :::caution
  - This migration guide skips v4.4.4, which introduced a problem in `koa/cors` due to a missing dependency update.
@@ -36,9 +34,9 @@ Stop the server before starting the upgrade.
 }
 ```
 
-2. Replace the existing `favicon.ico` with [`favicon.png`](https://user-images.githubusercontent.com/8593673/198366643-7261700d-c8c4-4ebb-83c8-792a330ab4a5.png):
+2. Save the edited `package.json` file.
 
-3. Save the edited `package.json` file.
+3. Replace the existing `favicon.ico` with [`favicon.png`](https://user-images.githubusercontent.com/8593673/198366643-7261700d-c8c4-4ebb-83c8-792a330ab4a5.png):
 
 4. Run either `yarn` or `npm install` to install the new version.
 

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/v4/migration-guide-4.4.3-to-4.4.5.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/v4/migration-guide-4.4.3-to-4.4.5.md
@@ -1,0 +1,49 @@
+---
+title: Migrate from 4.4.3 to 4.3.5 - Strapi Developer Docs
+description: Learn how you can migrate your Strapi application from 4.4.3 to 4.4.5.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/v4/migration-guide-4.4.3-to-4.4.5.html
+---
+
+# v4.4.3 to v4.4.5 migration guide
+
+The Strapi v4.4.3 to v4.4.5 migration guide upgrades v4.4.3 to v4.4.5. The migration changes the name of the favicon. The migration guide consists of:
+
+- renaming the `favicon.ico` file to `favicon.png`.
+
+:::caution
+ - This migration guide skips v4.4.4, which introduced a problem in `koa/cors` due to a missing dependency update.
+:::
+
+## Upgrading the application dependencies
+
+:::prerequisites
+Stop the server before starting the upgrade.
+:::
+
+1. Upgrade all of the Strapi packages in `package.json` to `4.4.5`:
+
+```json
+// path: package.json
+
+{
+  // ...
+  "dependencies": {
+    "@strapi/strapi": "4.4.5",
+    "@strapi/plugin-users-permissions": "4.4.5",
+    "@strapi/plugin-i18n": "4.4.5",
+    // ...
+  }
+}
+```
+
+2. Replace the existing `favicon.ico` with [`favicon.png`](https://user-images.githubusercontent.com/8593673/198366643-7261700d-c8c4-4ebb-83c8-792a330ab4a5.png):
+
+3. Save the edited `package.json` file.
+
+4. Run either `yarn` or `npm install` to install the new version.
+
+::: tip
+If the operation doesn't work, try removing your `yarn.lock` or `package-lock.json`. If that doesn't help, remove the `node_modules` folder as well and try again.
+:::
+
+!!!include(developer-docs/latest/update-migration-guides/migration-guides/v4/snippets/Rebuild-and-start-snippet.md)!!!

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/v4/migration-guide-4.4.3-to-4.4.5.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/v4/migration-guide-4.4.3-to-4.4.5.md
@@ -9,7 +9,7 @@ canonicalUrl: https://docs.strapi.io/developer-docs/latest/update-migration-guid
 The Strapi v4.4.3 to v4.4.5 migration guide upgrades v4.4.3 to v4.4.5. The migration changes the name of the favicon from `favicon.ico` to `favicon.png`.
 
 :::caution
- - This migration guide skips v4.4.4, which introduced a problem in `koa/cors` due to a missing dependency update.
+This migration guide skips v4.4.4, which introduced a problem in `koa/cors` due to a missing dependency update.
 :::
 
 ## Upgrading the application dependencies


### PR DESCRIPTION
### What does it do?

Adds a new migration guide for `@strapi/strapi@4.4.5`, which contains a breaking change.

### Why is it needed?

Several users reported https://github.com/strapi/strapi/issues/14693 which was introduced in https://github.com/strapi/strapi/pull/14655 and seems to be a breaking change.

https://github.com/strapi/strapi/pull/14736 will make it non-breaking for the next minor release, but it should still be added to the migration guide.

### Related issue(s)/PR(s)

- Refs https://github.com/strapi/strapi/issues/14693
