### PR TITLE
add query engine warnings

### DIFF
--- a/docusaurus/docs/dev-docs/api/query-engine.md
+++ b/docusaurus/docs/dev-docs/api/query-engine.md
@@ -5,17 +5,17 @@ displayed_sidebar: devDocsSidebar
 ---
 
 import EntityQueryKnex from '/docs/snippets/entity-query-knex.md'
+import RecommendEntityService from '/docs/snippets/recommend-entity-service.md'
 
 # Query Engine API
 
 Strapi provides a Query Engine API to interact with the database layer at a lower level. It should mostly be used by plugin developers and developers adding custom business logic to their applications. In most use cases, it's recommended to use the [Entity Service API](/dev-docs/api/entity-service/) instead.
 
-:::warning
-Only use the Query Engine API if the [Entity Service API](/dev-docs/api/entity-service/) does not cover your use case.
-:::
 :::strapi Entity Service API vs. Query Engine API
 <EntityQueryKnex components={props.components} />
 :::
+
+<RecommendEntityService/>
 
 ## Basic usage
 

--- a/docusaurus/docs/dev-docs/api/query-engine.md
+++ b/docusaurus/docs/dev-docs/api/query-engine.md
@@ -10,6 +10,9 @@ import EntityQueryKnex from '/docs/snippets/entity-query-knex.md'
 
 Strapi provides a Query Engine API to interact with the database layer at a lower level. It should mostly be used by plugin developers and developers adding custom business logic to their applications. In most use cases, it's recommended to use the [Entity Service API](/dev-docs/api/entity-service/) instead.
 
+:::warning
+Only use the Query Engine API if the [Entity Service API](/dev-docs/api/entity-service/) does not cover your use case.
+:::
 :::strapi Entity Service API vs. Query Engine API
 <EntityQueryKnex components={props.components} />
 :::

--- a/docusaurus/docs/dev-docs/api/query-engine/filtering.md
+++ b/docusaurus/docs/dev-docs/api/query-engine/filtering.md
@@ -3,14 +3,11 @@ title: Filtering
 description: Use Strapi's Query Engine API to filter the results of your queries.
 displayed_sidebar: devDocsSidebar
 ---
+import RecommendEntityService from '/docs/snippets/recommend-entity-service.md'
 
 # Filtering
 
