### PR TITLE
Change webhook execution command to node

### DIFF
--- a/docusaurus/docs/dev-docs/deployment/digitalocean.md
+++ b/docusaurus/docs/dev-docs/deployment/digitalocean.md
@@ -495,7 +495,7 @@ After=network.target
 Environment=PATH=your_path
 Type=simple
 User=your-name
-ExecStart=/usr/bin/nodejs /home/your-name/NodeWebHooks/webhook.js
+ExecStart=/usr/bin/node /home/your-name/NodeWebHooks/webhook.js
 Restart=on-failure
 
 [Install]


### PR DESCRIPTION
As several comments at the bottom of the linked article on L518 state, the 'nodejs' command has been replaced by 'node'. Attempting to run with 'nodejs' will result in a failure to start the webhook with a 203/EXEC status. https://prnt.sc/lRodj9tqwS4L
