### PR TITLE
Update docs for Strapi Cloud 1.0 release

### DIFF
--- a/docusaurus/docs/cloud/getting-started/deployment.md
+++ b/docusaurus/docs/cloud/getting-started/deployment.md
@@ -10,10 +10,6 @@ sidebar_position: 2
 
 This is a step-by-step guide for deploying your Strapi application on Strapi Cloud.
 
-:::strapi
-During the soft launch of Strapi Cloud, a progressively increasing number of users will be able to access the service. Access will be granted to a mix of users currently on the waitlist as well as new users that can sign up each day.
-:::
-
 ## Prerequisites
 
 Before you can deploy your Strapi application on Strapi Cloud, you need to have the following prerequisites:

--- a/docusaurus/src/pages/home/_home.content.js
+++ b/docusaurus/src/pages/home/_home.content.js
@@ -28,14 +28,14 @@ export default {
       title: 'Strapi Cloud',
       description: (
         <>
-          {'If demos are more your thing, we have a '}
-          <a href="https://youtu.be/zd0_S_FPzKg" target="_blank">video demo</a>
-          {', or you can request a '}
-          <a href="https://strapi.io/demo" target="_blank">live demo</a>!
+          {'Learn more on the '}
+          <a href="https://strapi.io/cloud" target="_blank">product page</a>
+          {', or start a '}
+          <a href="https://cloud.strapi.io/" target="_blank">free trial</a> today!
         </>
       ),
       button: {
-        label: 'Strapi Cloud',
+        label: 'Strapi Cloud docs',
         decorative: '☁️',
         to: '/cloud/intro',
       },


### PR DESCRIPTION
- Removes a callout about soft launch limitations
- Update the carousel card in home page with more relevant CTAs