### PR TITLE
Replace 'Edit this page' text for 'Improve this page'

### DIFF
--- a/docusaurus/i18n/en/code.json
+++ b/docusaurus/i18n/en/code.json
@@ -1,0 +1,6 @@
+{
+  "theme.common.editThisPage": {
+    "message": "Improve this page",
+    "description": "The link label to edit the current page"
+  }
+}


### PR DESCRIPTION
### What does it do?

It replaces the word `Edit` by `Improve` in the link "Edit this page" which is present at bottom of each page.

### Technical changes

To override the default text `Edit this page` from Docusaurus, the safest alternative is to creating this file `docusaurus/i18n/en/code.json`, which can be fully generated by the command `yarn write-translations`, where in this case was left the only single file and the single object which correspond to the replaced text which we want a different word.

### Why is it needed?

Requested by the Documentation Team:
A more collaborative word to give more space and freedom to our Community Users contributing/participating.
