### PR TITLE
Update 'code' style, as bold, when inside a link

### DIFF
--- a/docusaurus/src/scss/code.scss
+++ b/docusaurus/src/scss/code.scss
@@ -44,6 +44,7 @@ h1, h2, h3, li, p, table {
 
   a code {
     color: var(--ifm-link-color);
+    font-weight: var(--ifm-font-weight-bold);
   }
 }
 


### PR DESCRIPTION
### What does it do?

Apply bold style to the `<code>` tag in the text.

### Why is it needed?

Better readability.
