### PR TITLE
Add data import and export filters to the CLI

### DIFF
--- a/docs/developer-docs/latest/developer-resources/cli/CLI.md
+++ b/docs/developer-docs/latest/developer-resources/cli/CLI.md
@@ -111,13 +111,13 @@ The exported file is automatically named using the format `export_YYYYMMDDHHMMSS
 
 | Option           | Type    | Description                                                                                               |
 |------------------|---------|----------------------------------------------------------------------------|
-| `--no-encrypt`     |     -    | Disables file encryption and disables the `key` option.                                                   |
-| `--no-compress`    |     -    | Disables file compression.                                                                                |
-| `-k`, `--key`            | string  | Passes the encryption key as part of the `export` command. <br/> The `--key` option can't be combined with `--no-encrypt`. |                                |
-| `-f`, `--file`       | string  | Specifies the export filename. Do not include a file extension.                                           |
+| `‑‑no‑encrypt`     |     -    | Disables file encryption and disables the `key` option.                                                   |
+| `‑‑no‑compress`    |     -    | Disables file compression.                                                                                |
+| `-k`, <br/>`--key`            | string  | Passes the encryption key as part of the `export` command. <br/> The `--key` option can't be combined with `--no-encrypt`. |                                |
+| `-f`, <br/>`--file`       | string  | Specifies the export filename. Do not include a file extension.                                           |
 | `--exclude` | string | Exclude data using comma-separated data types. `--exclude` types override `--only` types. The available types are: `content`, `files`, and `config`.|
 | `--only`| string | Include only these data. The available types are: `content`, `files`, and `config`.|
-| `-h`, `--help`       |     -    | Displays help for the `strapi export` command.                                                            |
+| `-h`, <br/>`--help`       |     -    | Displays help for the `strapi export` command.                                                            |
 
 **Examples**
 
@@ -136,15 +136,14 @@ strapi export --exclude files
 
 [Imports data](/developer-docs/latest/developer-resources/data-management.md) into your project. The imported data must originate from another Strapi application. You must pass the `--file` option to specify the filename and location for the import action.
 
-| Option             | Type   | Description                                                                   |
-|--------------------|--------|-------------------------------------------------------------------------------|
-| `-k,` `--key`          | string | Provide the encryption key in the command instead of a subsequent prompt. |
-| `-f`, `--file`         | string | Path and filename with extension for the data to be imported.             |
-| `--force`| - |  Automatically answers "yes" to all prompts, including potentially destructive requests      |
-| `--exclude` | string | Exclude data using comma-separated data types. `--exclude` types override `--only` types. The available types are: `content`, `files`, and `config`.|
-| `--only`| string | Include only these data. The available types are: `content`, `files`, and `config`.      |
-
-| `-h`, `--help`         |   -     | Display the `strapi import` help commands.                               |
+| Option              |   Type   | Description                                                                                                                                                |
+|---------------------|:--------:|------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `-k`, <br/> `--key` | `string` | Provide the encryption key in the command instead of a subsequent prompt.                                                                                  |
+| `-f`, <br/>`--file` | `string` | Path and filename with extension for the data to be imported.                                                                                              |
+| `--force`           |     -    | Automatically answers "yes" to all prompts, including potentially destructive requests.                                                                 |
+| `‑‑exclude`        | `string` | Exclude data using comma-separated data types. <br/> `--exclude` types override `--only` types.<br/>  The available types are: `content`, `files`, and `config`. |
+| `--only`            | `string` | Include only these data. The available types are: `content`, `files`, and `config`.                                                                        |
+| `-h`, <br/>`--help` |     -    | Display the `strapi import` help commands.                                                                                                                 |                                                                                                 |
 
 **Examples**
 
@@ -156,10 +155,10 @@ strapi export --exclude files
 strapi import -f <your-filepath-and-filename> --key my-key
 
 # import your data forcing "yes" for all subsequent prompts:
-strapi import --force
+strapi import -f <your-filepath-and-filename> --force
 
 # import only your configuration (schemas are always included): 
-strapi import --only config
+strapi import -f <your-filepath-and-filename> --only config
 
 ```
 

--- a/docs/developer-docs/latest/developer-resources/cli/CLI.md
+++ b/docs/developer-docs/latest/developer-resources/cli/CLI.md
@@ -128,7 +128,7 @@ The exported file is automatically named using the format `export_YYYYMMDDHHMMSS
 strapi export -f myData 
 # exports your data without encryption:
 strapi export --no-encrypt
-#export your data and configuration but not media files:
+# export your data and configuration but not media files:
 strapi export --exclude files 
 ```
 

--- a/docs/developer-docs/latest/developer-resources/cli/CLI.md
+++ b/docs/developer-docs/latest/developer-resources/cli/CLI.md
@@ -136,15 +136,15 @@ strapi export --exclude files
 
 [Imports data](/developer-docs/latest/developer-resources/data-management.md) into your project. The imported data must originate from another Strapi application. You must pass the `--file` option to specify the filename and location for the import action.
 
-| Option             | Type   | Description                                                               |
-|--------------------|--------|---------------------------------------------------------------------------|
+| Option             | Type   | Description                                                                   |
+|--------------------|--------|-------------------------------------------------------------------------------|
 | `-k,` `--key`          | string | Provide the encryption key in the command instead of a subsequent prompt. |
 | `-f`, `--file`         | string | Path and filename with extension for the data to be imported.             |