-:::warning
-Entity service has the same filter functionality as where only under the filter and not where.
-It is highly recommended you use the entity service over the query engine.
-see [entity service filter documentation](http://localhost:8080/dev-docs/api/entity-service/filter)
-:::
+<RecommendEntityService/>
 
 The [Query Engine API](/dev-docs/api/query-engine/) offers the ability to filter results found with its [findMany()](/dev-docs/api/query-engine/single-operations#findmany) method.
 

--- a/docusaurus/docs/dev-docs/api/query-engine/filtering.md
+++ b/docusaurus/docs/dev-docs/api/query-engine/filtering.md
@@ -6,6 +6,12 @@ displayed_sidebar: devDocsSidebar
 
 # Filtering
 
+:::warning
+Entity service has the same filter functionality as where only under the filter and not where.
+It is highly recommended you use the entity service over the query engine.
+see [entity service filter documentation](http://localhost:8080/dev-docs/api/entity-service/filter)
+:::
+
 The [Query Engine API](/dev-docs/api/query-engine/) offers the ability to filter results found with its [findMany()](/dev-docs/api/query-engine/single-operations#findmany) method.
 
 Results are filtered with the `where` parameter that accepts [logical operators](#logical-operators) and [attribute operators](#attribute-operators). Every operator should be prefixed with `$`.

--- a/docusaurus/docs/dev-docs/api/query-engine/order-pagination.md
+++ b/docusaurus/docs/dev-docs/api/query-engine/order-pagination.md
@@ -5,6 +5,11 @@ displayed_sidebar: devDocsSidebar
 ---
 
 # Ordering & Paginating
+:::warning
+Entity service has the same order and paginate functionality as where only under the filter and not where.
+see [entity service order & pagination documentation](http://localhost:8080/dev-docs/api/entity-service/order-pagination)
+It is highly recommended you use the entity service over the query engine.
+:::
 
 The [Query Engine API](/dev-docs/api/query-engine) offers the ability to [order](#ordering) and [paginate](#pagination) results.
 

--- a/docusaurus/docs/dev-docs/api/query-engine/order-pagination.md
+++ b/docusaurus/docs/dev-docs/api/query-engine/order-pagination.md
@@ -3,13 +3,11 @@ title: Ordering & Pagination
 description: Use Strapi's Query Engine API to order and paginate the results of your queries.
 displayed_sidebar: devDocsSidebar
 ---
+import RecommendEntityService from '/docs/snippets/recommend-entity-service.md'
 
 # Ordering & Paginating
-:::warning
-Entity service has the same order and paginate functionality as where only under the filter and not where.
-see [entity service order & pagination documentation](http://localhost:8080/dev-docs/api/entity-service/order-pagination)
-It is highly recommended you use the entity service over the query engine.
-:::
+
+<RecommendEntityService/>
 
 The [Query Engine API](/dev-docs/api/query-engine) offers the ability to [order](#ordering) and [paginate](#pagination) results.
 

--- a/docusaurus/docs/dev-docs/api/query-engine/populating.md
+++ b/docusaurus/docs/dev-docs/api/query-engine/populating.md
@@ -6,6 +6,12 @@ displayed_sidebar: devDocsSidebar
 
 # Populating
 
+:::warning
+Entity service has the same population functionality.
+see [entity service order & pagination documentation](http://localhost:8080/dev-docs/api/entity-service/order-pagination)
+It is highly recommended you use the entity service over the query engine.
+:::
+
 Relations and components have a unified API for populating them.
 
 To populate all the root level relations, use `populate: true`:

--- a/docusaurus/docs/dev-docs/api/query-engine/populating.md
+++ b/docusaurus/docs/dev-docs/api/query-engine/populating.md
@@ -3,14 +3,11 @@ title: Populating
 description: Use Strapi's Query Engine API to populate relations when querying your content.
 displayed_sidebar: devDocsSidebar
 ---
+import RecommendEntityService from '/docs/snippets/recommend-entity-service.md'
 
 # Populating
 
-:::warning
-Entity service has the same population functionality.
-see [entity service order & pagination documentation](http://localhost:8080/dev-docs/api/entity-service/order-pagination)
-It is highly recommended you use the entity service over the query engine.
-:::
+<RecommendEntityService/>
 
 Relations and components have a unified API for populating them.
 

--- a/docusaurus/docs/dev-docs/api/query-engine/single-operations.md
+++ b/docusaurus/docs/dev-docs/api/query-engine/single-operations.md
@@ -10,7 +10,7 @@ import ManagingRelations from '/docs/snippets/managing-relations.md'
 ## findOne()
 
 :::note
- Only use the Query Engine's findOne if the [Entity Service](/dev-docs/api/entity-service/crud#findone) can't cover your use case.
+ Only use the Query Engine's findOne if the [Entity Service findOne](/dev-docs/api/entity-service/crud#findone) can't cover your use case.
 :::
 Finds the first entry matching the parameters.
 

--- a/docusaurus/docs/dev-docs/api/query-engine/single-operations.md
+++ b/docusaurus/docs/dev-docs/api/query-engine/single-operations.md
@@ -9,9 +9,8 @@ import ManagingRelations from '/docs/snippets/managing-relations.md'
 
 ## findOne()
 
-:::warning
-Only use if findMany or findOne on the entity service can't solve your problem.
-see [entity service findOne documentation](/dev-docs/api/entity-service/crud#findone)
+:::note
+ Only use the Query Engine's findOne if the [Entity Service](/dev-docs/api/entity-service/crud#findone) can't cover your use case.
 :::
 Finds the first entry matching the parameters.
 
@@ -39,10 +38,10 @@ const entry = await strapi.db.query('api::blog.article').findOne({
 
 ## findMany()
 
-:::warning
-Only findMany on the entity service can't solve your problem.
-see [entity service findMany documentation](/dev-docs/api/entity-service/crud#findmany)
+:::note
+ Only use the Query Engine's findMany if the [Entity Service findMany](/dev-docs/api/entity-service/crud#findmany) can't cover your use case.
 :::
+
 Finds entries matching the parameters.
 
 Syntax: `findMany(parameters) ⇒ Entry[]`
@@ -100,9 +99,8 @@ const [entries, count] = await strapi.db.query('api::blog.article').findWithCoun
 
 ## create()
 
-:::warning
-Only create on the entity service can't solve your problem.
-see [entity service create documentation](/dev-docs/api/entity-service/crud#create)
+:::note
+ Only use the Query Engine's create if the [Entity Service create](/dev-docs/api/entity-service/crud#create) can't cover your use case.
 :::
 
 Creates one entry and returns it.
@@ -131,10 +129,10 @@ const entry = await strapi.db.query('api::blog.article').create({
 
 ## update()
 
-:::warning
-Only update on the entity service can't solve your problem.
-see [entity service update documentation](/dev-docs/api/entity-service/crud#update)
+:::note
+ Only use the Query Engine's update if the [Entity Service update](/dev-docs/api/entity-service/crud#update) can't cover your use case.
 :::
+
 Updates one entry and returns it.
 
 Syntax: `update(parameters) => Entry`
@@ -163,10 +161,10 @@ const entry = await strapi.db.query('api::blog.article').update({
 
 ## delete()
 
-:::warning
-Only delete on the entity service can't solve your problem.
-see [entity service delete documentation](/dev-docs/api/entity-service/crud#delete)
+:::note
+ Only use the Query Engine's delete if the [Entity Service delete](/dev-docs/api/entity-service/crud#delete) can't cover your use case.
 :::
+
 Deletes one entry and returns it.
 
 Syntax: `delete(parameters) => Entry`

--- a/docusaurus/docs/dev-docs/api/query-engine/single-operations.md
+++ b/docusaurus/docs/dev-docs/api/query-engine/single-operations.md
@@ -9,6 +9,10 @@ import ManagingRelations from '/docs/snippets/managing-relations.md'
 
 ## findOne()
 
+:::warning
+Only use if findMany or findOne on the entity service can't solve your problem.
+see [entity service findOne documentation](/dev-docs/api/entity-service/crud#findone)
+:::
 Finds the first entry matching the parameters.
 
 Syntax: `findOne(parameters) ⇒ Entry`
@@ -35,6 +39,10 @@ const entry = await strapi.db.query('api::blog.article').findOne({
 
 ## findMany()
 
+:::warning
+Only findMany on the entity service can't solve your problem.
+see [entity service findMany documentation](/dev-docs/api/entity-service/crud#findmany)
+:::
 Finds entries matching the parameters.
 
 Syntax: `findMany(parameters) ⇒ Entry[]`
@@ -92,6 +100,11 @@ const [entries, count] = await strapi.db.query('api::blog.article').findWithCoun
 
 ## create()
 
+:::warning
+Only create on the entity service can't solve your problem.
+see [entity service create documentation](/dev-docs/api/entity-service/crud#create)
+:::
+
 Creates one entry and returns it.
 
 Syntax: `create(parameters) => Entry`
@@ -118,6 +131,10 @@ const entry = await strapi.db.query('api::blog.article').create({
 
 ## update()
 
+:::warning
+Only update on the entity service can't solve your problem.
+see [entity service update documentation](/dev-docs/api/entity-service/crud#update)
+:::
 Updates one entry and returns it.
 
 Syntax: `update(parameters) => Entry`
@@ -146,6 +163,10 @@ const entry = await strapi.db.query('api::blog.article').update({
 
 ## delete()
 
+:::warning
+Only delete on the entity service can't solve your problem.
+see [entity service delete documentation](/dev-docs/api/entity-service/crud#delete)
+:::
 Deletes one entry and returns it.
 
 Syntax: `delete(parameters) => Entry`

--- a/docusaurus/docs/snippets/recommend-entity-service.md
+++ b/docusaurus/docs/snippets/recommend-entity-service.md
@@ -1,0 +1,3 @@
+:::strapi Have you considered the Entity Service API?
+ The [Entity Service API](/dev-docs/api/entity-service) is the recommended API to interact with your application's database. Only use QueryEngine if EntityService does not cover your use case.
+:::


### PR DESCRIPTION
### What does it do?

add warnings to everything in the query engine what entity service also can do 

### Why is it needed?

Documentation warnings for using query engine are not jumping out enough what causes lots of people to use the query engine while the entity service is what they are looking for.
