### PR TITLE
Migration guide for removing relationship duplicates

### DIFF
--- a/docs/developer-docs/latest/update-migration-guides/migration-guides.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides.md
@@ -21,7 +21,7 @@ Migrations are necessary when upgrades to Strapi include breaking changes. The m
 - [Migration guide from 4.2.x to 4.3.x](migration-guides/v4/migration-guide-4.2.x-to-4.3.x.md)
 - [Migration guide from 4.3.6 to 4.3.8](migration-guides/v4/migration-guide-4.3.6-to-4.3.8.md)
 - [Migration guide from 4.4.3 to 4.4.5](migration-guides/v4/migration-guide-4.4.3-to-4.4.5.md)
-- [Migration guide from 4.5.0 to 4.5.1](migration-guides/v4/migration-guide-4.4.5-to-4.5.1.md)
+- [Migration guide from 4.4.5 to 4.5.1](migration-guides/v4/migration-guide-4.4.5-to-4.5.1.md)
 
 ## v3 to v4 migration guides
 

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides.md
@@ -10,7 +10,7 @@ sidebarDepth: 0
 Migrations are necessary when upgrades to Strapi include breaking changes. The migration guides are sequential, meaning if there is more than 1 migration guide between your current version and the latest release, follow each guide in order. If there is no specific migration guide between your current version and the latest release follow the [Update Strapi guide](update-version.md).
 
 :::caution
- [Plugins extension](/developer-docs/latest/plugins/users-permissions.md) that create custom code or modify existing code will need to be updated and compared to the changes in the repository. Not updating the plugin extensions could break the application.
+[Plugins extension](/developer-docs/latest/plugins/users-permissions.md) that create custom code or modify existing code will need to be updated and compared to the changes in the repository. Not updating the plugin extensions could break the application.
 :::
 
 ## v4 migration guides
@@ -21,10 +21,11 @@ Migrations are necessary when upgrades to Strapi include breaking changes. The m
 - [Migration guide from 4.2.x to 4.3.x](migration-guides/v4/migration-guide-4.2.x-to-4.3.x.md)
 - [Migration guide from 4.3.6 to 4.3.8](migration-guides/v4/migration-guide-4.3.6-to-4.3.8.md)
 - [Migration guide from 4.4.3 to 4.4.5](migration-guides/v4/migration-guide-4.4.3-to-4.4.5.md)
+- [Migration guide from 4.5.0 to 4.5.1](migration-guides/v4/migration-guide-4.5.0-to-4.5.1.md)
 
 ## v3 to v4 migration guides
 
