### PR TITLE
Remove outdated public middleware docs, update admin redirect

### DIFF
--- a/docusaurus/docs/dev-docs/configurations/middlewares.md
+++ b/docusaurus/docs/dev-docs/configurations/middlewares.md
@@ -656,9 +656,6 @@ The `public` middleware is a static file serving middleware, based on [koa-stati
 | Option         | Description                                                                                  | Type      | Default value |
 |----------------|----------------------------------------------------------------------------------------------|-----------|---------------|
 | `maxAge`       | Cache-control max-age directive, in milliseconds                                             | `Integer` | `60000`       |
-| `hidden`       | Allow transfer of hidden files                                                               | `Boolean` | `false`       |
-| `defer`        | If `true`, serves after `return next()`, allowing any downstream middleware to respond first | `Boolean` | `false`       |
-| `index`        | Default file name                                                                            | `String`  | `index.html`  |
 | `defaultIndex` | Display default index page at `/` and `/index.html`                                          | `Boolean` | `true`        |
 
 :::tip

--- a/docusaurus/docs/dev-docs/deployment/snippets-proxy/admin-redirect.md
+++ b/docusaurus/docs/dev-docs/deployment/snippets-proxy/admin-redirect.md
@@ -1,17 +1,32 @@
 ### Redirecting landing page to admin panel
 
-If you do not wish to have the default landing page mounted on `/` you can create a custom `./public/index.html` using the sample code below to automatically redirect to your admin panel.
+If you do not wish to have the default landing page mounted on `/` you can create a custom middleware using the sample code below to automatically redirect to your admin panel.
 
 :::caution
 This sample configuration expects that the admin panel is accessible on `/admin`. If you used one of the above configurations to change this to `/dashboard` you will also need to adjust this sample configuration.
 :::
 
-**Path —** `./public/index.html`
+**Path —** `./config/middlewares.js`
 
-```html
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0;URL='/admin'" />
-  </head>
-</html>
+```js
+module.exports = ({ env }) => [
+	// ...
+	{ resolve: './src/middlewares/admin-redirect' },
+];
+
+```
+
+**Path —** `./src/middlewares/admin-redirect.js`
+
+```js
+module.exports = (_config, { strapi }) => {
+	const redirects = ['/', '/index.html'].map((path) => ({
+		method: 'GET',
+		path,
+		handler: (ctx) => ctx.redirect('/admin'),
+		config: { auth: false },
+	}));
+
+	strapi.server.routes(redirects);
+};
 ```

--- a/docusaurus/docs/dev-docs/deployment/snippets-proxy/admin-redirect.md
+++ b/docusaurus/docs/dev-docs/deployment/snippets-proxy/admin-redirect.md
@@ -6,9 +6,7 @@ If you do not wish to have the default landing page mounted on `/` you can creat
 This sample configuration expects that the admin panel is accessible on `/admin`. If you used one of the above configurations to change this to `/dashboard` you will also need to adjust this sample configuration.
 :::
 
-**Path —** `./config/middlewares.js`
-
-```js
+```js title="./config/middlewares.js"
 module.exports = ({ env }) => [
 	// ...
 	{ resolve: './src/middlewares/admin-redirect' },
@@ -16,9 +14,7 @@ module.exports = ({ env }) => [
 
 ```
 
-**Path —** `./src/middlewares/admin-redirect.js`
-
-```js
+```js title="./src/middlewares/admin-redirect.js"
 module.exports = (_config, { strapi }) => {
 	const redirects = ['/', '/index.html'].map((path) => ({
 		method: 'GET',


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

Remove outdated public middleware options, and update recommendations for admin redirect.

### Why is it needed?

- [Public middleware](https://github.com/strapi/strapi/blob/a9fe3a0191870500b7f56ff7dd30fdda494e666a/packages/core/strapi/lib/middlewares/public/index.js#L21) is no longer using the current mentioned options.
- [Admin redirect](https://docs.strapi.io/dev-docs/deployment/snippets-proxy/admin-redirect) seems to no longer work, mostly because of public middleware changes.

