### PR TITLE
add cron docs

### DIFF
--- a/docs/developer-docs/latest/developer-resources/plugin-api-reference/server.md
+++ b/docs/developer-docs/latest/developer-resources/plugin-api-reference/server.md
@@ -21,7 +21,7 @@ To tap into the Server API, create a `strapi-server.js` file at the root of the 
 | Parameter type         | Available parameters                                                                                                                                                                                           |
 | ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Lifecycle functions    | <ul><li> [register](#register)</li><li>[bootstrap](#bootstrap)</li><li>[destroy](#destroy)</li></ul>                                                                                                           |
-| Configuration          | [config](#configuration) object                                                                                                                                                                                |
+| Configuration          | <ul><li>[config](#configuration) object   </li> <li>[Cron](#cron)</li></ul>                                                                                                                                                                             |
 | Backend customizations | <ul><li>[contentTypes](#content-types)</li><li>[routes](#routes)</li><li>[controllers](#controllers)</li><li>[services](#services)</li><li>[policies](#policies)</li><li>[middlewares](#middlewares)</li></ul> |
 
 ## Lifecycle functions
@@ -114,6 +114,29 @@ Once defined, the configuration can be accessed:
 
 * with `strapi.plugin('plugin-name').config('some-key')` for a specific configuration property,
 * or with `strapi.config.get('plugin.plugin-name')` for the whole configuration object.
+
+## Cron
+
+:::caution
+Cron needs to be [enabled](/developer-docs/latest/setup-deployment-guides/configurations/optional/cronjobs.md#enabling-cron-jobs) in your main Strapi instance. Otherwise, the cron jobs will not be executed.
+:::
+
+The `cron` object allows to add cron jobs to the Strapi instance but this must be done in the [bootstrap](/developer-docs/latest/developer-resources/plugin-api-reference/server.md#bootstrap) lifecycle function
+
+```js
+// path: ./src/plugins/my-plugin/strapi-server.js
+
+module.exports = () => ({
+  bootstrap({ strapi }) {
+        strapi.cron.add({
+          // runs every second
+        '* * * * * *': ({ strapi }) => {
+          console.log("hello from plugin")
+        },
+    })
+  },
+});
+```
 
 ## Backend customization
 

--- a/docs/developer-docs/latest/developer-resources/plugin-api-reference/server.md
+++ b/docs/developer-docs/latest/developer-resources/plugin-api-reference/server.md
@@ -121,7 +121,7 @@ Once defined, the configuration can be accessed:
 Cron needs to be [enabled](/developer-docs/latest/setup-deployment-guides/configurations/optional/cronjobs.md#enabling-cron-jobs) in your main Strapi instance. Otherwise, the cron jobs will not be executed.
 :::
 
-The `cron` object allows you to add cron jobs to the Strapi instance but this must be done in the [bootstrap](/developer-docs/latest/developer-resources/plugin-api-reference/server.md#bootstrap) lifecycle function
+The `cron` object allows you to add cron jobs to the Strapi instance.
 
 ```js
 // path: ./src/plugins/my-plugin/strapi-server.js

--- a/docs/developer-docs/latest/developer-resources/plugin-api-reference/server.md
+++ b/docs/developer-docs/latest/developer-resources/plugin-api-reference/server.md
@@ -121,7 +121,7 @@ Once defined, the configuration can be accessed:
 Cron needs to be [enabled](/developer-docs/latest/setup-deployment-guides/configurations/optional/cronjobs.md#enabling-cron-jobs) in your main Strapi instance. Otherwise, the cron jobs will not be executed.
 :::
 
-The `cron` object allows to add cron jobs to the Strapi instance but this must be done in the [bootstrap](/developer-docs/latest/developer-resources/plugin-api-reference/server.md#bootstrap) lifecycle function
+The `cron` object allows you to add cron jobs to the Strapi instance but this must be done in the [bootstrap](/developer-docs/latest/developer-resources/plugin-api-reference/server.md#bootstrap) lifecycle function
 
 ```js
 // path: ./src/plugins/my-plugin/strapi-server.js


### PR DESCRIPTION
### What does it do?

Added the docs on how to add cron jobs programmatically to plugin server api docs

### Why is it needed?

Missing info

