### PR TITLE
Fix Heroku deployment guide

### DIFF
--- a/docusaurus/docs/dev-docs/deployment/heroku.md
+++ b/docusaurus/docs/dev-docs/deployment/heroku.md
@@ -68,7 +68,7 @@ module.exports = ({ env }) => {
 ```ts
 // path: ./config/env/production/database.ts
 
-import parse = require('pg-connection-string').parse;
+import { parse } from 'pg-connection-string';
 const config = parse(process.env.DATABASE_URL);
 
 export default ({ env }) => ({


### PR DESCRIPTION
### What does it do?

I updated the 'import' statement to ES6 syntax which is compatible with TypeScript. 

### Why is it needed?

The 'pg-connection-string' library was not being imported correctly. When running the code, an error message occurs, stating the imported object is not callable and a typeOf error is thrown. 
