### PR TITLE
Fixes in doc for building prod images

### DIFF
--- a/docs/developer-docs/latest/setup-deployment-guides/installation/docker.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/installation/docker.md
@@ -333,7 +333,7 @@ The following `Dockerfile` can be used to build a production Docker image for a 
 
 FROM node:16-alpine as build
 # Installing libvips-dev for sharp Compatibility
-RUN apk update && apk add build-base gcc autoconf automake zlib-dev libpng-dev vips-dev && rm -rf /var/cache/apk/* > /dev/null 2>&1
+RUN apk update && apk add --no-cache build-base gcc autoconf automake zlib-dev libpng-dev vips-dev > /dev/null 2>&1
 ARG NODE_ENV=production
 ENV NODE_ENV=${NODE_ENV}
 WORKDIR /opt/
@@ -346,13 +346,12 @@ RUN yarn build
 
 
 FROM node:16-alpine
-RUN apk add vips-dev
-RUN rm -rf /var/cache/apk/*
+RUN apk add --no-cache vips-dev
 ARG NODE_ENV=production
 ENV NODE_ENV=${NODE_ENV}
 WORKDIR /opt/app
 COPY --from=build /opt/node_modules ./node_modules
-ENV PATH /opt/node_modules/.bin:$PATH
+ENV PATH /opt/app/node_modules/.bin:$PATH
 COPY --from=build /opt/app ./
 EXPOSE 1337
 CMD ["yarn", "start"]


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

It fixes problems with the documentation for building production images:

- In the final image, removal of apk cache was done in a separate `RUN`. This creates a new layer, so the image size isn't reduced as expected. It's better to use the `--no-cache` flag
- The PATH on the final image was incorrect

### Why is it needed?

Because images built by following the documentation will be smaller, and utilities in the `/opt/app/node_modules/.bin` directory will be easily accessible, without having to type the full path

### Related issue(s)/PR(s)

None
