### PR TITLE
Fix middleware not found error by adding 'global::' prefix to custom …

### DIFF
--- a/docusaurus/docs/dev-docs/configurations/middlewares.md
+++ b/docusaurus/docs/dev-docs/configurations/middlewares.md
@@ -40,7 +40,7 @@ module.exports = [
   'strapi::cors',
 
   // custom middleware that does not require any configuration
-  'my-custom-node-module', 
+  'global::my-custom-node-module', 
 
   // custom name to find a package or a path
   {


### PR DESCRIPTION
…middleware

Resolved middleware not found error by adding 'global::' prefix to the custom middleware in the middleware.md file. The error occurred when the 'my-custom-node-module' middleware was not being recognized. By modifying the middleware configuration to 'global::my-custom-node-module', the middleware is now successfully detected and can be used.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

This pull request resolves the middleware not found error in the Strapi v4 documentation by adding the 'global::' prefix to the custom middleware configuration in the middleware.md file. The 'my-custom-node-module' middleware was previously not being recognized, leading to the error. By modifying the configuration to 'global::my-custom-node-module', the middleware is now successfully detected and can be used.

### Why is it needed?

The custom middleware was not functioning correctly due to the missing 'global::' prefix in the middleware configuration. This PR addresses the issue by adding the necessary prefix, allowing the middleware to be found and utilized without any errors.

### Related issue(s)/PR(s)

Please specify if this pull request is related to any open issue or pull request. If it is, please provide the relevant issue or pull request number.
