### PR TITLE
Added --no-cache and --production flags for docker

### DIFF
--- a/docs/developer-docs/latest/setup-deployment-guides/installation/docker.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/installation/docker.md
@@ -53,7 +53,7 @@ Sample `Dockerfile`:
 
 FROM node:16-alpine
 # Installing libvips-dev for sharp Compatibility
-RUN apk update && apk add build-base gcc autoconf automake zlib-dev libpng-dev nasm bash vips-dev
+RUN apk update && apk add --no-cache build-base gcc autoconf automake zlib-dev libpng-dev nasm bash vips-dev
 ARG NODE_ENV=development
 ENV NODE_ENV=${NODE_ENV}
 WORKDIR /opt/
@@ -76,7 +76,7 @@ CMD ["yarn", "develop"]
 
 FROM node:16-alpine
 # Installing libvips-dev for sharp Compatibility
-RUN apk update && apk add  build-base gcc autoconf automake zlib-dev libpng-dev nasm bash vips-dev
+RUN apk update && apk add --no-cache build-base gcc autoconf automake zlib-dev libpng-dev nasm bash vips-dev
 ARG NODE_ENV=development
 ENV NODE_ENV=${NODE_ENV}
 WORKDIR /opt/
@@ -280,7 +280,7 @@ services:
       - strapi
     depends_on:
       - strapiDB
-      
+
   strapiDB:
     container_name: strapiDB
     platform: linux/amd64 #for platform error on Apple M1 chips
@@ -333,21 +333,20 @@ The following `Dockerfile` can be used to build a production Docker image for a 
 
 FROM node:16-alpine as build
 # Installing libvips-dev for sharp Compatibility
-RUN apk update && apk add build-base gcc autoconf automake zlib-dev libpng-dev vips-dev && rm -rf /var/cache/apk/* > /dev/null 2>&1
+RUN apk update && apk add --no-cache build-base gcc autoconf automake zlib-dev libpng-dev vips-dev > /dev/null 2>&1
 ARG NODE_ENV=production
 ENV NODE_ENV=${NODE_ENV}
 WORKDIR /opt/
 COPY ./package.json ./yarn.lock ./
 ENV PATH /opt/node_modules/.bin:$PATH
-RUN yarn config set network-timeout 600000 -g && yarn install
+RUN yarn config set network-timeout 600000 -g && yarn install --production
 WORKDIR /opt/app
 COPY ./ .
 RUN yarn build
 
 
 FROM node:16-alpine
-RUN apk add vips-dev
-RUN rm -rf /var/cache/apk/*
+RUN apk add --no-cache vips-dev
 ARG NODE_ENV=production
 ENV NODE_ENV=${NODE_ENV}
 WORKDIR /opt/app
@@ -367,7 +366,7 @@ CMD ["yarn", "start"]
 
 FROM node:16-alpine as build
 # Installing libvips-dev for sharp Compatibility
-RUN apk update && apk add build-base gcc autoconf automake zlib-dev libpng-dev vips-dev && rm -rf /var/cache/apk/* > /dev/null 2>&1
+RUN apk update && apk add --no-cache build-base gcc autoconf automake zlib-dev libpng-dev vips-dev > /dev/null 2>&1
 ARG NODE_ENV=production
 ENV NODE_ENV=${NODE_ENV}
 WORKDIR /opt/


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

Minor optimization tweaks to `Docker` part of the Documentation.
- Changed to use `--no-cache`
- Removed extra `RUN` command as we are using `--no-cache` no longer needed
- Optimized `yarn` install for production adding `--production` flag (This will then install with production flag and not install any `devdependencies`

### Why is it needed?

Dockerize Tool has been updated with this, so updating Docs to reflect the file it generates.
### Related issue(s)/PR(s)

https://github.com/strapi/documentation/pull/1381
https://github.com/strapi/documentation/issues/1317
https://github.com/strapi/documentation/pull/1258

Let us know if this is related to any issue/pull request
