### PR TITLE
update Dockerfile.prod instructions to fix "strapi not found" error

### DIFF
--- a/docusaurus/docs/dev-docs/installation/docker.md
+++ b/docusaurus/docs/dev-docs/installation/docker.md
@@ -342,16 +342,15 @@ RUN yarn config set network-timeout 600000 -g && yarn install --production
 WORKDIR /opt/app
 COPY ./ .
 RUN yarn build
-FROM node:16-alpine
-RUN apk add --no-cache vips-dev
 
 FROM node:16-alpine
-RUN apk add --no-cache vips-dev
+RUN apk add --no-cache vips-dev && rm -rf /var/cache/apk/*
 ARG NODE_ENV=production
 ENV NODE_ENV=${NODE_ENV}
-WORKDIR /opt/app
+WORKDIR /opt/
 COPY --from=build /opt/node_modules ./node_modules
 ENV PATH /opt/node_modules/.bin:$PATH
+WORKDIR /opt/app
 COPY --from=build /opt/app ./
 EXPOSE 1337
 CMD ["yarn", "start"]
@@ -379,13 +378,13 @@ RUN npm run build
 
 FROM node:16-alpine
 # Installing libvips-dev for sharp Compatibility
-RUN apk add vips-dev
-RUN rm -rf /var/cache/apk/*
+RUN apk add vips-dev && rm -rf /var/cache/apk/*
 ARG NODE_ENV=production
 ENV NODE_ENV=${NODE_ENV}
-WORKDIR /opt/app
+WORKDIR /opt/
 COPY --from=build /opt/node_modules ./node_modules
 ENV PATH /opt/node_modules/.bin:$PATH
+WORKDIR /opt/app
 COPY --from=build /opt/app ./
 EXPOSE 1337
 CMD ["npm", "run","start"]


### PR DESCRIPTION
### What does it do?

- after copying node_modules to /opt dir, change the working dir to /opt/app for both `yarn` and `npm` specific Dockerfile.prod
- remove unused intermediate build from yarn's Dockerfile.prod
- write single line instruction to install and delete apk cache to reduce docker layer size.

### Why is it needed?

First point is required to fix the "strapi not found" error.
Other points are related to clean-up and docker optimisation.

### Related issue(s)/PR(s)

No