### PR TITLE
Fix broken links reported in issue #1423

### DIFF
--- a/docs/developer-docs/latest/developer-resources/error-handling.md
+++ b/docs/developer-docs/latest/developer-resources/error-handling.md
@@ -63,7 +63,7 @@ Errors thrown by the GraphQL API are included in the [response](/developer-docs/
 
 ### Controllers and middlewares
 
-The recommended way to throw errors when developing any custom logic with Strapi is to have the [controller](/developer-docs/latest/development/backend-customization/controllers.md) or [middleware](/developer-docs/latest/development/backend-customization/) respond with the correct status and body.
+The recommended way to throw errors when developing any custom logic with Strapi is to have the [controller](/developer-docs/latest/development/backend-customization/controllers.md) or [middleware](/developer-docs/latest/development/backend-customization.md) respond with the correct status and body.
 
 This can be done by calling an error function on the context (i.e. `ctx`). Available error functions are listed in the [http-errors documentation](https://github.com/jshttp/http-errors#list-of-all-constructors) but their name should be lower camel-cased to be used by Strapi (e.g. `badRequest`).
 
@@ -367,7 +367,7 @@ throw new PolicyError('Something went wrong', { policy: 'my-policy' });
 
 ::: tab Pagination
 
-The `PaginationError` class is a specific error class that is typically used when parsing the pagination information from [REST](/developer-resources/database-apis-reference/rest/sort-pagination.md#pagination), [GraphQL](/developer-resources/database-apis-reference/graphql-api.md#pagination), or the [Entity Service](/developer-resources/database-apis-reference/entity-service/order-pagination.md#pagination). It accepts the following parameters:
+The `PaginationError` class is a specific error class that is typically used when parsing the pagination information from [REST](/developer-docs/latest/developer-resources/database-apis-reference/rest/sort-pagination.md#pagination), [GraphQL](/developer-docs/latest/developer-resources/database-apis-reference/graphql-api.md#pagination), or the [Entity Service](/developer-docs/latest/developer-resources/database-apis-reference/entity-service/order-pagination.md#pagination). It accepts the following parameters:
 
 | Parameter | Type | Description | Default |
 | --- | --- | --- | --- |

--- a/docs/developer-docs/latest/developer-resources/error-handling.md
+++ b/docs/developer-docs/latest/developer-resources/error-handling.md
@@ -63,7 +63,7 @@ Errors thrown by the GraphQL API are included in the [response](/developer-docs/
 
 ### Controllers and middlewares
 
-The recommended way to throw errors when developing any custom logic with Strapi is to have the [controller](/developer-docs/latest/development/backend-customization/controllers.md) or [middleware](/developer-docs/latest/development/backend-customization.md) respond with the correct status and body.
+The recommended way to throw errors when developing any custom logic with Strapi is to have the [controller](/developer-docs/latest/development/backend-customization/controllers.md) or [middleware](/developer-docs/latest/development/backend-customization/middlewares.md) respond with the correct status and body.
 
 This can be done by calling an error function on the context (i.e. `ctx`). Available error functions are listed in the [http-errors documentation](https://github.com/jshttp/http-errors#list-of-all-constructors) but their name should be lower camel-cased to be used by Strapi (e.g. `badRequest`).
 

--- a/docs/developer-docs/latest/developer-resources/unit-testing.md
+++ b/docs/developer-docs/latest/developer-resources/unit-testing.md
@@ -96,7 +96,7 @@ module.exports = ({ env }) => ({
 ### Strapi instance
 
 In order to test anything we need to have a strapi instance that runs in the testing environment,
-basically we want to get instance of strapi app as object, similar like creating an instance for [process manager](process-manager.md).
+basically we want to get instance of strapi app as object, similar like creating an instance for [process manager](/developer-docs/latest/setup-deployment-guides/deployment/optional-software/process-manager.md).
 
 These tasks require adding some files - let's create a folder `tests` where all the tests will be put and inside it, next to folder `helpers` where main Strapi helper will be in file strapi.js.
 


### PR DESCRIPTION
Fix broken links reported in issue #1423. Most of them were missing the proper `/developer-docs/latest/` prefix (+ process manager docs have been moved elsewhere).