### PR TITLE
fix: ignore polymorphic relations in 4.5.1 migration

### DIFF
--- a/docusaurus/docs/dev-docs/migration/v4/migration-guide-4.4.5-to-4.5.1.md
+++ b/docusaurus/docs/dev-docs/migration/v4/migration-guide-4.4.5-to-4.5.1.md
@@ -78,13 +78,17 @@ const getLinkTables = ({ strapi }) => {
   const contentTypes = strapi.db.metadata;
   const tablesToUpdate = {};
 
-  contentTypes.forEach(contentType => {
+  contentTypes.forEach((contentType) => {
     // Get attributes
     const attributes = contentType.attributes;
 
     // For each relation type, add the joinTable name to tablesToUpdate
-    Object.values(attributes).forEach(attribute => {
-      if (attribute.type === 'relation' && attribute.joinTable) {
+    Object.values(attributes).forEach((attribute) => {
+      if (
+        attribute.type === 'relation' &&
+        attribute.joinTable &&
+        !attribute.relation.startsWith('morph') // Ignore polymorphic relations
+      ) {
         tablesToUpdate[attribute.joinTable.name] = attribute.joinTable;
       }
     });


### PR DESCRIPTION
### What does it do?

https://github.com/strapi/strapi/issues/16450
User reported this migration script deleted some of the image attributes , and it's because this script should ignore polymorphic relations (the ones media uses).

### Why is it needed?
So migration script does not delete media attributes.

### Related issue(s)/PR(s)
Fixes https://github.com/strapi/strapi/issues/16450
