### PR TITLE
Postgres database user is granted schema privileges

### DIFF
--- a/docs/developer-docs/latest/setup-deployment-guides/configurations/required/databases.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/configurations/required/databases.md
@@ -289,7 +289,7 @@ Installation guides for other databases (MySQL, MariaDB) are being reworked. [Co
 :::
 
 :::note
-When connecting Strapi to a postgres database, the database user requires SCHEMA permissions. While the database admin has this permission by default, a new database user that's created specifically for the Strapi application will not and result in a 500 error when trying to load the admin console.
+When connecting Strapi to a PostgreSQL database, the database user requires SCHEMA permissions. While the database admin has this permission by default, a new database user explicitly created for the Strapi application will not. This would result in a 500 error when trying to load the admin console.
 
 To create a new postgres user with the SCHEMA permission, use the following steps.
 

--- a/docs/developer-docs/latest/setup-deployment-guides/configurations/required/databases.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/configurations/required/databases.md
@@ -300,7 +300,7 @@ $ CREATE USER my_strapi_db_user WITH PASSWORD 'password';
 # Connect to the database as the PostgreSQL admin
 $ \c my_strapi_db_name admin_user
 
-# Grant schema privileges  to the user
+# Grant schema privileges to the user
 $ GRANT ALL ON SCHEMA public TO my_strapi_db_user;
 ```
 :::

--- a/docs/developer-docs/latest/setup-deployment-guides/configurations/required/databases.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/configurations/required/databases.md
@@ -287,3 +287,20 @@ The following documentation covers how to install SQLite locally (for developmen
 :::caution
 Installation guides for other databases (MySQL, MariaDB) are being reworked. [Contributions](https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md) are most welcome.
 :::
+
+:::note
+When connecting Strapi to a postgres database, the database user requires SCHEMA permissions. While the database admin has this permission by default, a new database user that's created specifically for the Strapi application will not and result in a 500 error when trying to load the admin console.
+
+To create a new postgres user with the SCHEMA permission, use the following steps.
+
+```shell
+# Create a new db user with a secure password
+$ CREATE USER my_strapi_db_user WITH PASSWORD 'password';
+
+# Connect to the database as the postgres admin
+$ \c my_strapi_db_name admin_user
+
+# Grant schema privileges  to the user
+$ GRANT ALL ON SCHEMA public TO my_strapi_db_user;
+```
+:::

--- a/docs/developer-docs/latest/setup-deployment-guides/configurations/required/databases.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/configurations/required/databases.md
@@ -291,7 +291,7 @@ Installation guides for other databases (MySQL, MariaDB) are being reworked. [Co
 :::note
 When connecting Strapi to a PostgreSQL database, the database user requires SCHEMA permissions. While the database admin has this permission by default, a new database user explicitly created for the Strapi application will not. This would result in a 500 error when trying to load the admin console.
 
-To create a new postgres user with the SCHEMA permission, use the following steps.
+To create a new PostgreSQL user with the SCHEMA permission, use the following steps.
 
 ```shell
 # Create a new db user with a secure password

--- a/docs/developer-docs/latest/setup-deployment-guides/configurations/required/databases.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/configurations/required/databases.md
@@ -294,7 +294,7 @@ When connecting Strapi to a PostgreSQL database, the database user requires SCHE
 To create a new PostgreSQL user with the SCHEMA permission, use the following steps.
 
 ```shell
-# Create a new db user with a secure password
+# Create a new database user with a secure password
 $ CREATE USER my_strapi_db_user WITH PASSWORD 'password';
 
 # Connect to the database as the postgres admin

--- a/docs/developer-docs/latest/setup-deployment-guides/configurations/required/databases.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/configurations/required/databases.md
@@ -297,7 +297,7 @@ To create a new PostgreSQL user with the SCHEMA permission, use the following st
 # Create a new database user with a secure password
 $ CREATE USER my_strapi_db_user WITH PASSWORD 'password';
 
-# Connect to the database as the postgres admin
+# Connect to the database as the PostgreSQL admin
 $ \c my_strapi_db_name admin_user
 
 # Grant schema privileges  to the user


### PR DESCRIPTION
When connecting Strapi to a postgres database, the database user requires public SCHEMA permissions. This can be confusing for the developer since when the permission is not configured, Strapi only throws a 500 error without specific details.

This documentation aims to help postgres/strapi devs avoid friction when setting up new postgres dbs.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

Describe the technical changes you did.

### Why is it needed?

Describe the issue you are solving.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
