### PR TITLE
Fix improperly rendered code block in routes documentation

### DIFF
--- a/docs/developer-docs/latest/development/backend-customization/routes.md
+++ b/docs/developer-docs/latest/development/backend-customization/routes.md
@@ -206,7 +206,7 @@ module.exports = {
 <code-block title=TYPESCRIPT>
 
 ```js
-// path: ./src/api/restaurant/routes/custom-restaurant.ts
+// path: ./src/api/restaurant/routes/01-custom-restaurant.ts
 
 export default {
   routes: [

--- a/docs/developer-docs/latest/development/backend-customization/routes.md
+++ b/docs/developer-docs/latest/development/backend-customization/routes.md
@@ -178,6 +178,10 @@ Routes files are loaded in alphabetical order. To load custom routes before core
 
 In the following example, the custom routes file name is prefixed with `01-` to make sure the route is reached before the core routes.
 
+<code-group>
+
+<code-block title="JAVASCRIPT">
+
 ```js
 // path: ./src/api/restaurant/routes/01-custom-restaurant.js
 


### PR DESCRIPTION
I was wondering why we had only one code block rendered in this section while the raw Markdown clearly shows 2 code examples (JS and TS). (see screenshot, found in the details block right above the [Configuration](https://docs.strapi.io/developer-docs/latest/development/backend-customization/routes.html#configuration) heading) Turns out we forgot the opening tag 😅 This fixes it.

Plus, I think we need to add the `01-` prefix to the file path in the TypeScript code block as well.
![Screenshot 2022-11-30 at 18 51 12](https://user-images.githubusercontent.com/4233866/204871514-60211563-aceb-44f5-b215-bf9a9e0b54ca.png)


***
Note: Added to the (already closed) 4.5.3 milestone as I'll publish this hot fix as soon as ready.