### PR TITLE
Email plugin: Add typescript callout

### DIFF
--- a/docs/developer-docs/latest/plugins/email.md
+++ b/docs/developer-docs/latest/plugins/email.md
@@ -10,7 +10,7 @@ The Email plugin enables applications to send emails from a server or an externa
 
 ::: prerequisites
 
-The Email plugin requires a provider and a provider configuration in the `plugins.js` file. See the [Providers](/developer-docs/latest/development/providers.md) documentation for detailed installation and configuration instructions.
+The Email plugin requires a provider and a provider configuration in the `plugins.js` or `plugins.ts` file. See the [Providers](/developer-docs/latest/development/providers.md) documentation for detailed installation and configuration instructions.
 
 :::
 


### PR DESCRIPTION
This PR adds the `plugins.ts` config file to the prerequisites callout. This is in response to user issues noticed on Discord where they were creating a `plugins.js` file in a TypeScript project. 