### PR TITLE
Chore: Add docs for `STRAPI_ENFORCE_SOURCEMAPS` env variable

### DIFF
--- a/docusaurus/docs/dev-docs/configurations/environment.md
+++ b/docusaurus/docs/dev-docs/configurations/environment.md
@@ -22,7 +22,9 @@ Strapi provides the following environment variables:
 | `BROWSER`                                                  | Open the admin panel in the browser after startup                                                                                                                                                                                                                             | `Boolean` | `true`          |
 | `ENV_PATH`                                                 | Path to the file that contains your environment variables                                                                                                                                                                                                                     | `String`  | `'./.env'`      |
 | `STRAPI_PLUGIN_I18N_INIT_LOCALE_CODE` <br/><br/>_Optional_ | Initialization locale for the application, if the [Internationalization (i18n) plugin](/dev-docs/plugins/i18n) is installed and enabled on Content-Types (see [Configuration of i18n in production environments](/dev-docs/plugins/i18n#configuration-of-the-default-locale)) | `String`  | `'en'`          |
+| `STRAPI_ENFORCE_SOURCEMAPS`                                | Forces the bundler to emit source-maps, which is helpful for debugging errors in the admin app.  | `boolean` | `false`          |
 | `FAST_REFRESH`                                             | Use [react-refresh](https://github.com/pmmmwh/react-refresh-webpack-plugin) to enable "Fast Refresh" for near-instant feedback while developing the Strapi admin panel.                                                                                                       | `boolean` | `true`          |
+
 
 :::tip
 Prefixing an environment variable name with `STRAPI_ADMIN_` exposes the variable to the admin front end (e.g., `STRAPI_ADMIN_MY_PLUGIN_VARIABLE` is accessible through `process.env.STRAPI_ADMIN_MY_PLUGIN_VARIABLE`).


### PR DESCRIPTION
### What does it do?

Adds a new environment variable `STRAPI_ENFORCE_SOURCEMAPS` to the list.

### Why is it needed?

Complete docs 💅🏼 

### Related issue(s)/PR(s)

- Refs https://github.com/strapi/strapi/pull/17458
