### PR TITLE
Document the new allowedFields config option

### DIFF
--- a/docusaurus/docs/dev-docs/plugins/users-permissions.md
+++ b/docusaurus/docs/dev-docs/plugins/users-permissions.md
@@ -201,12 +201,58 @@ Setting JWT expiry for more than 30 days is **not recommended** due to security 
 
 ### Registration
 
-Creates a new user in the database with a default role as 'registered'.
+#### Configuration
+
+If you have added any additional fields to your user model that need to be accepted on registration, they need to be added to the list of allowed fields in the `register` configuration option, otherwise they will be ignored.
+
+For example, if you have added a field called "nickname" that you wish to accept from the user:
+
+<Tabs groupId="js-ts">
+
+<TabItem value="javascript" label="JavaScript">
+
+```js title="./config/plugins.js"
+module.exports = ({ env }) => ({
+  // ...
+  "users-permissions": {
+    config: {
+      register: {
+        allowedFields: ["nickname"],
+      },
+    },
+  },
+  // ...
+});
+```
+
+</TabItem>
+
+<TabItem value="typescript" label="TypeScript">
+
+```ts title="./config/plugins.ts"
+export default ({ env }) => ({
+  // ...
+  "users-permissions": {
+    config: {
+      register: {
+        allowedFields: ["nickname"],
+      },
+    },
+  },
+  // ...
+});
+```
+
+</TabItem>
+
+</Tabs>
 
 #### Usage
 
+Creates a new user in the database with a default role as 'registered'.
+
 ```js
-import axios from 'axios';
+import axios from "axios";
 
 // Request API.
 // Add your own code here to customize or restrict how the public can register new users.


### PR DESCRIPTION
### What does it do?

Adds documentation for the new allowedFields config option of U&P

### Why is it needed?

It is a breaking change and must be documented at the same time as the release!

### Related issue(s)/PR(s)

[PR 16333 on strapi/strapi adds the feature](https://github.com/strapi/strapi/pull/16333)
