### PR TITLE
Show last updated information (who/when) on pages

### DIFF
--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -102,6 +102,8 @@ const config = {
               'warning',
             ],
           },
+          showLastUpdateAuthor: true,
+          showLastUpdateTime: true,
         },
         // we're using docs-only mode for now — see https://docusaurus.io/docs/docs-introduction
         blog: false,


### PR DESCRIPTION
This PR adds 2 configuration properties, so that the last updated information is displayed at the bottom of the pages.
![Screenshot 2023-08-01 at 18 41 59](https://github.com/strapi/documentation/assets/4233866/6128414d-320b-41dc-ac33-9eb02701fd7e)
