### PR TITLE
🚀 Production hotfix: Fix Docusaurus code fonts on all OSes

### DIFF
--- a/docusaurus/src/css/admonitions.css
+++ b/docusaurus/src/css/admonitions.css
@@ -33,7 +33,7 @@
 .theme-admonition code {
   font-weight: 400;
   font-style: normal;
-  font-family: 'Menlo';
+  font-family: "SFMono-Regular", "Menlo", "Monaco", "Consolas", "Liberation Mono", "Courier New", monospace;
   line-height: 24px;
   font-size: 13px;
   border-radius: 4px;

--- a/docusaurus/src/css/main.css
+++ b/docusaurus/src/css/main.css
@@ -91,7 +91,7 @@ footer.footer.footer--dark a:hover {
 }
 
 code {
-  font-family: 'Menlo';
+  font-family: 'Menlo', 'Courier', monospace, system-ui;
   font-weight: 400;
   line-height: 24px;
   padding: 4px 8px;

--- a/docusaurus/src/css/main.css
+++ b/docusaurus/src/css/main.css
@@ -91,7 +91,7 @@ footer.footer.footer--dark a:hover {
 }
 
 code {
-  font-family: 'Menlo', 'Courier', monospace, system-ui;
+  font-family: "SFMono-Regular", "Menlo", "Monaco", "Consolas", "Liberation Mono", "Courier New", monospace;
   font-weight: 400;
   line-height: 24px;
   padding: 4px 8px;


### PR DESCRIPTION
Code blocks should now use one of the following font families:
- SFMono-Regular, 
- Menlo, 
- Monaco,
- Consolas, 
- Liberation Mono,
- Courier New, 
- or any other monospace font installed on your system.