### PR TITLE
Add and re-enable plugin-image-zoom

### DIFF
--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -232,7 +232,7 @@ const config = {
         containerId: 'GTM-KN9JRWG',
       },
     ],
-    // 'plugin-image-zoom', // temp. disabled while we fix the bug
+    'plugin-image-zoom', // temp. disabled while we fix the bug
     /**
      * Seems like we have an issue where a medium-zoom--hidden class is applied on the second, top-most (z-index wise) image,
      * actually hiding the image when zoomed in. Found no related issue in the plugin's repo, might have to dig whether it's

--- a/docusaurus/package.json
+++ b/docusaurus/package.json
@@ -21,6 +21,7 @@
     "@docusaurus/theme-live-codeblock": "0.0.0-5304",
     "@mdx-js/react": "^1.6.22",
     "clsx": "^1.2.1",
+    "docusaurus-plugin-image-zoom": "^0.1.1",
     "plugin-image-zoom": "flexanalytics/plugin-image-zoom",
     "prism-react-renderer": "^1.3.5",
     "react": "^17.0.2",

--- a/docusaurus/yarn.lock
+++ b/docusaurus/yarn.lock
@@ -4324,6 +4324,13 @@ dns-packet@^5.2.2:
   dependencies:
     "@leichtgewicht/ip-codec" "^2.0.1"
 
+docusaurus-plugin-image-zoom@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/docusaurus-plugin-image-zoom/-/docusaurus-plugin-image-zoom-0.1.1.tgz#f5e16ae568f7b74e8a357ee67ea7922521f64539"
+  integrity sha512-cJXo5TKh9OR1gE4B5iS5ovLWYYDFwatqRm00iXFPOaShZG99l5tgkDKgbQPAwSL9wg4I+wz3aMwkOtDhMIpKDQ==
+  dependencies:
+    medium-zoom "^1.0.6"
+
 docusaurus-plugin-redoc@1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/docusaurus-plugin-redoc/-/docusaurus-plugin-redoc-1.2.3.tgz#24be9d5f38ee126133fd0173a56aab743bc44b42"
@@ -6009,6 +6016,11 @@ medium-zoom@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/medium-zoom/-/medium-zoom-1.0.6.tgz#9247f21ca9313d8bbe9420aca153a410df08d027"
   integrity sha512-UdiUWfvz9fZMg1pzf4dcuqA0W079o0mpqbTnOz5ip4VGYX96QjmbM+OgOU/0uOzAytxC0Ny4z+VcYQnhdifimg==
+
+medium-zoom@^1.0.6:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/medium-zoom/-/medium-zoom-1.0.8.tgz#2bd1fbcf2961fa7b0e318fe284462aa9b8608ed2"
+  integrity sha512-CjFVuFq/IfrdqesAXfg+hzlDKu6A2n80ZIq0Kl9kWjoHh9j1N9Uvk5X0/MmN0hOfm5F9YBswlClhcwnmtwz7gA==
 
 memfs@^3.1.2, memfs@^3.4.3:
   version "3.4.7"


### PR DESCRIPTION
This PR tries to re-enable the ability to zoom in on screenshots.

Note: We seem to have an issue where a `medium-zoom--hidden` class is applied on the second, top-most (z-index wise) image, hiding the image when zoomed in. Found no related issue in the plugin's repo, might have to dig into whether it's related to the Docusaurus canary build. 🤔 

I've created a simple PR, only re-enabling the plugin, so our team can test it on a preview link.
If I can't fix it myself, I'll probably file an issue with [the plugin's repo](https://github.com/gabrielcsapo/docusaurus-plugin-image-zoom).