### PR TITLE
Resolve Deprecation Warning in S3 Configuration

### DIFF
--- a/docusaurus/docs/dev-docs/deployment/amazon-aws.md
+++ b/docusaurus/docs/dev-docs/deployment/amazon-aws.md
@@ -411,12 +411,14 @@ module.exports = ({ env }) => ({
     config: {
       provider: 'aws-s3',
       providerOptions: {
-        accessKeyId: env('AWS_ACCESS_KEY_ID'),
-        secretAccessKey: env('AWS_ACCESS_SECRET'),
-        region: env('AWS_REGION'),
-        params: {
+        s3Options: {
+          accessKeyId: env('AWS_ACCESS_KEY_ID'),
+          secretAccessKey: env('AWS_ACCESS_SECRET'),
+          region: env('AWS_REGION'),
+          params: {
             Bucket: env('AWS_BUCKET_NAME'),
-        },
+          },
+        }
       },
       // These parameters could solve issues with ACL public-read access — see [this issue](https://github.com/strapi/strapi/issues/5868) for details
       actionOptions: {
@@ -442,12 +444,14 @@ export default ({ env }) => ({
       config: {
           provider: 'aws-s3',
           providerOptions: {
-              accessKeyId: env('AWS_ACCESS_KEY_ID'),
-              secretAccessKey: env('AWS_ACCESS_SECRET'),
-              region: env('AWS_REGION'),
-              params: {
-                  Bucket: env('AWS_BUCKET_NAME'),
-              },
+              s3Options: {
+                  accessKeyId: env('AWS_ACCESS_KEY_ID'),
+                  secretAccessKey: env('AWS_ACCESS_SECRET'),
+                  region: env('AWS_REGION'),
+                  params: {
+                    Bucket: env('AWS_BUCKET_NAME'),
+                  },
+              }
           },
       },
   }


### PR DESCRIPTION
### What does it do?

Wraps S3 bucket configuration variables with s3Options: {} in the AWS deployment guide. 

### Why is it needed?

Fixes 

Warning: S3 configuration options passed at root level of the plugin's providerOptions is deprecated and will be removed in a future release. Please wrap them inside the 's3Options:{}' property.
