### PR TITLE
Fix the params provided to s3.getSignedUrlPromise on providers page

### DIFF
--- a/docusaurus/docs/dev-docs/providers.md
+++ b/docusaurus/docs/dev-docs/providers.md
@@ -420,7 +420,6 @@ module.exports = {
           Bucket: config.params.Bucket,
           Key: file.path,
           Expires: 60, // URL expiration time in seconds
-          ACL: "private", // make sure the asset is private and can only be accessed via signed URLs
         };
 
         const signedUrl = await s3.getSignedUrlPromise("getObject", params);
@@ -460,7 +459,6 @@ module.exports = {
           Bucket: config.params.Bucket,
           Key: file.path,
           Expires: 60, // URL expiration time in seconds
-          ACL: "private", // make sure the asset is private and can only be accessed via signed URLs
         };
 
         const signedUrl = await s3.getSignedUrlPromise("getObject", params);


### PR DESCRIPTION
### What does it do?

Fixes the documentation for private url signing on the providers page by removing `ACL` from the params passed to `getSignedUrlPromise`.  ACL param should be passed on content upload, not as part of the URL signing.  Including it during signing will throw an exception.

### Why is it needed?

Including `ACL` as a param as its currently documented will cause `aws-sdk` package to throw an exception: 
```
error: UnexpectedParameter: Unexpected key 'ACL' found in params
```