### PR TITLE
Remove beta badge from Dev Docs & User Guide for relations reordering

### DIFF
--- a/docs/developer-docs/latest/developer-resources/database-apis-reference/rest/relations.md
+++ b/docs/developer-docs/latest/developer-resources/database-apis-reference/rest/relations.md
@@ -12,7 +12,7 @@ canonicalUrl: https://docs.strapi.io/developer-docs/latest/developer-resources/d
 }
 </style>
 
-# Managing relations through the REST API <BetaBadge />
+# Managing relations through the REST API
 
 Defining relations between content-types (that are designated as entities in the database layers) is connecting entities with each other.
 

--- a/docs/user-docs/latest/content-manager/managing-relational-fields.md
+++ b/docs/user-docs/latest/content-manager/managing-relational-fields.md
@@ -72,8 +72,8 @@ All selected entries are listed right below the drop-down list. Click on the nam
 
 To remove an entry, click on the cross button ![Cross icon](../assets/icons/cross.svg) in the selected entries list.
 
-Entries from multiple-choice relational fields can be reordered, indicated by a drag button ![Drag icon](../assets/icons/drag.svg). To move an entry, click and hold it, drag it to the desired position, then release it. This is a beta feature for now. <BetaBadge />.
+Entries from multiple-choice relational fields can be reordered, indicated by a drag button ![Drag icon](../assets/icons/drag.svg). To move an entry, click and hold it, drag it to the desired position, then release it.
 
-:::tip Using the keyboard to reorder <BetaBadge />
+:::tip Using the keyboard to reorder
 You can also use the keyboard to reorder relations: focus the relation using Tab, press Space on the drag & drop button Drag icon and use the arrow keys to then re-order, pressing Space again to drop the item.
 :::


### PR DESCRIPTION
Gets the documentation ready for General Availability of Relations reordering by removing mentions of beta status.