### PR TITLE
Fixes #1360 also for TypeScript not only JS example

### DIFF
--- a/docusaurus/docs/dev-docs/configurations/middlewares.md
+++ b/docusaurus/docs/dev-docs/configurations/middlewares.md
@@ -514,7 +514,7 @@ const {
   formats: { prettyPrint, levelFilter },
 } = require('@strapi/logger');
 
-export default [
+export default {
   transports: [
     new winston.transports.Console({
       level: 'http',
@@ -524,7 +524,7 @@ export default [
       ),
     }),
   ],
-];
+};
 ```
 
 </TabItem>


### PR DESCRIPTION
### What does it do?

The fix for #1360 only fixed the JS example, but the TypeScript code was forgetten.

### Why is it needed?

It's written:
module.exports = [
...
]

It should be
module.exports = {
...
}

(object not array braces)


### Related issue(s)/PR(s)

https://github.com/strapi/documentation/pull/1380

