### PR TITLE
docs: correct table formatting for responsive images

### DIFF
--- a/docusaurus/docs/dev-docs/plugins/upload.md
+++ b/docusaurus/docs/dev-docs/plugins/upload.md
@@ -175,6 +175,7 @@ export default {
 ### Responsive Images
 
 When the `Enable responsive friendly upload` setting is enabled in the settings panel the plugin will generate the following responsive image sizes:
+
 | Name    | Largest Dimension |
 | :------ | :--------- |
 | large   | 1000px     |


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

Fixes formatting of the rendered table in original docs.

Docs source: https://docs.strapi.io/dev-docs/plugins/upload#responsive-images

<img width="779" alt="image" src="https://github.com/strapi/documentation/assets/5487217/9cd97e8a-3ccd-41ed-a9ce-f640f7bb9b06">

### Why is it needed?

To render the table correctly as others.

E.g.:
<img width="538" alt="image" src="https://github.com/strapi/documentation/assets/5487217/0159229c-04cf-4596-87c3-8dbdb75e65eb">

### Related issue(s)/PR(s)

No related PR.
