### PR TITLE
[FIX] Dark Mode Code Element Readability

### DIFF
--- a/docusaurus/src/scss/code.scss
+++ b/docusaurus/src/scss/code.scss
@@ -65,7 +65,7 @@ table {
   body {
     --custom-code-background-color: var(--strapi-neutral-600);
     --custom-code-border-color: var(--strapi-neutral-600);
-    --custom-code-color: var(--strapi-neutral-100);
+    --custom-code-color: var(--strapi-neutral-800);
   }
 
   pre code {


### PR DESCRIPTION
### What does it do?

Updated scss for `code` element in dark mode so it is readable

### Why is it needed?

Context:
- As a Strapi user, I was reading the docs with dark mode. However, html elements wrapped in `<code></code>` in the document were barely readable. I was using windows but this occurs across all platforms (tested on mac/ios as well).

Before Fix:
![image](https://github.com/strapi/documentation/assets/111836326/aaa579b7-72ca-43f6-b314-3f0dc942b689)

After Fix:
![image](https://github.com/strapi/documentation/assets/111836326/8aeadbf3-42e0-4cab-a439-b09d18ad4976)

Possible reason for the poor readability:
- scss variables were inverted for dark mode, so maintainers may have used `--strapi-neutral-100` thinking it was white

```scss
/** Dark mode */
@include dark {
  /** Dark Color: Neutral */
  --strapi-neutral-1000: #FFFFFF; /* both 800 and 900 identical in Figma */
  --strapi-neutral-900: #FFFFFF; /* both 800 and 900 identical in Figma */
  --strapi-neutral-800: #FFFFFF;
  --strapi-neutral-700: #EAEAEF;
  --strapi-neutral-600: #666687;
  --strapi-neutral-500: #c0c0cf;
  --strapi-neutral-400: #A5A5BA; /* incorrecly named in Figma */
  --strapi-neutral-300: #666687;
  --strapi-neutral-200: #4A4A6A;
  --strapi-neutral-150: #32324D;
  --strapi-neutral-100: #181826;
  --strapi-neutral-0: #212134;

  /** Dark Color: Primary */
  --strapi-primary-600: #7B79FF;
}
```

### Related issue(s)/PR(s)

\-
