### PR TITLE
Update the Strapi Cloud minimum version

### DIFF
--- a/docusaurus/docs/cloud/advanced/database.md
+++ b/docusaurus/docs/cloud/advanced/database.md
@@ -16,7 +16,7 @@ While possible, it is not recommended to use an external database with Strapi Cl
 
 :::prerequisites
 
-- A local Strapi project running on `v4.8.1+`.
+- A local Strapi project running on `v4.8.2+`.
 - Credentials for external database.
 - If using an existing database, the schema must match the Strapi project schema.
 

--- a/docusaurus/docs/cloud/getting-started/deployment.md
+++ b/docusaurus/docs/cloud/getting-started/deployment.md
@@ -14,7 +14,7 @@ This is a step-by-step guide for deploying your Strapi application on Strapi Clo
 
 Before you can deploy your Strapi application on Strapi Cloud, you need to have the following prerequisites:
 
-* Strapi version `4.8.1` or higher
+* Strapi version `4.8.2` or higher
 *  Database: Project must be compatible with PostgreSQL. Strapi does not support and does not recommend using any external databases, though it's possible to configure one (see [advanced database configuration](/cloud/advanced/database)).
 * Project(s) source code hosted on [GitHub](https://github.com)
     * The connected repository can contain multiple Strapi applications. Each Strapi app must be in a separate directory.

--- a/docusaurus/docs/cloud/getting-started/intro.md
+++ b/docusaurus/docs/cloud/getting-started/intro.md
@@ -15,7 +15,7 @@ Strapi Cloud is a managed content platform built on top of Strapi, the leading o
 
 Strapi Cloud enables you to increase your content velocity without having to compromise on customization needs and requirements. Development teams can rely on Strapi Cloud to abstract away the complexity of infrastructure management while keeping your development workflow and extending the core capabilities of Strapi. Content managers can use Strapi Cloud to autonomously manage all types of content and benefit from a complete set of content collaboration, security, and compliance features.
 
-The typical workflow is to create your Strapi (v4.8.1 or later) application locally, extend the application with plugins or custom code, version the application's codebase through GitHub, and deploy the application in seconds with Strapi Cloud (see [deployment and prerequisites](/cloud/getting-started/deployment#prerequisites)).
+The typical workflow is to create your Strapi (v4.8.2 or later) application locally, extend the application with plugins or custom code, version the application's codebase through GitHub, and deploy the application in seconds with Strapi Cloud (see [deployment and prerequisites](/cloud/getting-started/deployment#prerequisites)).
 
 ## Strapi Community
 


### PR DESCRIPTION
### What does it do?

It updates the minimum version of the CMS to use in a Strapi Cloud project.

### Why is it needed?

To improve the Cloud documentation.