### PR TITLE
Fix error: minLength and maxLength are for String, not Integer

### DIFF
--- a/docusaurus/docs/dev-docs/backend-customization/models.md
+++ b/docusaurus/docs/dev-docs/backend-customization/models.md
@@ -149,8 +149,8 @@ Basic validations can be applied to attributes using the following parameters:
 | `required`     | Boolean | If `true`, adds a required validator for this property                                                     | `false` |
 | `max`          | Integer | Checks if the value is greater than or equal to the given maximum                                        | -       |
 | `min`          | Integer | Checks if the value is less than or equal to the given minimum                                           | -       |
-| `minLength`    | Integer | Minimum number of characters for a field input value                                                      | -       |
-| `maxLength`    | Integer | Maximum number of characters for a field input value                                                      | -       |
+| `minLength`    | String | Minimum number of characters for a field input value                                                      | -       |
+| `maxLength`    | String | Maximum number of characters for a field input value                                                      | -       |
 | `private`      | Boolean | If `true`, the attribute will be removed from the server response.<br/><br/>💡 This is useful to hide sensitive data. | `false` |
 | `configurable` | Boolean | If `false`, the attribute isn't configurable from the Content-type Builder plugin.                         | `true`  |
 


### PR DESCRIPTION
Hello! I'm new to Strapi, I'm learning from the docs. Great job on it! very edifying.

### What does it do?

This PR fixes what I think it's an error in the Backend Customization, Models docs. 

In the table about Validations, it says that the `minLength` and `maxLength` apply to Integer fields, when it seems from the example just below the table that they apply to String fields (which makes more sense to me). This is the example in the docs:

```json
    "title": {
      "type": "string",
      "minLength": 3,
      "maxLength": 99,
      "unique": true
    },
```

This PR fixes that.

Let me know if there's anything else I need to do to get this PR in a mergeable state. Hope I can help the community fix small things like this as I find them :D

### Why is it needed?

To fix the error described above :)

### Related issue(s)/PR(s)

N/A
