### PR TITLE
Clarify package.json flag for disabling telemetry

### DIFF
--- a/docusaurus/docs/dev-docs/usage-information.md
+++ b/docusaurus/docs/dev-docs/usage-information.md
@@ -78,7 +78,7 @@ npm run strapi telemetry:disable
 
 </Tabs>
 
-Alternatively, the `telemetryDisabled: true` flag in the project `package.json` file will also disable data collection.
+Alternatively, the `strapi.telemetryDisabled: true` flag in the project `package.json` file will also disable data collection.
 
 Data collection can later be re-enabled by deleting the flag or setting it to false, or by using the `telemetry:enable` command.
 


### PR DESCRIPTION
This caught me off guard after I couldn't disable telemetry by modifying my `package.json`, and only noticed the correct way to do it after running `strapi telemetry:disable`. Hopefully this makes it clearer.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->
