### PR TITLE
Add validate utility

### DIFF
--- a/docusaurus/docs/dev-docs/api/rest/parameters.md
+++ b/docusaurus/docs/dev-docs/api/rest/parameters.md
@@ -28,3 +28,12 @@ Query parameters use the [LHS bracket syntax](https://christiangiacomi.com/posts
 :::tip
 A wide range of REST API parameters can be used and combined to query your content, which can result in long and complex query URLs.<br/>👉 You can use Strapi's [interactive query builder](/dev-docs/api/rest/interactive-query-builder) tool to build query URLs more conveniently. 🤗
 :::
+
+:::warning
+In Strapi 4.13+, sending invalid query parameters will result in an error status instead of ignoring them. Please ensure that you are only querying fields that:
+- are in the correct format for the parameter
+- are not private or password fields
+- you have read permission on
+
+If you need your API to have the old behavior of ignoring invalid parameters, you will need to customize your controller to only sanitize and not validate.
+:::

--- a/docusaurus/docs/dev-docs/backend-customization/controllers.md
+++ b/docusaurus/docs/dev-docs/backend-customization/controllers.md
@@ -219,7 +219,7 @@ Within the Strapi factories the following functions are exposed that can be used
 These functions automatically inherit the sanitization settings from the model and sanitize the data accordingly based on the content-type schema and any of the content API authentication strategies, such as the Users & Permissions plugin or API tokens.
 
 :::warning
-Because these methods use the model associated with the current controller, if you query data that is from another model (i.e., doing a find for "menus" within a "restaurant" controller method), you must instead use the `@strapi/utils` tools, such as `sanitize.contentAPI.query` described below, or else the result of your query will be sanitized against the wrong model.
+Because these methods use the model associated with the current controller, if you query data that is from another model (i.e., doing a find for "menus" within a "restaurant" controller method), you must instead use the `@strapi/utils` tools, such as `sanitize.contentAPI.query` described in [Sanitizing Custom Controllers](#sanitize-validate-custom-controllers), or else the result of your query will be sanitized against the wrong model.
 :::
 
 <Tabs groupId="js-ts">
@@ -263,7 +263,7 @@ export default factories.createCoreController('api::restaurant.restaurant', ({ s
 </TabItem>
 </Tabs>
 
-#### Sanitization and validation when building custom controllers
+#### Sanitization and validation when building custom controllers  {#sanitize-validate-custom-controllers}
 
 Within custom controllers, there are 5 primary functions exposed via the `@strapi/utils` package that can be used for sanitization and validation:
 

--- a/docusaurus/docs/dev-docs/backend-customization/controllers.md
+++ b/docusaurus/docs/dev-docs/backend-customization/controllers.md
@@ -214,7 +214,7 @@ Within the Strapi factories the following functions are exposed that can be used
 | `sanitizeOutput` | `entity`/`entities`, `ctx` | Sanitizes the output data where entity/entities should be an object or array of data |
 | `sanitizeInput`  | `data`, `ctx`              | Sanitizes the input data                                                             |
 | `validateQuery`  | `ctx`                      | Validates the request query (throws an error on invalid params)                      |
-| `validateInput`  | `data`, `ctx`              | Validates the input data (throws an error on invalid data)                           |
+| `validateInput`  | `data`, `ctx`              | (EXPERIMENTAL) Validates the input data (throws an error on invalid data)                           |
 
 These functions automatically inherit the sanitization settings from the model and sanitize the data accordingly based on the content-type schema and any of the content API authentication strategies, such as the Users & Permissions plugin or API tokens.
 

--- a/docusaurus/docs/dev-docs/backend-customization/controllers.md
+++ b/docusaurus/docs/dev-docs/backend-customization/controllers.md
@@ -59,6 +59,12 @@ module.exports = createCoreController('api::restaurant.restaurant', ({ strapi })
 
   // Method 3: Replacing a core action with proper sanitization
   async find(ctx) {
+    // validateQuery (optional)
+    // to throw an error on query params that are invalid or the user does not have access to
+    await this.validateQuery(ctx);
+
+    // sanitizeQuery to remove any query params that are invalid or the user does not have access to
+    // It is strongly recommended to use sanitizeQuery even if validateQuery is used
     const sanitizedQueryParams = await this.sanitizeQuery(ctx);
     const { results, pagination } = await strapi.service('api::restaurant.restaurant').find(sanitizedQueryParams);
     const sanitizedResults = await this.sanitizeOutput(results, ctx);
@@ -102,8 +108,16 @@ export default factories.createCoreController('api::restaurant.restaurant', ({ s
 
   // Method 3: Replacing a core action with proper sanitization
   async find(ctx) {
+    // validateQuery (optional)
+    // to throw an error on query params that are invalid or the user does not have access to
+    await this.validateQuery(ctx); 
+
+    // sanitizeQuery to remove any query params that are invalid or the user does not have access to
+    // It is strongly recommended to use sanitizeQuery even if validateQuery is used
     const sanitizedQueryParams = await this.sanitizeQuery(ctx);
     const { results, pagination } = await strapi.service('api::restaurant.restaurant').find(sanitizedQueryParams);
+
+    // sanitizeOutput to ensure the user does not receive any data they do not have access to
     const sanitizedResults = await this.sanitizeOutput(results, ctx);
 
     return this.transformResponse(sanitizedResults, { pagination });
@@ -184,23 +198,29 @@ export default {
 When a new [content-type](/dev-docs/backend-customization/models#content-types) is created, Strapi builds a generic controller with placeholder code, ready to be customized.
 :::
 
-### Sanitization in controllers
+### Sanitization and Validation in controllers
 
 :::warning
-As of Strapi v4.8.0 and greater it's strongly recommended you sanitize your incoming request query and parameters utilizing the new `sanitizeQuery` function to prevent leaking of private data.
+It's strongly recommended you sanitize (v4.8.0) and/or validate (v4.13.0) your incoming request query and parameters utilizing the new `sanitizeQuery` and `validateQuery` functions to prevent leaking of private data.
 :::
 
 #### Sanitization when utilizing controller factories
 
-Within the Strapi factories there are 3 functions exposed that can be used for sanitization:
+Within the Strapi factories the following functions are exposed that can be used for sanitization and validation:
 
 | Function Name    | Parameters                 | Description                                                                          |
 |------------------|----------------------------|--------------------------------------------------------------------------------------|
 | `sanitizeQuery`  | `ctx`                      | Sanitizes the request query                                                          |
 | `sanitizeOutput` | `entity`/`entities`, `ctx` | Sanitizes the output data where entity/entities should be an object or array of data |
 | `sanitizeInput`  | `data`, `ctx`              | Sanitizes the input data                                                             |
+| `validateQuery`  | `ctx`                      | Validates the request query (throws an error on invalid params)                      |
+| `validateInput`  | `data`, `ctx`              | Validates the input data (throws an error on invalid data)                           |
 
 These functions automatically inherit the sanitization settings from the model and sanitize the data accordingly based on the content-type schema and any of the content API authentication strategies, such as the Users & Permissions plugin or API tokens.
+
+:::warning
+Because these methods use the model associated with the current controller, if you query data that is from another model (ie, doing a find for "menus" within a "restaurant" controller method) you must instead use the `@strapi/utils` tools, such as `sanitize.contentAPI.query` described below, or else the result of your query will be sanitized against the wrong model.
+:::
 
 <Tabs groupId="js-ts">
 <TabItem value="js" label="JavaScript">
@@ -211,6 +231,7 @@ const { createCoreController } = require('@strapi/strapi').factories;
 
 module.exports = createCoreController('api::restaurant.restaurant', ({ strapi }) =>  ({
   async find(ctx) {
+    await this.validateQuery(ctx);
     const sanitizedQueryParams = await this.sanitizeQuery(ctx);
     const { results, pagination } = await strapi.service('api::restaurant.restaurant').find(sanitizedQueryParams);
     const sanitizedResults = await this.sanitizeOutput(results, ctx);
@@ -242,18 +263,20 @@ export default factories.createCoreController('api::restaurant.restaurant', ({ s
 </TabItem>
 </Tabs>
 
-#### Sanitization when building custom controllers
+#### Sanitization and validation when building custom controllers
 
-Within custom controllers, there are 3 primary functions exposed via the `@strapi/utils` package that can be used for sanitization:
+Within custom controllers, there are 5 primary functions exposed via the `@strapi/utils` package that can be used for sanitization and validation:
 
-| Function Name       | Parameters                    | Description                                                                                                                            |
-|---------------------|-------------------------------|----------------------------------------------------------------------------------------------------------------------------------------|
-| `contentAPI.input`  | `data`, `schema`, `auth`      | Sanitizes the request input including non-writable fields, removing restricted relations, and other nested "visitors" added by plugins |
-| `contentAPI.output` | `data`, `schema`, `auth`      | Sanitizes the response output including restricted relations, private fields, passwords, and other nested "visitors" added by plugins  |
-| `contentAPI.query` | `ctx.query`, `schema`, `auth` | Sanitizes the request query including filters, sort, fields, and populate                                                   |
+| Function Name                | Parameters         | Description                                             |
+|------------------------------|--------------------|---------------------------------------------------------|
+| `sanitize.contentAPI.input`  | `data`, `schema`, `auth`      | Sanitizes the request input including non-writable fields, removing restricted relations, and other nested "visitors" added by plugins |
+| `sanitize.contentAPI.output` | `data`, `schema`, `auth`      | Sanitizes the response output including restricted relations, private fields, passwords, and other nested "visitors" added by plugins  |
+| `sanitize.contentAPI.query`  | `ctx.query`, `schema`, `auth` | Sanitizes the request query including filters, sort, fields, and populate  |
+| `validate.contentAPI.query`  | `ctx.query`, `schema`, `auth` | Validates the request query including filters, sort, fields (currently not populate) |
+| `validate.contentAPI.input`  | `data`, `schema`, `auth` | Validates the request input including non-writable fields, removing restricted relations, and other nested "visitors" added by plugins |
 
 :::note
-Depending on the complexity of your custom controllers, you may need additional sanitization that Strapi cannot currently account for especially when combining the data from multiple sources.
+Depending on the complexity of your custom controllers, you may need additional sanitization that Strapi cannot currently account for, especially when combining the data from multiple sources.
 :::
 
 <Tabs groupId="js-ts">
@@ -261,17 +284,17 @@ Depending on the complexity of your custom controllers, you may need additional 
 
 ```js title="./src/api/restaurant/controllers/restaurant.js"
 
-const { sanitize } = require('@strapi/utils')
-const { contentAPI } = sanitize;
+const { sanitize, validate } = require('@strapi/utils');
 
 module.exports = {
   async findCustom(ctx) {
-    const contentType = strapi.contentType('api::test.test')
-    const sanitizedQueryParams = await contentAPI.query(ctx.query, contentType, ctx.state.auth)
+    const contentType = strapi.contentType('api::test.test');
+    await validate.contentAPI.query(ctx.query, contentType, { auth: ctx.state.auth });
+    const sanitizedQueryParams = await sanitize.contentAPI.query(ctx.query, contentType, { auth: ctx.state.auth });
 
-    const entities = await strapi.entityService.findMany(contentType.uid, sanitizedQueryParams)
+    const entities = await strapi.entityService.findMany(contentType.uid, sanitizedQueryParams);
 
-    return await contentAPI.output(entities, contentType, ctx.state.auth);
+    return await sanitize.contentAPI.output(entities, contentType, { auth: ctx.state.auth });
   }
 }
 ```
@@ -282,17 +305,18 @@ module.exports = {
 
 ```js title="./src/api/restaurant/controllers/restaurant.ts"
 
-import { sanitize } from '@strapi/utils';
-const { contentAPI } = sanitize;
+import { sanitize, validate } from '@strapi/utils';
 
 export default {
   async findCustom(ctx) {
-    const contentType = strapi.contentType('api::test.test')
-    const sanitizedQueryParams = await contentAPI.query(ctx.query, contentType, ctx.state.auth)
+    const contentType = strapi.contentType('api::test.test');
 
-    const entities = await strapi.entityService.findMany(contentType.uid, sanitizedQueryParams)
+    await validate.contentAPI.query(ctx.query, contentType, { auth: ctx.state.auth });
+    const sanitizedQueryParams = await sanitize.contentAPI.query(ctx.query, contentType, { auth: ctx.state.auth });
 
-    return await contentAPI.output(entities, contentType, ctx.state.auth);
+    const entities = await strapi.entityService.findMany(contentType.uid, sanitizedQueryParams);
+
+    return await contentAPI.output(entities, contentType, { auth: ctx.state.auth });
   }
 }
 ```

--- a/docusaurus/docs/dev-docs/backend-customization/controllers.md
+++ b/docusaurus/docs/dev-docs/backend-customization/controllers.md
@@ -201,7 +201,7 @@ When a new [content-type](/dev-docs/backend-customization/models#content-types) 
 ### Sanitization and Validation in controllers
 
 :::warning
-It's strongly recommended you sanitize (v4.8.0) and/or validate (v4.13.0) your incoming request query and parameters utilizing the new `sanitizeQuery` and `validateQuery` functions to prevent leaking of private data.
+It's strongly recommended you sanitize (v4.8.0+) and/or validate (v4.13.0+) your incoming request query and parameters utilizing the new `sanitizeQuery` and `validateQuery` functions to prevent the leaking of private data.
 :::
 
 #### Sanitization when utilizing controller factories

--- a/docusaurus/docs/dev-docs/backend-customization/controllers.md
+++ b/docusaurus/docs/dev-docs/backend-customization/controllers.md
@@ -273,7 +273,7 @@ Within custom controllers, there are 5 primary functions exposed via the `@strap
 | `sanitize.contentAPI.output` | `data`, `schema`, `auth`      | Sanitizes the response output including restricted relations, private fields, passwords, and other nested "visitors" added by plugins  |
 | `sanitize.contentAPI.query`  | `ctx.query`, `schema`, `auth` | Sanitizes the request query including filters, sort, fields, and populate  |
 | `validate.contentAPI.query`  | `ctx.query`, `schema`, `auth` | Validates the request query including filters, sort, fields (currently not populate) |
-| `validate.contentAPI.input`  | `data`, `schema`, `auth` | Validates the request input including non-writable fields, removing restricted relations, and other nested "visitors" added by plugins |
+| `validate.contentAPI.input`  | `data`, `schema`, `auth` | (EXPERIMENTAL) Validates the request input including non-writable fields, removing restricted relations, and other nested "visitors" added by plugins |
 
 :::note
 Depending on the complexity of your custom controllers, you may need additional sanitization that Strapi cannot currently account for, especially when combining the data from multiple sources.

--- a/docusaurus/docs/dev-docs/backend-customization/controllers.md
+++ b/docusaurus/docs/dev-docs/backend-customization/controllers.md
@@ -219,7 +219,7 @@ Within the Strapi factories the following functions are exposed that can be used
 These functions automatically inherit the sanitization settings from the model and sanitize the data accordingly based on the content-type schema and any of the content API authentication strategies, such as the Users & Permissions plugin or API tokens.
 
 :::warning
-Because these methods use the model associated with the current controller, if you query data that is from another model (ie, doing a find for "menus" within a "restaurant" controller method) you must instead use the `@strapi/utils` tools, such as `sanitize.contentAPI.query` described below, or else the result of your query will be sanitized against the wrong model.
+Because these methods use the model associated with the current controller, if you query data that is from another model (i.e., doing a find for "menus" within a "restaurant" controller method), you must instead use the `@strapi/utils` tools, such as `sanitize.contentAPI.query` described below, or else the result of your query will be sanitized against the wrong model.
 :::
 
 <Tabs groupId="js-ts">


### PR DESCRIPTION
Important: This must be merged alongside the release of [the linked PR](https://github.com/strapi/strapi/pull/17639) and not before. It should happen in 4.13.0 at the end of August. I will be out that week, so @pwizla and @derrickmehaffy please coordinate on ensuring the proper timing of the change log notification and documention.

### What does it do?

- Adds description of a new validate utility in `@strapi/utils`
- Fixes a few incorrect examples in sanitize (auth isn't passed in directly, the sanitizer and validator require an { auth } object)
- adds a warning about usage of controller sanitize* methods

### Why is it needed?

1) To document the new validation utility feature
2) Because we are making a breaking change in that we will start throwing 400 status code errors in the content API when an invalidate query (NOT input at this time) is received by the API

### Related issue(s)/PR(s)

[Add validate utility and use by default on API controllers](https://github.com/strapi/strapi/pull/17639)

Note: In the future it would be nice to have the following examples. Writing this here for my own reference for later or for anyone else who feels like improving the docs.

- Bypassing validation but keeping sanitization by writing custom controller that only sanitizes (or wrapping the core controller to add a sanitize first, so that it keeps the original core controller and sanitizes->validates->sanitizes which should bypass the thrown error)

- Accepting disallowed fields (like if you want to allow your user to sort by a field they don't have permission on) by having a custom controller that stores the value before sanitizing, then explicitly adds it back in.