### PR TITLE
Docusaurus: add update version page

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+    "spellright.language": [
+        "en"
+    ],
+    "spellright.documentTypes": [
+        "markdown",
+        "latex",
+        "plaintext"
+    ]
+}

--- a/docusaurus/docs/dev-docs/migration-guides.md
+++ b/docusaurus/docs/dev-docs/migration-guides.md
@@ -1,0 +1,6 @@
+---
+title: Installation
+description: Learn how to migrate your Strapi application to the most recent version.
+---
+
+(Coming soon… — please visit [docs.strapi.io](https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides.html) in the meantime.)

--- a/docusaurus/docs/dev-docs/migration-guides.md
+++ b/docusaurus/docs/dev-docs/migration-guides.md
@@ -1,5 +1,5 @@
 ---
-title: Installation
+title: Migration guides
 description: Learn how to migrate your Strapi application to the most recent version.
 ---
 

--- a/docusaurus/docs/dev-docs/update-version.md
+++ b/docusaurus/docs/dev-docs/update-version.md
@@ -1,0 +1,59 @@
+---
+title: Update
+displayed_sidebar: devDocsSidebar
+description: The following documentation covers how to upgrade your application to the latest version of Strapi.
+canonicalUrl: https://docs.strapi.io/developer-docs/latest/update-migration-guides/update-version.html
+---
+import InstallCommand from '/docs/snippets/install-npm-yarn.md'
+import BuildCommand from '/docs/snippets/build-npm-yarn.md'
+import DevelopCommand from '/docs/snippets/develop-npm-yarn.md'
+
+# Upgrade Strapi version
+
+Strapi periodically releases code improvements through upgrades. Upgrades contain no breaking changes and are announced in both the terminal and in the administration panel. [Migration guides](/dev-docs/update-migration-guides/migration-guides) are provided whenever a new Strapi version includes breaking changes.
+
+:::caution
+ [Plugins extension](/dev-docs/plugins/users-permissions) that create custom code or modify existing code will need to be updated and compared to the changes in the repository. Not updating the plugin extensions could break the application.
+:::
+
+## Upgrade the dependencies
+
+:::prerequisites
+
+- Stop the server before starting the upgrade.
+- Confirm there are no [migrations](/dev-docs/update-migration-guides/migration-guides) between the current and ultimate Strapi versions.
+:::
+
+1. Upgrade all of the Strapi packages version numbers in `package.json` to the latest stable Strapi version:
+
+    ```jsx
+    // path: package.json
+
+    {
+      // ...
+      "dependencies": {
+        "@strapi/strapi": "4.7.0", 
+        "@strapi/plugin-users-permissions": "4.7.0",
+        "@strapi/plugin-i18n": "4.7.0",
+        "better-sqlite3": "7.4.6"
+        // ...
+      }
+    }
+
+    ```
+
+2. Save the edited `package.json` file.
+
+3. <InstallCommand components={props.components} />
+
+## Rebuild the application
+
+Rebuild the administration panel:
+
+<BuildCommand components={props.components} />
+
+## Start the application
+
+Start the application and ensure that everything is working as expected:
+
+<DevelopCommand components={props.components} />

--- a/docusaurus/docs/dev-docs/update-version.md
+++ b/docusaurus/docs/dev-docs/update-version.md
@@ -10,7 +10,7 @@ import DevelopCommand from '/docs/snippets/develop-npm-yarn.md'
 
 # Upgrade Strapi version
 
-Strapi periodically releases code improvements through upgrades. Upgrades contain no breaking changes and are announced in both the terminal and in the administration panel. [Migration guides](/dev-docs/update-migration-guides/migration-guides) are provided whenever a new Strapi version includes breaking changes.
+Strapi periodically releases code improvements through upgrades. Upgrades contain no breaking changes and are announced in both the terminal and in the administration panel. [Migration guides](/dev-docs/migration-guides) are provided whenever a new Strapi version includes breaking changes.
 
 :::caution
  [Plugins extension](/dev-docs/plugins/users-permissions) that create custom code or modify existing code will need to be updated and compared to the changes in the repository. Not updating the plugin extensions could break the application.

--- a/docusaurus/docs/snippets/build-npm-yarn.md
+++ b/docusaurus/docs/snippets/build-npm-yarn.md
@@ -1,0 +1,19 @@
+<Tabs groupId="yarn-npm">
+
+<TabItem value="yarn" label="yarn">
+
+```bash
+yarn build
+```
+
+</TabItem>
+
+<TabItem value="npm" label="npm">
+
+```bash
+npm run build
+```
+
+</TabItem>
+
+</Tabs>

--- a/docusaurus/docs/snippets/develop-npm-yarn.md
+++ b/docusaurus/docs/snippets/develop-npm-yarn.md
@@ -1,0 +1,19 @@
+<Tabs groupId="yarn-npm">
+
+<TabItem value="yarn" label="yarn">
+
+```bash
+yarn develop
+```
+
+</TabItem>
+
+<TabItem value="npm" label="npm">
+
+```bash
+npm run develop
+```
+
+</TabItem>
+
+</Tabs>

--- a/docusaurus/docs/snippets/install-npm-yarn.md
+++ b/docusaurus/docs/snippets/install-npm-yarn.md
@@ -1,0 +1,25 @@
+Install the upgraded version:
+
+<Tabs groupId="yarn-npm">
+
+<TabItem value="yarn" label="yarn">
+
+```bash
+yarn
+```
+
+</TabItem>
+
+<TabItem value="npm" label="npm">
+
+```bash
+npm install
+```
+
+</TabItem>
+
+</Tabs>
+
+:::tip
+If the operation doesn't work, try removing your `yarn.lock` or `package-lock.json`. If that doesn't help, remove the `node_modules` folder as well and try again.
+:::

--- a/docusaurus/docs/status.md
+++ b/docusaurus/docs/status.md
@@ -146,7 +146,7 @@ The following list is a sitemap of all the current and upcoming content for the 
     - [x] [Sentry](dev-docs/plugins/sentry)
     - [x] [API Documentation](dev-docs/plugins/documentation)
   - [ ] ♻️ Update & Migration
-    - [ ] Update (→ [docs.strapi.io](https://docs.strapi.io/developer-docs/latest/update-migration-guides/update-version.html))
+    - [x] Update (→ [docs.strapi.io](https://docs.strapi.io/developer-docs/latest/update-migration-guides/update-version.html))
     - [ ] Migration
       - [ ] v4 migration guides (→ [docs.strapi.io](https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides.html))
       - [ ] v3 to v4 migration guides (→ [docs.strapi.io](#))

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -293,8 +293,17 @@ const sidebars = {
             
           ]
     },
+    {
+      type: 'category',
+      collapsed: false,
+      label: 'Update and Migration',
+      items: [
+            'dev-docs/update-version'  
+          ]
+    },
   ],
 
+ 
 
   userDocsSidebar: [
     'user-docs/intro',


### PR DESCRIPTION
This PR adds the update version page to Docusaurus. It also creates some snippets for the common `install`, `build`, and `develop` commands