### PR TITLE
add examples for strapi middlewares/controllers to graphql docs

### DIFF
--- a/docusaurus/docs/dev-docs/plugins/graphql.md
+++ b/docusaurus/docs/dev-docs/plugins/graphql.md
@@ -799,7 +799,7 @@ module.exports = {
              * Basic middleware example #5
              * Uses a middleware already created in Strapi with a custom configuration
              */
-            { name: "api::model.middleware-name" options: { /* all config values I want to pass to the strapi middleware */ } },
+            { name: "api::model.middleware-name", options: { /* all config values I want to pass to the strapi middleware */ } },
           ],
           auth: false,
         },

--- a/docusaurus/docs/dev-docs/plugins/graphql.md
+++ b/docusaurus/docs/dev-docs/plugins/graphql.md
@@ -711,7 +711,7 @@ export default {
             /**
              * Uses a policy already created in Strapi with a custom configuration
              */
-            {name:"api::model.policy-name" options: {/* all the configuration values to pass to the strapi middleware */} },
+            {name:"api::model.policy-name", config: {/* all the configuration values to pass to the strapi policy */} },
           ],
           auth: false,
         },

--- a/docusaurus/docs/dev-docs/plugins/graphql.md
+++ b/docusaurus/docs/dev-docs/plugins/graphql.md
@@ -639,7 +639,7 @@ The `context` object gives access to:
 * Koa's [context](https://koajs.com/#context) with `context.http` and [state](https://koajs.com/#ctx-state) with `context.state`.
 
 <details>
-<summary> Example of some GraphQL policy applied to a resolver </summary>
+<summary> Example of GraphQL policies applied to resolvers</summary>
 
 <Tabs groupId="js-ts">
 
@@ -664,12 +664,12 @@ module.exports = {
               return context.parent !== undefined;
             }
             /**
-             * Uses a already created policy in strapi.
+             * Uses a policy already created in Strapi.
              */
             "api::model.policy-name",
 
             /**
-             * Uses a already created policy in strapi with custom config.
+             * Uses a policy already created in Strapi with a custom configuration
              */
             {name:"api::model.policy-name" options: {/* all config values I want to pass to the strapi middleware */} },
           ],
@@ -704,14 +704,14 @@ export default {
               return context.parent !== undefined;
             }
             /**
-             * Uses a already created policy in strapi.
+             * Uses a policy already created in Strapi.
              */
             "api::model.policy-name",
 
             /**
-             * Uses a already created policy in strapi with custom config.
+             * Uses a policy already created in Strapi with a custom configuration
              */
-            {name:"api::model.policy-name" options: {/* all config values I want to pass to the strapi middleware */} },
+            {name:"api::model.policy-name" options: {/* all the configuration values to pass to the strapi middleware */} },
           ],
           auth: false,
         },
