### PR TITLE
Fix/Update Azure deployment docs - App runtime version/syntax and SQL firewall rule syntax

### DIFF
--- a/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/azure.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/azure.md
@@ -48,7 +48,7 @@ In this section we'll use the Azure Portal to create the required resources to h
 
    - _Name_ - `my-strapi-app`
    - _Publish_ - `Code`
-   - _Runtime stack_ - `Node 14 LTS`
+   - _Runtime stack_ - `Node 16 LTS`
    - _Operating System_ - `Linux`
    - _Region_ - Select an appropriate region
 
@@ -126,11 +126,11 @@ In this section, we'll use the [Azure CLI](https://docs.microsoft.com/cli/azure/
    az appservice plan create --resource-group $rgName --name $appPlanName --is-linux --number-of-workers 4 --sku S1 --location $location
    ```
 
-3. Create a Web App running Node.js 14.
+3. Create a Web App running Node.js 16.
 
    ```bash
    webAppName=my-strapi-app
-   az webapp create --resource-group $rgName --name $webAppName --plan $appPlanName --runtime "node|14-lts"
+   az webapp create --resource-group $rgName --name $webAppName --plan $appPlanName --runtime "node|16-lts"
    ```
 
 4. Create a Storage Account.

--- a/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/azure.md
+++ b/docs/developer-docs/latest/setup-deployment-guides/deployment/hosting-guides/azure.md
@@ -130,7 +130,7 @@ In this section, we'll use the [Azure CLI](https://docs.microsoft.com/cli/azure/
 
    ```bash
    webAppName=my-strapi-app
-   az webapp create --resource-group $rgName --name $webAppName --plan $appPlanName --runtime "node|10.14"
+   az webapp create --resource-group $rgName --name $webAppName --plan $appPlanName --runtime "node|14-lts"
    ```
 
 4. Create a Storage Account.
@@ -162,7 +162,7 @@ In this section, we'll use the [Azure CLI](https://docs.microsoft.com/cli/azure/
    az mysql db create --resource-group $rgName --name $dbName --server-name $serverName
 
    # Allow Azure resources through the firewall
-   az mysql server firewall-rule create --resource-group $rgName --server-name $serverName --name AllowAllAzureIps --start-ip-range 0.0.0.0 --end-ip-range 0.0.0.0
+   az mysql server firewall-rule create --resource-group $rgName --server-name $serverName --name AllowAllAzureIps --start-ip-address 0.0.0.0 --end-ip-address 0.0.0.0
    ```
 
 6. Add configuration values to the Web App.


### PR DESCRIPTION
### Why is it needed?

Following the docs as-is today is not possible as the steps lead to errors. This is likely due to some relatively recent changes in Azure CLI syntax.

I've also reflected the change in runtime stack version to the Azure Portal section of the docs.


### What does it do?

#### Change 1: Update Node runtime argument of ```az webapp create```

Running the docs as-is produces an error:

```
Linux Runtime 'node|10.14' is not supported.Run 'az webapp list-runtimes --os-type linux' to cross check
```

Executing this command to check available runtimes today (6 Feb 2023), the available Node version inputs are:

```bash
"NODE:18-lts",
"NODE:16-lts",
"NODE:14-lts",
```

Hence in any case the syntax of the input needs to be updated. I've tested and validated these scripts with ```"node|14-lts"``` and ```"node|16-lts"``` as the input.

[As per Microsoft, community support for Node 14 LTS is ending 30 April 2023](https://azure.microsoft.com/en-us/updates/community-support-for-node-14-lts-is-ending-on-30-april-2023/). With this change IMO we may as well update at least to 16 - I've also tested this and it works. Hence the change to:

```bash
--runtime "node|16-lts"
```

#### Change 2: Update IP address block arguments of ```az mysql server firewall-rule create```

Running the docs as-is produces an error:

```
the following arguments are required: --start-ip-address, --end-ip-address
```

Based on [the most recent docs](https://learn.microsoft.com/en-us/cli/azure/mysql/server/firewall-rule?view=azure-cli-latest), the correct parameters to define the allowed IP blocks are:

```bash
--start-ip-address 0.0.0.0
--end-ip-address 0.0.0.0
```



### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
