### PR TITLE
Fixing permissions error in Dockerfile

### DIFF
--- a/docusaurus/docs/dev-docs/installation/docker.md
+++ b/docusaurus/docs/dev-docs/installation/docker.md
@@ -65,9 +65,9 @@ RUN yarn config set network-timeout 600000 -g && yarn install
 ENV PATH /opt/node_modules/.bin:$PATH
 
 WORKDIR /opt/app
+COPY . .
 RUN chown -R node:node /opt/app
 USER node
-COPY . .
 RUN ["yarn", "build"]
 EXPOSE 1337
 CMD ["yarn", "develop"]
@@ -90,9 +90,9 @@ RUN npm config set network-timeout 600000 -g && npm install
 ENV PATH /opt/node_modules/.bin:$PATH
 
 WORKDIR /opt/app
+COPY . .
 RUN chown -R node:node /opt/app
 USER node
-COPY . .
 RUN ["npm", "run", "build"]
 EXPOSE 1337
 CMD ["npm", "run", "develop"]


### PR DESCRIPTION
Using the `Dockerfile` as stated will incur in an `Error: EACCES: permission denied, watch '/opt/app/data'` error. The copy needs to be done first after doing the change of ownership in order to avoid it.
A complete error trace can be found here

```
backend   | node:internal/errors:478
backend   |     ErrorCaptureStackTrace(err);
backend   |     ^
backend   | 
backend   | Error: EACCES: permission denied, watch '/opt/app/data'
backend   |     at FSWatcher.<computed> (node:internal/fs/watchers:244:19)
backend   |     at Object.watch (node:fs:2296:34)
backend   |     at createFsWatchInstance (/opt/node_modules/@strapi/strapi/node_modules/chokidar/lib/nodefs-handler.js:119:15)
backend   |     at setFsWatchListener (/opt/node_modules/@strapi/strapi/node_modules/chokidar/lib/nodefs-handler.js:166:15)
backend   |     at NodeFsHandler._watchWithNodeFs (/opt/node_modules/@strapi/strapi/node_modules/chokidar/lib/nodefs-handler.js:331:14)
backend   |     at NodeFsHandler._handleDir (/opt/node_modules/@strapi/strapi/node_modules/chokidar/lib/nodefs-handler.js:559:19)
backend   |     at processTicksAndRejections (node:internal/process/task_queues:96:5)
backend   |     at async NodeFsHandler._addToNodeFs (/opt/node_modules/@strapi/strapi/node_modules/chokidar/lib/nodefs-handler.js:609:16)
backend   | Emitted 'error' event on FSWatcher instance at:
backend   |     at FSWatcher._handleError (/opt/node_modules/@strapi/strapi/node_modules/chokidar/index.js:647:10)
backend   |     at NodeFsHandler._addToNodeFs (/opt/node_modules/@strapi/strapi/node_modules/chokidar/lib/nodefs-handler.js:637:18)
backend   |     at processTicksAndRejections (node:internal/process/task_queues:96:5) {
backend   |   errno: -13,
backend   |   syscall: 'watch',
backend   |   code: 'EACCES',
backend   |   path: '/opt/app/data',
backend   |   filename: '/opt/app/data'
backend   | }
```
