### PR TITLE
Remove subscriptions options from graphql documentation

### DIFF
--- a/docusaurus/docs/dev-docs/configurations/plugins.md
+++ b/docusaurus/docs/dev-docs/configurations/plugins.md
@@ -92,7 +92,6 @@ The [GraphQL plugin](/dev-docs/plugins/graphql) has the following specific confi
 | `maxLimit`         | Maximum value for [the `pagination[limit]` parameter](/dev-docs/api/graphql#pagination-by-offset) used in API calls                                                                                                              | Integer  | `-1`    |
 | `playgroundAlways` | Whether the playground should be publicly exposed.<br/><br/>Enabled by default in if `NODE_ENV` is set to `development`.                                        | Boolean | `false`  |
 | `shadowCRUD`       | Whether type definitions for queries, mutations and resolvers based on models should be created automatically (see [Shadow CRUD documentation](/dev-docs/plugins/graphql#shadow-crud)). | Boolean | `true` |
-| `subscriptions`    | Enable GraphQL subscriptions (experimental feature).                                                                                                                                 | Boolean | `false` |
 
 <Tabs groupId="js-ts">
 


### PR DESCRIPTION
### What does it do?

Removes subscriptions options from the graphql optional configurations

### Why is it needed?

- Subscriptions don't work
- Subscriptions option will be remove in the next release https://github.com/strapi/strapi/pull/16108

