### PR TITLE
Error in the example of using "customFields"

### DIFF
--- a/docusaurus/docs/dev-docs/custom-fields.md
+++ b/docusaurus/docs/dev-docs/custom-fields.md
@@ -259,6 +259,7 @@ export default {
                   {
                     key: 'hex',
                     defaultValue: 'hex',
+                    value: 'hex',
                     metadatas: {
                       intlLabel: {
                         id: 'color-picker.color.format.hex',


### PR DESCRIPTION
The property `value` is required even if `defaultValue` is set.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

There is an error in the example. The "value" property is missing from the first select option. The current example crashes the dashboard.

### Why is it needed?

Describe the issue you are solving.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
