### PR TITLE
Docusaurus: Improve nested tabs look & feel

### DIFF
--- a/docusaurus/src/css/custom.css
+++ b/docusaurus/src/css/custom.css
@@ -9,6 +9,7 @@
 @import './admonitions.css';
 @import './navigation.css';
 @import './api-calls.css';
+@import './tabs.css';
 
 /**
  * Quick & easy theme improvements

--- a/docusaurus/src/css/tabs.css
+++ b/docusaurus/src/css/tabs.css
@@ -1,0 +1,15 @@
+.tabs-container .tabs-container .tabs__item {
+  font-size: .8rem;
+  padding-top: .5rem;
+  padding-bottom: .5rem;
+}
+
+.tabs-container .tabs-container .tabs__item.tabs__item--active {
+  background-color: var(--ifm-hover-overlay);
+  border-bottom: none;
+}
+
+/* Remove styling of a built-in div added by Docusaurus when we have nested tabs */
+.tabs-container .tabs-container .margin-top--md {
+  margin-top: 0 !important;
+}


### PR DESCRIPTION
Because Docusaurus does not have "code groups" like [VuePress does](https://vuepress.vuejs.org/theme/default-theme-config.html#code-groups-and-code-blocks), nested tabs look exactly like regular tabs. 
So I tweaked the CSS a bit. 

Before:

https://user-images.githubusercontent.com/4233866/204869344-fba96d99-191b-406f-87ad-c69d79129609.mov

After:
- light mode:

https://user-images.githubusercontent.com/4233866/204869418-0ff9625b-1693-4b0c-be43-f3e2b072fcbf.mov

- dark mode:

https://user-images.githubusercontent.com/4233866/204869502-c703a73b-8cf6-4653-b059-2c04c47ff49c.mov

