### PR TITLE
Add 4.5.1 migration preparation step

### DIFF
--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/v4/migration-guide-4.4.5-to-4.5.1.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/v4/migration-guide-4.4.5-to-4.5.1.md
@@ -60,7 +60,7 @@ To remove the duplicated relationships easily, the following migration script fi
 To prepare the migration:
 
 1. Make a backup of the database in case something unexpected happens.
-2. Make sure you are migrating from a version greater than or equal to 4.4.5. If not please migrate to that version first, else this script will not work.
+2. Make sure you are migrating from a version greater than or equal to 4.4.5. If not, please migrate to the 4.4.5 version first, else this script will not work.
 3. In the `./database/migrations` folder, create a file named `2022.11.16T00.00.00.remove_duplicated_relationships.js`.
 4. Copy and paste the following code into the previously created file:
 

--- a/docs/developer-docs/latest/update-migration-guides/migration-guides/v4/migration-guide-4.4.5-to-4.5.1.md
+++ b/docs/developer-docs/latest/update-migration-guides/migration-guides/v4/migration-guide-4.4.5-to-4.5.1.md
@@ -60,8 +60,9 @@ To remove the duplicated relationships easily, the following migration script fi
 To prepare the migration:
 
 1. Make a backup of the database in case something unexpected happens.
-2. In the `./database/migrations` folder, create a file named `2022.11.16T00.00.00.remove_duplicated_relationships.js`.
-3. Copy and paste the following code into the previously created file:
+2. Make sure you are migrating from a version greater than or equal to 4.4.5. If not please migrate to that version first, else this script will not work.
+3. In the `./database/migrations` folder, create a file named `2022.11.16T00.00.00.remove_duplicated_relationships.js`.
+4. Copy and paste the following code into the previously created file:
 
 ```jsx
 'use strict';


### PR DESCRIPTION
### What does it do?

As specified in the migration document name (v4.4.5 to v4.5.1 migration guide), The 4.5.X migration script is supposed to work when the app is migrating from versions older than 4.4.X. 

Some users were updating from older versions and having errors that were not pointing to what the problem was.
https://github.com/strapi/strapi/issues/14978

I did not find a way to look at which version the user is updating, so I think the best solution is to explain this in the migration preparation steps.

### Why is it needed?

So users know they have to update from versions older than 4.4.X.

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/14978
