### PR TITLE
Mention query and route parameters in the Requests/Responses documentation 

### DIFF
--- a/docusaurus/docs/dev-docs/backend-customization/requests-responses.md
+++ b/docusaurus/docs/dev-docs/backend-customization/requests-responses.md
@@ -10,9 +10,9 @@ description: Learn more about requests and responses for Strapi, the most popula
 
 The context object (`ctx`) contains all the requests related information. They are accessible through `ctx.request`, from [controllers](/dev-docs/backend-customization/controllers.md) and [policies](/dev-docs/backend-customization/policies.md).
 
-Strapi passes the `body` on `ctx.request.body` and `files` through `ctx.request.files`
+Strapi passes the `body` on `ctx.request.body`, `query` on `ctx.request.query`, `params` on `ctx.request.params` and `files` through `ctx.request.files`
 
-For more information, please refer to the [Koa request documentation](http://koajs.com/#request).
+For more information, please refer to the [Koa request documentation](http://koajs.com/#request) and [Koa Router documentation](https://github.com/koajs/router/blob/master/API.md).
 
 ## Responses
 


### PR DESCRIPTION
### What does it do?

- Add query and params to request ctx docs.
- Add Koa Router documentation for params ctx reference.

### Why is it needed?

Two of the four main ways of passing information to the backend (through query params and route params) are not described in the docs, and it's really handy to have that there so you don't have to always look through the Koa docs.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
