### PR TITLE
Remove reference to free plan of Heroku Postgres add-on.

### DIFF
--- a/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/heroku.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/heroku.md
@@ -150,7 +150,7 @@ Follow these steps to deploy your Strapi app to Heroku using **PostgreSQL**:
 
 ### 1. Install the [Heroku Postgres addon](https://elements.heroku.com/addons/heroku-postgresql) for using Postgres.
 
-To make things even easier, Heroku provides a powerful addon system. In this section, you are going to use the Heroku Postgres addon, which provides a free "Hobby Dev" plan. If you plan to deploy your app in production, it is highly recommended switching to a paid plan.
+To make things even easier, Heroku provides a powerful addon system. In this section, you are going to use the Heroku Postgres addon. The most basic plan is "Mini", which costs $5/mo. If you plan to deploy your app in production, check the row limit and storage capacity as you may want to upgrade to a higher plan.
 
 `Path: ./my-project/`
 


### PR DESCRIPTION
### What does it do?

Removes reference to free "Hobby Dev" plan of Heroku Postgres add-on.

### Why is it needed?

Free plan was replaces with "Mini" costing $5/mo.

### Related issue(s)/PR(s)

Fixes #1396 

Ready to be merged.