### PR TITLE
Fix npm version

### DIFF
--- a/docusaurus/docs/snippets/installation-prerequisites.md
+++ b/docusaurus/docs/snippets/installation-prerequisites.md
@@ -4,6 +4,6 @@ Before installing Strapi, the following requirements must be installed on your c
     - Node v18.x is recommended for Strapi `v4.3.9` and above
     - Node v16.x is recommended for Strapi `v4.0.x` to `v4.3.8`.
 - Your preferred Node.js package manager:
-    - [npm](https://docs.npmjs.com/cli/v6/commands/npm-install) (`v6` only)
+    - [npm](https://docs.npmjs.com/cli/v6/commands/npm-install) (`v6` and above)
     - [yarn](https://yarnpkg.com/getting-started/install)
 - [Python](https://www.python.org/downloads/) (if using a SQLite database)


### PR DESCRIPTION
Fixes a snippet used in various pages, mentioning that only npm v6 could be used.