### PR TITLE
Remove the duplicated `of` in the Troubleshooting document

### DIFF
--- a/docs/developer-docs/latest/getting-started/troubleshooting.md
+++ b/docs/developer-docs/latest/getting-started/troubleshooting.md
@@ -41,7 +41,7 @@ By default, the Community Edition includes 3 pre-defined roles (Administrators, 
 
 ## Relations aren't maintaining their sort order
 
-With the components there is a hidden field called `order` that allows entries to maintain their sort, however with relations there is no such field. If you consider the typical count of of component entries vs relational based entries (in retrospect they function in the backend the same) there is generally a much higher number of relations. If relations were to have an `order` field applied to them as well it could cause significant performance degradation when trying to update the order, and likewise in the case where a relation could be attached to multiple entries it would be quite difficult to maintain the order.
+With the components there is a hidden field called `order` that allows entries to maintain their sort, however with relations there is no such field. If you consider the typical count of component entries vs relational based entries (in retrospect they function in the backend the same) there is generally a much higher number of relations. If relations were to have an `order` field applied to them as well it could cause significant performance degradation when trying to update the order, and likewise in the case where a relation could be attached to multiple entries it would be quite difficult to maintain the order.
 
 For the time being there is no recommended way to handle this automatically and instead it may be required for you to create custom controllers to handle this within your own project.
 


### PR DESCRIPTION
### What does it do?

There is a useless `of` in the part `typical count of of component entries`

I am not good at English, but It looks like a wrong grammar in English

