### PR TITLE
Add VuePress component to ease targetting sections for Hotjar feedback widget

### DIFF
--- a/docs/.vuepress/theme/global-components/FeedbackPlaceholder.vue
+++ b/docs/.vuepress/theme/global-components/FeedbackPlaceholder.vue
@@ -1,0 +1,3 @@
+<template>
+ <span id="feedback-placeholder"></span>
+</template>

--- a/docs/user-docs/latest/content-manager/managing-relational-fields.md
+++ b/docs/user-docs/latest/content-manager/managing-relational-fields.md
@@ -77,3 +77,5 @@ Entries from multiple-choice relational fields can be reordered, indicated by a 
 :::tip Using the keyboard to reorder <BetaBadge />
 You can also use the keyboard to reorder relations: focus the relation using Tab, press Space on the drag & drop button Drag icon and use the arrow keys to then re-order, pressing Space again to drop the item.
 :::
+
+<FeedbackPlaceholder />


### PR DESCRIPTION
The [Hotjar feedback widget ](https://help.hotjar.com/hc/en-us/articles/10405253676823-How-to-Embed-a-Feedback-Widget-on-Your-Site) can now be embedded everywhere in a page. It needs to be _appended_ to an HTML element.

This PR creates a little `FeedbackPlaceholder` component that we can use anywhere in Markdown content to easily target where we'd like the widget to be inserted.
(VuePress by default does not provide another way to add an `id` to a Markdown element).

As a test, the component is added to the user guide for Relations Reordering.
