### PR TITLE
add warning for for unknown tables getting deleted

### DIFF
--- a/docusaurus/docs/dev-docs/database-migrations.md
+++ b/docusaurus/docs/dev-docs/database-migrations.md
@@ -18,9 +18,9 @@ Migrations are run using JavaScript migration files stored in `./database/migrat
 Strapi automatically detects migration files and run them once at the next startup in alphabetical order. Every new file is executed once. Migrations are run before the database tables are synced with the content-types schemas.
 
 :::warning
-Currently Strapi does not support down migrations. This means that if you need to revert a migration, you will have to do it manually. It is planned to implement down migrations in the future but no timeline is currently available.
+* Currently Strapi does not support down migrations. This means that if you need to revert a migration, you will have to do it manually. It is planned to implement down migrations in the future but no timeline is currently available.
 
-Strapi will delete any unknown tables without warning. This means that database migrations can only be used to keep data when changing the Strapi schema.
+* Strapi will delete any unknown tables without warning. This means that database migrations can only be used to keep data when changing the Strapi schema. The `forceMigration` and `runMigrations` [database configuration parameters](/dev-docs/configurations/database#settings-configuration-object) can be used to fine-tune the database migrations behavior.
 :::
 
 Migration files should export the function `up()`, which is used when upgrading (e.g. adding a new table `my_new_table`).

--- a/docusaurus/docs/dev-docs/database-migrations.md
+++ b/docusaurus/docs/dev-docs/database-migrations.md
@@ -19,6 +19,8 @@ Strapi automatically detects migration files and run them once at the next start
 
 :::warning
 Currently Strapi does not support down migrations. This means that if you need to revert a migration, you will have to do it manually. It is planned to implement down migrations in the future but no timeline is currently available.
+
+Strapi will delete any unknown tables without warning this means that database migrations can only be used to keep data when changing the Strapi schema
 :::
 
 Migration files should export the function `up()`, which is used when upgrading (e.g. adding a new table `my_new_table`).

--- a/docusaurus/docs/dev-docs/database-migrations.md
+++ b/docusaurus/docs/dev-docs/database-migrations.md
@@ -20,7 +20,7 @@ Strapi automatically detects migration files and run them once at the next start
 :::warning
 Currently Strapi does not support down migrations. This means that if you need to revert a migration, you will have to do it manually. It is planned to implement down migrations in the future but no timeline is currently available.
 
-Strapi will delete any unknown tables without warning this means that database migrations can only be used to keep data when changing the Strapi schema
+Strapi will delete any unknown tables without warning. This means that database migrations can only be used to keep data when changing the Strapi schema.
 :::
 
 Migration files should export the function `up()`, which is used when upgrading (e.g. adding a new table `my_new_table`).


### PR DESCRIPTION
### What does it do?

Add warning that strapi deletes all unknown tables or columns

### Why is it needed?

For people to understand that adding migrations to custom stuff won't work

### Related issue(s)/PR(s)
closes https://github.com/strapi/documentation/issues/1402