### PR TITLE
Fixed documentation plugin docs

### DIFF
--- a/docusaurus/docs/dev-docs/plugins/documentation.md
+++ b/docusaurus/docs/dev-docs/plugins/documentation.md
@@ -80,34 +80,39 @@ There are 2 ways to update the documentation after making changes to your API:
 The Documentation plugin is initialized with the following configuration, where all properties can be altered by providing new values to the documentation plugin's configuration object in `config/plugins.js`:
 
 ```js
-{
-  openapi: '3.0.0',
-  info: {
-    version: '1.0.0',
-    title: 'DOCUMENTATION',
-    description: '',
-    termsOfService: 'YOUR_TERMS_OF_SERVICE_URL',
-    contact: {
-      name: 'TEAM',
-      email: 'contact-email@something.io',
-      url: 'mywebsite.io'
-    },
-    license: {
-      name: 'Apache 2.0',
-      url: 'https://www.apache.org/licenses/LICENSE-2.0.html'
-    },
-  },
-  'x-strapi-config': {
-		// Leave empty to ignore plugins during generation
-    plugins: [ 'upload', 'users-permissions'],
-    path: '/documentation',
-  },
-  servers: [{ url: 'http://localhost:1337/api/api', description: 'Development server' }],
-  externalDocs: {
-    description: 'Find out more',
-    url: 'https://docs.strapi.io/developer-docs/latest/getting-started/introduction.html'
-  },
-  security: [ { bearerAuth: [] } ]
+module.exports = {
+  documentation: {
+    enabled: true,
+    config: {
+      openapi: '3.0.0',
+      info: {
+        version: '1.0.0',
+        title: 'DOCUMENTATION',
+        description: '',
+        termsOfService: 'YOUR_TERMS_OF_SERVICE_URL',
+        contact: {
+          name: 'TEAM',
+          email: 'contact-email@something.io',
+          url: 'mywebsite.io'
+        },
+        license: {
+          name: 'Apache 2.0',
+          url: 'https://www.apache.org/licenses/LICENSE-2.0.html'
+        },
+      },
+      'x-strapi-config': {
+        // Leave empty to ignore plugins during generation
+        plugins: [ 'upload', 'users-permissions'],
+        path: '/documentation',
+      },
+      servers: [{ url: 'http://localhost:1337/api/api', description: 'Development server' }],
+      externalDocs: {
+        description: 'Find out more',
+        url: 'https://docs.strapi.io/developer-docs/latest/getting-started/introduction.html'
+      },
+      security: [ { bearerAuth: [] } ]
+    }
+  }
 }
 ```
 
@@ -115,7 +120,7 @@ The Documentation plugin is initialized with the following configuration, where 
 
 To create a new version of your documentation, update the `version` key as follows:
 
-```js title="config/plugin.js"
+```js title="config/plugins.js"
 
 module.exports = {
   documentation: {
@@ -263,7 +268,7 @@ module.exports = {
       "x-strapi-config": {
         mutateDocumentation: (generatedDocumentationDraft) => {
           generatedDocumentationDraft.paths[
-            "/answer-to-everything"
+            "/answer-to-everything" //Needs to be an existing path.
           ].get.responses["200"].description = "*";
         },
       },


### PR DESCRIPTION
### What does it do?

Makes documentation more clear

### Why is it needed?

to make it less likely that someone miss understands 

### Related issue(s)/PR(s)
fixes https://github.com/strapi/documentation/issues/1517 note this issue was fixed in 4.10.2 and the other one was most likely a miss understanding with the documentation.