### PR TITLE
Improve 'Create a plugin' steps 

### DIFF
--- a/docs/developer-docs/latest/development/plugins-development.md
+++ b/docs/developer-docs/latest/development/plugins-development.md
@@ -20,7 +20,7 @@ Strapi provides a [command line interface (CLI)](/developer-docs/latest/develope
 2. Run `yarn strapi generate` or `npm run strapi generate` in a terminal window to start the interactive CLI.
 4. Choose "plugin" from the list, press Enter, and give the plugin a name in kebab-case (e.g. `my-plugin`)
 5. Choose either `JavaScript` or `TypeScript` for the plugin language.
-6. Create a plugins configuration file: `./config/plugins.js` or `./config/plugins.ts` for TypeScript projects.
+6. Create a plugins configuration file if one does not already exist: `./config/plugins.js` or `./config/plugins.ts` for TypeScript projects.
 7. Enable the plugin by adding it to the [plugins configurations](/developer-docs/latest/setup-deployment-guides/configurations/optional/plugins.md) file:
 
 <code-group>

--- a/docs/developer-docs/latest/development/plugins-development.md
+++ b/docs/developer-docs/latest/development/plugins-development.md
@@ -20,7 +20,8 @@ Strapi provides a [command line interface (CLI)](/developer-docs/latest/develope
 2. Run `yarn strapi generate` or `npm run strapi generate` in a terminal window to start the interactive CLI.
 4. Choose "plugin" from the list, press Enter, and give the plugin a name in kebab-case (e.g. `my-plugin`)
 5. Choose either `JavaScript` or `TypeScript` for the plugin language.
-6. Enable the plugin by adding it to the [plugins configurations](/developer-docs/latest/setup-deployment-guides/configurations/optional/plugins.md) file:
+6. Create a plugins configuration file: `./config/plugins.js` or `./config/plugins.ts` for TypeScript projects.
+7. Enable the plugin by adding it to the [plugins configurations](/developer-docs/latest/setup-deployment-guides/configurations/optional/plugins.md) file:
 
 <code-group>
 
@@ -56,6 +57,7 @@ Strapi provides a [command line interface (CLI)](/developer-docs/latest/develope
 
 
 ```
+
 </code-block>
 
 </code-group>


### PR DESCRIPTION
This PR addresses user feedback by explicitly declaring that the `plugins.js` or `plugins.ts` file needs to be created manually by the developer.