### PR TITLE
Mention environment variables prefixed by `STRAPI_ADMIN_` are accessible to the front end

### DIFF
--- a/docusaurus/docs/dev-docs/configurations/environment.md
+++ b/docusaurus/docs/dev-docs/configurations/environment.md
@@ -25,7 +25,7 @@ Strapi provides the following environment variables:
 | `FAST_REFRESH`                                             | Use [react-refresh](https://github.com/pmmmwh/react-refresh-webpack-plugin) to enable "Fast Refresh" for near-instant feedback while developing the Strapi admin panel.                                                                                                       | `boolean` | `true`          |
 
 :::tip
-Prefixing an environment variable name with `STRAPI_ADMIN_` exposes the variable to the admin front end (e.g., `STRAPI_ADMIN_MY_PLUGIN_VARIABLE` is accessible through `process.env.STRAPI_ADMIN_MY_PLUGIN_VARIABLE`.
+Prefixing an environment variable name with `STRAPI_ADMIN_` exposes the variable to the admin front end (e.g., `STRAPI_ADMIN_MY_PLUGIN_VARIABLE` is accessible through `process.env.STRAPI_ADMIN_MY_PLUGIN_VARIABLE`).
 :::
 
 ## Configuration using environment variables

--- a/docusaurus/docs/dev-docs/configurations/environment.md
+++ b/docusaurus/docs/dev-docs/configurations/environment.md
@@ -25,7 +25,7 @@ Strapi provides the following environment variables:
 | `FAST_REFRESH`                                             | Use [react-refresh](https://github.com/pmmmwh/react-refresh-webpack-plugin) to enable "Fast Refresh" for near-instant feedback while developing the Strapi admin panel.                                                                                                       | `boolean` | `true`          |
 
 :::tip
-Prefixing an environment variable name with `STRAPI_ADMIN` exposes the variable to the admin front end.
+Prefixing an environment variable name with `STRAPI_ADMIN_` exposes the variable to the admin front end (e.g., `STRAPI_ADMIN_MY_PLUGIN_VARIABLE` is accessible through `process.env(STRAPI_ADMIN_MY_PLUGIN_VARIABLE)`.
 :::
 
 ## Configuration using environment variables

--- a/docusaurus/docs/dev-docs/configurations/environment.md
+++ b/docusaurus/docs/dev-docs/configurations/environment.md
@@ -24,6 +24,9 @@ Strapi provides the following environment variables:
 | `STRAPI_PLUGIN_I18N_INIT_LOCALE_CODE` <br/><br/>_Optional_ | Initialization locale for the application, if the [Internationalization (i18n) plugin](/dev-docs/plugins/i18n) is installed and enabled on Content-Types (see [Configuration of i18n in production environments](/dev-docs/plugins/i18n#configuration-of-the-default-locale)) | `String`  | `'en'`          |
 | `FAST_REFRESH`                                             | Use [react-refresh](https://github.com/pmmmwh/react-refresh-webpack-plugin) to enable "Fast Refresh" for near-instant feedback while developing the Strapi admin panel.                                                                                                       | `boolean` | `true`          |
 
+:::tip
+Prefixing an environment variable name with `STRAPI_ADMIN` exposes the variable to the admin front end.
+:::
 
 ## Configuration using environment variables
 

--- a/docusaurus/docs/dev-docs/configurations/environment.md
+++ b/docusaurus/docs/dev-docs/configurations/environment.md
@@ -25,7 +25,7 @@ Strapi provides the following environment variables:
 | `FAST_REFRESH`                                             | Use [react-refresh](https://github.com/pmmmwh/react-refresh-webpack-plugin) to enable "Fast Refresh" for near-instant feedback while developing the Strapi admin panel.                                                                                                       | `boolean` | `true`          |
 
 :::tip
-Prefixing an environment variable name with `STRAPI_ADMIN_` exposes the variable to the admin front end (e.g., `STRAPI_ADMIN_MY_PLUGIN_VARIABLE` is accessible through `process.env(STRAPI_ADMIN_MY_PLUGIN_VARIABLE)`.
+Prefixing an environment variable name with `STRAPI_ADMIN_` exposes the variable to the admin front end (e.g., `STRAPI_ADMIN_MY_PLUGIN_VARIABLE` is accessible through `process.env.STRAPI_ADMIN_MY_PLUGIN_VARIABLE`.
 :::
 
 ## Configuration using environment variables


### PR DESCRIPTION
Per [user feedback](https://stackoverflow.com/questions/64740664/retrieve-env-variables-in-strapi-plugin/72109326#comment133838878_72109326:~:text=It%20is%20not%20mentioned%20in%20the%20docs%20that%20having%20a%20prefix%20STRAPI_ADMIN%20will%20expose%20that%20var%20to%20admin%20frontend). 
