### PR TITLE
Update the Node.js version to 14.x

### DIFF
--- a/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/azure.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/azure.md
@@ -331,7 +331,7 @@ sudo apt install libpng-dev build-essential -y
 For Node.js it is recommended you use the [official source](https://github.com/nodesource/distributions/blob/master/README.md#debinstall), per the instructions we will use the following commands:
 
 ```bash
-curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
+curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash -
 sudo apt install nodejs -y
 ```
 


### PR DESCRIPTION
Update the Node.js version to 14.x as the 12.x is not supported by Strapi

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

Update the Node.js version to 14.x as the 12.x is not supported by Strapi

### Why is it needed?

The current version of Strapi 4.x does not run on top of Node 12.x 

### Related issue(s)/PR(s)

None
