### PR TITLE
Fix typo; needed a comma after moving sizeLimit

### DIFF
--- a/docusaurus/docs/dev-docs/migration/v4/migration-guide-4.5.1-to-4.6.1.md
+++ b/docusaurus/docs/dev-docs/migration/v4/migration-guide-4.5.1-to-4.6.1.md
@@ -92,7 +92,7 @@ module.exports = {
   // ...
   upload: {
     config: {
-      sizeLimit: 250 * 1024 * 1024 // Now
+      sizeLimit: 250 * 1024 * 1024, // Now
       providerOptions: {
         sizeLimit: 250 * 1024 * 1024 // Before
       }
@@ -111,7 +111,7 @@ export default {
   // ...
   upload: {
     config: {
-      sizeLimit: 250 * 1024 * 1024 // Now
+      sizeLimit: 250 * 1024 * 1024, // Now
       providerOptions: {
         sizeLimit: 250 * 1024 * 1024 // Before
       }


### PR DESCRIPTION
I upgrade from Strapi 4.5.4 to 4.9.0 and discovered this syntax error when following the documentation from here: https://docs.strapi.io/dev-docs/migration/v4/migration-guide-4.5.1-to-4.6.1

### What does it do?

Fixes typo that created a syntax error upon running *yarn build*

### Why is it needed?

Fixes syntax typo that allows running yarn build without an error.

### Related issue(s)/PR(s)

No, not that I know of.
