### PR TITLE
add info on db drivers

### DIFF
--- a/docusaurus/docs/dev-docs/configurations/database.md
+++ b/docusaurus/docs/dev-docs/configurations/database.md
@@ -542,13 +542,13 @@ $ GRANT ALL ON SCHEMA public TO my_strapi_db_user;
 
 ### Alternative database driver packages
 
-Strapi attempts to load database drivers for each client based on which packages have been added to the project.
+Strapi checks which database drivers are available in the project for the client before setting the `client` value that is used for Knex.
 
-| client   | order of driver packages selected when available |
-| -------- | ------------------------------------------------ |
-| mysql    | mysql2, mysql                                    |
-| sqlite   | better-sqlite3, @vscode/sqlite3, sqlite3         |
-| postgres | pg                                               |
+| client   | order of driver packages selected when available                                                                 |
+| -------- | ---------------------------------------------------------------------------------------------------------------- |
+| mysql    | [mysql2](https://www.npmjs.com/package/mysql2), [mysql](https://www.npmjs.com/package/mysql)                     |
+| sqlite   | [better-sqlite3](https://www.npmjs.com/package/better-sqlite3), [sqlite3](https://www.npmjs.com/package/sqlite3) |
+| postgres | [pg](https://www.npmjs.com/package/pg)                                                                           |
 
 ::: note
 `mysql2` is required for the `caching_sha2_password` auth method used by default in MySQL v8+. If you receive an `"ER_NOT_SUPPORTED_AUTH_MODE"` error when using the `mysql` driver, try adding the `mysql2` package to your project. You should then remove the deprecated `connectionString` parameter from your connection configuration in favor of the `username` and `password` values.

--- a/docusaurus/docs/dev-docs/configurations/database.md
+++ b/docusaurus/docs/dev-docs/configurations/database.md
@@ -40,6 +40,10 @@ The `./config/database.js` (or `./config/database.ts` for TypeScript) accepts 2 
 | `pool`<br /><br />_Optional_                             | [Database pooling options](#database-pooling-options)                                                 | `Object`  | -       |
 | `acquireConnectionTimeout`<br /><br />_Optional_         | How long knex will wait before throwing a timeout error when acquiring a connection (in milliseconds) | `Integer` | `60000` |
 
+::: note
+The `client` value may be replaced by Strapi before being passed to Knex, based on which database driver packages are available in the project
+:::
+
 #### Connection parameters
 
 The `connection.connection` object found in `./config/database.js` (or `./config/database.ts` for TypeScript) is used to pass database connection information and accepts the following parameters:
@@ -534,4 +538,18 @@ $ \c my_strapi_db_name admin_user
 $ GRANT ALL ON SCHEMA public TO my_strapi_db_user;
 ```
 
+:::
+
+### Alternative database drivers
+
+Strapi attempts to load database drivers for each client based on which packages have been added to the project.
+
+| client   | preferred package, in order of availability |
+| -------- | ------------------------------------------- |
+| mysql    | mysql2, mysql                               |
+| sqlite   | better-sqlite3, @vscode/sqlite3, sqlite3    |
+| postgres | pg                                          |
+
+::: note
+`mysql2` is required for the `caching_sha2_password` auth method used by default in MySQL v8+. If you receive an `"ER_NOT_SUPPORTED_AUTH_MODE"` error when using the `mysql` driver, try adding the `mysql2` package to your project. You should then remove the deprecated `connectionString` parameter from your connection configuration in favor of the `username` and `password` values.
 :::

--- a/docusaurus/docs/dev-docs/configurations/database.md
+++ b/docusaurus/docs/dev-docs/configurations/database.md
@@ -41,7 +41,7 @@ The `./config/database.js` (or `./config/database.ts` for TypeScript) accepts 2 
 | `acquireConnectionTimeout`<br /><br />_Optional_         | How long knex will wait before throwing a timeout error when acquiring a connection (in milliseconds) | `Integer` | `60000` |
 
 ::: note
-The `client` value may be replaced by Strapi before being passed to Knex, based on which database driver packages are available in the project
+The `client` value may be replaced by Strapi before being passed to Knex, based on which database driver packages are available in the project.
 :::
 
 #### Connection parameters

--- a/docusaurus/docs/dev-docs/configurations/database.md
+++ b/docusaurus/docs/dev-docs/configurations/database.md
@@ -546,7 +546,7 @@ Strapi checks which database drivers are available in the project for the client
 
 | client   | order of driver packages selected when available                                                                 |
 | -------- | ---------------------------------------------------------------------------------------------------------------- |
-| mysql    | [mysql](https://www.npmjs.com/package/mysql), [mysql2](https://www.npmjs.com/package/mysql2)                     |
+| mysql    | [mysql2](https://www.npmjs.com/package/mysql2), [mysql](https://www.npmjs.com/package/mysql)                     |
 | sqlite   | [better-sqlite3](https://www.npmjs.com/package/better-sqlite3), [sqlite3](https://www.npmjs.com/package/sqlite3) |
 | postgres | [pg](https://www.npmjs.com/package/pg)                                                                           |
 

--- a/docusaurus/docs/dev-docs/configurations/database.md
+++ b/docusaurus/docs/dev-docs/configurations/database.md
@@ -41,7 +41,7 @@ The `./config/database.js` (or `./config/database.ts` for TypeScript) accepts 2 
 | `acquireConnectionTimeout`<br /><br />_Optional_         | How long knex will wait before throwing a timeout error when acquiring a connection (in milliseconds) | `Integer` | `60000` |
 
 ::: note
-The `client` value may be replaced by Strapi before being passed to Knex, based on which database driver packages are available in the project.
+A client value of sqlite will be modified by Strapi to be better-sqlite3 if the package is available in your project, or sqlite3 if it is not.
 :::
 
 #### Connection parameters

--- a/docusaurus/docs/dev-docs/configurations/database.md
+++ b/docusaurus/docs/dev-docs/configurations/database.md
@@ -542,8 +542,7 @@ $ GRANT ALL ON SCHEMA public TO my_strapi_db_user;
 
 ### Alternative database driver packages
 
-In addition to the `client` values of '[postgres](https://www.npmjs.com/package/pg)', 'sqlite', and '[mysql](https://www.npmjs.com/package/mysql)', Strapi also allows a `client` value of '[mysql2](https://www.npmjs.com/package/mysql2)' for those who install and wish to use that package.
-
+In addition to `client` values of '[postgres](https://www.npmjs.com/package/pg)', 'sqlite', and '[mysql](https://www.npmjs.com/package/mysql)', Strapi also allows a `client` value of '[mysql2](https://www.npmjs.com/package/mysql2)' for those who install and wish to use that package.
 
 ::: note
 `mysql2` is required for the `caching_sha2_password` auth method used by default in MySQL v8+. If you receive an `"ER_NOT_SUPPORTED_AUTH_MODE"` error when using the `mysql` driver, try adding the `mysql2` package to your project. You should then remove the deprecated `connectionString` parameter from your connection configuration in favor of the `username` and `password` values.

--- a/docusaurus/docs/dev-docs/configurations/database.md
+++ b/docusaurus/docs/dev-docs/configurations/database.md
@@ -544,11 +544,11 @@ $ GRANT ALL ON SCHEMA public TO my_strapi_db_user;
 
 Strapi attempts to load database drivers for each client based on which packages have been added to the project.
 
-| client   | preferred package, in order of availability |
-| -------- | ------------------------------------------- |
-| mysql    | mysql2, mysql                               |
-| sqlite   | better-sqlite3, @vscode/sqlite3, sqlite3    |
-| postgres | pg                                          |
+| client   | order of driver selected when available  |
+| -------- | ---------------------------------------- |
+| mysql    | mysql2, mysql                            |
+| sqlite   | better-sqlite3, @vscode/sqlite3, sqlite3 |
+| postgres | pg                                       |
 
 ::: note
 `mysql2` is required for the `caching_sha2_password` auth method used by default in MySQL v8+. If you receive an `"ER_NOT_SUPPORTED_AUTH_MODE"` error when using the `mysql` driver, try adding the `mysql2` package to your project. You should then remove the deprecated `connectionString` parameter from your connection configuration in favor of the `username` and `password` values.

--- a/docusaurus/docs/dev-docs/configurations/database.md
+++ b/docusaurus/docs/dev-docs/configurations/database.md
@@ -542,13 +542,8 @@ $ GRANT ALL ON SCHEMA public TO my_strapi_db_user;
 
 ### Alternative database driver packages
 
-Strapi checks which database drivers are available in the project for the client before setting the `client` value that is used for Knex.
+In addition to the `client` values of '[postgres](https://www.npmjs.com/package/pg)', 'sqlite', and '[mysql](https://www.npmjs.com/package/mysql)', Strapi also allows a `client` value of '[mysql2](https://www.npmjs.com/package/mysql2)' for those who install and wish to use that package.
 
-| client   | order of driver packages selected when available                                                                 |
-| -------- | ---------------------------------------------------------------------------------------------------------------- |
-| mysql    | [mysql2](https://www.npmjs.com/package/mysql2), [mysql](https://www.npmjs.com/package/mysql)                     |
-| sqlite   | [better-sqlite3](https://www.npmjs.com/package/better-sqlite3), [sqlite3](https://www.npmjs.com/package/sqlite3) |
-| postgres | [pg](https://www.npmjs.com/package/pg)                                                                           |
 
 ::: note
 `mysql2` is required for the `caching_sha2_password` auth method used by default in MySQL v8+. If you receive an `"ER_NOT_SUPPORTED_AUTH_MODE"` error when using the `mysql` driver, try adding the `mysql2` package to your project. You should then remove the deprecated `connectionString` parameter from your connection configuration in favor of the `username` and `password` values.

--- a/docusaurus/docs/dev-docs/configurations/database.md
+++ b/docusaurus/docs/dev-docs/configurations/database.md
@@ -41,7 +41,7 @@ The `./config/database.js` (or `./config/database.ts` for TypeScript) accepts 2 
 | `acquireConnectionTimeout`<br /><br />_Optional_         | How long knex will wait before throwing a timeout error when acquiring a connection (in milliseconds) | `Integer` | `60000` |
 
 ::: note
-A client value of sqlite will be modified by Strapi to be better-sqlite3 if the package is available in your project, or sqlite3 if it is not.
+A `client` value of 'sqlite' will be modified by Strapi to be 'better-sqlite3' if the package is available in your project, or 'sqlite3' if it is not.
 :::
 
 #### Connection parameters

--- a/docusaurus/docs/dev-docs/configurations/database.md
+++ b/docusaurus/docs/dev-docs/configurations/database.md
@@ -546,7 +546,7 @@ Strapi checks which database drivers are available in the project for the client
 
 | client   | order of driver packages selected when available                                                                 |
 | -------- | ---------------------------------------------------------------------------------------------------------------- |
-| mysql    | [mysql2](https://www.npmjs.com/package/mysql2), [mysql](https://www.npmjs.com/package/mysql)                     |
+| mysql    | [mysql](https://www.npmjs.com/package/mysql), [mysql2](https://www.npmjs.com/package/mysql2)                     |
 | sqlite   | [better-sqlite3](https://www.npmjs.com/package/better-sqlite3), [sqlite3](https://www.npmjs.com/package/sqlite3) |
 | postgres | [pg](https://www.npmjs.com/package/pg)                                                                           |
 

--- a/docusaurus/docs/dev-docs/configurations/database.md
+++ b/docusaurus/docs/dev-docs/configurations/database.md
@@ -540,15 +540,15 @@ $ GRANT ALL ON SCHEMA public TO my_strapi_db_user;
 
 :::
 
-### Alternative database drivers
+### Alternative database driver packages
 
 Strapi attempts to load database drivers for each client based on which packages have been added to the project.
 
-| client   | order of driver selected when available  |
-| -------- | ---------------------------------------- |
-| mysql    | mysql2, mysql                            |
-| sqlite   | better-sqlite3, @vscode/sqlite3, sqlite3 |
-| postgres | pg                                       |
+| client   | order of driver packages selected when available |
+| -------- | ------------------------------------------------ |
+| mysql    | mysql2, mysql                                    |
+| sqlite   | better-sqlite3, @vscode/sqlite3, sqlite3         |
+| postgres | pg                                               |
 
 ::: note
 `mysql2` is required for the `caching_sha2_password` auth method used by default in MySQL v8+. If you receive an `"ER_NOT_SUPPORTED_AUTH_MODE"` error when using the `mysql` driver, try adding the `mysql2` package to your project. You should then remove the deprecated `connectionString` parameter from your connection configuration in favor of the `username` and `password` values.


### PR DESCRIPTION
### What does it do?

Adds information on using alternative database drivers for Knex
Corrects some inaccurate info about connection.client (client is not passed directly to knex as stated above, we modify it)

### Why is it needed?

`mysql2` is necessary for using mysql 8+ auth

We also don't have any documentation (as far as I know) about the ability to use alternative sqlite

### Related issue(s)/PR(s)

Do not merge until the release after https://github.com/strapi/strapi/pull/16180 has been merged (should now be 4.9.1, there were some issues with CI), which adds support for `mysql2`