### PR TITLE
Relations reordering: Dev docs updates

### DIFF
--- a/docs/.vuepress/config/sidebar-developer.js
+++ b/docs/.vuepress/config/sidebar-developer.js
@@ -242,6 +242,7 @@ const developer = [
               ],
             ]
           },
+          ['/developer-docs/latest/developer-resources/database-apis-reference/rest/relations.html', 'Relations']
         ],
       },
       [

--- a/docs/developer-docs/latest/developer-resources/database-apis-reference/rest-api.md
+++ b/docs/developer-docs/latest/developer-resources/database-apis-reference/rest-api.md
@@ -265,6 +265,10 @@ If the [Internationalization (i18n) plugin](/developer-docs/latest/plugins/i18n.
 
 ::::
 
+:::note
+While creating an entry, you can define its relations and their order (see [Managing relations through the REST API](/developer-docs/latest/developer-resources/database-apis-reference/rest/relations.md) for more details).
+:::
+
 ### Update an entry
 
 Partially updates an entry by `id` and returns its value.
@@ -304,8 +308,9 @@ Fields that aren't sent in the query are not changed in the database. Send a `nu
 
 ::::
 
-:::note
-Even with the [Internationalization (i18n) plugin](/developer-docs/latest/plugins/i18n.md) installed, it's currently not possible to [update the locale of an entry](/developer-docs/latest/plugins/i18n.md#updating-an-entry).
+:::note NOTES
+* Even with the [Internationalization (i18n) plugin](/developer-docs/latest/plugins/i18n.md) installed, it's currently not possible to [update the locale of an entry](/developer-docs/latest/plugins/i18n.md#updating-an-entry).
+* While updating an entry, you can define its relations and their order (see [Managing relations through the REST API](/developer-docs/latest/developer-resources/database-apis-reference/rest/relations.md) for more details).
 :::
 
 ### Delete an entry

--- a/docs/developer-docs/latest/developer-resources/database-apis-reference/rest/relations.md
+++ b/docs/developer-docs/latest/developer-resources/database-apis-reference/rest/relations.md
@@ -149,16 +149,16 @@ Sending the following example in the request body of a PUT or POST request updat
 categories: {
   connect: [
     // By default positional info will be end: true
-    { id: 6, position: { after: 1} },    // It should be after relation with id 1
-    { id: 7, position: { before: 2 }},   // It should be before relation with id 2
-    { id: 8, position: { end: true }},   // It should be at the end
-    { id: 9 },                           // It should also be at the end
-    { id: 10, position: { start: true }} // It should be at the start
+    { id: 6, position: { after: 1} },    // It will be after relation with id 1
+    { id: 7, position: { before: 2 }},   // It will be before relation with id 2
+    { id: 8, position: { end: true }},   // It will be at the end
+    { id: 9 },                           // It will also be at the end
+    { id: 10, position: { start: true }} // It will be at the start
   ]
 }
 ```
 
-The resulting database record could be the following:
+The resulting database record will be the following:
 
 ```json
 categories: [

--- a/docs/developer-docs/latest/developer-resources/database-apis-reference/rest/relations.md
+++ b/docs/developer-docs/latest/developer-resources/database-apis-reference/rest/relations.md
@@ -1,0 +1,229 @@
+---
+title: Reordering relations
+description: Use the REST API to manage the order of relations
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/rest/relations-reordering.html
+---
+
+# Managing relations through the REST API
+
+<!-- TODO: add link to user guide -->
+Relations between content-types can be managed through the [admin panel]() or through REST requests sent to the Content API.
+
+Relations can be added, updated, or removed through the Content API. The `connect`, `disconnect`, and `set` attributes, passed in the body of POST or PUT requests, have different behaviors:
+
+- `connect` and `disconnect` perform partial updates
+- `set` performs a full update, effectively replacing all existing relations
+
+Using the longhand syntax with `connect` allows adding [positional arguments](#longhand-syntax) to define an order for relations.
+
+```json
+/** 
+ * Partial update (will add/remove the specified relations)
+ */
+
+// Using the shorthand syntax
+{
+  data: {
+    categories: { connect: [2, 4], disconnect: [5] }
+  }
+}
+
+// Using the longhand syntax
+{
+  data: {
+    categories: { connect: [{ id: 2 }, { id: 4 }], disconnect: [{ id: 5 }] }
+  }
+}
+
+/**
+ * Full update (will delete all current relations and set those ones instead)
+ */
+
+// Using the shorthand syntax
+{
+  data: {
+    categories: { set: [2, 4] }
+  }
+}
+
+// Using the longhand syntax
+{
+  data: {
+    categories: { set: [{ id: 2 }, { id: 4 }] }
+  }
+}
+```
+
+## `connect`
+
+Using `connect` in the body of a request performs a partial update, adding specified relations.
+
+`connect` accepts either a shorthand or a longhand syntax.
+
+### Shorthand syntax
+
+With the shorthand syntax, pass an array of ids of relations to create.
+
+**Example:**
+
+Passing the following example of body request adds the `categories` entries with ids `2` and `4` to a content-type's relations:
+
+```json
+{
+  data: {
+    categories: { connect: [2, 4] }
+  }
+}
+```
+
+### Longhand syntax
+
+With the longhand syntax, you can pass optional positional arguments to define the order of relations.
+
+The longhand syntax accepts an array of objects, each object containing the `id` of the relation to be connected and an optional `position` object to define where to connect the relation.
+
+`position` accepts 4 different positional attributes:
+
+| Parameter name and syntax | Description |
+|---------------------------|-------------|
+| `before: id`              | Positions the relation before the given `id` |
+| `after: id`               | Positions the relation after the given `id` |
+| `start`                   | Positions the relation at the start of the existing list of relations. |
+| `end`                     | Positions the relation at the end of the existing list of relations. |
+
+The `position` argument is optional and defaults to `position: { end: true }`.
+
+:::note Sequential order
+Since `connect` is an array, the order of operations is important and connect operations will be treated sequentially (see elaborated example below).
+:::
+
+**Basic example:**
+
+Given the following record in the database:
+
+```json
+categories: [
+  { id: 1, order: 1 }
+  { id: 2, order: 2 }
+]
+```
+
+sending the following in the request body of a PUT or POST request will create a third relation of `id` `3` and position it before the relation with `id` `2`:
+
+```json
+categories: {
+  connect: [
+    { id: 3, position: { before: 2 } }, // It should be placed before relation id=2
+  ]
+}
+```
+
+**Combined example:**
+
+Sending the following example in the request body of a PUT or POST request updates multiple relations:
+
+```json
+categories: {
+  connect: [
+    // By default positional info will be end: true
+    { id: 6, position: { after: 1} },    // It should be after relation with id 1
+    { id: 7, position: { before: 2 }},   // It should be before relation with id 2
+    { id: 8, position: { end: true }},   // It should be at the end
+    { id: 9 },                           // It should also be at the end
+    { id: 10, position: { start: true }} // It should be at the start
+  ]
+}
+```
+
+The resulting database record could be the following:
+
+```json
+categories: [
+  { id: 10, order: 1},
+  { id: 1, order: 2},
+  { id: 6, order: 3},
+  { id: 7, order: 4},
+  { id: 2, order: 5},
+  { id: 8, order: 6},
+  { id: 9, order: 7}
+]
+```
+
+## `disconnect`
+
+Using `disconnect` in the body of a request performs a partial update, removing specified relations.
+
+`disconnect` accepts either a shorthand or a longhand syntax.
+
+### Shorthand syntax
+
+With the shorthand syntax, pass an array of ids of relations to be removed.
+
+**Example:**
+
+Passing the following example of a body request removes the categories with the id 4 from the content type's relations:
+
+```json
+categories: {
+  disconnect: [4]
+}
+```
+
+### Longhand syntax
+
+With the longhand syntax, pass an array of objects with the `id` property for each relation to remove.
+
+**Example:**
+
+Passing the following example of a body request removes the categories with the id 4 from the content type's relations:
+
+```json
+categories: {
+  disconnect: [
+    { id: 4 }
+  ]
+}
+```
+
+## `set`
+
+Using `set` performs a full update, replacing all existing relations with the ones specified, in the order specified.
+
+`set` accepts a shorthand or a longhand syntax.
+
+### Shorthand syntax
+
+With the shorthand syntax, pass an array of ids of relations to be set.
+
+**Example:**
+
+Passing the following example of a body request will override all existing relations previously defined for `categories` and replace them only with ids `2` and `4`:
+
+```json
+{
+  data: {
+    categories: { set: [2, 4] }
+  }
+}
+```
+
+### Longhand syntax
+
+With the longhand syntax, pass an array of objects with the `id` property for each relation to set.
+
+**Example:**
+
+Passing the following example of a body request will override all existing relations previously defined for `categories` and replace them only with ids `2` and `4`:
+
+```json
+{
+  data: {
+    categories: { 
+      set: [
+        { id: 2 },
+        { id: 4 }
+      ]
+    }
+  }
+}
+```

--- a/docs/developer-docs/latest/developer-resources/database-apis-reference/rest/relations.md
+++ b/docs/developer-docs/latest/developer-resources/database-apis-reference/rest/relations.md
@@ -23,14 +23,25 @@ Relations can be added, updated, or removed through the Content API. The `connec
 // Using the shorthand syntax
 {
   data: {
-    categories: { connect: [2, 4], disconnect: [5] }
+    categories: { 
+      connect: [2, 4],
+      disconnect: [5]
+    }
   }
 }
 
 // Using the longhand syntax
 {
   data: {
-    categories: { connect: [{ id: 2 }, { id: 4 }], disconnect: [{ id: 5 }] }
+    categories: { 
+      connect: [
+        { id: 2 },
+        { id: 4 }
+      ], 
+      disconnect: [
+        { id: 5 }
+      ]
+    }
   }
 }
 
@@ -48,7 +59,12 @@ Relations can be added, updated, or removed through the Content API. The `connec
 // Using the longhand syntax
 {
   data: {
-    categories: { set: [{ id: 2 }, { id: 4 }] }
+    categories: {
+      set: [
+        { id: 2 },
+        { id: 4 }
+      ]
+    }
   }
 }
 ```

--- a/docs/developer-docs/latest/developer-resources/database-apis-reference/rest/relations.md
+++ b/docs/developer-docs/latest/developer-resources/database-apis-reference/rest/relations.md
@@ -162,13 +162,13 @@ The resulting database record will be the following:
 
 ```json
 categories: [
-  { id: 10, order: 1},
-  { id: 1, order: 2},
-  { id: 6, order: 3},
-  { id: 7, order: 4},
-  { id: 2, order: 5},
-  { id: 8, order: 6},
-  { id: 9, order: 7}
+  { id: 10, order: 1 },
+  { id: 1, order: 2 },
+  { id: 6, order: 3 },
+  { id: 7, order: 4 },
+  { id: 2, order: 5 },
+  { id: 8, order: 6 },
+  { id: 9, order: 7 }
 ]
 ```
 

--- a/docs/developer-docs/latest/developer-resources/database-apis-reference/rest/relations.md
+++ b/docs/developer-docs/latest/developer-resources/database-apis-reference/rest/relations.md
@@ -6,8 +6,7 @@ canonicalUrl: https://docs.strapi.io/developer-docs/latest/developer-resources/d
 
 # Managing relations through the REST API
 
-<!-- TODO: add link to user guide -->
-Relations between content-types can be managed through the [admin panel]() or through REST requests sent to the Content API.
+Relations between content-types can be managed through the [admin panel](/user-docs/latest/content-manager/managing-relational-fields.md#managing-multiple-choices-relational-fields) or through REST requests sent to the Content API.
 
 Relations can be added, updated, or removed through the Content API. The `connect`, `disconnect`, and `set` attributes, passed in the body of POST or PUT requests, have different behaviors:
 

--- a/docs/developer-docs/latest/developer-resources/database-apis-reference/rest/relations.md
+++ b/docs/developer-docs/latest/developer-resources/database-apis-reference/rest/relations.md
@@ -6,7 +6,7 @@ canonicalUrl: https://docs.strapi.io/developer-docs/latest/developer-resources/d
 
 # Managing relations through the REST API <BetaBadge />
 
-Relations between content-types can be managed through the [admin panel](/user-docs/latest/content-manager/managing-relational-fields.md#managing-multiple-choices-relational-fields) or through REST requests sent to the Content API.
+Relations between content-types can be managed through the [admin panel](/user-docs/latest/content-manager/managing-relational-fields.md#managing-multiple-choices-relational-fields) or through [REST](/developer-docs/latest/developer-resources/database-apis-reference/rest-api.md) requests sent to the Content API.
 
 Relations can be added, updated, or removed through the Content API. The `connect`, `disconnect`, and `set` attributes, passed in the body of POST or PUT requests, have different behaviors:
 
@@ -46,8 +46,6 @@ Relations can be added, updated, or removed through the Content API. The `connec
 }
 
 /**
- * Full update (will delete all current relations and set those ones instead)
- */
 
 // Using the shorthand syntax
 {
@@ -56,7 +54,6 @@ Relations can be added, updated, or removed through the Content API. The `connec
   }
 }
 
-// Using the longhand syntax
 {
   data: {
     categories: {

--- a/docs/developer-docs/latest/developer-resources/database-apis-reference/rest/relations.md
+++ b/docs/developer-docs/latest/developer-resources/database-apis-reference/rest/relations.md
@@ -4,6 +4,14 @@ description: Use the REST API to manage the order of relations
 canonicalUrl: https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/rest/relations-reordering.html
 ---
 
+<style lang="scss" scoped>
+@media (min-width: 1536px) {
+  .custom-block.api-call > .response {
+    flex: 0 0 32%;
+  }
+}
+</style>
+
 # Managing relations through the REST API <BetaBadge />
 
 Relations between content-types can be managed through the [admin panel](/user-docs/latest/content-manager/managing-relational-fields.md#managing-multiple-choices-relational-fields) or through [REST](/developer-docs/latest/developer-resources/database-apis-reference/rest-api.md) requests sent to the Content API.

--- a/docs/developer-docs/latest/developer-resources/database-apis-reference/rest/relations.md
+++ b/docs/developer-docs/latest/developer-resources/database-apis-reference/rest/relations.md
@@ -13,6 +13,8 @@ Relations can be added, updated, or removed through the Content API. The `connec
 - `connect` and `disconnect` perform partial updates
 - `set` performs a full update, effectively replacing all existing relations
 
+`connect` and `disconnect` can be passed together while `set` should be used alone.
+
 ```json
 /** 
  * Partial update (will add/remove the specified relations)

--- a/docs/developer-docs/latest/developer-resources/database-apis-reference/rest/relations.md
+++ b/docs/developer-docs/latest/developer-resources/database-apis-reference/rest/relations.md
@@ -13,8 +13,6 @@ Relations can be added, updated, or removed through the Content API. The `connec
 - `connect` and `disconnect` perform partial updates
 - `set` performs a full update, effectively replacing all existing relations
 
-Using the longhand syntax with `connect` allows adding [positional arguments](#longhand-syntax) to define an order for relations.
-
 ```json
 /** 
  * Partial update (will add/remove the specified relations)
@@ -53,6 +51,8 @@ Using the longhand syntax with `connect` allows adding [positional arguments](#l
 }
 ```
 
+Using the longhand syntax with `connect` allows adding [positional arguments](#longhand-syntax) to define an order for relations.
+
 ## `connect`
 
 Using `connect` in the body of a request performs a partial update, adding specified relations.
@@ -85,18 +85,22 @@ The longhand syntax accepts an array of objects, each object containing the `id`
 
 | Parameter name and syntax | Description |
 |---------------------------|-------------|
-| `before: id`              | Positions the relation before the given `id` |
-| `after: id`               | Positions the relation after the given `id` |
+| `before: id`              | Positions the relation before the given `id`. |
+| `after: id`               | Positions the relation after the given `id`. |
 | `start`                   | Positions the relation at the start of the existing list of relations. |
 | `end`                     | Positions the relation at the end of the existing list of relations. |
 
 The `position` argument is optional and defaults to `position: { end: true }`.
 
 :::note Sequential order
-Since `connect` is an array, the order of operations is important and connect operations will be treated sequentially (see elaborated example below).
+Since `connect` is an array, the order of operations is important as they will be treated sequentially (see combined example below).
 :::
 
-**Basic example:**
+**Examples:**
+
+:::: tabs card
+
+::: tab Basic example
 
 Given the following record in the database:
 
@@ -117,7 +121,9 @@ categories: {
 }
 ```
 
-**Combined example:**
+:::
+
+::: tab Combined example
 
 Sending the following example in the request body of a PUT or POST request updates multiple relations:
 
@@ -148,6 +154,10 @@ categories: [
 ]
 ```
 
+:::
+
+::::
+
 ## `disconnect`
 
 Using `disconnect` in the body of a request performs a partial update, removing specified relations.
@@ -160,7 +170,7 @@ With the shorthand syntax, pass an array of ids of relations to be removed.
 
 **Example:**
 
-Passing the following example of a body request removes the categories with the id 4 from the content type's relations:
+Passing the following example of a body request removes the categories with `id` `4` from the content type's relations:
 
 ```json
 categories: {
@@ -196,7 +206,7 @@ With the shorthand syntax, pass an array of ids of relations to be set.
 
 **Example:**
 
-Passing the following example of a body request will override all existing relations previously defined for `categories` and replace them only with ids `2` and `4`:
+Passing the following example of a body request will override all existing relations previously defined for `categories` and replace them only with `id` `2` and `4`:
 
 ```json
 {
@@ -212,7 +222,7 @@ With the longhand syntax, pass an array of objects with the `id` property for ea
 
 **Example:**
 
-Passing the following example of a body request will override all existing relations previously defined for `categories` and replace them only with ids `2` and `4`:
+Passing the following example of a body request will override all existing relations previously defined for `categories` and replace them only with `id` `2` and `4`:
 
 ```json
 {

--- a/docs/developer-docs/latest/developer-resources/database-apis-reference/rest/relations.md
+++ b/docs/developer-docs/latest/developer-resources/database-apis-reference/rest/relations.md
@@ -111,7 +111,7 @@ categories: [
 ]
 ```
 
-sending the following in the request body of a PUT or POST request will create a third relation of `id` `3` and position it before the relation with `id` `2`:
+sending the following in the request body of a PUT or POST request creates a third relation of `id` `3` and position it before the relation with `id` `2`:
 
 ```json
 categories: {

--- a/docs/developer-docs/latest/developer-resources/database-apis-reference/rest/relations.md
+++ b/docs/developer-docs/latest/developer-resources/database-apis-reference/rest/relations.md
@@ -298,7 +298,7 @@ categories: {
 
 ::: tab Combined example
 
-Sending the following example in the request body of a PUT or POST request updates multiple relations:
+Sending the following example in the request body of a PUT request updates multiple relations:
 
 ```json
 categories: {

--- a/docs/developer-docs/latest/developer-resources/database-apis-reference/rest/relations.md
+++ b/docs/developer-docs/latest/developer-resources/database-apis-reference/rest/relations.md
@@ -4,7 +4,7 @@ description: Use the REST API to manage the order of relations
 canonicalUrl: https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/rest/relations-reordering.html
 ---
 
-# Managing relations through the REST API
+# Managing relations through the REST API <BetaBadge />
 
 Relations between content-types can be managed through the [admin panel](/user-docs/latest/content-manager/managing-relational-fields.md#managing-multiple-choices-relational-fields) or through REST requests sent to the Content API.
 

--- a/docs/developer-docs/latest/developer-resources/database-apis-reference/rest/relations.md
+++ b/docs/developer-docs/latest/developer-resources/database-apis-reference/rest/relations.md
@@ -207,11 +207,30 @@ Different syntaxes can be used and are detailed in the following recapitulative 
 :::::
 ::::::
 
+::: note
+
+- The syntaxes described in this documentation are specially made for one-to-many, many-to-many and many-ways relationships.
+- For one-to-one, many-to-one and one-way, the syntaxes are also supported but:
+  - Only the last relation will be used.
+  - A simpler format can also be used:
+
+    ```json
+    {
+      data: {
+        category: 2
+      }
+    }
+    ```
+
+:::
+
+
 ## `connect`
 
 Using `connect` in the body of a request performs a partial update, adding specified relations.
 
 `connect` accepts either a shorthand or a longhand syntax.
+
 
 ### Shorthand syntax
 

--- a/docs/developer-docs/latest/developer-resources/database-apis-reference/rest/relations.md
+++ b/docs/developer-docs/latest/developer-resources/database-apis-reference/rest/relations.md
@@ -120,7 +120,7 @@ Since `connect` is an array, the order of operations is important as they will b
 
 ::: tab Basic example
 
-Given the following record in the database:
+Consider the following record in the database:
 
 ```json
 categories: [
@@ -129,7 +129,7 @@ categories: [
 ]
 ```
 
-sending the following in the request body of a PUT or POST request creates a third relation of `id` `3` and position it before the relation with `id` `2`:
+Sending the following in the request body to update an entry creates a third relation of `id` `3` and position it before the relation with `id` `2`:
 
 ```json
 categories: {

--- a/docs/developer-docs/latest/developer-resources/database-apis-reference/rest/relations.md
+++ b/docs/developer-docs/latest/developer-resources/database-apis-reference/rest/relations.md
@@ -15,12 +15,18 @@ Relations can be added, updated, or removed through the Content API. The `connec
 
 `connect` and `disconnect` can be passed together while `set` should be used alone.
 
-```json
-/** 
- * Partial update (will add/remove the specified relations)
- */
+Different syntaxes can be used and are detailed in the following recapitulative examples and in the following sections. Using the longhand syntax with `connect` allows adding [positional arguments](#longhand-syntax) to define an order for relations.
 
-// Using the shorthand syntax
+:::::: tabs card
+
+::::: tab Partial update with connect & disconnect
+:::: api-call
+
+::: request Example request using the shorthand syntax
+
+`PUT http://localhost:1337/api/restaurants/1`
+
+```json
 {
   data: {
     categories: { 
@@ -29,8 +35,32 @@ Relations can be added, updated, or removed through the Content API. The `connec
     }
   }
 }
+```
 
-// Using the longhand syntax
+:::
+
+::: response Example response
+
+```json
+{
+  "data": {
+    "id": 1,
+    "attributes": {},
+    "meta": {}
+  },
+  "meta": {}
+}
+```
+
+::::
+
+:::: api-call
+
+::: request Example request using the longhand syntax
+
+`PUT http://localhost:1337/api/restaurants/1`
+
+```json
 {
   data: {
     categories: { 
@@ -44,16 +74,100 @@ Relations can be added, updated, or removed through the Content API. The `connec
     }
   }
 }
+```
 
-/**
+:::
 
-// Using the shorthand syntax
+::: response Example response
+
+```json
+{
+  "data": {
+    "id": 1,
+    "attributes": {},
+    "meta": {}
+  },
+  "meta": {}
+}
+```
+
+::::
+
+:::::
+
+::::: tab Full update with set
+
+:::: api-call
+
+::: request Example request using the shortest possible syntax
+
+`PUT http://localhost:1337/api/restaurants/1`
+
+```json
 {
   data: {
-    categories: { set: [2, 4] }
+    categories: [2, 4]
   }
 }
+```
 
+:::
+
+::: response Example response
+
+```json
+{
+  "data": {
+    "id": 1,
+    "attributes": {},
+    "meta": {}
+  },
+  "meta": {}
+}
+```
+
+::::
+
+:::: api-call
+
+::: request Example request using the shorthand syntax
+
+`PUT http://localhost:1337/api/restaurants/1`
+
+```json
+{
+  data: {
+    categories: {
+      set: [2, 4]
+    }
+  }
+}
+```
+
+:::
+
+::: response Example response
+
+```json
+{
+  "data": {
+    "id": 1,
+    "attributes": {},
+    "meta": {}
+  },
+  "meta": {}
+}
+```
+
+::::
+
+:::: api-call
+
+::: request Example request using the longhand syntax
+
+`PUT http://localhost:1337/api/restaurants/1`
+
+```json
 {
   data: {
     categories: {
@@ -66,7 +180,24 @@ Relations can be added, updated, or removed through the Content API. The `connec
 }
 ```
 
-Using the longhand syntax with `connect` allows adding [positional arguments](#longhand-syntax) to define an order for relations.
+:::
+
+::: response Example response
+
+```json
+{
+  "data": {
+    "id": 1,
+    "attributes": {},
+    "meta": {}
+  },
+  "meta": {}
+}
+```
+
+::::
+:::::
+::::::
 
 ## `connect`
 

--- a/docs/developer-docs/latest/developer-resources/database-apis-reference/rest/relations.md
+++ b/docs/developer-docs/latest/developer-resources/database-apis-reference/rest/relations.md
@@ -101,12 +101,12 @@ The longhand syntax accepts an array of objects, each object containing the `id`
 
 `position` accepts 4 different positional attributes:
 
-| Parameter name and syntax | Description |
-|---------------------------|-------------|
-| `before: id`              | Positions the relation before the given `id`. |
-| `after: id`               | Positions the relation after the given `id`. |
-| `start`                   | Positions the relation at the start of the existing list of relations. |
-| `end`                     | Positions the relation at the end of the existing list of relations. |
+| Parameter name and syntax | Description | Type |
+|---------------------------|-------------|------|
+| `before: id`              | Positions the relation before the given `id`. | `id` is an entry id |
+| `after: id`               | Positions the relation after the given `id`. | `id` is an entry id |
+| `start`                   | Positions the relation at the start of the existing list of relations. | Boolean |
+| `end`                     | Positions the relation at the end of the existing list of relations. | Boolean |
 
 The `position` argument is optional and defaults to `position: { end: true }`.
 

--- a/docs/developer-docs/latest/developer-resources/database-apis-reference/rest/relations.md
+++ b/docs/developer-docs/latest/developer-resources/database-apis-reference/rest/relations.md
@@ -298,6 +298,15 @@ categories: {
 
 ::: tab Combined example
 
+Consider the following record in the database:
+
+```json
+categories: [
+  { id: 1, order: 1 }
+  { id: 2, order: 2 }
+]
+```
+
 Sending the following example in the request body of a PUT request updates multiple relations:
 
 ```json

--- a/docs/developer-docs/latest/developer-resources/database-apis-reference/rest/relations.md
+++ b/docs/developer-docs/latest/developer-resources/database-apis-reference/rest/relations.md
@@ -289,7 +289,7 @@ Sending the following in the request body to update an entry creates a third rel
 ```json
 categories: {
   connect: [
-    { id: 3, position: { before: 2 } }, // It should be placed before relation id=2
+    { id: 3, position: { before: 2 } }, // It will be placed before relation id=2
   ]
 }
 ```


### PR DESCRIPTION
- Creates a new page in the REST API documentation to explain how relations can be defined and ordered through the REST API.
- Mentions this page in the API endpoints page