### PR TITLE
Update google-app-engine.md

### DIFF
--- a/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/google-app-engine.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/google-app-engine.md
@@ -189,7 +189,8 @@ module.exports = ({ env }) => ({
   connection: {
     client: 'postgres',
     connection: {
-      host: `/cloudsql/${env('INSTANCE_CONNECTION_NAME')}`,
+      host: `/cloudsql/${env('INSTANCE_CONNECTION_NAME')}`, // for a PostgreSQL database
+      // ⚠️ For a MySQL database, use socketPath: `/cloudsql/${env('INSTANCE_CONNECTION_NAME')}` instead
       database: env('DATABASE_NAME'),
       user: env('DATABASE_USER'),
       password: env('DATABASE_PASSWORD'),
@@ -209,7 +210,8 @@ export default ({ env }) => ({
   connection: {
     client: 'postgres',
     connection: {
-      host: `/cloudsql/${env('INSTANCE_CONNECTION_NAME')}`,
+      host: `/cloudsql/${env('INSTANCE_CONNECTION_NAME')}`, // for a PostgreSQL database
+      // ⚠️ For a MySQL database, use socketPath: `/cloudsql/${env('INSTANCE_CONNECTION_NAME')}` instead
       database: env('DATABASE_NAME'),
       user: env('DATABASE_USER'),
       password: env('DATABASE_PASSWORD'),


### PR DESCRIPTION
My app was failing to start with Error: getaddrinfo ENOTFOUND /cloudsql/INSTANCE_CONNECTION_NAME  sources:
https://cloud.google.com/sql/docs/mysql/connect-app-engine-standard https://docs-v3.strapi.io/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/google-app-engine.html

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

Prevents people that use a glcoud mysql instance from setting the database config like this:
```js
connection: {
      host: '/cloudsql/${env("INSTANCE_CONNECTION_NAME")}',
      database: env("DATABASE_NAME", "strapi"),
      user: env("DATABASE_USER", "strapi"),
      password: env("DATABASE_PASSWORD"),
    },
```
### Why is it needed?

Describe the issue you are solving.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
