### PR TITLE
Add docsly integration to collect actionable feedback

### DIFF
--- a/docusaurus/package.json
+++ b/docusaurus/package.json
@@ -14,6 +14,7 @@
     "write-heading-ids": "docusaurus write-heading-ids"
   },
   "dependencies": {
+    "@docsly/react": "^1.8.6",
     "@docusaurus/core": "2.4.0",
     "@docusaurus/plugin-client-redirects": "2.4.0",
     "@docusaurus/plugin-google-tag-manager": "2.4.0",

--- a/docusaurus/src/theme/Footer/index.js
+++ b/docusaurus/src/theme/Footer/index.js
@@ -1,0 +1,15 @@
+import React from "react";
+import Footer from "@theme-original/Footer";
+import Docsly from "@docsly/react";
+import "@docsly/react/styles.css";
+import { useLocation } from "@docusaurus/router";
+ 
+export default function FooterWrapper(props) {
+  const { pathname } = useLocation();
+  return (
+    <>
+      <Footer {...props} />
+      <Docsly publicId="public_FpkRFtHG3zlOAQ1PwmZ84zpg4bEt3od1jh6B648GpXJ4JrXvSEH8j5yazVwG07KQ" pathname={pathname} />
+    </>
+  );
+}

--- a/docusaurus/yarn.lock
+++ b/docusaurus/yarn.lock
@@ -1441,6 +1441,18 @@
     "@docsearch/css" "3.3.3"
     algoliasearch "^4.0.0"
 
+"@docsly/react@^1.8.6":
+  version "1.8.6"
+  resolved "https://registry.yarnpkg.com/@docsly/react/-/react-1.8.6.tgz#24debe04fdd97a3c1c7f11a23497fea755e030b2"
+  integrity sha512-FwcVeTYsZnOMIFYgW0R9/0xaWKWfzvW4eKA9QjJApXKbfGFHgzm0tWEmVf9TyZgsA3qoI+0qaUuJ3JlQrdONXg==
+  dependencies:
+    "@heroicons/react" "^2.0.18"
+    clsx "^1.2.1"
+    dayjs "^1.11.7"
+    react-error-boundary "^3.1.4"
+    react-hot-toast "^2.4.0"
+    swr "^2.1.0"
+
 "@docusaurus/core@2.4.0":
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@docusaurus/core/-/core-2.4.0.tgz#a12c175cb2e5a7e4582e65876a50813f6168913d"
@@ -1934,6 +1946,11 @@
   integrity sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==
   dependencies:
     "@hapi/hoek" "^9.0.0"
+
+"@heroicons/react@^2.0.18":
+  version "2.0.18"
+  resolved "https://registry.yarnpkg.com/@heroicons/react/-/react-2.0.18.tgz#f80301907c243df03c7e9fd76c0286e95361f7c1"
+  integrity sha512-7TyMjRrZZMBPa+/5Y8lN0iyvUU/01PeMGX2+RE7cQWpEUIcb4QotzUObFkJDejj/HUH4qjP/eQ0gzzKs2f+6Yw==
 
 "@jridgewell/gen-mapping@^0.1.0":
   version "0.1.1"
@@ -5004,6 +5021,11 @@ globby@^13.1.1:
     merge2 "^1.4.1"
     slash "^4.0.0"
 
+goober@^2.1.10:
+  version "2.1.13"
+  resolved "https://registry.yarnpkg.com/goober/-/goober-2.1.13.tgz#e3c06d5578486212a76c9eba860cbc3232ff6d7c"
+  integrity sha512-jFj3BQeleOoy7t93E9rZ2de+ScC4lQICLwiAQmKMg9F6roKGaLSHoCDYKkWlSafg138jejvq/mTdvmnwDQgqoQ==
+
 got@^9.6.0:
   version "9.6.0"
   resolved "https://registry.yarnpkg.com/got/-/got-9.6.0.tgz#edf45e7d67f99545705de1f7bbeeeb121765ed85"
@@ -7253,6 +7275,13 @@ react-dom@^17.0.2:
     object-assign "^4.1.1"
     scheduler "^0.20.2"
 
+react-error-boundary@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.4.tgz#255db92b23197108757a888b01e5b729919abde0"
+  integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 react-error-overlay@^6.0.11:
   version "6.0.11"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.11.tgz#92835de5841c5cf08ba00ddd2d677b6d17ff9adb"
@@ -7273,6 +7302,13 @@ react-helmet-async@*, react-helmet-async@^1.3.0:
     prop-types "^15.7.2"
     react-fast-compare "^3.2.0"
     shallowequal "^1.1.0"
+
+react-hot-toast@^2.4.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/react-hot-toast/-/react-hot-toast-2.4.1.tgz#df04295eda8a7b12c4f968e54a61c8d36f4c0994"
+  integrity sha512-j8z+cQbWIM5LY37pR6uZR6D4LfseplqnuAO4co4u8917hBUvXlEqyP1ZzqVLcqoyUesZZv/ImreoCeHVDpE5pQ==
+  dependencies:
+    goober "^2.1.10"
 
 react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0:
   version "16.13.1"
@@ -8400,6 +8436,13 @@ swagger2openapi@^7.0.6:
     reftools "^1.1.9"
     yaml "^1.10.0"
     yargs "^17.0.1"
+
+swr@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/swr/-/swr-2.2.0.tgz#575c6ac1bec087847f4c86a39ccbc0043c834d6a"
+  integrity sha512-AjqHOv2lAhkuUdIiBu9xbuettzAzWXmCEcLONNKJRba87WAefz8Ca9d6ds/SzrPc235n1IxWYdhJ2zF3MNUaoQ==
+  dependencies:
+    use-sync-external-store "^1.2.0"
 
 tapable@^1.0.0:
   version "1.1.3"


### PR DESCRIPTION
## Background

Strapi has become widely popular and adopted by developers. The documentation of any developer product plays a crucial role in the overall developer experience and helps them get started quickly. Collecting feedback on the Strapi documentation will further improve the developer experience and help the community.

## Description

[Docsly](https://docsly.dev) is a feedback tool crafted for developer documentation. It lets the readers leave contextual feedback  (comments) on the documentation website and helps the maintainer by showing the feedback exactly where the user left it.

The feedback feature (like/dislike) gives a general sense of whether users are finding a particular page helpful.

  - Dependencies: Installed `@docsly/react` in the Docusaurus project

### Example project for preview

[Clerk](https://clerk.com/docs), [Tigris](https://www.tigrisdata.com/docs/), and [Dyte](https://docs.dyte.io) are using docsly in production already.

![image](https://github.com/strapi/documentation/assets/28081510/71ebce12-3a1b-4683-b717-6be8328fb051)

### Todo

- [ ] Sign up on [docsly.dev ](https://docsly.dev/dashboard)for a fresh account for maintainers

### Cost implications

[Docsly](https://docsly.dev) is free to use for open-source projects. 

