### PR TITLE
Edit wrong title of migration-guide-4.4.3-to-4.4.5.md

### DIFF
--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/v4/migration-guide-4.4.3-to-4.4.5.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/v4/migration-guide-4.4.3-to-4.4.5.md
@@ -1,5 +1,5 @@
 ---
-title: Migrate from 4.4.3 to 4.3.5 - Strapi Developer Docs
+title: Migrate from 4.4.3 to 4.4.5 - Strapi Developer Docs
 description: Learn how you can migrate your Strapi application from 4.4.3 to 4.4.5.
 canonicalUrl: https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/v4/migration-guide-4.4.3-to-4.4.5.html
 ---


### PR DESCRIPTION


<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

Just edit the "4.3.5" in title to "4.4.5" since it's the migration guide for 4.4.5 not 4.3.5 .

### Why is it needed?

Make sure the title match the content.

### Related issue(s)/PR(s)

N/A
