### PR TITLE
Update controllers.md

### DIFF
--- a/docusaurus/docs/dev-docs/backend-customization/controllers.md
+++ b/docusaurus/docs/dev-docs/backend-customization/controllers.md
@@ -205,7 +205,7 @@ These functions automatically inherit the sanitization settings from the model a
 const { createCoreController } = require('@strapi/strapi').factories;
 
 module.exports = createCoreController('api::restaurant.restaurant', ({ strapi }) =>  ({
-  async findOne(ctx) {
+  async find(ctx) {
     const sanitizedQueryParams = await this.sanitizeQuery(ctx);
     const { results, pagination } = await strapi.service('api::restaurant.restaurant').find(sanitizedQueryParams);
     const sanitizedResults = await this.sanitizeOutput(results, ctx);
@@ -224,7 +224,7 @@ module.exports = createCoreController('api::restaurant.restaurant', ({ strapi })
 import { factories } from '@strapi/strapi';
 
 export default factories.createCoreController('api::restaurant.restaurant', ({ strapi }) =>  ({
-  async findOne(ctx) {
+  async find(ctx) {
     const sanitizedQueryParams = await this.sanitizeQuery(ctx);
     const { results, pagination } = await strapi.service('api::restaurant.restaurant').find(sanitizedQueryParams);
     const sanitizedResults = await this.sanitizeOutput(results, ctx);


### PR DESCRIPTION


I noticed here is find, however the document is naming findOne, I edited it and created a PR

### What does it do?

The function context is describing for find, because there is pagination. however the function name is findOne. This is easy for users to read and misunderstand

### Why is it needed?

I think it needs to be adjusted so that users can read it to avoid misunderstandings

### Related issue(s)/PR(s)

No related issue
