### PR TITLE
Make 3rd level TOC items expanded by default + autocollapse siblings

### DIFF
--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -137,7 +137,8 @@ const config = {
       // },
       docs: {
         sidebar: {
-          hideable: true
+          hideable: true,
+          autoCollapseCategories: true,
         },
       },
       algolia: {

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -67,6 +67,7 @@ const sidebars = {
             {
               type: 'category',
               label: 'Required configurations',
+              collapsed: false,
               items: [
                 'dev-docs/configurations/database',
                 'dev-docs/configurations/server',
@@ -77,6 +78,7 @@ const sidebars = {
             {
               type: 'category',
               label: 'Optional configurations',
+              collapsed: false,
               items: [
                 'dev-docs/configurations/api',
                 'dev-docs/configurations/api-tokens',
@@ -103,6 +105,7 @@ const sidebars = {
             {
               type: 'category',
               label: 'Other Hosting Guides',
+              collapsed: false,
               link: {
                 type: 'doc',
                 id: 'dev-docs/deployment/hosting-guides',
@@ -120,6 +123,7 @@ const sidebars = {
             {
               type: 'category',
               label: 'Optional Software Guides',
+              collapsed: false,
               link: {
                 type: 'doc',
                 id: 'dev-docs/deployment/optional-software-guides',
@@ -323,7 +327,7 @@ const sidebars = {
           items: [
             {
               type: 'category',
-              collapsed: true,
+              collapsed: false,
               link: {
                 type: 'doc',
                 id: 'dev-docs/migration/v3-to-v4/code-migration'
@@ -349,9 +353,7 @@ const sidebars = {
                           'dev-docs/migration/v3-to-v4/code/route-middlewares',
                           'dev-docs/migration/v3-to-v4/code/routes',
                           'dev-docs/migration/v3-to-v4/code/services',
-
                   ]
-
                 },
                 {
                   type: 'category',
@@ -368,13 +370,12 @@ const sidebars = {
                           'dev-docs/migration/v3-to-v4/code/webpack',
                           'dev-docs/migration/v3-to-v4/code/wysiwyg',
                   ]
-
                 },
               ]
             },
             {
               type: 'category',
-              collapsed: true,
+              collapsed: false,
               link: {
                 type: 'doc',
                 id: 'dev-docs/migration/v3-to-v4/plugin-migration'
@@ -389,7 +390,7 @@ const sidebars = {
             },
             {
               type: 'category',
-              collapsed: true,
+              collapsed: false,
               link: {
                 type: 'doc',
                 id: 'dev-docs/migration/v3-to-v4/data-migration'


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

This PR:
- expands by default the 3rd level items in the TOC (configurations, deployment, and v3 → v4 migration pages),
- and auto-collapses sibling items when you click on an item in the list _after_ collapsing another one (otherwise, 3rd-level lists are expanded by default)

2-minute screen capture (no sound) to showcase before/after comparison (right: current website, left: this PR) 👇

https://user-images.githubusercontent.com/4233866/225586444-7d8e7cf3-5648-4aad-b7df-f1a747793d7e.mov

### Why is it needed?

To improve the UX of the table of content and respond to some users' feedback.

 

