### PR TITLE
Update uninstall for plugins

### DIFF
--- a/docs/developer-docs/latest/developer-resources/cli/CLI.md
+++ b/docs/developer-docs/latest/developer-resources/cli/CLI.md
@@ -388,7 +388,10 @@ options [--delete-files]
   Example: `strapi uninstall graphql --delete-files` will remove the plugin `strapi-plugin-graphql` and all the files in `./extensions/graphql`
 
 :::caution
-Some plugins have admin panel integrations, your admin panel might have to be rebuilt. This can take some time.
+
+- In addition to the `uninstall` command you need to remove the plugin configuration from `./config/plugins.js`.
+- Some plugins have admin panel integrations, your admin panel might have to be rebuilt. This can take some time.
+
 :::
 
 ## strapi telemetry:disable


### PR DESCRIPTION
This PR informs users that when uninstalling a plugin they also need to remove the plugin from the ./config/plugins.js` file. 