### PR TITLE
Add pageRank/search_weight

### DIFF
--- a/docusaurus/docs/dev-docs/api/entity-service/components-dynamic-zones.md
+++ b/docusaurus/docs/dev-docs/api/entity-service/components-dynamic-zones.md
@@ -2,6 +2,7 @@
 title: Components and Dynamic Zones
 description: Use Strapi's Entity Service to create and update components and dynamic zones.
 displayed_sidebar: devDocsSidebar
+search_weight: 1
 ---
 
 # Components and dynamic zones

--- a/docusaurus/docs/dev-docs/api/entity-service/crud.md
+++ b/docusaurus/docs/dev-docs/api/entity-service/crud.md
@@ -2,6 +2,7 @@
 title: CRUD operations
 description: Use Strapi's Entity Service API to perform CRUD (create, read, update, delete) operations on your content.
 displayed_sidebar: devDocsSidebar
+search_weight: 1
 ---
 import ManagingRelations from '/docs/snippets/managing-relations.md'
 

--- a/docusaurus/docs/dev-docs/api/entity-service/filter.md
+++ b/docusaurus/docs/dev-docs/api/entity-service/filter.md
@@ -2,6 +2,7 @@
 title: Filtering
 description: Use Strapi's Entity Service API to filter your queries results.
 displayed_sidebar: devDocsSidebar
+search_weight: 1
 ---
 
 # Filtering

--- a/docusaurus/docs/dev-docs/api/entity-service/order-pagination.md
+++ b/docusaurus/docs/dev-docs/api/entity-service/order-pagination.md
@@ -2,6 +2,7 @@
 title: Ordering & Pagination
 description: Use Strapi's Entity Service API to order and paginate queries results.
 displayed_sidebar: devDocsSidebar
+search_weight: 1
 ---
 
 # Ordering & Pagination

--- a/docusaurus/docs/dev-docs/api/entity-service/populate.md
+++ b/docusaurus/docs/dev-docs/api/entity-service/populate.md
@@ -2,6 +2,7 @@
 title: Populating
 description: Use Strapi's Entity Service API to populate relations in your queries.
 displayed_sidebar: devDocsSidebar
+search_weight: 1
 ---
 
 # Populating

--- a/docusaurus/docs/dev-docs/api/graphql.md
+++ b/docusaurus/docs/dev-docs/api/graphql.md
@@ -1,6 +1,7 @@
 ---
 title: GraphQL API
 displayed_sidebar: devDocsSidebar
+search_weight: 2
 ---
 
 # GraphQL API

--- a/docusaurus/docs/dev-docs/api/rest.md
+++ b/docusaurus/docs/dev-docs/api/rest.md
@@ -1,7 +1,7 @@
 ---
 title: REST API 
 description: Interact with your Content-Types using the REST API endpoints Strapi generates for you.
-
+search_weight: 2
 ---
 
 # REST API

--- a/docusaurus/docs/dev-docs/api/rest/filters-locale-publication.md
+++ b/docusaurus/docs/dev-docs/api/rest/filters-locale-publication.md
@@ -2,7 +2,7 @@
 title: Filters, Locale, and Publication State
 description: Use Strapi's REST API to filter the results of your requests.
 sidebarDepth: 3
-
+search_weight: 3
 ---
 
 import QsIntroFull from '/docs/snippets/qs-intro-full.md'

--- a/docusaurus/docs/dev-docs/api/rest/parameters.md
+++ b/docusaurus/docs/dev-docs/api/rest/parameters.md
@@ -3,6 +3,7 @@ title: Parameters
 description: Use API parameters to refine your Strapi REST API queries.
 
 next: ./filtering-locale-publication.md
+search_weight: 3
 ---
 
 import QsIntroShort from '/docs/snippets/qs-intro-short.md'

--- a/docusaurus/docs/dev-docs/api/rest/populate-select.md
+++ b/docusaurus/docs/dev-docs/api/rest/populate-select.md
@@ -2,7 +2,7 @@
 title: Populate and Select
 description: Use Strapi's REST API to populate or select certain fields.
 sidebarDepth: 3
-
+search_weight: 3
 ---
 
 import QsIntroFull from '/docs/snippets/qs-intro-full.md'

--- a/docusaurus/docs/dev-docs/api/rest/relations.md
+++ b/docusaurus/docs/dev-docs/api/rest/relations.md
@@ -1,7 +1,7 @@
 ---
 title: Relations
 description: Use the REST API to manage the order of relations
-
+search_weight: 3
 ---
 
 # Managing relations through the REST API

--- a/docusaurus/docs/dev-docs/api/rest/sort-pagination.md
+++ b/docusaurus/docs/dev-docs/api/rest/sort-pagination.md
@@ -2,7 +2,7 @@
 title: Sort and Pagination
 description: Use Strapi's REST API to sort or paginate your data.
 sidebarDepth: 3
-
+search_weight: 3
 ---
 
 import QsIntroFull from '/docs/snippets/qs-intro-full.md'

