### PR TITLE
small typo fix

### DIFF
--- a/docs/developer-docs/latest/plugins/users-permissions.md
+++ b/docs/developer-docs/latest/plugins/users-permissions.md
@@ -603,7 +603,7 @@ Don't forget to update the server url in the backend config file `config/server.
 
 #### Using ngrok
 
-Discord accepts the `localhost` urls. <br>
+VK accepts the `localhost` urls. <br>
 The use of `ngrok` is not needed.
 
 #### VK configuration


### PR DESCRIPTION
Fixed typo in the users & permissions page

### What does it do?

Nothing technical. Fixed a typo in "Setting up the provider - examples" in the VK section.

### Why is it needed?
Just a small typo fix.

#### state: ready to be merged