### PR TITLE
Port #1479 to Docusaurus

### DIFF
--- a/docusaurus/docs/dev-docs/deployment/heroku.md
+++ b/docusaurus/docs/dev-docs/deployment/heroku.md
@@ -38,25 +38,27 @@ Strapi uses [environment configurations](/dev-docs/configurations/environment) t
 ```js
 // path: ./config/env/production/database.js
 
-const parse = require('pg-connection-string').parse;
-const config = parse(process.env.DATABASE_URL);
+const { parse } = require("pg-connection-string");
 
-module.exports = ({ env }) => ({
-  connection: {
-    client: 'postgres',
+module.exports = ({ env }) => {
+  const { host, port, database, user, password } = parse(env("DATABASE_URL"));
+  
+  return {
     connection: {
-      host: config.host,
-      port: config.port,
-      database: config.database,
-      user: config.user,
-      password: config.password,
-      ssl: {
-        rejectUnauthorized: false
+      client: 'postgres',
+      connection: {
+        host,
+        port,
+        database,
+        user,
+        password,
+        ssl: { rejectUnauthorized: false },
       },
+      debug: false,
     },
-    debug: false,
-  },
-});
+  }
+};
+
 ```
 
 </TabItem>


### PR DESCRIPTION
This ports the suggested change for the Heroku configuration in #1479 to the new Docusaurus-based documentation.