### PR TITLE
Add page/pageSize parameters to Entity Service

### DIFF
--- a/docusaurus/docs/dev-docs/api/entity-service/order-pagination.md
+++ b/docusaurus/docs/dev-docs/api/entity-service/order-pagination.md
@@ -64,11 +64,20 @@ strapi.entityService.findMany('api::article.article', {
 
 ## Pagination
 
-To paginate results returned by the Entity Service API, use the `start` and `limit` parameters:
+To paginate results returned by the Entity Service API, you can use the `start` and `limit` parameters:
 
 ```js
 strapi.entityService.findMany('api::article.article', {
   start: 10,
   limit: 15,
+});
+```
+
+You may instead use the `page` and `pageSize` parameters:
+
+```js
+strapi.entityService.findMany('api::article.article', {
+  page: 1,
+  pageSize: 15,
 });
 ```


### PR DESCRIPTION
### What does it do?

Adds description of page and pageSize parameters

### Why is it needed?

These parameters are available in the REST API and are often passed through to the entity service, and are supported parameters.

### Related issue(s)/PR(s)

Discovered while working on https://github.com/strapi/strapi/pull/17032