### PR TITLE
Mention API tokens configuration in REST API documentation introduction

### DIFF
--- a/docusaurus/docs/dev-docs/api/rest.md
+++ b/docusaurus/docs/dev-docs/api/rest.md
@@ -9,7 +9,7 @@ description: Interact with your Content-Types using the REST API endpoints Strap
 The REST API allows accessing the [content-types](/dev-docs/backend-customization/models) through API endpoints. Strapi automatically creates [API endpoints](#endpoints) when a content-type is created. [API parameters](/dev-docs/api/rest/parameters) can be used when querying API endpoints to refine the results.
 
 :::note
-All content types are private by default and need to be either made public or queries need to be authenticated with the proper permissions. See the [Quick Start Guide](/dev-docs/quick-start#step-3-set-roles--permissions) and the [Users & Permissions user guide](/user-docs/users-roles-permissions/configuring-end-users-roles#editing-a-role) for more details.
+All content types are private by default and need to be either made public or queries need to be authenticated with the proper permissions. See the [Quick Start Guide](/dev-docs/quick-start#step-3-set-roles--permissions), the user guide for the [Users & Permissions plugin](/user-docs/users-roles-permissions/configuring-end-users-roles), and [API tokens configuration documentation](/dev-docs/configurations/api-tokens) for more details.
 :::
 
 :::caution


### PR DESCRIPTION
Based on some user feedback, this PR builds on PR #1587 and also mentions API tokens in the introduction of the REST API docs, while modifying the link to Users & Permissions documentation in the user guide.