--- a/docusaurus/docs/dev-docs/migration/v3-to-v4/code-migration.md
+++ b/docusaurus/docs/dev-docs/migration/v3-to-v4/code-migration.md
@@ -2,7 +2,7 @@
 title: v4 code migration
 displayed_sidebar: devDocsSidebar
 description: Migrate the backend and frontend code of a Strapi application from v3.6.x to v4.0.x with step-by-step instructions
-
+search_weight: 0
 ---
 
 # v4 code migration guide

--- a/docusaurus/docs/dev-docs/migration/v3-to-v4/data-migration.md
+++ b/docusaurus/docs/dev-docs/migration/v3-to-v4/data-migration.md
@@ -1,6 +1,7 @@
 ---
 title: Data migration
 displayed_sidebar: devDocsSidebar
+search_weight: 0
 ---
 
 # Data migration guide

--- a/docusaurus/docs/dev-docs/migration/v3-to-v4/plugin-migration.md
+++ b/docusaurus/docs/dev-docs/migration/v3-to-v4/plugin-migration.md
@@ -2,7 +2,7 @@
 title: Plugin migration guide
 description: Migrate a Strapi plugin from v3.6.x to v4.0.x with step-by-step instructions
 sidebarDepth: 2
-
+search_weight: 0
 ---
 
 # v4 plugin migration guide

--- a/docusaurus/docs/dev-docs/migration/v3-to-v4/plugin/enable-plugin.md
+++ b/docusaurus/docs/dev-docs/migration/v3-to-v4/plugin/enable-plugin.md
@@ -2,7 +2,7 @@
 title: Enabling a plugin
 description: Enable a Strapi plugin while migrating from v3.6.x to v4.0.x with step-by-step instructions
 displayed_sidebar: devDocsSidebar
-
+search_weight: 0
 # pagination_prev: /dev-docs/migration/v3-to-v4/plugin/migrate-front-end.md
 ---
 

--- a/docusaurus/docs/dev-docs/migration/v3-to-v4/plugin/migrate-back-end.md
+++ b/docusaurus/docs/dev-docs/migration/v3-to-v4/plugin/migrate-back-end.md
@@ -2,7 +2,7 @@
 title: Migrating the back end
 description: Migrate the backend of a Strapi plugin from v3.6.x to v4.0.x with step-by-step instructions
 displayed_sidebar: devDocsSidebar
-
+search_weight: 0
 ---
 
 import PluginMigrationIntro from '/docs/snippets/plugin-migration-intro.md'

--- a/docusaurus/docs/dev-docs/migration/v3-to-v4/plugin/migrate-front-end.md
+++ b/docusaurus/docs/dev-docs/migration/v3-to-v4/plugin/migrate-front-end.md
@@ -2,7 +2,7 @@
 title: Migrating the front end
 description: Migrate the front end of a Strapi plugin from v3.6.x to v4.0.x with step-by-step instructions
 displayed_sidebar: devDocsSidebar
-
+search_weight: 0
 # pagination_next: ./enable-plugin.md
 ---
 

--- a/docusaurus/docs/dev-docs/migration/v3-to-v4/plugin/update-folder-structure.md
+++ b/docusaurus/docs/dev-docs/migration/v3-to-v4/plugin/update-folder-structure.md
@@ -2,7 +2,7 @@
 title: Updating the folder structure
 description: Migrate the folder structure of a Strapi plugin from v3.6.x to v4.0.x with step-by-step instructions
 displayed_sidebar: devDocsSidebar
-
+search_weight: 0
 ---
 
 import PluginMigrationIntro from '/docs/snippets/plugin-migration-intro.md'

--- a/docusaurus/src/theme/DocItem/Metadata/index.js
+++ b/docusaurus/src/theme/DocItem/Metadata/index.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import {PageMetadata} from '@docusaurus/theme-common';
+import {useDoc} from '@docusaurus/theme-common/internal';
+export default function DocItemMetadata() {
+  const {metadata, frontMatter, assets} = useDoc();
+  return (
+    <PageMetadata
+      title={metadata.title}
+      description={metadata.description}
+      keywords={frontMatter.keywords}
+      image={assets.image ?? frontMatter.image}
+    >
+      <meta property="search:weight" content={frontMatter.search_weight} />
+    </PageMetadata>
+  );
+}


### PR DESCRIPTION
### What does it do?

Added search:weight to metadata

Added search_weight an option for docs pages

### Why is it needed?

makes search better

### Related issue(s)/PR(s)

fixes https://github.com/strapi/documentation/issues/1673

### Work required on strapi's
After the PR is accepted the following should be added to the crawler for search
```js
recordExtractor: ({ $, helpers }) => {
    return helpers.docsearch({
      recordProps: {
        lvl0: {
          selectors: "header h1",
        },
        lvl1: "article h2",
        lvl2: "article h3",
        lvl3: "article h4",
        lvl4: "article h5",
        lvl5: "article h6",
        content: "article p, article li",
        // Add the line bellow 
        pageRank: ["meta[property="search:weight"]", 0.5]
      },
    });
  },
``
