### PR TITLE
CTB: Reword D&P and i18n docs

### DIFF
--- a/docs/user-docs/latest/content-types-builder/creating-new-content-type.md
+++ b/docs/user-docs/latest/content-types-builder/creating-new-content-type.md
@@ -28,8 +28,8 @@ To create a new content-type:
 
 | Setting name    | Instructions                                                                                                                                     |
 |-----------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
-| Draft & Publish | Click on **ON** to activate the Draft & Publish feature for your content-type (see [Saving & publishing content](/user-docs/latest/content-manager/saving-and-publishing-content.md#saving-publishing-content)). Click on **OFF** to deactivate the feature. |
-| Enable localization for this Content-Type | (if the [Internationalization plugin](/user-docs/latest/plugins/strapi-plugins.md#internationalization-plugin) is installed) Tick the box to allow the content-type to be managed in various locales. |
+| Draft & publish | Tick the checkbox to allow entries of the content-type to be managed as draft versions, before they are published (see [Saving & publishing content](/user-docs/latest/content-manager/saving-and-publishing-content.md#saving-publishing-content)). |
+| Localization | (if the [Internationalization plugin](/user-docs/latest/plugins/strapi-plugins.md#internationalization-plugin) is installed) Tick the checkbox to allow entries of the content-type to be translated into other locales. |
 
 6. Click on the **Continue** button.
 7. Add and configure chosen fields for your content-type (see [Configuring fields for content-types](/user-docs/latest/content-types-builder/configuring-fields-content-type.md)).


### PR DESCRIPTION
### What does it do?

Small rewording to reflect changes made in https://github.com/strapi/strapi/pull/15430

### Why is it needed?

Soon this modal will follow a consistent UI and the docs need to reflect that.

### Related issue(s)/PR(s)

- https://github.com/strapi/strapi/pull/15430
