### PR TITLE
Fix documentation plugin example

### DIFF
--- a/docs/developer-docs/latest/plugins/documentation.md
+++ b/docs/developer-docs/latest/plugins/documentation.md
@@ -97,7 +97,7 @@ Here are the file that needs to be created in order to change the documentation 
   "x-strapi-config": {
     "path": "/documentation",
     "showGeneratedFiles": true,
-    "pluginsForWhichToGenerateDoc": [
+    "plugins": [
       "email",
       "upload",
       "users-permissions"

--- a/docs/developer-docs/latest/plugins/documentation.md
+++ b/docs/developer-docs/latest/plugins/documentation.md
@@ -97,6 +97,7 @@ Here are the file that needs to be created in order to change the documentation 
   "x-strapi-config": {
     "path": "/documentation",
     "showGeneratedFiles": true,
+    "generateDefaultResponse": true,
     "plugins": [
       "email",
       "upload",


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

The documentation is misleading users to use the property `pluginsForWhichToGenerateDoc` which is not even used. The actual implementation has the following default config: https://github.com/strapi/strapi/blob/5e1fda7e13b226ddd2f27526514e0cc32684f36a/packages/plugins/documentation/server/config/default-plugin-config.js#L20 where it's clear that the property is `plugins`.

The implementation that gets the property can also be seen here: https://github.com/strapi/strapi/blob/59b83c59534de5ef728059f32be5ebb994242ddc/packages/plugins/documentation/server/services/documentation.js#L102 where it looks for `plugins` instead of `pluginsForWhichToGenerateDoc`.

### Why is it needed?

It will help people configure their documentation plugin correctly, so they get the expected output.

### Related issue(s)/PR(s)
https://github.com/strapi/strapi/issues/13808
https://github.com/strapi/strapi/issues/14020
