### PR TITLE
Docusaurus: Add v3 → v4 plugin migration pages

### DIFF
--- a/docusaurus/docs/dev-docs/api/rest/sort-pagination.md
+++ b/docusaurus/docs/dev-docs/api/rest/sort-pagination.md
@@ -224,7 +224,7 @@ To paginate results by offset, use the following parameters:
 | `pagination[withCount]` | Boolean | Toggles displaying the total number of entries to the response | `true`  |
 
 :::tip
-The default and maximum values for `pagination[limit]` can be [configured in the `./config/api.js`](/dev-docs/setup-deployment-guides/configurations/optional/api) file with the `api.rest.defaultLimit` and `api.rest.maxLimit` keys.
+The default and maximum values for `pagination[limit]` can be [configured in the `./config/api.js`](/dev-docs/configurations//api) file with the `api.rest.defaultLimit` and `api.rest.maxLimit` keys.
 :::
 
 <ApiCall>

--- a/docusaurus/docs/dev-docs/migration/v3-to-v4/plugin-migration.md
+++ b/docusaurus/docs/dev-docs/migration/v3-to-v4/plugin-migration.md
@@ -1,0 +1,34 @@
+---
+title: Plugin migration guide
+description: Migrate a Strapi plugin from v3.6.x to v4.0.x with step-by-step instructions
+sidebarDepth: 2
+canonicalUrl: https://docs.strapi.io/dev-docs/migration/v3-to-v4/plugin/-migration.html
+---
+
+# v4 plugin migration guide
+
+The goal of this guide is to get a v3 plugin up and running on v4 by resolving breaking changes.
+
+:::note
+This guide is not an exhaustive resource for the v4 plugin APIs, which are described in the [Server API](/dev-docs/api/plugins/server-api.md#server-api-for-plugins) and [Admin Panel API](/dev-docs/api/plugins/admin-panel-api.md#admin-panel-api-for-plugins) documentations.
+:::
+
+Migrating a plugin from Strapi v3.6.x to v4.0.x consists in the following steps:
+
+- [updating the folder structure](/dev-docs/migration/v3-to-v4/plugin/update-folder-structure),
+- optionally, [migrating the back-end code](/dev-docs/migration/v3-to-v4/plugin/migrate-back-end.md) if the plugin interacts with Strapi's back end,
+- optionally, [migrating the front-end code](/dev-docs/migration/v3-to-v4/plugin/migrate-front-end.md) if the plugin interacts with the admin panel,
+- and [enabling the plugin](/dev-docs/migration/v3-to-v4/plugin/enable-plugin.md).
+
+Depending on these steps, some actions can only be done manually while others can be performed automatically by scripts that modify the code, which are called codemods. The following table lists available options for each step of the migration:
+
+| Action                              | Migration type                                                                                             |
+| ----------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| Update the folder structure         | [Automatic](/dev-docs/migration/v3-to-v4/plugin/update-folder-structure.md#updating-folder-structure-automatically) or [manual](/dev-docs/migration/v3-to-v4/plugin/update-folder-structure.md#updating-folder-structure-manually) |
+| Migrate the back end of the plugin  | [Partially automatic](/dev-docs/migration/v3-to-v4/plugin/migrate-back-end.md)                                      |
+| Migrate the front end of the plugin | [Manual](/dev-docs/migration/v3-to-v4/plugin/migrate-front-end.md)                                                                      |
+| Enable the plugin                   | [Manual](/dev-docs/migration/v3-to-v4/plugin/enable-plugin.md)                                                                               |
+
+:::strapi Codemods support & community contributions
+If you have any issues with the codemods or would like to contribute to the project please [create an issue](https://github.com/strapi/codemods/issues) or [open a pull request](https://github.com/strapi/codemods/pulls).
+:::

--- a/docusaurus/docs/dev-docs/migration/v3-to-v4/plugin/enable-plugin.md
+++ b/docusaurus/docs/dev-docs/migration/v3-to-v4/plugin/enable-plugin.md
@@ -1,5 +1,5 @@
 ---
-title: v4 plugin migration - Enabling a plugin - Strapi Developer Docs
+title: Enabling a plugin
 description: Enable a Strapi plugin while migrating from v3.6.x to v4.0.x with step-by-step instructions
 displayed_sidebar: devDocsSidebar
 canonicalUrl: http://docs.strapi.io/dev-docs/migration/v3-to-v4/plugin/enable-plugin.html

--- a/docusaurus/docs/dev-docs/migration/v3-to-v4/plugin/enable-plugin.md
+++ b/docusaurus/docs/dev-docs/migration/v3-to-v4/plugin/enable-plugin.md
@@ -3,7 +3,7 @@ title: Enabling a plugin
 description: Enable a Strapi plugin while migrating from v3.6.x to v4.0.x with step-by-step instructions
 displayed_sidebar: devDocsSidebar
 canonicalUrl: http://docs.strapi.io/dev-docs/migration/v3-to-v4/plugin/enable-plugin.html
-prev: /dev-docs/migration/v3-to-v4/plugin/-migration.md
+pagination_prev: /dev-docs/migration/v3-to-v4/plugin/-migration.md
 ---
 
 import PluginMigrationIntro from '/docs/snippets/plugin-migration-intro.md'

--- a/docusaurus/docs/dev-docs/migration/v3-to-v4/plugin/enable-plugin.md
+++ b/docusaurus/docs/dev-docs/migration/v3-to-v4/plugin/enable-plugin.md
@@ -1,0 +1,58 @@
+---
+title: v4 plugin migration - Enabling a plugin - Strapi Developer Docs
+description: Enable a Strapi plugin while migrating from v3.6.x to v4.0.x with step-by-step instructions
+displayed_sidebar: devDocsSidebar
+canonicalUrl: http://docs.strapi.io/dev-docs/migration/v3-to-v4/plugin/enable-plugin.html
+prev: /dev-docs/migration/v3-to-v4/plugin/-migration.md
+---
+
+import PluginMigrationIntro from '/docs/snippets/plugin-migration-intro.md'
+
+# v4 plugin migration: Enabling a plugin
+
+<PluginMigrationIntro components={props.components} />
+
+:::strapi v3/v4 comparison
+A Strapi v3 plugin was enabled if it was manually installed or found in the `plugins` directory.
+
+In Strapi v4:
+
+- Installed plugins following the [automatic plugins discovery](/dev-docs/plugins/plugins-intro.md#automatic-plugins-discovery) pattern will automatically be enabled.
+- While developing a local plugin, the plugin must explicitly be enabled in [the `./config/plugins.js` file](/dev-docs/configurations//plugins.md) of the Strapi application.
+:::
+
+To enable a local plugin in v4 and define an optional configuration:
+
+1. If it does not already exist, create the `./config/plugins.js` file.
+
+2. In the `./config/plugins.js` file, export a function that:
+    - returns an object
+    - and can take the `{ env }` object as a parameter (see [Environment configuration](/dev-docs/configurations//environment.md) documentation).
+
+3. Within the object exported by `./config/plugins.js`, create a key with the name of the plugin (e.g. `"my-plugin"`). The value of this key is also an object.
+
+4. Within the `"my-plugin"` object, set the `enabled` key value to `true` (boolean).
+
+5. _(optional)_ Add a `resolve` key, whose value is the path of the plugin folder (as a string), and a `config` key (as an object) that can include additional configuration for the plugin (see [plugins configuration](/dev-docs/configurations//plugins.md) documentation).
+
+<details>
+<summary>Example: Enabling and configuring a "my-plugin" plugin</summary>
+
+```js title="./config/plugins.js"
+
+module.exports = ({ env }) => ({
+  "my-plugin": {
+    enabled: true,
+    resolve: "./path-to-my-plugin",
+    config: {
+      // additional configuration goes here
+    },
+  },
+});
+```
+
+</details>
+
+:::note Plugins published on npm
+If the plugin will be published on npm, the `package.json` file should include a `strapi.kind` key with a value set to `"plugin"` (i.e. `{ "strapi": { "kind": "plugin" } }`).
+:::

--- a/docusaurus/docs/dev-docs/migration/v3-to-v4/plugin/migrate-back-end.md
+++ b/docusaurus/docs/dev-docs/migration/v3-to-v4/plugin/migrate-back-end.md
@@ -1,5 +1,5 @@
 ---
-title: v4 Plugin Migration - Migrating the back end - Strapi Developer Docs
+title: Migrating the back end
 description: Migrate the backend of a Strapi plugin from v3.6.x to v4.0.x with step-by-step instructions
 displayed_sidebar: devDocsSidebar
 canonicalUrl: http://docs.strapi.io/dev-docs/migration/v3-to-v4/plugin/migrate-back-end.html

--- a/docusaurus/docs/dev-docs/migration/v3-to-v4/plugin/migrate-back-end.md
+++ b/docusaurus/docs/dev-docs/migration/v3-to-v4/plugin/migrate-back-end.md
@@ -1,0 +1,242 @@
+---
+title: v4 Plugin Migration - Migrating the back end - Strapi Developer Docs
+description: Migrate the backend of a Strapi plugin from v3.6.x to v4.0.x with step-by-step instructions
+displayed_sidebar: devDocsSidebar
+canonicalUrl: http://docs.strapi.io/dev-docs/migration/v3-to-v4/plugin/migrate-back-end.html
+---
+
+import PluginMigrationIntro from '/docs/snippets/plugin-migration-intro.md'
+import CodemodsModifySourceCode from '/docs/snippets/codemods-modify-source-code.md'
+
+# v4 plugin migration: Migrating the back end
+
+<PluginMigrationIntro components={props.components} />
+
+Migrating the back end of a plugin to Strapi v4 requires:
+
+- updating [Strapi packages](#updating-strapi-packages)
+- updating content-types [getters](#updating-content-types-getters) and, optionally, [relations](#updating-content-types-relations)
+- updating the [plugin configuration](#updating-plugin-configuration)
+
+Depending on these steps, some actions can only be done manually while others can be performed automatically by scripts that modify the code, which are called codemods. The following table lists available options for each step of the migration:
+
+| Action                         | Migration type                                                                                               |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------ |
+| Update Strapi packages                 | [Automatic](#automatic-strapi-packages-update) or [manual](#manual-strapi-packages-update)                             |
+| Update content-types getters   | [Automatic](#automatic-content-types-getters-update) or [manual](#manual-content-types-getters-update) |
+| Update content-types relations | [Manual](#updating-content-types-relations)                                                                    |
+| Update configuration           | [Manual](#updating-plugin-configuration)                                                                              |
+
+## Updating Strapi packages
+
+:::strapi v3/v4 comparison
+Package names in Strapi v3 are prefixed by `strapi-`.
+
+Strapi v4 uses scoped packages.
+:::
+
+To migrate to Strapi v4, rename all Strapi packages from `strapi-package-name` to `@strapi/package-name`. This needs to be done in the `package.json` dependencies and anywhere the package is imported.
+
+Strapi scoped packages can be updated [automatically](#automatic-strapi-packages-update) or [manually](#manual-strapi-packages-update).
+
+### Automatic Strapi packages update
+
+:::caution
+<CodemodsModifySourceCode components={props.components} />
+:::
+
+To update Strapi scoped packages automatically:
+
+1. Use the [`update-package-dependencies` codemod](https://github.com/strapi/codemods/blob/main/lib/v4/migration-helpers/update-package-dependencies.js) by running the following command:
+
+    ```sh
+    npx @strapi/codemods migrate:dependencies [path-to-strapi-plugin]
+    ```
+
+2. Use the [`update-strapi-scoped-imports` codemod](https://github.com/strapi/codemods/blob/main/lib/v4/transforms/update-strapi-scoped-imports.js) by running the following command:
+
+    ```sh
+    npx @strapi/codemods transform update-strapi-scoped-imports [path-to-file | folder]
+    ```
+
+### Manual Strapi packages update
+
+To update Strapi scoped packages manually:
+
+1. Rename all Strapi packages (e.g. `strapi-package-name`) in `package.json` to `@strapi/package-name`
+2. Repeat for all instances where the package is imported.
+
+## Updating content-types getters
+
+:::strapi v3/v4 comparison
+Strapi v3 models have been renamed to [content-types](/dev-docs/backend-customization/models.md#content-types) in Strapi v4.
+:::
+
+If the plugin declares models, update the syntax for all getters from `strapi.models` to `strapi.contentTypes`. The syntax can be updated [automatically](#automatic-content-types-getters-update) or [manually](#manual-content-types-getters-update).
+
+### Automatic content-types getters update
+
+:::caution
+<CodemodsModifySourceCode />
+:::
+
+To update the syntax for content-types getters automatically, use the [`change-model-getters-to-content-types` codemod](https://github.com/strapi/codemods/blob/main/lib/v4/transforms/change-model-getters-to-content-types.js). The codemod replaces all instances of `strapi.models` with `strapi.contentTypes` in the indicated file or folder.
+
+To use the codemod, run the following command in a terminal:
+
+```jsx
+npx @strapi/codemods transform change-model-getters-to-content-types [path-to-file | folder]
+```
+
+### Manual content-types getters update
+
+To update the syntax for content-types getters manually, replace any instance of `strapi.models` with `strapi.contentTypes`.
+
+:::tip
+Strapi v4 introduced new getters that can be used to refactor the plugin code further (see [Server API usage documentation](/dev-docs/api/plugins/server-api.md#usage)).
+:::
+
+## Updating content-types relations
+
+:::prerequisites
+Updating content-types relations to Strapi v4 requires that the v3 models have been converted to Strapi v4 content-types (see [converting models to content-types documentation](/dev-docs/migration/v3-to-v4/plugin/update-folder-structure.md#converting-models-to-content-types)).
+:::
+
+:::strapi v3/v4 comparison
+Strapi v3 defines relations between content-types with the `via`, `model` and `collection` properties in the model settings.
+
+In Strapi v4, relations should be explicitly described in the `schema.json` file of the content-types (see [relations documentation](/dev-docs/backend-customization/models.md#relations)).
+:::
+
+If the plugin declares content-types with relations between them, migrating relations to Strapi v4 should be done manually in the [schema](/dev-docs/backend-customization/models.md#model-schema) of the content-types.
+
+To update content-type relations, update the `server/content-types/<content-type-name>/schema.json` file for each content-type with the following procedure:
+
+1. Declare the relation explicitly by setting the `type` attribute value to `"relation"`.
+
+2. Define the type of relation with the `relation` property.<br/>The value should be a string among the following possible options: `"oneToOne"`, `"oneToMany"`, `"manyToOne"` or `"manyToMany"`.
+
+3. Define the content-type target with the `target` property.<br/>The value should be a string following the `api::api-name.content-type-name` or `plugin::plugin-name.content-type-name` syntax convention.
+
+4. (_optional_) In [bidirectional relations](/dev-docs/backend-customization/models.md#relations), define `mappedBy` and `inversedBy` properties on each content-type.
+
+<details>
+<summary>Example of all possible relations between an article and an author content-types</summary>
+
+  ```json title="./src/plugins/my-plugin/server/content-types/article/schema.json"
+  
+  // Attributes for the Article content-type
+  "articleHasOneAuthor": {
+    "type": "relation",
+    "relation": "oneToOne",
+    "target": "api::author.author"
+  },
+  "articleHasAndBelongsToOneAuthor": {
+    "type": "relation",
+    "relation": "oneToOne",
+    "target": "api::author.author",
+    "inversedBy": "article"
+  },
+  "articleBelongsToManyAuthors": {
+    "type": "relation",
+    "relation": "oneToMany",
+    "target": "api::author.author",
+    "mappedBy": "article"
+  },
+  "authorHasManyArticles": {
+    "type": "relation",
+    "relation": "manyToOne",
+    "target": "api::author.author",
+    "inversedBy": "articles"
+  },
+  "articlesHasAndBelongsToManyAuthors": {
+    "type": "relation",
+    "relation": "manyToMany",
+    "target": "api::author.author",
+    "inversedBy": "articles"
+  },
+  "articleHasManyAuthors": {
+    "type": "relation",
+    "relation": "oneToMany",
+    "target": "api::author.author"
+  }
+  ```
+
+  ```json title="./src/plugins/my-plugin/server/content-types/author/schema.json"
+
+  // Attributes for the Author content-type
+  "article": {
+    "type": "relation",
+    "relation": "manyToOne",
+    "target": "api::article.article",
+    "inversedBy": "articleBelongsToManyAuthors"
+  },
+  "articles": {
+    "type": "relation",
+    "relation": "manyToMany",
+    "target": "api::article.article",
+    "inversedBy": "articlesHasAndBelongsToManyAuthors"
+  }
+  ```
+
+</details>
+
+## Updating plugin configuration
+
+:::strapi v3/v4 comparison
+Strapi v3 defines plugin configurations in a `config` folder.
+
+In Strapi v4, the default configuration of a plugin is defined as an object found in the `config.js` file or in the `config/index.js` file. These are then called from the entry file (see [default plugin configuration documentation](/dev-docs/api/plugins/server-api.md#configuration)).
+:::
+
+To handle default plugin configurations in Strapi v4 the recommended way:
+
+1. Create the `server/config/index.js` file containing an exported object.
+
+2. Within the `config` object:
+   - Define a `default` key that takes an object to store the default configuration.
+   - (_optional_) Add a `validator` key, which is a function taking the `config` as an argument.
+
+    <details>
+      <summary>Example of a default plugin configuration</summary>
+
+      ```jsx title="./src/plugins/my-plugin/server/config/index.js"
+
+      module.exports = {
+        default: { optionA: true },
+        validator: (config) => {
+          if (typeof config.optionA !== 'boolean') {
+            throw new Error('optionA has to be a boolean');
+          }
+        },
+      }
+      ```
+
+    </details>
+
+3. In the `server/index.js` file, import the configuration and export it.
+
+    <details>
+      <summary>Example of a default entry file</summary>
+
+      ```jsx title="./src/plugins/my-plugin/server/index.js"
+
+      // ...
+      const config = require('./config');
+      // ...
+
+      module.exports = {
+        // ...
+        config,
+        // ...
+      };
+      ```
+
+    </details>
+
+4. Make sure that Strapi is aware of the plugin's back-end interface exported from `server/index.js` by adding the following line to the `<plugin-name>/strapi-server.js` entry file:
+
+    ```jsx title="./src/plugins/my-plugin/strapi-server.js"
+
+    module.exports = require('./server');
+    ```

--- a/docusaurus/docs/dev-docs/migration/v3-to-v4/plugin/migrate-front-end.md
+++ b/docusaurus/docs/dev-docs/migration/v3-to-v4/plugin/migrate-front-end.md
@@ -3,7 +3,7 @@ title: Migrating the front end
 description: Migrate the front end of a Strapi plugin from v3.6.x to v4.0.x with step-by-step instructions
 displayed_sidebar: devDocsSidebar
 canonicalUrl: http://docs.strapi.io/dev-docs/migration/v3-to-v4/plugin/migrate-front-end.html
-next: ./enable-plugin.md
+pagination_next: ./enable-plugin.md
 ---
 
 import PluginMigrationIntro from '/docs/snippets/plugin-migration-intro.md'

--- a/docusaurus/docs/dev-docs/migration/v3-to-v4/plugin/migrate-front-end.md
+++ b/docusaurus/docs/dev-docs/migration/v3-to-v4/plugin/migrate-front-end.md
@@ -1,5 +1,5 @@
 ---
-title: v4 Plugin Migration - Migrating the front end - Strapi Developer Docs
+title: Migrating the front end
 description: Migrate the front end of a Strapi plugin from v3.6.x to v4.0.x with step-by-step instructions
 displayed_sidebar: devDocsSidebar
 canonicalUrl: http://docs.strapi.io/dev-docs/migration/v3-to-v4/plugin/migrate-front-end.html

--- a/docusaurus/docs/dev-docs/migration/v3-to-v4/plugin/migrate-front-end.md
+++ b/docusaurus/docs/dev-docs/migration/v3-to-v4/plugin/migrate-front-end.md
@@ -1,0 +1,398 @@
+---
+title: v4 Plugin Migration - Migrating the front end - Strapi Developer Docs
+description: Migrate the front end of a Strapi plugin from v3.6.x to v4.0.x with step-by-step instructions
+displayed_sidebar: devDocsSidebar
+canonicalUrl: http://docs.strapi.io/dev-docs/migration/v3-to-v4/plugin/migrate-front-end.html
+next: ./enable-plugin.md
+---
+
+import PluginMigrationIntro from '/docs/snippets/plugin-migration-intro.md'
+
+# v4 plugin migration: Migrating the front end
+
+<PluginMigrationIntro components={props.components} />
+
+Migrating the front end of a plugin to Strapi v4 might require:
+
+- updating how the plugin's front-end is [registered](#registering-the-plugin-with-the-admin-panel)
+- updating how the plugin is [added to the amin panel menu](#adding-a-menu-link)
+- updating how the plugin [adds settings to the admin panel](#adding-settings)
+- updating how the plugin [adds reducers](#adding-reducers)
+- updating how the plugin [injects components to the Content Manager](#adding-injection-zones)
+- updating how the plugin [uses the admin panel `Initializer` component](#using-the-initializer-component)
+- [registering translations](#registering-translations)
+
+Migrating the front end of a plugin to Strapi v4 should be done entirely manually.
+
+:::strapi Going further with the new Admin Panel APIs
+Following this guide should help you migrate a basic plugin with a single view. However, the [Admin Panel APIs](/dev-docs/api/plugins/admin-panel-api.md) introduced in Strapi v4 allow for further customization.
+
+In addition to the [`register()` lifecycle function](/dev-docs/api/plugins/admin-panel-api.md#register), which is executed as soon as the plugin is loaded, a [`bootstrap()` lifecycle function](/dev-docs/api/plugins/admin-panel-api.md#bootstrap) executes after all plugins are loaded.
+
+To add a settings link or section, use Redux reducers, hook into other plugins, and modify the user interface with injection zones, consult [the "available actions" table](/dev-docs/api/plugins/admin-panel-api.md#available-actions) for all available APIs and their associated lifecycle functions.
+:::
+
+## Registering the plugin with the admin panel
+
+:::strapi v3/v4 comparison
+A Strapi v3 plugin is registered with the admin panel by using the `strapi.registerPlugin()` function in the `<my-plugin-name>/admin/src/index.js` file.
+
+In Strapi v4, the plugin is registered within the [`register()` lifecycle function](/dev-docs/api/plugins/admin-panel-api.md#register).
+:::
+
+To update the front-end registration of a plugin to Strapi v4:
+
+1. If it does not already exist, create an `admin/src/index.js` file at the root of the plugin folder.
+2. In the `<plugin-name>/admin/src/index.js` file, export a function that calls the `register()` lifecycle function, passing the current Strapi application instance as an argument.
+3. Inside the `register()` lifecycle function body, call [the `registerPlugin()` function](/dev-docs/api/plugins/admin-panel-api.md#registerplugin) on the application instance, grabbing the `name` and `id` keys from the Strapi v3 configuration object.
+4. Make sure that Strapi is aware of the plugin's front-end interface exported from `admin/src/index.js` by adding the following line to the `<plugin-name>/strapi-admin.js` entry file:
+
+    ```jsx
+    module.exports = require('./admin/src').default;
+    ```
+
+<details>
+<summary>Example of a Strapi v4 plugin registration</summary>
+
+  ```jsx title="./src/plugins/my-plugin/admin/src/index.js"
+
+  import pluginId from './pluginId';
+
+  const pluginDescription = pluginPkg.strapi.description || pluginPkg.description;
+const { name } = pluginPkg.strapi;
+
+  export default {
+    register(app) {
+        // executes as soon as the plugin is loaded
+        app.registerPlugin({
+          id: pluginId
+          name,
+        })
+      }
+    }
+  ```
+
+  ```jsx title=".src/plugins/my-plugin/strapi-admin.js"
+
+  module.exports = require('./admin/src').default;
+  ```
+
+</details>
+
+## Adding a menu link
+
+:::strapi v3/v4 comparison
+A Strapi v3 plugin adds a link to the menu in the admin panel by exporting a `menu` object during the plugin registration.
+
+In Strapi v4, a plugin adds a link to the menu programmatically with the [`addMenuLink()` function](/dev-docs/api/plugins/admin-panel-api.md#menu-api) called in the `register` lifecycle. 
+:::
+
+To migrate to Strapi v4, pass the `menu` key from the Strapi v3 configuration object to `app.addMenuLink()` with the following properties updated:
+
+| Property name and type in v3                      | Equivalent in v4             |
+| ------------------------------------------------- | ---------------------------- |
+| `destination` (String)                            | `to` (String)                |
+| `label` (String)                                  | `intlLabel` (String)   |
+| `icon` (String)<br/><br/>`mainComponent` (String) | `<Icon />` (React component) |
+
+The React-based icon component can be created in a separate file.
+
+<details>
+<summary>Example of an PluginIcon component</summary>
+
+```jsx title="./src/plugins/my-plugin/admin/src/components/PluginIcon/index.js"
+
+import React from "react";
+import { Icon } from "@strapi/parts/Icon";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+
+const PluginIcon = () => (
+  <Icon as={() => <FontAwesomeIcon icon="paint-brush" />} width="16px" />
+);
+
+export default PluginIcon;
+```
+
+</details>
+
+In Strapi v3 the icon component is specified on the `mainComponent` key, in Strapi v4 the component is passed as a dynamic import to the `app.addMenuLink()` function.
+
+<details>
+<summary>Example of adding a menu link with a custom plugin icon component</summary>
+
+```jsx title="./src/plugins/my-plugin/admin/src/index.js"
+
+import pluginId from './pluginId';
+import pluginPermissions from './permissions';
+import PluginIcon from './PluginIcon'
+
+const pluginDescription = pluginPkg.strapi.description || pluginPkg.description;
+const { name } = pluginPkg.strapi;
+
+export default {
+  register(app) {
+    app.addMenuLink({
+      to: `/plugins/${pluginId}`,
+      icon: PluginIcon,
+      intlLabel: {
+        id: `${pluginId}.plugin.name`,
+        defaultMessage: 'My Plugin',
+      },
+      permissions: pluginPermissions.main,
+      Component: async () => {
+        const component = await import(/* webpackChunkName: "my-plugin-page" */ './pages/PluginPage');
+
+        return component;
+      },
+    });
+
+    app.registerPlugin({
+      description: pluginDescription,
+      id: pluginId
+      name
+    });
+  }
+}
+```
+
+</details>
+
+## Adding settings
+
+:::strapi v3/v4 comparison
+
+A Strapi v3 plugin adds a settings section by exporting a `settings` property during the plugin registration.
+
+In Strapi v4, a plugin adds a settings section programmatically using the [Settings API](/dev-docs/api/plugins/admin-panel-api.md#settings-api).
+:::
+
+To migrate to Strapi v4, depending on what your Strapi v3 plugin does, use the following table to find the appropriate Settings API method to use, and click on the method name to go to its dedicated documentation:
+
+| Action     | Method |
+|-----|----|
+| Create a new settings section<br/> and define new links to include in this section | [`createSettingsSection()`](/dev-docs/api/plugins/admin-panel-api.md#createsettingsection) |
+| Add link(s) to an existing settings section:<ul><li>a single link</li><li>multiple links</li></ul> | <br/><ul><li>[`addSettingsLink()`](/dev-docs/api/plugins/admin-panel-api.md#addsettingslink)</li><li>[`addSettingsLinks()`](/dev-docs/api/plugins/admin-panel-api.md#addsettingslinks)</li></ul> |
+
+<details>
+<summary>Example of creating a new settings section</summary>
+
+```js title="./src/plugins/my-plugin/admin/src/index.js"
+
+import getTrad from './utils/getTrad';
+
+register(app) {
+  // Create the plugin's settings section
+  app.createSettingSection(
+    // created section
+    {
+      id: pluginId,
+      intlLabel: {
+        id: getTrad('Settings.section-label'),
+        defaultMessage: 'My plugin settings',
+      },
+    },
+    // links
+    [
+      {
+        intlLabel: {
+          id: 'settings.page',
+          defaultMessage: 'Setting page 1',
+        },
+        id: 'settings',
+        to: `/settings/my-plugin/`,
+        Component: async () => {
+          const component = await import(
+            /* webpackChunkName: "my-plugin-settings-page" */ './pages/Settings'
+          );
+
+          return component;
+        },
+        permissions: [],
+      },
+
+    ]
+  );
+
+  app.registerPlugin({
+    id: pluginId,
+    name,
+  });
+},
+```
+
+</details>
+
+## Adding reducers
+
+:::strapi v3/v4 comparison
+
+A Strapi v3 plugin adds reducers by exporting a `reducers` property during the plugin registration.
+
+In Strapi v4, a plugin adds reducers programmatically using the [Reducers API](/dev-docs/api/plugins/admin-panel-api.md#reducers-api).
+:::
+
+To migrate to Strapi v4, make sure reducers are added programmatically with the `addReducers()` method.
+
+<details>
+<summary>Example of adding reducers</summary>
+
+```js title="./src/plugins/my-plugin/admin/src/index.js"
+
+import myReducer from './components/MyCompo/reducer';
+import myReducer1 from './components/MyCompo1/reducer';
+import pluginId from './pluginId';
+
+const reducers = {
+  [`${pluginId}_reducer`]: myReducer,
+  [`${pluginId}_reducer1`]: myReducer1,
+};
+
+export default {
+  register(app) {
+    app.addReducers(reducers);
+
+    app.registerPlugin({
+      id: pluginId,
+      name,
+    });
+  },
+ }
+}
+```
+
+</details>
+
+## Adding injection zones
+
+:::strapi v3/v4 comparison
+A Strapi v3 plugin can inject components into the Content Manager's Edit view, using the `registerField()` method or the `useStrapi` hook within the `Initializer` component.
+
+In Strapi v4, a plugin can inject components into several locations of the Content Manager using the [Injection Zones API](/dev-docs/api/plugins/admin-panel-api.md#injection-zones-api).
+:::
+
+To migrate to Strapi v4, make sure components are injected using Strapi v4 [Injection Zones API](/dev-docs/api/plugins/admin-panel-api.md#injection-zones-api). Depending on where the component should be injected, use:
+
+- either the `injectContentManagerComponent()` method to inject into [predefined injection zones](/dev-docs/api/plugins/admin-panel-api.md#using-predefined-injection-zones) of the Content Manager
+- or the `injectComponent()` method to inject into [custom zones](/dev-docs/api/plugins/admin-panel-api.md#creating-a-custom-injection-zone)
+
+<details>
+<summary>Example of injecting a component into the Content Manager's Edit view</summary>
+
+```jsx title=" ./src/plugins/my-plugin/admin/src/index.js"
+
+import pluginId from './pluginId;
+import Link from './components/Link'
+
+export default {
+  bootstrap(app){
+    // insert a link in the 'right-links' zone of the Content Manager's edit view
+    app.injectContentManagerComponent('editView', 'right-links', {
+      name: `${pluginId}-link`,
+      Component: Link,
+    });
+  }
+}
+```
+
+</details>
+
+## Using the `Initializer` component
+
+:::strapi v3/v4 comparison
+In both Strapi v3 and v4, the `Initializer` component is generated by default when a plugin is created. `Initializer` could be used to execute some logic when the application is loading, for instance to dispatch an action after the user logs in into the admin panel.
+
+In Strapi v4, the `Initializer` component code has changed and uses the `useRef` and `useEffect`  React hooks to dispatch actions.
+:::
+
+The Initializer component is useful to store a global state in the application, which will be loaded before the application is rendered using Redux. To make sure the Initializer component is mounted in the application, set the `isReady` key to `false` when registering the plugin with `registerPlugin()`.
+
+To migrate to Strapi v4, make sure the plugin uses the latest `Initializer` code, which can be copied and pasted from the following code example:
+
+```jsx title="./src/plugins/my-plugin/admin/src/components/Initializer/index.js"
+
+import { useEffect, useRef } from 'react';
+import PropTypes from 'prop-types';
+import pluginId from '../../pluginId';
+
+const Initializer = ({ setPlugin }) => {
+  const ref = useRef();
+  ref.current = setPlugin;
+
+  useEffect(() => {
+    ref.current(pluginId);
+  }, []);
+
+  return null;
+};
+
+Initializer.propTypes = {
+  setPlugin: PropTypes.func.isRequired,
+};
+
+export default Initializer;
+```
+
+<details>
+<summary>Example of registering a plugin that uses the new Initializer component</summary>
+
+```js title="./src/plugins/my-plugin/admin/src/index.js"
+
+export default {
+  register(app) {
+    app.registerPlugin({
+      id: pluginId,
+      initializer: Initializer,
+      isReady: false, // ensures the Initializer component is mounted in the application
+      name,
+    });
+  },
+ }
+}
+```
+
+</details>
+
+## Registering translations
+
+In Strapi v4, the front-end plugin interface can export an [asynchronous `registerTrads()` function](/dev-docs/api/plugins/admin-panel-api.md#async-function) for registering translation files.
+
+<details>
+<summary>Example of translation registration</summary>
+
+```jsx
+import { prefixPluginTranslations } from "@strapi/helper-plugin";
+
+export default {
+  register(app) {
+    // register code...
+  },
+  bootstrap(app) {
+    // bootstrap code...
+  },
+  async registerTrads({ locales }) {
+    const importedTrads = await Promise.all(
+      locales.map((locale) => {
+        return import(
+          /* webpackChunkName: "[pluginId]-[request]" */ `./translations/${locale}.json`
+        )
+          .then(({ default: data }) => {
+            return {
+              data: prefixPluginTranslations(data, pluginId),
+              locale,
+            };
+          })
+          .catch(() => {
+            return {
+              data: {},
+              locale,
+            };
+          });
+      })
+    );
+
+    return Promise.resolve(importedTrads);
+  },
+};
+```
+
+</details>

--- a/docusaurus/docs/dev-docs/migration/v3-to-v4/plugin/update-folder-structure.md
+++ b/docusaurus/docs/dev-docs/migration/v3-to-v4/plugin/update-folder-structure.md
@@ -1,0 +1,367 @@
+---
+title: v4 Plugin Migration - Updating the folder structure
+description: Migrate the folder structure of a Strapi plugin from v3.6.x to v4.0.x with step-by-step instructions
+displayed_sidebar: devDocsSidebar
+canonicalUrl: http://docs.strapi.io/dev-docs/migration/v3-to-v4/plugin/update-folder-structure.html
+---
+
+import PluginMigrationIntro from '/docs/snippets/plugin-migration-intro.md'
+
+# v4 plugin migration: Updating the folder structure
+
+<PluginMigrationIntro components={props.components} />
+
+:::strapi v3/v4 comparison
+Strapi v3 plugins required a specific folder structure.
+
+In Strapi v4, plugins are developed using a programmatic API, which gives flexibility in the folder structure.
+:::
+
+The folder structure of a Strapi v4 plugin should meet the following requirements:
+
+- The root of the plugin folder should include:
+  - a `strapi-server.js` entry file, if the plugin interacts with Strapi's back-end (see [Server API](/dev-docs/api/plugins/server-api.md))
+  - a `strapi-admin.js` entry file, if the plugin interacts with Strapi's admin panel (see [Admin Panel API](/dev-docs/api/plugins/admin-panel-api.md)).
+
+- `strapi-admin.js` and `strapi-server.js` should export the plugin's interface.
+
+As long as these requirements are met, the rest of the folder structure is up to you.
+
+<details>
+<summary>Example of a Strapi v4 plugin structure</summary>
+
+```jsx
+my-plugin
+├─ admin
+│  └─ src
+│     ├─ components
+│     ├─ pages
+│     ├─ // more folders and files
+│     └─ index.js
+├─ server
+│  ├─ config
+│  ├─ content-types
+│  ├─ controllers
+│  ├─ middlewares
+│  ├─ policies
+│  ├─ routes
+│  ├─ services
+│  ├─ bootstrap.js
+│  ├─ destroy.js
+│  ├─ register.js
+│  ├─ // more folders and files
+│  └─ index.js
+├─ strapi-admin.js // require('./admin')
+└─ strapi-server.js // require('./server')
+```
+
+</details>
+
+The folder structure of a Strapi v3 plugin can be migrated to a v4 plugin either [automatically](#updating-folder-structure-automatically) or [manually](#updating-folder-structure-manually).
+
+## Updating folder structure automatically
+
+:::caution
+The codemod creates a new Strapi v4 plugin, leaving the Strapi v3 plugin in place. We recommend confirming the v4 version of the plugin is working properly before deleting the v3 version.
+:::
+
+A codemod can be used to automatically update the folder structure of a plugin for Strapi v4. The codemod performs the following actions:
+
+- creation of 2 entry files: `strapi-server.js` and `strapi-admin.js`,
+- organization of files and folders into a `server` and an `admin` folders, respectively,
+- conversion of `models` to `contentTypes`,
+- and export of `services` as functions.
+
+To execute the codemod, run the following commands in a terminal:
+
+```sh
+npx @strapi/codemods migrate:plugin <path-to-v3-plugin> [path-for-v4-plugin]
+```
+
+## Updating folder structure manually
+
+Manually updating the folder structure requires moving and updating the content of multiple files and folders. These steps are described in the following subsections.
+
+:::note
+The folder structure is given as an example, and files and folders can be organized freely as long as `strapi-server.js` or `strapi-admin.js` exist and export the plugin interface.
+:::
+
+### Creating a `server` folder
+
+The `server` folder includes all the code for the back end of the plugin. To create it at the root of the plugin folder, run the following command in a terminal:
+
+```sh
+cd <my-plugin-folder-name>
+mkdir server
+```
+
+### Moving controllers, services, and middlewares
+
+:::strapi v3/v4 comparison
+In Strapi v3, controllers, services, and middlewares of a plugin must follow a strict folder structure convention.
+
+In Strapi v4, the organization of files and folders for plugins is flexible. However, it is recommended to create dedicated folders for every type of back-end element (e.g. [controllers](/dev-docs/api/plugins/server-api.md#controllers), [services](/dev-docs/api/plugins/server-api.md#services), and [middlewares](/dev-docs/api/plugins/server-api.md#middlewares)) inside a `server` folder (see [project structure](/dev-docs/project-structure.md)).
+
+:::
+
+To update the controllers, services, and middlewares of a plugin to Strapi v4, create specific sub-folders in a `server` folder.
+
+Plugin files and folders in Strapi v4 should meet 2 requirements:
+
+- Each file in the `server/<subfolder-name>/<element-name>` (e.g. `server/controllers/my-controller.js`) should:
+  * export a function taking the `strapi` instance (object) as a parameter
+  * and return an object.
+- Each of the `server/<subfolder-name>` folders should include an `index.js` file that exports all files in the folder.
+
+<details>
+<summary>Example of files and folder for Strapi v4 plugin controllers</summary>
+
+```jsx title="./src/plugins/my-plugin/server/controllers/my-controllerA.js"
+
+module.exports = ({ strapi }) => ({
+  doSomething(ctx) {
+    ctx.body = { message: "HelloWorld" };
+  },
+});
+```
+
+```jsx title="./src/plugins/my-plugin/server/controllers/index.js"
+
+"use strict";
+
+const myControllerA = require("./my-controllerA");
+const myControllerB = require("./my-controllerB");
+
+module.exports = {
+  myControllerA,
+  myControllerB,
+};
+
+```
+
+</details>
+
+### Moving the `bootstrap` function
+
+:::strapi v3/v4 comparison
+Strapi v3 has a dedicated `config/functions` folder for each plugin.
+
+In Strapi v4, the `config` folder does not necessarily exist for a plugin and [the `bootstrap` function](/dev-docs/api/plugins/server-api.md#bootstrap) and other lifecycle functions can be declared elsewhere.
+:::
+
+To update the plugin's `bootstrap` function to Strapi v4:
+
+- move the `bootstrap()` function from `server/config/functions/bootstrap.js` to `server/bootstrap.js`
+- pass the `strapi` instance (object) as a parameter
+
+```jsx title="./src/plugins/my-plugin/server/bootstrap.js"
+
+"use strict";
+
+module.exports = ({ strapi }) => ({
+  // bootstrap the plugin
+});
+```
+
+### Moving routes
+
+:::strapi v3/v4 comparison
+Strapi v3 declares routes for a plugin in a specific `config/routes.json` file.
+
+In Strapi v4, the `config` folder does not necessarily exist for a plugin and [plugin routes](/dev-docs/api/plugins/server-api.md#routes) can be declared in a `server/routes/index.json` file.
+:::
+
+To update plugin routes to Strapi v4, move routes from `config/routes.json` to `server/routes/index.json`.
+
+Routes in Strapi v4 should meet 2 requirements:
+
+- Routes should return an array or an object specifying `admin` or `content-api` routes.
+- Routes handler names should match the same casing as the controller exports.
+
+<details>
+<summary>Example of controllers export and routes in a Strapi v4 plugin</summary>
+
+```jsx title="./src/plugins/my-plugin/server/controllers/index.js"
+
+"use strict";
+
+const myControllerA = require("./my-controllerA");
+const myControllerB = require("./my-controllerB");
+
+module.exports = {
+  myControllerA,
+  myControllerB,
+};
+```
+
+```jsx title="./src/plugins/my-plugin/server/routes/index.js"
+
+module.exports = [
+  {
+    method: "GET",
+    path: "/my-controller-a",
+    // Camel case handler to match export in server/controllers/index.js
+    handler: "myControllerA.doSomething",
+    config: { policies: [] },
+  },
+];
+```
+
+</details>
+
+### Moving policies
+
+:::strapi v3/v4 comparison
+Strapi v3 declares policies for a plugin in a specific `config/policies` folder.
+
+In Strapi v4, the `config` folder does not necessarily exist for a plugin and [plugin policies](/dev-docs/api/plugins/server-api.md#policies) can be declared in dedicated files found under `server/policies`.
+:::
+
+To update plugin policies to Strapi v4:
+
+1. Move policies from `config/policies` to `server/policies/<policy-name>.js`
+
+2. Add an `index.js` file to the `server/policies` folder and make sure it exports all files in the folder.
+
+### Converting models to content-types
+
+:::strapi v3/v4 comparison
+Strapi v3 declares plugin models in `<model-name>.settings.json` files found in a `models` folder.
+
+In Strapi v4, [plugin content-types](/dev-docs/api/plugins/server-api.md#content-types) are declared in `schema.json` files found in a `server/content-types/<contentTypeName>` folder. The `schema.json` files introduce some new properties (see [schema documentation](/dev-docs/backend-customization/models.md#model-schema)).
+:::
+
+To convert Strapi v3 models to v4 content-types:
+
+1. Move the `models` folder under the `server` folder and rename `models` to `content-types`:
+
+    ```sh
+    mv models/ server/content-types/
+    ```
+
+2. Move/rename each model's `<modelName>.settings.json` file to `server/content-types/<contentTypeName>/schema.json` files.
+3. In each `<contentTypeName>/schema.json` file, update [the `info` object](/dev-docs/backend-customization/models.md#model-information), which now requires declaring the 3 new `singularName`, `pluralName` and `displayName` keys and respecting some case-formatting conventions:
+
+    ```json title="./src/plugins/my-plugin/content-types/<content-type-name>/schema.json"
+
+    // ...
+    "info": {
+      "singularName": "content-type-name", // kebab-case required
+      "pluralName": "content-type-names", // kebab-case required
+      "displayName": "Content-type name",
+      "name": "Content-type name",
+    };
+    // ...
+    ```
+
+4. (_optional_) If the Strapi v3 model uses lifecycle hooks found in `<model-name>.js`, move/rename the file to `server/content-types/<contentTypeName>/lifecycle.js`, otherwise delete the file.
+5. Create an `index.js` file for each content-type to export the schema and, optionally, lifecycle hooks:
+
+    ```jsx title="./src/plugins/my-plugin/server/content-types/<content-type-name>/index.js"
+
+    const schema = require("./schema.json");
+    const lifecycles = require("./lifecycles.js"); // optional
+
+    module.exports = {
+      schema,
+      lifecycles, // optional
+    };
+    ```
+
+6. Create a `server/content-types/index.js` file.
+7. In `server/content-types/index.js`, export all content-types and make sure the key of each content-type matches the `singularName` found in the `info` object of the content-type’s `schema.json` file:
+
+    ```json title="./src/plugins/my-plugin/server/content-types/content-type-a/schema.json"
+
+    "info": {
+      "singularName": "content-type-a", // kebab-case required
+      "pluralName": "content-type-as", // kebab-case required
+      "displayName": "Content-Type A",
+      "name": "Content-Type A",
+    };
+    ```
+
+    ```jsx title="./src/plugins/my-plugin/server/content-types/index.js"
+
+    "use strict";
+
+    const contentTypeA = require("./content-type-a");
+    const contentTypeB = require("./content-type-b");
+
+    module.exports = {
+      // Key names should match info.singularName key values found in corresponding schema.json files
+      "content-type-a": contentTypeA,
+      "content-type-b": contentTypeB,
+    };
+    ```
+
+:::note
+Converting Strapi v3 models to v4 content-types also requires updating getters and, optionally, relations (see [plugin back end migration documentation](/dev-docs/migration/v3-to-v4/plugin/migrate-back-end.md)).
+:::
+
+### Creating entry files
+
+:::strapi v3/v4 comparison
+Strapi v3 plugins use a strict folder structure convention.
+
+In Strapi v4, the folder structure for plugins is flexible. However, each plugin needs at least a `strapi-server.js` entry file or a `strapi-admin.js` entry file. The 2 entry files are used to take advantage of, respectively, the [Server API](/dev-docs/api/plugins/server-api.md) for the back end of the plugin and the [Admin Panel API](/dev-docs/api/plugins/admin-panel-api.md) for the front end of the plugin.
+:::
+
+To update the plugin to Strapi v4:
+
+- If the plugin interacts with Strapi's backend, create the `strapi-server.js` back-end entry file at the root of the plugin folder. The file should require all necessary files and export the back-end plugin interface (see [migrating the back end of a plugin](/dev-docs/migration/v3-to-v4/plugin/migrate-back-end.md)). 
+
+  <details>
+  <summary>Example strapi-server.js and server/index.js entry files</summary>
+
+    ```js title="./src/plugins/my-plugin/strapi-server.js"
+
+    "use strict";
+
+    module.exports = require('./server');
+    ```
+
+    ```js title="./src/plugins/my-plugin/server/index.js"
+
+    "use strict";
+
+    const register = require('./register');
+    const bootstrap = require('./bootstrap');
+    const destroy = require('./destroy');
+    const config = require('./config');
+    const contentTypes = require('./content-types');
+    const controllers = require('./controllers');
+    const routes = require('./routes');
+    const middlewares = require('./middlewares');
+    const policies = require('./policies');
+    const services = require('./services');
+
+    module.exports = {
+      register,
+      bootstrap,
+      destroy,
+      config,
+      controllers,
+      routes,
+      services,
+      contentTypes,
+      policies,
+      middlewares,
+    };
+    ```
+
+  </details>
+
+- If the plugin interacts with Strapi's admin panel, create the `strapi-admin.js` front-end entry file at the root of the plugin folder. The file should require all necessary files and export the front-end plugin interface (see [migrating the front end of a plugin](/dev-docs/migration/v3-to-v4/plugin/migrate-front-end.md)).
+
+  <details>
+  <summary>Example strapi-admin.js entry file</summary>
+
+    ```jsx title="./src/plugins/my-plugin/strapi-admin.js"
+
+    "use strict";
+
+    module.exports = require("./admin/src").default;
+    ```
+
+  </details>

--- a/docusaurus/docs/dev-docs/migration/v3-to-v4/plugin/update-folder-structure.md
+++ b/docusaurus/docs/dev-docs/migration/v3-to-v4/plugin/update-folder-structure.md
@@ -1,5 +1,5 @@
 ---
-title: v4 Plugin Migration - Updating the folder structure
+title: Updating the folder structure
 description: Migrate the folder structure of a Strapi plugin from v3.6.x to v4.0.x with step-by-step instructions
 displayed_sidebar: devDocsSidebar
 canonicalUrl: http://docs.strapi.io/dev-docs/migration/v3-to-v4/plugin/update-folder-structure.html

--- a/docusaurus/docs/snippets/codemods-modify-source-code.md
+++ b/docusaurus/docs/snippets/codemods-modify-source-code.md
@@ -1,0 +1,1 @@
+Codemods modify the plugin source code. Before running a command, make sure you have initialized a git repo, the working tree is clean, you've pushed your v3 plugin, and you are on a new branch.

--- a/docusaurus/docs/snippets/plugin-migration-intro.md
+++ b/docusaurus/docs/snippets/plugin-migration-intro.md
@@ -1,0 +1,1 @@
+This guide is part of the [v4 plugin migration guide](/dev-docs/migration/v3-to-v4/plugin-migration.md) designed to help you migrate a plugin from Strapi v3.6.x to v4.0.x.

--- a/docusaurus/docs/status.md
+++ b/docusaurus/docs/status.md
@@ -27,7 +27,7 @@ In the meantime, we would love to hear your feedback, so [please let us know](ht
 **Content conversion progress:**
 
 <details>
-<summary>Developer documentation ▮▮▮▮▯▯▯▯▯▯ ~40% complete</summary>
+<summary>Developer documentation ▮▮▮▮▮▮▮▯▯▯ ~75% complete</summary>
 
 The following list is a sitemap of all the current and upcoming content for the Developer Docs:
 
@@ -173,11 +173,11 @@ The following list is a sitemap of all the current and upcoming content for the 
       - [ ] SQL relations cheatsheet (→ [docs.strapi.io](https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/v4/data/sql-relations.html))
       - [ ] MongoDB v3 to SQL v3 migration (→ [docs.strapi.io](https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/v4/data/mongo.html))
       - [ ] MongoDB vs. SQL cheatsheet (→ [docs.strapi.io](https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/v4/data/mongo-sql-cheatsheet.html))
-    - [ ] Plugin migration guide (→ [docs.strapi.io](https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/v4/plugin-migration.html))
-      - [ ] Updating the folder structure (→ [docs.strapi.io](https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/v4/plugin/update-folder-structure.html))
-      - [ ] Migrating the back end (→ [docs.strapi.io](https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/v4/plugin/migrate-back-end.html))
-      - [ ] Migrating the front end (→ [docs.strapi.io](https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/v4/plugin/migrate-front-end.html))
-      - [ ] Enabling a plugin (→ [docs.strapi.io](https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/v4/plugin/enable-plugin.html))
+    - [x] Plugin migration guide (→ [docs.strapi.io](https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/v4/plugin-migration.html))
+      - [x] Updating the folder structure (→ [docs.strapi.io](https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/v4/plugin/update-folder-structure.html))
+      - [x] Migrating the back end (→ [docs.strapi.io](https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/v4/plugin/migrate-back-end.html))
+      - [x] Migrating the front end (→ [docs.strapi.io](https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/v4/plugin/migrate-front-end.html))
+      - [x] Enabling a plugin (→ [docs.strapi.io](https://docs.strapi.io/developer-docs/latest/update-migration-guides/migration-guides/v4/plugin/enable-plugin.html))
 
 </details>
 

--- a/docusaurus/docs/status.md
+++ b/docusaurus/docs/status.md
@@ -19,7 +19,6 @@ To find what you're looking for on this beta website, you can use one of the fol
 
 Once the initial content is fully converted, we will gradually improve the documentation further, for instance, adding a new homepage and more in-depth and interactive content for both beginners and more advanced users. Stay tuned!
 
-<!-- TODO: update with actual communication link -->
 In the meantime, we would love to hear your feedback, so [please let us know](https://forum.strapi.io)!
 
 ***

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -306,13 +306,13 @@ const sidebars = {
         'dev-docs/update-version',
         {
           type: 'category',
-          collapsed: false,
+          collapsed: true,
           label: 'v3 to v4 migration guides',
           items: [
             // 'dev-docs/migration/v3-to-v4/code-migration',
             {
               type: 'category',
-              collapsed: false,
+              collapsed: true,
               link: {
                 type: 'doc',
                 id: 'dev-docs/migration/v3-to-v4/plugin-migration'

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -192,6 +192,7 @@ const sidebars = {
           ]
         },
         'dev-docs/api/plugins/admin-panel-api',
+        'dev-docs/api/plugins/server-api',
       ]
     },
     {
@@ -302,12 +303,22 @@ const sidebars = {
       collapsed: false,
       label: 'Update and Migration',
       items: [
-            'dev-docs/update-version'  
+        'dev-docs/update-version',
+        {
+          type: 'category',
+          collapsed: false,
+          label: 'v3 to v4 migration guides',
+          items: [
+            // 'dev-docs/migration/v3-to-v4/code-migration',
+            'dev-docs/migration/v3-to-v4/plugin-migration',
+            // 'dev-docs/migration/v3-to-v4/data-migration',
           ]
+        }
+      ],
     },
   ],
 
- 
+
 
   userDocsSidebar: [
     'user-docs/intro',

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -310,7 +310,21 @@ const sidebars = {
           label: 'v3 to v4 migration guides',
           items: [
             // 'dev-docs/migration/v3-to-v4/code-migration',
-            'dev-docs/migration/v3-to-v4/plugin-migration',
+            {
+              type: 'category',
+              collapsed: false,
+              link: {
+                type: 'doc',
+                id: 'dev-docs/migration/v3-to-v4/plugin-migration'
+              },
+              label: 'Plugin migration',
+              items: [
+                'dev-docs/migration/v3-to-v4/plugin/update-folder-structure',
+                'dev-docs/migration/v3-to-v4/plugin/migrate-back-end',
+                'dev-docs/migration/v3-to-v4/plugin/migrate-front-end',
+                'dev-docs/migration/v3-to-v4/plugin/enable-plugin',
+              ]
+            },
             // 'dev-docs/migration/v3-to-v4/data-migration',
           ]
         }


### PR DESCRIPTION
Converts plugin migration pages.

- [x] Introduction page
- [X] Update the folder structure
- [x] Migrate the front end
- [x] Migrate the back end
- [x] Enable the plugin