### PR TITLE
Update table-of-contents icons style

### DIFF
--- a/docusaurus/src/css/custom.css
+++ b/docusaurus/src/css/custom.css
@@ -18,3 +18,4 @@
 @import './details.css';
 @import './tables.css';
 @import './code-blocks.css';
+@import './table-of-contents.css';

--- a/docusaurus/src/css/main.css
+++ b/docusaurus/src/css/main.css
@@ -33,6 +33,12 @@ h2 {
   font-size: 24px;
 }
 
+h3 img {
+  display: inline-block;
+  vertical-align: middle;
+  margin: 0 2px 3px 0;
+}
+
 [data-theme="light"] .theme-doc-markdown.markdown {
   font-weight: 400;
 }

--- a/docusaurus/src/css/table-of-contents.css
+++ b/docusaurus/src/css/table-of-contents.css
@@ -1,0 +1,14 @@
+.table-of-contents > li {
+  --ifm-toc-padding-vertical: 1rem;
+}
+
+.table-of-contents > li > ul {
+  --ifm-toc-padding-vertical: 0.5rem;
+}
+
+.table-of-contents__link img {
+  display: inline-block;
+  vertical-align: middle;
+  margin: 0 2px 3px 0;
+  max-width: 22px;
+}


### PR DESCRIPTION
### What does it do?

Fix the vertical alignment of images/icons in the right-side navigation links and in the markdown titles.

![Screenshot 2023-03-07 at 1 18 35 PM](https://user-images.githubusercontent.com/4141420/223483635-12f28220-2b51-4ec9-8f78-b7a120b2e255.png)

![Screenshot 2023-03-07 at 1 19 50 PM](https://user-images.githubusercontent.com/4141420/223483682-331d0c59-67f1-41f5-a8b7-97e035b943ad.png)

