### PR TITLE
Explicitly repeat to include the `/admin` part in transfer URLs examples

### DIFF
--- a/docusaurus/docs/dev-docs/data-management/transfer.md
+++ b/docusaurus/docs/dev-docs/data-management/transfer.md
@@ -80,7 +80,7 @@ Initiating a data transfer depends on whether you want to push data to a remote 
 
   1. Start the Strapi server for the destination instance.
   2. In a new terminal window, navigate to the root directory of the source instance.
-  3. Run the following minimal command to initiate the transfer:
+  3. Run the following minimal command to initiate the transfer (don't forget to append /admin to the URL):
 
     <Tabs groupId="yarn-npm">
 
@@ -111,7 +111,7 @@ Initiating a data transfer depends on whether you want to push data to a remote 
 
 1. Start the Strapi server for the source instance.
 2. In a new terminal window, navigate to the root directory of the destination instance.
-3. Run the following minimal command to initiate the transfer:
+3. Run the following minimal command to initiate the transfer (don't forget to append /admin to the URL):
 
   <Tabs groupId="yarn-npm">
 

--- a/docusaurus/docs/dev-docs/data-management/transfer.md
+++ b/docusaurus/docs/dev-docs/data-management/transfer.md
@@ -111,7 +111,7 @@ Initiating a data transfer depends on whether you want to push data to a remote 
 
 1. Start the Strapi server for the source instance.
 2. In a new terminal window, navigate to the root directory of the destination instance.
-3. Run the following minimal command to initiate the transfer (don't forget to append /admin to the URL):
+  3. Run the following minimal command to initiate the transfer, ensuring `remoteURL` is the full URL to the admin panel (i.e., the URL includes the `/admin` part):
 
   <Tabs groupId="yarn-npm">
 

--- a/docusaurus/docs/dev-docs/data-management/transfer.md
+++ b/docusaurus/docs/dev-docs/data-management/transfer.md
@@ -80,7 +80,7 @@ Initiating a data transfer depends on whether you want to push data to a remote 
 
   1. Start the Strapi server for the destination instance.
   2. In a new terminal window, navigate to the root directory of the source instance.
-  3. Run the following minimal command to initiate the transfer (don't forget to append /admin to the URL):
+  3. Run the following minimal command to initiate the transfer, ensuring `destinationURL` is the full URL to the admin panel (i.e., the URL includes the `/admin` part):
 
     <Tabs groupId="yarn-npm">
 


### PR DESCRIPTION
### What does it do?

The transfer will fail if there is no /admin appended to the URL. This should be mentioned.

### Why is it needed?

Clarity. Related to https://github.com/strapi/strapi/issues/17015

