### PR TITLE
user-permissions plugin: document how to add Patreon as an Oauth prov…

### DIFF
--- a/docs/developer-docs/latest/plugins/users-permissions.md
+++ b/docs/developer-docs/latest/plugins/users-permissions.md
@@ -786,6 +786,45 @@ The use of `ngrok` is not needed.
 
 :::
 
+::: tab Patreon
+
+#### Using ngrok
+
+Patreon does not accept `localhost` urls. <br>
+Use `ngrok` to serve the backend app.
+
+```
+ngrok http 1337
+```
+
+Don't forget to update the server url in the backend config file `config/server.js` and the server url in your frontend app (environment variable `REACT_APP_BACKEND_URL` if you use [react login example app](https://github.com/strapi/strapi-examples/tree/master/login-react)) with the generated ngrok url.
+
+#### Patreon configuration
+
+- You must be a Patreon Creator in order to register an Oauth client.
+- Go to the [Patreon developer portal](https://www.patreon.com/portal)
+- Click on [Clients & API Keys](https://www.patreon.com/portal/registration/register-clients)
+- Click on "Create Client"
+- Enter the details of your organisation and website.
+- There is a drop-down for "App Category" but no explanation of what the different categories mean.
+"Community" seems to work fine. 
+- You can choose either version 1 or version 2 of the API - neither are actively developed.
+Version 2 is probably the best choice. See their 
+[developer docs](https://docs.patreon.com/#introduction) for more detail.
+- Under "Redirect URI's" enter `https://your-site.com/api/connect/patreon/callback`
+- Save the client details and you will then see the Client ID and Client Secret.
+
+#### Strapi configuration
+
+- Visit the User Permissions provider settings page <br> [http://localhost:1337/admin/settings/users-permissions/providers](http://localhost:1337/admin/settings/users-permissions/providers)
+- Click on the **Patreon** provider
+- Fill the information:
+  - Enable: `ON`
+  - Client ID: `<Your Patreon Client ID>` - as above
+  - Client Secret: `<Your Patreon Client Secret>` - as above
+
+:::
+
 ::::
 
 Your configuration is done.

--- a/docs/developer-docs/latest/plugins/users-permissions.md
+++ b/docs/developer-docs/latest/plugins/users-permissions.md
@@ -797,7 +797,7 @@ Use `ngrok` to serve the backend app.
 ngrok http 1337
 ```
 
-Don't forget to update the server url in the backend config file `config/server.js` and the server url in your frontend app (environment variable `REACT_APP_BACKEND_URL` if you use [react login example app](https://github.com/strapi/strapi-examples/tree/master/login-react)) with the generated ngrok url.
+Don't forget to update the server url in the Strapi config file `./config/server.js` and the server URL in your frontend app (environment variable `REACT_APP_BACKEND_URL` if you use [react login example app](https://github.com/strapi/strapi-examples/tree/master/login-react)) with the generated ngrok URL.
 
 #### Patreon configuration
 

--- a/docs/developer-docs/latest/plugins/users-permissions.md
+++ b/docs/developer-docs/latest/plugins/users-permissions.md
@@ -805,7 +805,7 @@ Don't forget to update the server url in the backend config file `config/server.
 - Go to the [Patreon developer portal](https://www.patreon.com/portal)
 - Click on [Clients & API Keys](https://www.patreon.com/portal/registration/register-clients)
 - Click on "Create Client"
-- Enter the details of your organisation and website.
+- Enter the details of your organization and website.
 - There is a drop-down for "App Category" but no explanation of what the different categories mean.
 "Community" seems to work fine. 
 - You can choose either version 1 or version 2 of the API - neither are actively developed.


### PR DESCRIPTION
### What does it do?

Updates the dev docs for the Users & Permissions plugin to document how to add Patreon as an auth provider.

### Why is it needed?

I have opened a PR to add this functionality to strapi and this updates the documentation to match

### Related issue(s)/PR(s)

strapi/strapi#15216