@@ -729,7 +729,7 @@ export default {
 
 ##### Middlewares
 
-[Middlewares](/dev-docs/backend-customization/middlewares) can be applied to a GraphQL resolver through the `resolversConfig.[MyResolverName].middlewares` key. Only difference between the GraphQL and REST implementation is that the `config` key becomes `options`.  
+[Middlewares](/dev-docs/backend-customization/middlewares) can be applied to a GraphQL resolver through the `resolversConfig.[MyResolverName].middlewares` key. The only difference between the GraphQL and REST implementations is that the `config` key becomes `options`.  
 
 The `middlewares` key is an array accepting a list of middlewares, each item in this list being either a reference to an already registered middleware or an implementation that is passed directly (see [middlewares configuration documentation](/dev-docs/backend-customization/routes#middlewares)).
 
@@ -791,13 +791,13 @@ module.exports = {
             }
             /**
              * Basic middleware example #4
-             * Uses a already created middleware in strapi.
+             * Uses a middleware already created in Strapi.
              */
             "api::model.middleware-name",
 
             /**
              * Basic middleware example #5
-             * Uses a already created middleware in strapi with custom config.
+             * Uses a middleware already created in Strapi with a custom configuration
              */
             { name: "api::model.middleware-name" options: { /* all config values I want to pass to the strapi middleware */ } },
           ],
@@ -859,15 +859,15 @@ export default {
 
             /**
              * Basic middleware example #4
-             * Uses a already created middleware in strapi.
+             * Uses a middleware already created in Strapi.
              */
             "api::model.middleware-name",
 
             /**
              * Basic middleware example #5
-             * Uses a already created middleware in strapi with custom config.
+             * Uses a middleware already created in Strapi with a custom configuration
              */
-            {name:"api::model.middleware-name" options: {/* all config values I want to pass to the strapi middleware */} },
+            {name:"api::model.middleware-name" options: {/* all the configuration values to pass to the middleware */} },
           ],
           auth: false,
         },

--- a/docusaurus/docs/dev-docs/plugins/graphql.md
+++ b/docusaurus/docs/dev-docs/plugins/graphql.md
@@ -867,7 +867,7 @@ export default {
              * Basic middleware example #5
              * Uses a middleware already created in Strapi with a custom configuration
              */
-            {name:"api::model.middleware-name" options: {/* all the configuration values to pass to the middleware */} },
+            {name:"api::model.middleware-name", options: {/* all the configuration values to pass to the middleware */} },
           ],
           auth: false,
         },

