### PR TITLE
Add an interactive query builder

### DIFF
--- a/docusaurus/docs/dev-docs/api/rest/interactive-query-builder.md
+++ b/docusaurus/docs/dev-docs/api/rest/interactive-query-builder.md
@@ -53,7 +53,7 @@ The default endpoint path is prefixed with `/api/` and should be kept as-is unle
 
 :::caution Disclaimer
 The `qs` library and the interactive query builder provided on this page:
-- do not detect syntax errors,
+- might not detect all syntax errors,
 - are not aware of the parameters and values available in a Strapi project,
 - and do not provide autocomplete features.
 

--- a/docusaurus/docs/dev-docs/api/rest/interactive-query-builder.md
+++ b/docusaurus/docs/dev-docs/api/rest/interactive-query-builder.md
@@ -1,0 +1,61 @@
+---
+title: Interactive Query Builder
+description: Use an interactive tool that leverages the querystring library to build your query URL
+displayed_sidebar: devDocsSidebar
+---
+
+# Build your query URL with Strapi's interactive tool
+
+A wide range of parameters can be used and combined to query your content with the [REST API](/dev-docs/api/rest), which can result in long and complex query URLs.
+
+Strapi's codebase uses [the `qs` library](https://github.com/ljharb/qs) to parse and stringify nested JavaScript objects. It's recommended to use `qs` directly to generate complex query URLs instead of creating them manually.
+
+You can use the following interactive query builder tool to generate query URLs automatically:
+
+1. Replace the values in the _Endpoint_ and _Endpoint Query Parameters_ fields with content that fits your needs.
+2. Click the **Copy to clipboard** button to copy the automatically generated _Query String URL_ which is updated as you type.
+
+:::info Parameters usage
+Please refer to the [REST API parameters table](/dev-docs/api/rest/parameters) and read the corresponding parameters documentation pages to better understand parameters usage.
+:::
+
+<br />
+
+<InteractiveQueryBuilder
+  endpoint="/api/books"
+  code={`
+{
+  sort: ['title:asc'],
+  filters: {
+    title: {
+      $eq: 'hello',
+    },
+  },
+  populate: '*',
+  fields: ['title'],
+  pagination: {
+    pageSize: 10,
+    page: 1,
+  },
+  publicationState: 'live',
+  locale: ['en'],
+}
+  `}
+/>
+
+<br />
+ 
+<br />
+
+:::note
+The default endpoint path is prefixed with `/api/` and should be kept as-is unless you configured a different API prefix using [the `rest.prefix` API configuration option](/dev-docs/configurations/api).<br/> For instance, to query the `books` collection type using the default API prefix, type `/api/books`.
+:::
+
+:::caution Disclaimer
+The `qs` library and the interactive query builder provided on this page:
+- do not detect syntax errors,
+- are not aware of the parameters and values available in a Strapi project,
+- and do not provide autocomplete features.
+
+Currently, these tools are only provided to transform the JavaScript object in an inline query string URL. Using the generated query string URL does not guarantee that proper results will get returned with your API.
+:::

--- a/docusaurus/docs/dev-docs/api/rest/interactive-query-builder.md
+++ b/docusaurus/docs/dev-docs/api/rest/interactive-query-builder.md
@@ -48,7 +48,7 @@ Please refer to the [REST API parameters table](/dev-docs/api/rest/parameters) a
 <br />
 
 :::note
-The default endpoint path is prefixed with `/api/` and should be kept as-is unless you configured a different API prefix using [the `rest.prefix` API configuration option](/dev-docs/configurations/api).<br/> For instance, to query the `books` collection type using the default API prefix, type `/api/books`.
+The default endpoint path is prefixed with `/api/` and should be kept as-is unless you configured a different API prefix using [the `rest.prefix` API configuration option](/dev-docs/configurations/api).<br/> For instance, to query the `books` collection type using the default API prefix, type `/api/books` in the _Endpoint_ field.
 :::
 
 :::caution Disclaimer
@@ -57,5 +57,5 @@ The `qs` library and the interactive query builder provided on this page:
 - are not aware of the parameters and values available in a Strapi project,
 - and do not provide autocomplete features.
 
-Currently, these tools are only provided to transform the JavaScript object in an inline query string URL. Using the generated query string URL does not guarantee that proper results will get returned with your API.
+Currently, these tools are only provided to transform the JavaScript object in an inline query string URL. Using the generated query URL does not guarantee that proper results will get returned with your API.
 :::

--- a/docusaurus/docs/dev-docs/api/rest/parameters.md
+++ b/docusaurus/docs/dev-docs/api/rest/parameters.md
@@ -1,5 +1,5 @@
 ---
