### PR TITLE
Add npm options syntax and yarn preference to CLI docs

### DIFF
--- a/docs/developer-docs/latest/developer-resources/cli/CLI.md
+++ b/docs/developer-docs/latest/developer-resources/cli/CLI.md
@@ -6,10 +6,13 @@ canonicalUrl: https://docs.strapi.io/developer-docs/latest/developer-resources/c
 
 # Command Line Interface (CLI)
 
-Strapi comes with a full featured Command Line Interface (CLI) which lets you scaffold and manage your project in seconds.
+Strapi comes with a full featured Command Line Interface (CLI) which lets you scaffold and manage your project in seconds. The CLI works with both the `yarn` and `npm` package managers, however, `yarn` generally provides a better user experience.
 
 ::: note
 It is recommended to install Strapi locally only, which requires prefixing all of the following `strapi` commands with the package manager used for the project setup (e.g `npm run strapi help` or `yarn strapi help`) or a dedicated node package executor (e.g. `npx strapi help`).
+
+To pass options with `npm` use the syntax: `npm run strapi <command> -- --<option>`
+
 :::
 
 ## strapi new


### PR DESCRIPTION
This PR: 

- [ ] Details the correct syntax for passion options with `npm`
- [ ] Suggests `yarn` is the better choice for Strapi development