### PR TITLE
Improve example for extending a content type

### DIFF
--- a/docusaurus/docs/dev-docs/plugins-extension.md
+++ b/docusaurus/docs/dev-docs/plugins-extension.md
@@ -107,7 +107,11 @@ To extend a plugin's interface within `./src/index.js`, use the `bootstrap()` an
 
 module.exports = {
   register({ strapi }) {
-    strapi.contentType('plugin::my-plugin.content-type-name').attributes = {
+    const contentTypeName = strapi.contentType('plugin::my-plugin.content-type-name')  
+    contentTypeName.attributes = {
+      // Spread previous defined attributes
+      ...contentTypeName.attributes,
+      // Add new, or override attributes
       'toto': {
         type: 'string',
       }


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

Improved the example for extending a content type

### Why is it needed?

Previous example said that is extending the content type, but it actually completely overridden the original attributes
