### PR TITLE
Update documentation for Node 14 -> 20

### DIFF
--- a/docusaurus/docs/dev-docs/deployment.md
+++ b/docusaurus/docs/dev-docs/deployment.md
@@ -34,7 +34,7 @@ Another possible workflow is to first create the data structure locally, push yo
 
 To provide the best possible environment for Strapi the following requirements apply to development (local) and staging and production workflows.
 
-- Node LTS (v14 or v16) **Odd-number releases of Node are not supported (e.g. v13, v15).**
+- Node LTS (currently v16, v18, and v20) **Odd-number releases of Node are not supported (e.g. v17, v19).**
 - NPM v6 (or the version shipped with the LTS Node versions)
 - Standard build tools for your OS (the `build-essentials` package on most Debian-based systems)
 - Hardware specifications for your server (CPU, RAM, storage):

--- a/docusaurus/docs/dev-docs/deployment/amazon-aws.md
+++ b/docusaurus/docs/dev-docs/deployment/amazon-aws.md
@@ -248,18 +248,18 @@ ubuntu@ip-1.2.3.4:~$
 
 #### 3. Install **Node.js** with **npm**:
 
-Strapi currently supports `Node.js` `v14.x.x`, `v16.x.x`, and `v18.x.x`. The following steps will install Node.js onto your EC2 server.
+Strapi currently supports `Node.js` `v16.x.x`, `v18.x.x`, and `v20.x.x`. The following steps will install Node.js onto your EC2 server.
 
-```bash title="example using Node.js 14"
+```bash title="example using Node.js 20"
 cd ~
-curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash -
+curl -sL https://deb.nodesource.com/setup_20.x | sudo -E bash -
 ...
 sudo apt-get install nodejs
 ...
 node -v && npm -v
 ```
 
-The last command `node -v && npm -v` should output two versions numbers, eg. `v14.x.x, 6.x.x`.
+The last command `node -v && npm -v` should output two versions numbers, eg. `v20.x.x, 6.x.x`.
 
 #### 4. Create and change npm's default directory.
 

--- a/docusaurus/docs/dev-docs/migration/v3-to-v4/code/dependencies.md
+++ b/docusaurus/docs/dev-docs/migration/v3-to-v4/code/dependencies.md
@@ -97,7 +97,7 @@ The following examples show a comparison of a Strapi v3 `package.json` and a Str
     "uuid": "b8aa7baf-d6dc-4c50-93d4-7739bc88c3fd"
   },
   "engines": {
-    "node": ">=14.19.1 <=18.x.x",
+    "node": ">=16.x.x <=20.x.x",
     "npm": ">=6.0.0"
   },
   "license": "MIT"

--- a/docusaurus/docs/snippets/installation-prerequisites.md
+++ b/docusaurus/docs/snippets/installation-prerequisites.md
@@ -1,8 +1,8 @@
 Before installing Strapi, the following requirements must be installed on your computer:
 
 - [Node.js](https://nodejs.org): Only Maintenance and LTS versions are supported (`v16`, `v18`, and `v20`).
-  - Node v18.x is recommended for Strapi `v4.3.9` and above
-  - Node v16.x is recommended for Strapi `v4.0.x` to `v4.3.8`.
+    - Node v18.x is recommended for Strapi `v4.3.9` and above
+    - Node v16.x is recommended for Strapi `v4.0.x` to `v4.3.8`.
 - Your preferred Node.js package manager:
   - [npm](https://docs.npmjs.com/cli/v6/commands/npm-install) (`v6` and above)
   - [yarn](https://yarnpkg.com/getting-started/install)

--- a/docusaurus/docs/snippets/installation-prerequisites.md
+++ b/docusaurus/docs/snippets/installation-prerequisites.md
@@ -1,9 +1,9 @@
 Before installing Strapi, the following requirements must be installed on your computer:
 
-- [Node.js](https://nodejs.org): Only Maintenance and LTS versions are supported (`v14`, `v16`, and `v18`).
-    - Node v18.x is recommended for Strapi `v4.3.9` and above
-    - Node v16.x is recommended for Strapi `v4.0.x` to `v4.3.8`.
+- [Node.js](https://nodejs.org): Only Maintenance and LTS versions are supported (`v16`, `v18`, and `v20`).
+  - Node v18.x is recommended for Strapi `v4.3.9` and above
+  - Node v16.x is recommended for Strapi `v4.0.x` to `v4.3.8`.
 - Your preferred Node.js package manager:
-    - [npm](https://docs.npmjs.com/cli/v6/commands/npm-install) (`v6` and above)
-    - [yarn](https://yarnpkg.com/getting-started/install)
+  - [npm](https://docs.npmjs.com/cli/v6/commands/npm-install) (`v6` and above)
+  - [yarn](https://yarnpkg.com/getting-started/install)
 - [Python](https://www.python.org/downloads/) (if using a SQLite database)

--- a/docusaurus/docs/snippets/installation-prerequisites.md
+++ b/docusaurus/docs/snippets/installation-prerequisites.md
@@ -4,6 +4,6 @@ Before installing Strapi, the following requirements must be installed on your c
     - Node v18.x is recommended for Strapi `v4.3.9` and above
     - Node v16.x is recommended for Strapi `v4.0.x` to `v4.3.8`.
 - Your preferred Node.js package manager:
-  - [npm](https://docs.npmjs.com/cli/v6/commands/npm-install) (`v6` and above)
-  - [yarn](https://yarnpkg.com/getting-started/install)
+    - [npm](https://docs.npmjs.com/cli/v6/commands/npm-install) (`v6` and above)
+    - [yarn](https://yarnpkg.com/getting-started/install)
 - [Python](https://www.python.org/downloads/) (if using a SQLite database)


### PR DESCRIPTION
### What does it do?

Remove Node 14 as a supported version, add Node 20.

Replace examples with Node 20 so we don't have to jump them again soon :)

### Why is it needed?

Strapi supported versions are moving to Node 16, 18, and 20

### Related issue(s)/PR(s)

Wait to merge until [Node 20 PR is released](https://github.com/strapi/strapi/pull/16557). Hoping for 4.11.4 but could be pushed to later if it doesn't get QAd and merged in the next couple days.