-title: Parameters 
+title: Parameters
 description: Use API parameters to refine your Strapi REST API queries.
 
 next: ./filtering-locale-publication.md
@@ -28,15 +28,10 @@ Query parameters use the LHS bracket syntax (i.e. they are encoded using square 
 :::tip
 <QsIntroShort />
 
-<details>
-<summary>Example using qs:</summary>
-
-In the following example, the `qs` library is used to build the following URL:
-`/api/books?sort[0]=title%3Aasc&filters[title][$eq]=hello&populate=%2A&fields[0]=title&pagination[pageSize]=10&pagination[page]=1&publicationState=live&locale[0]=en`
-
-```js
-const qs = require('qs');
-const query = qs.stringify({
+<InteractiveQueryBuilder
+  endpoint="/api/books"
+  code={`
+{
   sort: ['title:asc'],
   filters: {
     title: {
@@ -51,12 +46,8 @@ const query = qs.stringify({
   },
   publicationState: 'live',
   locale: ['en'],
-}, {
-  encodeValuesOnly: true, // prettify URL
-});
+}
+  `}
+/>
 
-await request(`/api/books?${query}`);
-```
-
-</details>
 :::

--- a/docusaurus/docs/dev-docs/api/rest/parameters.md
+++ b/docusaurus/docs/dev-docs/api/rest/parameters.md
@@ -25,8 +25,13 @@ The following API parameters are available:
 
 Query parameters use the LHS bracket syntax (i.e. they are encoded using square brackets `[]`)
 
-:::tip
-<QsIntroShort />
+:::strapi Interactive Query Builder
+
+A wide range of REST API parameters can be used and combined to query your content, which can result in long query URLs. Strapi's codebase uses [the `qs` library](https://github.com/ljharb/qs) to parse and stringify nested objects, and it's recommended to use `qs` directly to generate complex query strings instead of creating them manually. You can use the following interactive query builder, which leverages `qs` to generate URLs:
+
+1. In the _Endpoint_ field, type the path of the endpoint you want to query. The default endpoint path is prefixed with `/api/` and should be kept as-is unless you configured a different API prefix using [the `rest.prefix` API configuration option](/dev-docs/configurations/api). For instance, to query the `books` content-type using the default API prefix, type `/api/books`.
+2. In the _Endpoint query parameters_ field, type whatever parameters and values you would like to use to define a specific query. Refer to the parameters table at the beginning of this page and read the corresponding parameters pages to better understand parameters usage. The _Query String URL_ field is updated as you type.
+3. Click the **Copy to clipboard** button. The automatically generated query string is copied to your clipboard and ready to be pasted in the tool of your choice to query your content.
 
 <InteractiveQueryBuilder
   endpoint="/api/books"
@@ -50,4 +55,8 @@ Query parameters use the LHS bracket syntax (i.e. they are encoded using square 
   `}
 />
 
+:::
+
+:::caution
+The `qs` library and the interactive query builder provided above do not validate the syntax. These tools are only provided to simplify building the query string but do not guarantee a valid syntax or result. 
 :::

--- a/docusaurus/docs/dev-docs/api/rest/parameters.md
+++ b/docusaurus/docs/dev-docs/api/rest/parameters.md
@@ -27,7 +27,7 @@ Query parameters use the LHS bracket syntax (i.e. they are encoded using square 
 
 :::strapi Interactive Query Builder
 
-A wide range of REST API parameters can be used and combined to query your content, which can result in long query URLs. Strapi's codebase uses [the `qs` library](https://github.com/ljharb/qs) to parse and stringify nested objects, and it's recommended to use `qs` directly to generate complex query strings instead of creating them manually. You can use the following interactive query builder, which leverages `qs` to generate URLs:
+A wide range of REST API parameters can be used and combined to query your content, which can result in long query URLs. Strapi's codebase uses [the `qs` library](https://github.com/ljharb/qs) to parse and stringify nested objects. It's recommended to use `qs` directly to generate complex query strings from JavaScript objects instead of creating query strings manually. You can use the following interactive query builder that leverages `qs` to generate URLs automatically:
 
 1. In the _Endpoint_ field, type the path of the endpoint you want to query. The default endpoint path is prefixed with `/api/` and should be kept as-is unless you configured a different API prefix using [the `rest.prefix` API configuration option](/dev-docs/configurations/api). For instance, to query the `books` content-type using the default API prefix, type `/api/books`.
 2. In the _Endpoint query parameters_ field, type whatever parameters and values you would like to use to define a specific query. Refer to the parameters table at the beginning of this page and read the corresponding parameters pages to better understand parameters usage. The _Query String URL_ field is updated as you type.

--- a/docusaurus/docs/dev-docs/api/rest/parameters.md
+++ b/docusaurus/docs/dev-docs/api/rest/parameters.md
@@ -25,38 +25,6 @@ The following API parameters are available:
 
 Query parameters use the LHS bracket syntax (i.e. they are encoded using square brackets `[]`)
 
-:::strapi Interactive Query Builder
-
-A wide range of REST API parameters can be used and combined to query your content, which can result in long query URLs. Strapi's codebase uses [the `qs` library](https://github.com/ljharb/qs) to parse and stringify nested objects. It's recommended to use `qs` directly to generate complex query strings from JavaScript objects instead of creating query strings manually. You can use the following interactive query builder that leverages `qs` to generate URLs automatically:
-
-1. In the _Endpoint_ field, type the path of the endpoint you want to query. The default endpoint path is prefixed with `/api/` and should be kept as-is unless you configured a different API prefix using [the `rest.prefix` API configuration option](/dev-docs/configurations/api). For instance, to query the `books` content-type using the default API prefix, type `/api/books`.
-2. In the _Endpoint query parameters_ field, type whatever parameters and values you would like to use to define a specific query. Refer to the parameters table at the beginning of this page and read the corresponding parameters pages to better understand parameters usage. The _Query String URL_ field is updated as you type.
-3. Click the **Copy to clipboard** button. The automatically generated query string is copied to your clipboard and ready to be pasted in the tool of your choice to query your content.
-
-<InteractiveQueryBuilder
-  endpoint="/api/books"
-  code={`
-{
-  sort: ['title:asc'],
-  filters: {
-    title: {
-      $eq: 'hello',
-    },
-  },
-  populate: '*',
-  fields: ['title'],
-  pagination: {
-    pageSize: 10,
-    page: 1,
-  },
-  publicationState: 'live',
-  locale: ['en'],
-}
-  `}
-/>
-
-:::
-
-:::caution
-The `qs` library and the interactive query builder provided above do not validate the syntax. These tools are only provided to simplify building the query string but do not guarantee a valid syntax or result. 
+:::tip
+A wide range of REST API parameters can be used and combined to query your content, which can result in long and complex query URLs.<br/>👉 You can use Strapi's [interactive query builder](/dev-docs/api/rest/interactive-query-builder) tool to build query URLs more conveniently. 🤗
 :::

--- a/docusaurus/docs/snippets/qs-intro-short.md
+++ b/docusaurus/docs/snippets/qs-intro-short.md
@@ -1,2 +1,2 @@
-Strapi takes advantage of the ability of the [`qs`](https://github.com/ljharb/qs) library to parse nested objects to create more complex queries.
+Strapi takes advantage of the ability of [the `qs` library](https://github.com/ljharb/qs) to parse nested objects to create more complex queries.
 Use `qs` directly to generate complex queries instead of creating them manually.

--- a/docusaurus/package.json
+++ b/docusaurus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-docs",
-  "version": "4.10.4",
+  "version": "4.10.6",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/docusaurus/package.json
+++ b/docusaurus/package.json
@@ -27,6 +27,7 @@
     "embla-carousel-react": "^7.1.0",
     "embla-carousel-wheel-gestures": "^3.0.0",
     "prism-react-renderer": "^1.3.5",
+    "qs": "^6.11.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "redocusaurus": "^1.6.1",

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -159,6 +159,7 @@ const sidebars = {
             'dev-docs/api/rest/filters-locale-publication',
             'dev-docs/api/rest/sort-pagination',
             'dev-docs/api/rest/relations',
+            'dev-docs/api/rest/interactive-query-builder',
           ]
         },
         'dev-docs/api/graphql',

--- a/docusaurus/src/components/Button/Button.jsx
+++ b/docusaurus/src/components/Button/Button.jsx
@@ -22,7 +22,7 @@ export function Button({
       {...(!to ? {} : { to })}
       className={clsx(
         'button',
-        (variant && `button--${variant}`),
+        (variant && styles[`button--${variant}`]),
         (size && styles[`button--${size}`]),
         styles.button,
         styles[variant],

--- a/docusaurus/src/components/Button/button.module.scss
+++ b/docusaurus/src/components/Button/button.module.scss
@@ -1,7 +1,10 @@
 /** Component: Button */
 
+@import '../../scss/_mixins.scss';
+
 .button {
   --strapi-button-background-color: var(--strapi-primary-600);
+  --strapi-button-border-color: var(--strapi-primary-600);
   --strapi-button-border-radius: 4px;
   --strapi-button-box-shadow: 0 0 0 transparent;
   --strapi-button-color: #fff;
@@ -13,12 +16,21 @@
   --strapi-button-px: 15px;
   --strapi-button-transition-property: color, background, border-color, box-shadow;
 
+  --strapi-button-hover-background-color: var(--strapi-primary-700);
+  --strapi-button-hover-border-color: var(--strapi-primary-700);
+  --strapi-button-hover-box-shadow: 0px 9px 10px rgba(44, 56, 148, 0.2475);
+  --strapi-button-hover-color: #fff;
+
   --ifm-button-color: var(--strapi-button-color);
+  --ifm-button-background-color: var(--strapi-button-background-color);
+  --ifm-button-border-color: var(--strapi-button-border-color);
   --ifm-button-border-radius: var(--strapi-button-border-radius);
   --ifm-button-font-weight: var(--strapi-button-font-weight);
   --ifm-button-padding-horizontal: var(--strapi-button-px);
   --ifm-button-padding-vertical: var(--strapi-button-py);
   --ifm-button-size-multiplier: 1;
+
+  --ifm-color-primary-darker: var(--strapi-primary-200);
 
   --ifm-link-hover-color: var(--strapi-button-color);
   --ifm-link-hover-decoration: none;
@@ -37,8 +49,14 @@
     right: -8px;
   }
 
-  &:focus, &:hover {
-    --strapi-button-box-shadow: 0px 9px 10px rgba(44, 56, 148, 0.2475);
+  &:not(:disabled),
+  &:not([aria-disabled="true"]) {
+    &:focus, &:hover {
+      --strapi-button-box-shadow: var(--strapi-button-hover-box-shadow);
+      --strapi-button-background-color: var(--strapi-button-hover-background-color);
+      --strapi-button-border-color: var(--strapi-button-hover-border-color);
+      --strapi-button-color: var(--strapi-button-hover-color);
+    }
   }
 
   /** Sizes */
@@ -48,5 +66,31 @@
     --strapi-button-line-height: 23px;
     --strapi-button-py: 11px;
     --strapi-button-px: 71px;
+  }
+
+  /** Variants */
+  &--secondary {
+    --strapi-button-background-color: #f0f0ff;
+    --strapi-button-border-color: #d9d8ff;
+    --strapi-button-color: var(--strapi-primary-600);
+
+    --strapi-button-hover-background-color: var(--strapi-neutral-0);
+    --strapi-button-hover-border-color: #d9d8ff;
+    --strapi-button-hover-box-shadow: none;
+    --strapi-button-hover-color: var(--strapi-primary-600);
+  }
+}
+
+/** Dark mode */
+@include dark {
+  .button {
+    /** Dark mode Variants */
+    &--secondary {
+      --strapi-button-background-color: var(--strapi-neutral-100);
+      --strapi-button-border-color: var(--strapi-neutral-200);
+
+      --strapi-button-hover-background-color: var(--strapi-neutral-0);
+      --strapi-button-hover-border-color: var(--strapi-neutral-200);
+    }
   }
 }

--- a/docusaurus/src/components/Form/FormField/FormField.jsx
+++ b/docusaurus/src/components/Form/FormField/FormField.jsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import clsx from 'clsx';
+import styles from './form-field.module.scss';
+import { FormFieldHint } from '../FormFieldHint/FormFieldHint';
+import { FormFieldInput } from '../FormFieldInput/FormFieldInput';
+import { FormFieldLabel } from '../FormFieldLabel/FormFieldLabel';
+
+export function FormField({
+  children,
+  className,
+  id,
+
+  // Optional - Object which contains Input props
+  input,
+
+  // Optional - Simple String or an Object which contains 'FormFieldLabel' props
+  label,
+
+  // Optional - Simple String or an Object which contains 'FormFieldHint' props
+  hint,
+
+  ...rest
+}) {
+  return (
+    <fieldset
+      {...rest}
+      id={`${id}-wrapper`}
+      className={clsx(
+        styles['form-field'],
+        className,
+      )}
+    >
+      {label && (
+        <FormFieldLabel
+          id={`${id}-label`}
+          htmlFor={id}
+          {...((typeof label === 'object') ? label : { children: label })}
+        />
+      )}
+      {input && (
+        <FormFieldInput
+          id={id}
+          {...input}
+        />
+      )}
+      {children}
+      {hint && (
+        <FormFieldHint
+          id={`${id}-hint`}
+          htmlFor={id}
+          {...((typeof hint === 'object') ? hint : { children: hint })}
+        />
+      )}
+    </fieldset>
+  );
+}

--- a/docusaurus/src/components/Form/FormField/form-field.module.scss
+++ b/docusaurus/src/components/Form/FormField/form-field.module.scss
@@ -1,0 +1,9 @@
+/** Component: Form Field */
+
+.form-field {
+  display: var(--strapi-form-field-input-display, block);
+  width: var(--strapi-form-field-input-width, 100%);
+  border: var(--strapi-form-field-border, 0);
+  margin: var(--strapi-form-field-my, var(--strapi-spacing-4)) var(--strapi-form-field-mx, 0);
+  padding: var(--strapi-form-field-py, 0) var(--strapi-form-field-px, 0);
+}

--- a/docusaurus/src/components/Form/FormFieldHint/FormFieldHint.jsx
+++ b/docusaurus/src/components/Form/FormFieldHint/FormFieldHint.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import clsx from 'clsx';
+import styles from './form-field-hint.module.scss';
+
+export function FormFieldHint({
+  className,
+  ...rest
+}) {
+  return (
+    <label
+      {...rest}
+      className={clsx(
+        styles['form-field__hint'],
+        className,
+      )}
+    />
+  );
+}

--- a/docusaurus/src/components/Form/FormFieldHint/form-field-hint.module.scss
+++ b/docusaurus/src/components/Form/FormFieldHint/form-field-hint.module.scss
@@ -1,0 +1,11 @@
+/** Component: Form Field Hint */
+
+.form-field__hint {
+  display: var(--strapi-form-field-hint-display, block);
+  width: var(--strapi-form-field-hint-width, 100%);
+  color: var(--strapi-form-field-hint-color, var(--strapi-neutral-600));
+  font-size: var(--strapi-form-field-hint-font-size, 0.75rem);
+  font-weight: var(--strapi-form-field-hint-font-weight, 400);
+  line-height: var(--strapi-form-field-hint-line-height, 1.33);
+  margin-top: var(--strapi-form-field-hint-mt, 0.25rem);
+}

--- a/docusaurus/src/components/Form/FormFieldInput/FormFieldInput.jsx
+++ b/docusaurus/src/components/Form/FormFieldInput/FormFieldInput.jsx
@@ -3,14 +3,16 @@ import clsx from 'clsx';
 import styles from './form-field-input.module.scss';
 
 export function FormFieldInput({
+  as: Component = 'input',
   className,
   ...rest
 }) {
   return (
-    <input
+    <Component
       {...rest}
       className={clsx(
         styles['form-field__input'],
+        styles[`form-field__input--${Component}`],
         className,
       )}
     />

--- a/docusaurus/src/components/Form/FormFieldInput/FormFieldInput.jsx
+++ b/docusaurus/src/components/Form/FormFieldInput/FormFieldInput.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import clsx from 'clsx';
+import styles from './form-field-input.module.scss';
+
+export function FormFieldInput({
+  className,
+  ...rest
+}) {
+  return (
+    <input
+      {...rest}
+      className={clsx(
+        styles['form-field__input'],
+        className,
+      )}
+    />
+  );
+}
+
+FormFieldInput.defaultProps = {
+  type: 'text',
+};

--- a/docusaurus/src/components/Form/FormFieldInput/form-field-input.module.scss
+++ b/docusaurus/src/components/Form/FormFieldInput/form-field-input.module.scss
@@ -1,0 +1,38 @@
+/** Component: Form Field Input */
+
+.form-field__input {
+  display: var(--strapi-form-field-input-display, block);
+  width: var(--strapi-form-field-input-width, 100%);
+  min-height: var(--strapi-form-field-input-min-height, 2.25rem);
+  background: var(--strapi-form-field-input-bg, var(--strapi-neutral-0));
+  border-color: var(--strapi-form-field-input-border-color, var(--strapi-neutral-200));
+  border-radius: var(--strapi-form-field-input-border-radius, 0.25rem);
+  border-style: var(--strapi-form-field-input-border-style, solid);
+  border-width: var(--strapi-form-field-input-border-width, 0.0625rem);
+  color: var(--strapi-form-field-input-color, var(--strapi-neutral-800));
+  font-size: var(--strapi-form-field-input-font-size, var(--strapi-font-size-sm));
+  font-weight: var(--strapi-form-field-input-font-weight, 400);
+  line-height: var(--strapi-form-field-input-line-height, 1.33);
+  padding:
+    var(--strapi-form-field-input-py, var(--strapi-spacing-2))
+    var(--strapi-form-field-input-px, var(--strapi-spacing-4))
+  ;
+  outline-color: var(--strapi-form-field-outline-color, transparent);
+  outline-offset: var(--strapi-form-field-outline-offset, 0);
+  outline-style: var(--strapi-form-field-outline-style, solid);
+  outline-width: var(--strapi-form-field-outline-width, 0.125rem);
+  transition: var(--strapi-form-field-input-transition, all ease 0.2s);
+
+  &:disabled,
+  &[aria-disabled="true"] {
+    --strapi-form-field-input-bg: var(--strapi-neutral-150);
+    --strapi-form-field-input-border-color: var(--strapi-neutral-200);
+    --strapi-form-field-input-color: var(--strapi-neutral-600);
+  }
+
+  &:focus,
+  &:focus-visible {
+    --strapi-form-field-input-border-color: var(--strapi-primary-600);
+    --strapi-form-field-outline-color: var(--strapi-primary-600);
+  }
+}

--- a/docusaurus/src/components/Form/FormFieldInput/form-field-input.module.scss
+++ b/docusaurus/src/components/Form/FormFieldInput/form-field-input.module.scss
@@ -35,4 +35,9 @@
     --strapi-form-field-input-border-color: var(--strapi-primary-600);
     --strapi-form-field-outline-color: var(--strapi-primary-600);
   }
+
+  &--textarea {
+    min-height: 4.625rem;
+    resize: vertical;
+  }
 }

--- a/docusaurus/src/components/Form/FormFieldLabel/FormFieldLabel.jsx
+++ b/docusaurus/src/components/Form/FormFieldLabel/FormFieldLabel.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import clsx from 'clsx';
+import styles from './form-field-label.module.scss';
+
+export function FormFieldLabel({
+  className,
+  ...rest
+}) {
+  return (
+    <label
+      {...rest}
+      className={clsx(
+        styles['form-field__label'],
+        className,
+      )}
+    />
+  );
+}

--- a/docusaurus/src/components/Form/FormFieldLabel/form-field-label.module.scss
+++ b/docusaurus/src/components/Form/FormFieldLabel/form-field-label.module.scss
@@ -1,0 +1,11 @@
+/** Component: Form Field Label */
+
+.form-field__label {
+  display: var(--strapi-form-field-label-display, block);
+  width: var(--strapi-form-field-label-width, 100%);
+  color: var(--strapi-form-field-label-color, var(--strapi-neutral-800));
+  font-size: var(--strapi-form-field-label-font-size, 0.875rem);
+  font-weight: var(--strapi-form-field-label-font-weight, 600);
+  line-height: var(--strapi-form-field-label-line-height, 1.33);
+  margin-bottom: var(--strapi-form-field-label-mb, 0.25rem);
+}

--- a/docusaurus/src/components/Form/index.js
+++ b/docusaurus/src/components/Form/index.js
@@ -1,0 +1,4 @@
+export * from './FormField/FormField';
+export * from './FormFieldHint/FormFieldHint';
+export * from './FormFieldInput/FormFieldInput';
+export * from './FormFieldLabel/FormFieldLabel';

--- a/docusaurus/src/components/InteractiveQueryBuilder/InteractiveQueryBuilder.jsx
+++ b/docusaurus/src/components/InteractiveQueryBuilder/InteractiveQueryBuilder.jsx
@@ -101,6 +101,7 @@ export function InteractiveQueryBuilder({
                   label="Query String URL:"
                   input={{
                     'aria-disabled': true,
+                    as: 'textarea',
                     readOnly: true,
                     value: queryStringified,
                   }}

--- a/docusaurus/src/components/InteractiveQueryBuilder/InteractiveQueryBuilder.jsx
+++ b/docusaurus/src/components/InteractiveQueryBuilder/InteractiveQueryBuilder.jsx
@@ -130,6 +130,7 @@ export function InteractiveQueryBuilder({
             value: endpoint,
             onChange: handleEndpointChange,
           }}
+          hint="Please keep the /api/ part unless you explicitly configured it differently in your project."
         />
         <FormField
           id={`${id}-query`}

--- a/docusaurus/src/components/InteractiveQueryBuilder/InteractiveQueryBuilder.jsx
+++ b/docusaurus/src/components/InteractiveQueryBuilder/InteractiveQueryBuilder.jsx
@@ -1,0 +1,146 @@
+import qs from 'qs';
+import clsx from 'clsx';
+import React, { useCallback, useLayoutEffect, useState } from 'react';
+import { LiveEditor, LiveError, LivePreview, LiveProvider } from 'react-live';
+import { usePrismTheme } from '@docusaurus/theme-common';
+import { Button } from '../Button/Button';
+import { FormField } from '../Form';
+import styles from './interactive-query-builder.module.scss';
+
+export function InteractiveQueryBuilder({
+  className,
+  code = '',
+  endpoint: inheritEndpoint = '/api/books',
+  id: inheritId = '',
+}) {
+  const id = (inheritId || `strapi-iqb-${Math.random()}`);
+  const localStorageKey = `strapi-iqb-value-for-${inheritEndpoint}`;
+  const prismTheme = usePrismTheme();
+  const [endpoint, setEndpoint] = useState(inheritEndpoint);
+  const [clipboardStatus, setClipboardStatus] = useState('');
+
+  /**
+   * Copy to Clipboard
+   */
+  const handleClickClipboard = useCallback((textToCopy) => {
+    try {
+      navigator.clipboard.writeText(textToCopy);
+      setClipboardStatus('success');
+    } catch (err) {
+      setClipboardStatus('error');
+    } finally {
+      setTimeout(() => setClipboardStatus(''), 5000);
+    }
+  }, []);
+
+  /**
+   * Local state management to the "Endpoint" input field.
+   * Additionally, storage the changed value to the Browser's LocalStorage API.
+   */
+  const handleEndpointChange = useCallback((evt) => {
+    setEndpoint(evt.target.value);
+
+    if (evt.target.value === inheritEndpoint) {
+      localStorage.removeItem(localStorageKey);
+    } else {
+      localStorage.setItem(localStorageKey, evt.target.value);
+    }
+  }, [inheritEndpoint, localStorageKey]);
+
+  /**
+   * Restore the "Endpoint" input field value, based on what the user have typed before.
+   */
+  useLayoutEffect(() => {
+    const endpointChangedBeforeByUser = localStorage.getItem(localStorageKey);
+
+    if (typeof endpointChangedBeforeByUser !== 'string') {
+      return;
+    }
+
+    setEndpoint(endpointChangedBeforeByUser);
+  }, [localStorageKey]);
+
+  return (
+    <form
+      onSubmit={(evt) => evt.preventDefault()}
+      className={clsx('strapi-iqb', styles.iqb, className)}
+    >
+      <LiveProvider
+        language="jsx"
+        theme={prismTheme}
+        code={code.trim()}
+        scope={{
+          clipboardStatus,
+          endpoint,
+          handleClickClipboard,
+          id,
+          qs,
+          Button,
+          FormField,
+        }}
+        transformCode={(writtenQueryByUser) =>
+          `() => {
+            const queryObject =
+
+
+  ${writtenQueryByUser}
+
+
+            ;
+
+            const queryStringified = (
+              endpoint +
+              '?' +
+              qs.stringify(queryObject, { encodeValuesOnly: true })
+            );
+
+            return (
+              <>
+                <FormField
+                  id={id + '-result'}
+                  label="Query String URL:"
+                  input={{
+                    'aria-disabled': true,
+                    readOnly: true,
+                    value: queryStringified,
+                  }}
+                />
+                <Button
+                  id={id + '-copy-to-clipboard'}
+                  type="button"
+                  variant="secondary"
+                  onClick={() => handleClickClipboard(queryStringified)}
+                >
+                  Copy to clipboard
+                  <span style={{ marginLeft: '0.25rem' }}>
+                    {clipboardStatus === '' && ' 📑'}
+                    {clipboardStatus === 'error' && ' ❌'}
+                    {clipboardStatus === 'success' && ' ✅'}
+                  </span>
+                </Button>
+              </>
+            );
+          }`
+        }
+      >
+        <FormField
+          id={`${id}-endpoint`}
+          label="Endpoint:"
+          input={{
+            value: endpoint,
+            onChange: handleEndpointChange,
+          }}
+        />
+        <FormField
+          id={`${id}-query`}
+          label="Endpoint Query Parameters:"
+          hint="Feel free to modify the code above."
+        >
+          <LiveEditor className={clsx(styles.iqb__editor)} />
+        </FormField>
+        <LiveError />
+        <LivePreview />
+      </LiveProvider>
+    </form>
+  );
+}

--- a/docusaurus/src/components/InteractiveQueryBuilder/InteractiveQueryBuilder.jsx
+++ b/docusaurus/src/components/InteractiveQueryBuilder/InteractiveQueryBuilder.jsx
@@ -91,7 +91,7 @@ export function InteractiveQueryBuilder({
             const queryStringified = (
               endpoint +
               '?' +
-              qs.stringify(queryObject, { encodeValuesOnly: true })
+              qs.stringify(queryObject, { encode: false })
             );
 
             return (

--- a/docusaurus/src/components/InteractiveQueryBuilder/interactive-query-builder.module.scss
+++ b/docusaurus/src/components/InteractiveQueryBuilder/interactive-query-builder.module.scss
@@ -1,0 +1,20 @@
+/** Component: Interactive Query Builder */
+
+.iqb {
+  &__editor {
+    overflow: hidden;
+    border-radius: 0.25rem;
+    font-family: var(--custom-code-font-family);
+    font-size: var(--strapi-font-size-sm);
+    font-weight: 600;
+    background-color: var(--strapi-iqb-background-color, var(--custom-code-block-background-color)) !important;
+
+    pre, textarea {
+      padding:
+        var(--strapi-iqb-py, var(--strapi-spacing-3))
+        var(--strapi-iqb-px, var(--strapi-spacing-4))
+        !important
+      ;
+    }
+  }
+}

--- a/docusaurus/src/scss/_fonts.scss
+++ b/docusaurus/src/scss/_fonts.scss
@@ -3,7 +3,8 @@
 @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;700&display=swap');
 
 .font-poppins,
-.font-poppins button {
+.font-poppins button,
+.font-poppins input {
   --custom-font-family: "Poppins", sans-serif;
   --ifm-heading-font-family: "Poppins", sans-serif;
 

--- a/docusaurus/src/scss/admonition.scss
+++ b/docusaurus/src/scss/admonition.scss
@@ -167,5 +167,9 @@
       --custom-code-background-color: var(--custom-admonition-code-background-color);
       --custom-code-color: var(--custom-admonition-code-color);
     }
+
+    .strapi-iqb {
+      --strapi-iqb-background-color: var(--strapi-neutral-0);
+    }
   }
 }

--- a/docusaurus/src/scss/code-block.scss
+++ b/docusaurus/src/scss/code-block.scss
@@ -113,13 +113,13 @@ pre.prism-code {
 
 /** Dark theme */
 @include dark {
+  --custom-code-block-background-color: var(--strapi-neutral-100);
+  --custom-code-block-color: var(--strapi-neutral-1000);
+  --custom-code-block-punctuation-color: var(--strapi-primary-200);
+  --custom-code-block-value-color: var(--strapi-neutral-900);
+
   pre,
   .theme-code-block {
-    --custom-code-block-background-color: var(--strapi-neutral-100);
-    --custom-code-block-color: var(--strapi-neutral-1000);
-    --custom-code-block-punctuation-color: var(--strapi-primary-200);
-    --custom-code-block-value-color: var(--strapi-neutral-900);
-
     --ifm-scrollbar-track-background-color: var(--strapi-neutral-200);
     --ifm-scrollbar-thumb-background-color: var(--strapi-neutral-300);
   }

--- a/docusaurus/src/theme/MDXComponents.js
+++ b/docusaurus/src/theme/MDXComponents.js
@@ -12,6 +12,7 @@ import ColumnLeft from '../components/ColumnLeft';
 import ColumnRight from '../components/ColumnRight';
 import FeedbackPlaceholder from '../components/FeedbackPlaceholder';
 import CustomDocCard from '../components/CustomDocCard';
+import { InteractiveQueryBuilder } from '../components/InteractiveQueryBuilder/InteractiveQueryBuilder';
 import { AlphaBadge, BetaBadge, EnterpriseBadge } from '../components/Badge';
 
 export default {
@@ -38,4 +39,5 @@ export default {
   ColumnRight,
   FeedbackPlaceholder,
   CustomDocCard,
+  InteractiveQueryBuilder,
 };

--- a/docusaurus/yarn.lock
+++ b/docusaurus/yarn.lock
@@ -6754,6 +6754,13 @@ qs@6.10.3:
   dependencies:
     side-channel "^1.0.4"
 
+qs@^6.11.1:
+  version "6.11.1"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.1.tgz#6c29dff97f0c0060765911ba65cbc9764186109f"
+  integrity sha512-0wsrzgTz/kAVIeuxSjnpGC56rzYtr6JT/2BwEvMaPhFIoYa1aGO8LbzuU1R0uUYQkLpWBTOj0l/CLAJB64J6nQ==
+  dependencies:
+    side-channel "^1.0.4"
+
 queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"


### PR DESCRIPTION
### What does it do?

Add an interactive query builder to the Developer Docs / REST API / Parameters page.

| Before | After |
| ------ | ------ |
| <img width="1710" alt="Screenshot 2023-05-18 at 12 48 49 PM" src="https://github.com/strapi/documentation/assets/4141420/dad83dbb-44e3-4384-8cce-064284190f1a"> | <img width="1710" alt="Screenshot 2023-05-18 at 12 49 02 PM" src="https://github.com/strapi/documentation/assets/4141420/cb452bc5-a54e-44f7-b22f-381ffb4b00d6"> |