-| `-f`, `--force`| - |  Automatically answers "yes" to all prompts, including potentially destructive requests|
+| `--force`| - |  Automatically answers "yes" to all prompts, including potentially destructive requests      |
 | `--exclude` | string | Exclude data using comma-separated data types. `--exclude` types override `--only` types. The available types are: `content`, `files`, and `config`.|
-| `--only`| string | Include only these data. The available types are: `content`, `files`, and `config`.|
+| `--only`| string | Include only these data. The available types are: `content`, `files`, and `config`.      |
 
-| `-h`, `--help`         |   -     | Display the `strapi import` help commands.                                |
+| `-h`, `--help`         |   -     | Display the `strapi import` help commands.                               |
 
 **Examples**
 
@@ -155,7 +155,10 @@ strapi export --exclude files
 # import your data with the default parameters and pass an encryption key: 
 strapi import -f <your-filepath-and-filename> --key my-key
 
-# import only your configuration: 
+# import your data forcing "yes" for all subsequent prompts:
+strapi import --force
+
+# import only your configuration (schemas are always included): 
 strapi import --only config
 
 ```

--- a/docs/developer-docs/latest/developer-resources/cli/CLI.md
+++ b/docs/developer-docs/latest/developer-resources/cli/CLI.md
@@ -157,7 +157,7 @@ strapi import -f <your-filepath-and-filename> --key my-key
 # import your data forcing "yes" for all subsequent prompts:
 strapi import -f <your-filepath-and-filename> --force
 
-# import only your configuration (schemas are always included): 
+# import only your configuration: 
 strapi import -f <your-filepath-and-filename> --only config
 
 ```

--- a/docs/developer-docs/latest/developer-resources/cli/CLI.md
+++ b/docs/developer-docs/latest/developer-resources/cli/CLI.md
@@ -115,6 +115,8 @@ The exported file is automatically named using the format `export_YYYYMMDDHHMMSS
 | `--no-compress`    |     -    | Disables file compression.                                                                                |
 | `-k`, `--key`            | string  | Passes the encryption key as part of the `export` command. <br/> The `--key` option can't be combined with `--no-encrypt`. |                                |
 | `-f`, `--file`       | string  | Specifies the export filename. Do not include a file extension.                                           |
+| `--exclude` | string | Exclude data using comma-separated data types. `--exclude` types override `--only` types. The available types are: `content`, `files`, and `config`.|
+| `--only`| string | Include only these data. The available types are: `content`, `files`, and `config`.|
 | `-h`, `--help`       |     -    | Displays help for the `strapi export` command.                                                            |
 
 **Examples**
@@ -134,6 +136,10 @@ strapi export --no-encrypt # exports your data without encryption.
 |--------------------|--------|---------------------------------------------------------------------------|
 | `-k,` `--key`          | string | Provide the encryption key in the command instead of a subsequent prompt. |
 | `-f`, `--file`         | string | Path and filename with extension for the data to be imported.             |
+| `-f`, `--force`| - |  Automatically answers "yes" to all prompts, including potentially destructive requests|
+| `--exclude` | string | Exclude data using comma-separated data types. `--exclude` types override `--only` types. The available types are: `content`, `files`, and `config`.|
+| `--only`| string | Include only these data. The available types are: `content`, `files`, and `config`.|
+
 | `-h`, `--help`         |   -     | Display the `strapi import` help commands.                                |
 
 **Examples**

--- a/docs/developer-docs/latest/developer-resources/cli/CLI.md
+++ b/docs/developer-docs/latest/developer-resources/cli/CLI.md
@@ -99,7 +99,7 @@ options: [--browser <name>]
 ```
 
 
-## strapi export <BetaBadge />
+## strapi export
 
 [Exports your project data](/developer-docs/latest/developer-resources/data-management.md). The default settings create a `.tar` file, compressed using `gzip` and encrypted using `aes-128-ecb`.
 
@@ -124,11 +124,15 @@ The exported file is automatically named using the format `export_YYYYMMDDHHMMSS
 ```bash
 # examples of strapi export:
 
-strapi export -f myData # exports your data with the default options and the filename myData (which will result in a file named myData.tar.gz.enc)
-strapi export --no-encrypt # exports your data without encryption. 
+# export your data with the default options and the filename myData (which will result in a file named myData.tar.gz.enc):
+strapi export -f myData 
+# exports your data without encryption:
+strapi export --no-encrypt
+#export your data and configuration but not media files:
+strapi export --exclude files 
 ```
 
-## strapi import <BetaBadge />
+## strapi import
 
 [Imports data](/developer-docs/latest/developer-resources/data-management.md) into your project. The imported data must originate from another Strapi application. You must pass the `--file` option to specify the filename and location for the import action.
 
@@ -150,6 +154,9 @@ strapi export --no-encrypt # exports your data without encryption.
 
 # import your data with the default parameters and pass an encryption key: 
 strapi import -f <your-filepath-and-filename> --key my-key
+
+# import only your configuration: 
+strapi import --only config
 
 ```
 


### PR DESCRIPTION
This PR adds the following flags to the import and export  CLI documentation:
- `--force`
- `--exclude`
- `--only` 

It also adds new examples and removes the beta badges for `import` and `export`. 
