### PR TITLE
Fix sentry plugin frontmatter

### DIFF
--- a/docs/developer-docs/latest/plugins/sentry.md
+++ b/docs/developer-docs/latest/plugins/sentry.md
@@ -1,7 +1,7 @@
 ---
 title: Sentry - Strapi Developer Docs
-description: Send email from your server or externals providers.
-canonicalUrl: https://docs.strapi.io/developer-docs/latest/plugins/email.html
+description: Track errors in your Strapi application.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/plugins/sentry.html
 ---
 
 # Sentry


### PR DESCRIPTION
This PR fixes the canonical URL and description for the Sentry plugin.  