### PR TITLE
Connect can not be used for media attributes

### DIFF
--- a/docs/developer-docs/latest/developer-resources/database-apis-reference/rest/relations.md
+++ b/docs/developer-docs/latest/developer-resources/database-apis-reference/rest/relations.md
@@ -41,6 +41,12 @@ You can also use the longhand syntax to [reorder relations](#relations-reorderin
 
 `connect` can be used in combination with [`disconnect`](#disconnect).
 
+:::warning
+
+`connect` can not be used for media attributes.
+
+:::
+
 <br />
 
 :::::: tabs card

--- a/docs/developer-docs/latest/developer-resources/database-apis-reference/rest/relations.md
+++ b/docs/developer-docs/latest/developer-resources/database-apis-reference/rest/relations.md
@@ -41,7 +41,7 @@ You can also use the longhand syntax to [reorder relations](#relations-reorderin
 
 `connect` can be used in combination with [`disconnect`](#disconnect).
 
-:::warning
+:::caution
 
 `connect` can not be used for media attributes.
 


### PR DESCRIPTION
### What does it do?

Mentions `connect` attribute can not be used when managing relations of media attributes.

### Why is it needed?

Some users have been complaining about this behaviour. We forgot to mention this is not supported 😄 

### Related issue(s)/PR(s)
https://github.com/strapi/strapi/issues/15601