--- a/docusaurus/docs/dev-docs/plugins/graphql.md
+++ b/docusaurus/docs/dev-docs/plugins/graphql.md
@@ -727,7 +727,7 @@ export default {
 
 </details>
 
-#### Middlewares
+##### Middlewares
 
 [Middlewares](/dev-docs/backend-customization/middlewares) can be applied to a GraphQL resolver through the `resolversConfig.[MyResolverName].middlewares` key. Only difference between the GraphQL and REST implementation is that the `config` key becomes `options`.  
 

--- a/docusaurus/docs/dev-docs/plugins/graphql.md
+++ b/docusaurus/docs/dev-docs/plugins/graphql.md
@@ -628,7 +628,7 @@ export default {
 
 ##### Policies
 
-[Policies](/dev-docs/backend-customization/policies) can be applied to a GraphQL resolver through the `resolversConfig.[MyResolverName].policies` key. Only difference between the GraphQL and REST implementation is that the `config` key becomes `options`.
+[Policies](/dev-docs/backend-customization/policies) can be applied to a GraphQL resolver through the `resolversConfig.[MyResolverName].policies` key.
 
 The `policies` key is an array accepting a list of policies, each item in this list being either a reference to an already registered policy or an implementation that is passed directly (see [policies configuration documentation](/dev-docs/backend-customization/routes#policies)).
 

--- a/docusaurus/docs/dev-docs/plugins/graphql.md
+++ b/docusaurus/docs/dev-docs/plugins/graphql.md
@@ -671,7 +671,7 @@ module.exports = {
             /**
              * Uses a policy already created in Strapi with a custom configuration
              */
-            {name:"api::model.policy-name" options: {/* all config values I want to pass to the strapi middleware */} },
+            {name:"api::model.policy-name", config: {/* all config values I want to pass to the strapi policy */} },
           ],
           auth: false,
         },

--- a/docusaurus/docs/dev-docs/plugins/graphql.md
+++ b/docusaurus/docs/dev-docs/plugins/graphql.md
@@ -628,7 +628,7 @@ export default {
 
 ##### Policies
 
-[Policies](/dev-docs/backend-customization/policies) can be applied to a GraphQL resolver through the `resolversConfig.[MyResolverName].policies` key.
+[Policies](/dev-docs/backend-customization/policies) can be applied to a GraphQL resolver through the `resolversConfig.[MyResolverName].policies` key. Only difference between the GraphQL and REST implementation is that the `config` key becomes `options`.
 
 The `policies` key is an array accepting a list of policies, each item in this list being either a reference to an already registered policy or an implementation that is passed directly (see [policies configuration documentation](/dev-docs/backend-customization/routes#policies)).
 
@@ -639,7 +639,7 @@ The `context` object gives access to:
 * Koa's [context](https://koajs.com/#context) with `context.http` and [state](https://koajs.com/#ctx-state) with `context.state`.
 
 <details>
-<summary> Example of a custom GraphQL policy applied to a resolver </summary>
+<summary> Example of some GraphQL policy applied to a resolver </summary>
 
 <Tabs groupId="js-ts">
 
@@ -663,6 +663,15 @@ module.exports = {
                */ 
               return context.parent !== undefined;
             }
+            /**
+             * Uses a already created policy in strapi.
+             */
+            "api::model.policy-name",
+
+            /**
+             * Uses a already created policy in strapi with custom config.
+             */
+            {name:"api::model.policy-name" options: {/* all config values I want to pass to the strapi middleware */} },
           ],
           auth: false,
         },
@@ -694,6 +703,15 @@ export default {
                */ 
               return context.parent !== undefined;
             }
+            /**
+             * Uses a already created policy in strapi.
+             */
+            "api::model.policy-name",
+
+            /**
+             * Uses a already created policy in strapi with custom config.
+             */
+            {name:"api::model.policy-name" options: {/* all config values I want to pass to the strapi middleware */} },
           ],
           auth: false,
         },
@@ -711,9 +729,9 @@ export default {
 
 #### Middlewares
 
-[Middlewares](/dev-docs/backend-customization/middlewares) can be applied to a GraphQL resolver through the `resolversConfig.[MyResolverName].middlewares` key.
+[Middlewares](/dev-docs/backend-customization/middlewares) can be applied to a GraphQL resolver through the `resolversConfig.[MyResolverName].middlewares` key. Only difference between the GraphQL and REST implementation is that the `config` key becomes `options`.  
 
-The `middlewares` key is an array accepting a list of middlewares, each item in this list being either a reference to an already registered policy or an implementation that is passed directly (see [middlewares configuration documentation](/dev-docs/backend-customization/routes#middlewares)).
+The `middlewares` key is an array accepting a list of middlewares, each item in this list being either a reference to an already registered middleware or an implementation that is passed directly (see [middlewares configuration documentation](/dev-docs/backend-customization/routes#middlewares)).
 
 Middlewares directly implemented in `resolversConfig` can take the GraphQL resolver's [`parent`, `args`, `context` and `info` objects](https://www.apollographql.com/docs/apollo-server/data/resolvers/#resolver-arguments) as arguments.
 
@@ -722,7 +740,7 @@ Middlewares with GraphQL can even act on nested resolvers, which offer a more gr
 :::
 
 <details>
-<summary> Examples of custom GraphQL middlewares applied to a resolver</summary>
+<summary> Examples of GraphQL middlewares applied to a resolver</summary>
 
 <Tabs groupId="js-ts">
 
@@ -771,6 +789,17 @@ module.exports = {
 
               return resolve(parent, ...rest);
             }
+            /**
+             * Basic middleware example #4
+             * Uses a already created middleware in strapi.
+             */
+            "api::model.middleware-name",
+
+            /**
+             * Basic middleware example #5
+             * Uses a already created middleware in strapi with custom config.
+             */
+            { name: "api::model.middleware-name" options: { /* all config values I want to pass to the strapi middleware */ } },
           ],
           auth: false,
         },
@@ -827,6 +856,18 @@ export default {
 
               return resolve(parent, ...rest);
             }
+
+            /**
+             * Basic middleware example #4
+             * Uses a already created middleware in strapi.
+             */
+            "api::model.middleware-name",
+
+            /**
+             * Basic middleware example #5
+             * Uses a already created middleware in strapi with custom config.
+             */
+            {name:"api::model.middleware-name" options: {/* all config values I want to pass to the strapi middleware */} },
           ],
           auth: false,
         },


### PR DESCRIPTION
### What does it do?

Adds documentation of how to use the strapi controllers in graphql

### Why is it needed?

since options was not documented and to improve the graphql experience.

### Related issue(s)/PR(s)
fixes https://github.com/strapi/documentation/issues/1679
