### PR TITLE
Mention the experimental Content Source Map plugin

### DIFF
--- a/docusaurus/docs/user-docs/content-manager/writing-content.md
+++ b/docusaurus/docs/user-docs/content-manager/writing-content.md
@@ -44,7 +44,7 @@ Filling out a [custom field](/user-docs/content-type-builder/configuring-fields-
 :::
 
 :::strapi Experimental: Preview and edit your content live on your website
-By installing the experimental [Content Source Map](https://www.npmjs.com/package/@strapi/plugin-content-source-map) plugin and combining it with [Vercel's Visual Editing](https://vercel.com/docs/workflow-collaboration/visual-editing) experience, you can preview your content on the rendered website, and edit fields from there. Using this plugin requires an <EnterpriseBadge /> licence and some good understanding of how Strapi plugins and configurations work. A more user-friendly documentation will be provided once the plugin is out of beta.  
+By installing the experimental [Content Source Map](https://www.npmjs.com/package/@strapi/plugin-content-source-map) plugin and combining it with [Vercel's Visual Editing](https://vercel.com/docs/workflow-collaboration/visual-editing) experience, you can preview your content on the rendered website, and edit fields from there. Using this plugin requires an <EnterpriseBadge /> licence and some good understanding of how Strapi plugins and configurations work. Additional documentation will be provided once the plugin is out of beta.  
 :::
 
 ### Components

--- a/docusaurus/docs/user-docs/content-manager/writing-content.md
+++ b/docusaurus/docs/user-docs/content-manager/writing-content.md
@@ -43,6 +43,10 @@ To write or edit content:
 Filling out a [custom field](/user-docs/content-type-builder/configuring-fields-content-type.md#custom-fields) depends on the type of content handled by the field. Please refer to the dedicated documentation for each custom field hosted on the [Marketplace](https://market.strapi.io).
 :::
 
+:::strapi Experimental: Preview and edit your content live on your website
+By installing the experimental [Content Source Map](https://www.npmjs.com/package/@strapi/plugin-content-source-map) plugin and combining it with [Vercel's Visual Editing](https://vercel.com/docs/workflow-collaboration/visual-editing) experience, you can preview your content on the rendered website, and edit fields from there. Using this plugin requires an <EnterpriseBadge /> licence and some good understanding of how Strapi plugins and configurations work. A more user-friendly documentation will be provided once the plugin is out of beta.  
+:::
+
 ### Components
 
 Components are a combination of several fields, which are grouped together in the edit view. Writing their content works exactly like for independent fields, but there are some specificities to components.


### PR DESCRIPTION
This PR adds an "MVP" callout to "Writing Content" in the User Guide to highlight the existence of the [Content Source Map](https://www.npmjs.com/package/@strapi/plugin-content-source-map) plugin.