### PR TITLE
Pluralized 'runLifecyclesFunction'

### DIFF
--- a/docusaurus/docs/dev-docs/typescript.md
+++ b/docusaurus/docs/dev-docs/typescript.md
@@ -60,7 +60,7 @@ To experience TypeScript-based autocomplete while developing Strapi applications
     ```
 
 2. Within the body of the `register` method, start typing `strapi.` and use keyboard arrows to browse the available properties.
-3. Choose `runLifecyclesfunction` from the list.
+3. Choose `runLifecyclesfunctions` from the list.
 4. When the `strapi.runLifecyclesFunctions` method is added, a list of available lifecycle types (i.e. `register`, `bootstrap` and `destroy`) are returned by the code editor. Use keyboard arrows to choose one of the lifecycles and the code will autocomplete.
 
 ## Generate typings for project schemas


### PR DESCRIPTION
Pluralized 'runLifecyclesFunction'  by adding "s" at the end, making it "runLifecyclesFunctions"

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

Describe the technical changes you did.

### Why is it needed?

Describe the issue you are solving.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
