### PR TITLE
Fix note about default directives in middlewares::security for in-app market

### DIFF
--- a/docusaurus/docs/dev-docs/configurations/middlewares.md
+++ b/docusaurus/docs/dev-docs/configurations/middlewares.md
@@ -732,7 +732,7 @@ When using any 3rd party upload provider, generally it's required to set a custo
 :::
 
 :::note
-The default directives include a `dl.airtable.com` value. This value is set for the [in-app market](/user-docs/plugins/installing-plugins-via-marketplace) and is safe to keep.
+The default directives include a `https://market-assets.strapi.io` value. This value is set for the [in-app market](/user-docs/plugins/installing-plugins-via-marketplace) and is safe to keep.
 :::
 
 <details>
@@ -757,14 +757,14 @@ module.exports = [
             "'self'",
             'data:',
             'blob:',
-            'dl.airtable.com',
+            'https://market-assets.strapi.io',
             'yourBucketName.s3.yourRegion.amazonaws.com',
           ],
           'media-src': [
             "'self'",
             'data:',
             'blob:',
-            'dl.airtable.com',
+            'https://market-assets.strapi.io',
             'yourBucketName.s3.yourRegion.amazonaws.com',
           ],
           upgradeInsecureRequests: null,
@@ -795,14 +795,14 @@ export default [
             "'self'",
             'data:',
             'blob:',
-            'dl.airtable.com',
+            'https://market-assets.strapi.io',
             'yourBucketName.s3.yourRegion.amazonaws.com',
           ],
           'media-src': [
             "'self'",
             'data:',
             'blob:',
-            'dl.airtable.com',
+            'https://market-assets.strapi.io',
             'yourBucketName.s3.yourRegion.amazonaws.com',
           ],
           upgradeInsecureRequests: null,


### PR DESCRIPTION
### What does it do?

Based on strapi/packages/core/strapi/lib/middlewares/security.js, we need change 'dl.airtable.com' on 'https://market-assets.strapi.io'