-::: callout 🚧  Migration guides
+::: callout 🚧 Migration guides
 This section is still a work in progress and will continue to be updated and improved. In the meantime, feel free to ask for help on the [forum](https://forum.strapi.io/) or on the community [Discord](https://discord.strapi.io).
 :::
 

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides.md
@@ -21,7 +21,7 @@ Migrations are necessary when upgrades to Strapi include breaking changes. The m
 - [Migration guide from 4.2.x to 4.3.x](migration-guides/v4/migration-guide-4.2.x-to-4.3.x.md)
 - [Migration guide from 4.3.6 to 4.3.8](migration-guides/v4/migration-guide-4.3.6-to-4.3.8.md)
 - [Migration guide from 4.4.3 to 4.4.5](migration-guides/v4/migration-guide-4.4.3-to-4.4.5.md)
-- [Migration guide from 4.5.0 to 4.5.1](migration-guides/v4/migration-guide-4.5.0-to-4.5.1.md)
+- [Migration guide from 4.5.0 to 4.5.1](migration-guides/v4/migration-guide-4.4.5-to-4.5.1.md)
 
 ## v3 to v4 migration guides
 

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/v4/migration-guide-4.4.5-to-4.5.1.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/v4/migration-guide-4.4.5-to-4.5.1.md
@@ -93,7 +93,7 @@ async function up(trx) {
 
   // Remove duplicates from link tables
   for (const table of linkTablesToUpdate) {
-    const tableExists = await strapi.db.getSchemaConnection().hasTable(table.name);
+    const tableExists = await trx.schema.hasTable(table.name);
     if (!tableExists) continue;
 
     strapi.log.info(`Deleting duplicates of table ${table.name}...`);

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/v4/migration-guide-4.4.5-to-4.5.1.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/v4/migration-guide-4.4.5-to-4.5.1.md
@@ -55,7 +55,7 @@ error: alter table <SOME_TABLE> add constraint <SOME_TABLE_INDEX>
 unique (<COLUMN_NAME>, <COLUMN_NAME>) - could not create unique index <SOME_TABLE>
 ```
 
-To remove the duplicated relationships easily, the following migration script file was created. It will automatically removes duplicates of any relationship in the database and will be executed only once at the next launch of Strapi.
+To remove the duplicated relationships easily, the following migration script file was created. It will automatically remove duplicates of any relationship in the database and will be executed only once at the next launch of Strapi.
 
 To run the migration:
 

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/v4/migration-guide-4.4.5-to-4.5.1.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/v4/migration-guide-4.4.5-to-4.5.1.md
@@ -57,7 +57,7 @@ unique (<COLUMN_NAME>, <COLUMN_NAME>) - could not create unique index <SOME_TABL
 
 To remove the duplicated relationships easily, the following migration script file was created. It will automatically remove duplicates of any relationship in the database and will be executed only once at the next launch of Strapi.
 
-To run the migration:
+To prepare the migration:
 
 1. Make a backup of the database in case something unexpected happens.
 2. In the `./database/migrations` folder, create a file named `2022.11.16T00.00.00.remove_duplicated_relationships.js`.

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/v4/migration-guide-4.4.5-to-4.5.1.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/v4/migration-guide-4.4.5-to-4.5.1.md
@@ -6,11 +6,11 @@ canonicalUrl: https://docs.strapi.io/developer-docs/latest/update-migration-guid
 
 # v4.4.5 to v4.5.1 migration guide
 
-The Strapi v4.4.5 to v4.5.1 migration guide upgrades v4.4.5 to v4.5.1. We introduced unique indices on relationships tables and the application will not start if there are duplicated relationships. The migration guide consists of:
+The Strapi v4.4.5 to v4.5.1 migration guide upgrades v4.4.5 to v4.5.1. We introduced unique indexes on relationship tables and the application will not start if there are duplicated relationships. The migration guide consists of:
 
-- Upgrading the application dependencies,
+- Upgrading the application dependencies
 - Installing database migration script (optional)
-- Reinitializing the application.
+- Reinitializing the application
 
 <!-- TODO: explain what the migration focuses on (i.e. what breaking changes it fixes). -->
 

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/v4/migration-guide-4.4.5-to-4.5.1.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/v4/migration-guide-4.4.5-to-4.5.1.md
@@ -1,12 +1,12 @@
 ---
-title: Migrate from 4.5.0 to 4.5.1 - Strapi Developer Docs
-description: Learn how you can migrate your Strapi application from 4.5.0 to 4.5.1.
-canonicalUrl: https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/v4/migration-guide-4.5.0-to-4.5.1.html
+title: Migrate from 4.4.5 to 4.5.1 - Strapi Developer Docs
+description: Learn how you can migrate your Strapi application from 4.4.5 to 4.5.1.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/v4/migration-guide-4.4.5-to-4.5.1.html
 ---
 
-# v4.5.0 to v4.5.1 migration guide
+# v4.4.5 to v4.5.1 migration guide
 
-The Strapi v4.5.0 to v4.5.1 migration guide upgrades v4.5.0 to v4.5.1. We introduced unique indices on relationships tables and the application will not start if there are duplicated relationships. The migration guide consists of:
+The Strapi v4.4.5 to v4.5.1 migration guide upgrades v4.4.5 to v4.5.1. We introduced unique indices on relationships tables and the application will not start if there are duplicated relationships. The migration guide consists of:
 
 - Upgrading the application dependencies,
 - Installing database migration script (optional)

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/v4/migration-guide-4.4.5-to-4.5.1.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/v4/migration-guide-4.4.5-to-4.5.1.md
@@ -55,7 +55,7 @@ error: alter table <SOME_TABLE> add constraint <SOME_TABLE_INDEX>
 unique (<COLUMN_NAME>, <COLUMN_NAME>) - could not create unique index <SOME_TABLE>
 ```
 
-To remove the duplicated relationships easily, the following migration script file was created. To use it, it has to be added added to `./database/migrations`. The script automatically removes duplicates of any relationship in the database. The script will be automatically executed only once at the next launch of Strapi.
+To remove the duplicated relationships easily, the following migration script file was created. It will automatically removes duplicates of any relationship in the database and will be executed only once at the next launch of Strapi.
 
 To run the migration:
 

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/v4/migration-guide-4.5.0-to-4.5.1.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/v4/migration-guide-4.5.0-to-4.5.1.md
@@ -93,6 +93,9 @@ async function up(trx) {
 
   // Remove duplicates from link tables
   for (const table of linkTablesToUpdate) {
+    const tableExists = await strapi.db.getSchemaConnection().hasTable(table.name);
+    if (!tableExists) continue;
+
     strapi.log.info(`Deleting duplicates of table ${table.name}...`);
 
     try {

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/v4/migration-guide-4.5.0-to-4.5.1.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/v4/migration-guide-4.5.0-to-4.5.1.md
@@ -1,0 +1,51 @@
+---
+title: Migrate from 4.5.0 to 4.5.1 - Strapi Developer Docs
+description: Learn how you can migrate your Strapi application from 4.5.0 to 4.5.1.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/v4/migration-guide-4.5.0-to-4.5.1.html
+---
+
+# v4.5.0 to v4.5.1 migration guide
+
+The Strapi v4.5.0 to v4.5.1 migration guide upgrades v4.5.0 to v4.5.1. The migration … 
+
+<!-- TODO: explain what the migration focuses on (i.e. what breaking changes it fixes). -->
+
+## Upgrading the application dependencies
+
+:::prerequisites
+Stop the server before starting the upgrade.
+:::
+
+<!-- TODO: update version numbers below 👇 -->
+1. Upgrade all of the Strapi packages in `package.json` to `4.5.1`:
+
+    ```json
+    // path: package.json
+
+    {
+      // ...
+      "dependencies": {
+        "@strapi/strapi": "4.5.1",
+        "@strapi/plugin-users-permissions": "4.5.1",
+        "@strapi/plugin-i18n": "4.5.1",
+        // ...
+      }
+    }
+    ```
+
+2. Save the edited `package.json` file.
+
+<!-- TODO: add additional steps if required -->
+3. …
+
+4. Run either `yarn` or `npm install` to install the new version.
+
+::: tip
+If the operation doesn't work, try removing your `yarn.lock` or `package-lock.json`. If that doesn't help, remove the `node_modules` folder as well and try again.
+:::
+
+## Fixing the breaking changes
+
+<!-- TODO: complete this part -->
+
+!!!include(developer-docs/latest/update-migration-guides/migration-guides/v4/snippets/Rebuild-and-start-snippet.md)!!!

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/v4/migration-guide-4.5.0-to-4.5.1.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/v4/migration-guide-4.5.0-to-4.5.1.md
@@ -40,11 +40,7 @@ Stop the server before starting the upgrade.
 
 2. Save the edited `package.json` file.
 
-<!-- TODO: add additional steps if required -->
-
-3. …
-
-4. Run either `yarn` or `npm install` to install the new version.
+3. Run either `yarn` or `npm install` to install the new version.
 
 ::: tip
 If the operation doesn't work, try removing your `yarn.lock` or `package-lock.json`. If that doesn't help, remove the `node_modules` folder as well and try again.
@@ -55,8 +51,8 @@ If the operation doesn't work, try removing your `yarn.lock` or `package-lock.js
 This step is only required if you have relationship duplicates in your application. If you have them, the application will not start and you will see an error message in the terminal similar to:
 
 ```
-error: alter table <SOME_TABLE> add constraint <SOME_TABLE_INDEX> unique (<COLUMN_NAME>, <COLUMN_NAME>) - could not create unique index <SOME_TABLE>
-
+error: alter table <SOME_TABLE> add constraint <SOME_TABLE_INDEX>
+unique (<COLUMN_NAME>, <COLUMN_NAME>) - could not create unique index <SOME_TABLE>
 ```
 
 To remove the duplicated relationships, the following migration script file must be added to `./database/migrations`. The script automatically removes duplicates from any relationship in your database. The script will be automatically executed only once at the next launch of Strapi.
@@ -102,7 +98,8 @@ async function up(trx) {
     try {
       // Query to delete duplicates from a link table
       let query = `
-        CREATE TEMPORARY TABLE tmp as SELECT DISTINCT t2.id as id FROM ?? as t1 JOIN ?? as t2
+        CREATE TEMPORARY TABLE tmp as SELECT DISTINCT t2.id as id 
+        FROM ?? as t1 JOIN ?? as t2
         ON t1.id < t2.id
       `;
       const pivotWhereParams = [];

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/v4/migration-guide-4.5.0-to-4.5.1.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/v4/migration-guide-4.5.0-to-4.5.1.md
@@ -55,7 +55,7 @@ error: alter table <SOME_TABLE> add constraint <SOME_TABLE_INDEX>
 unique (<COLUMN_NAME>, <COLUMN_NAME>) - could not create unique index <SOME_TABLE>
 ```
 
-To remove the duplicated relationships, the following migration script file must be added to `./database/migrations`. The script automatically removes duplicates from any relationship in your database. The script will be automatically executed only once at the next launch of Strapi.
+To remove the duplicated relationships, the following migration script file must be added to `./database/migrations`. The script automatically removes duplicates of any relationship in your database. The script will be automatically executed only once at the next launch of Strapi.
 
 To add the script:
 

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/v4/migration-guide-4.5.0-to-4.5.1.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/v4/migration-guide-4.5.0-to-4.5.1.md
@@ -6,7 +6,7 @@ canonicalUrl: https://docs.strapi.io/developer-docs/latest/update-migration-guid
 
 # v4.5.0 to v4.5.1 migration guide
 
-The Strapi v4.5.0 to v4.5.1 migration guide upgrades v4.5.0 to v4.5.1. We introduced unique indices on relationships tables and the application will not start if it has duplicates. The migration guide consists of:
+The Strapi v4.5.0 to v4.5.1 migration guide upgrades v4.5.0 to v4.5.1. We introduced unique indices on relationships tables and the application will not start if there are duplicated relationships. The migration guide consists of:
 
 - Upgrading the application dependencies,
 - Installing database migration script (optional)


### PR DESCRIPTION
This adds a migration guide to handle the MySQL 8 fix to be shipped with Strapi v4.5.1