### PR TITLE
Migration guide for v4.14.0

### DIFF
--- a/docusaurus/docs/dev-docs/migration-guides.md
+++ b/docusaurus/docs/dev-docs/migration-guides.md
@@ -28,6 +28,7 @@ If there is no specific migration guide between your current version and the lat
 - [Migration guide from 4.5.1 to 4.6.1](/dev-docs/migration/v4/migration-guide-4.5.1-to-4.6.1)
 - [Migration guide from 4.6.1 to 4.7.0](/dev-docs/migration/v4/migration-guide-4.6.1-to-4.7.0)
 - [Migration guide from 4.7.0 to 4.11.4](/dev-docs/migration/v4/migration-guide-4.7.0-to-4.11.4)
+- [Migration guide from 4.11.4 to 4.14.0](/dev-docs/migration/v4/migration-guide-4.11.4-to-4.14.0)
 
 ## v3 to v4 migration guides
 

--- a/docusaurus/docs/dev-docs/migration/v4/migration-guide-4.11.4-to-4.14.0.md
+++ b/docusaurus/docs/dev-docs/migration/v4/migration-guide-4.11.4-to-4.14.0.md
@@ -1,5 +1,5 @@
 ---
-title: Migrate from 4.14.0 to 4.14.0
+title: Migrate from 4.11.4 to 4.14.0
 displayed_sidebar: devDocsSidebar
 description: Learn how you can migrate your Strapi application from 4.14.0 to 4.14.0.
 ---

--- a/docusaurus/docs/dev-docs/migration/v4/migration-guide-4.11.4-to-4.14.0.md
+++ b/docusaurus/docs/dev-docs/migration/v4/migration-guide-4.11.4-to-4.14.0.md
@@ -19,7 +19,6 @@ The Strapi v4.11.4 to v4.14.0 migration guide upgrades v4.11.4 to v4.14.0. Strap
 
 <PluginsCaution components={props.components} />
 
-<!-- TODO: explain what the migration focuses on (i.e. what breaking changes it fixes). -->
 
 ## Upgrading the application dependencies to 4.14.0
 

--- a/docusaurus/docs/dev-docs/migration/v4/migration-guide-4.11.4-to-4.14.0.md
+++ b/docusaurus/docs/dev-docs/migration/v4/migration-guide-4.11.4-to-4.14.0.md
@@ -9,7 +9,7 @@ import BuildCommand from '/docs/snippets/build-npm-yarn.md'
 import DevelopCommand from '/docs/snippets/develop-npm-yarn.md'
 import InstallCommand from '/docs/snippets/install-npm-yarn.md'
 
-# v4.14.0 to v4.14.0 migration guide
+# v4.11.4 to v4.14.0 migration guide
 
 The Strapi v4.11.4 to v4.14.0 migration guide upgrades v4.11.4 to v4.14.0. Strapi v4.14.0 migrated the `strapi/strapi` package to TypeScript and introduced a new `@strapi/typings` package. This migration is required if you have used TypeScript in your project prior to 4.14.0. The migration guide consists of:
 

--- a/docusaurus/docs/dev-docs/migration/v4/migration-guide-4.11.4-to-4.14.0.md
+++ b/docusaurus/docs/dev-docs/migration/v4/migration-guide-4.11.4-to-4.14.0.md
@@ -1,0 +1,79 @@
+---
+title: Migrate from 4.14.0 to 4.14.0
+displayed_sidebar: devDocsSidebar
+description: Learn how you can migrate your Strapi application from 4.14.0 to 4.14.0.
+---
+
+import PluginsCaution from '/docs/snippets/migrate-plugins-extension-caution.md'
+import BuildCommand from '/docs/snippets/build-npm-yarn.md'
+import DevelopCommand from '/docs/snippets/develop-npm-yarn.md'
+import InstallCommand from '/docs/snippets/install-npm-yarn.md'
+
+# v4.14.0 to v4.14.0 migration guide
+
+The Strapi v4.11.4 to v4.14.0 migration guide upgrades v4.11.4 to v4.14.0. Strapi v4.14.0 migrated the `strapi/strapi` package to TypeScript and introduced a new `@strapi/typings` package. This migration is required if you have used TypeScript in your project prior to 4.14.0. The migration guide consists of:
+
+- Upgrading the application dependencies
+- Generating your TypeScript typings
+- Reinitializing the application
+
+<PluginsCaution components={props.components} />
+
+<!-- TODO: explain what the migration focuses on (i.e. what breaking changes it fixes). -->
+
+## Upgrading the application dependencies to 4.14.0
+
+:::prerequisites
+Stop the server before starting the upgrade.
+:::
+
+1. Upgrade all of the Strapi packages in `package.json` to `4.14.0`:
+
+   ```json title="path: package.json"
+   {
+     // ...
+     "dependencies": {
+       "@strapi/strapi": "4.14.0",
+       "@strapi/plugin-users-permissions": "4.14.0",
+       "@strapi/plugin-i18n": "4.14.0"
+       // ...
+     }
+   }
+   ```
+
+2. Save the edited `package.json` file.
+
+3. Run the install command:
+   <InstallCommand components={props.components} />
+
+## Generate TypeScript typings
+
+Generate your TypeScript typings by running the following command in the terminal:
+
+<Tabs groupId="yarn-npm">
+
+<TabItem value="yarn" label="yarn">
+
+```bash
+yarn strapi ts:generate-types
+```
+
+</TabItem>
+
+<TabItem value="npm" label="npm">
+
+```bash
+npm run strapi ts:generate-types
+```
+
+</TabItem>
+
+</Tabs>
+
+## Rebuild the application
+
+<BuildCommand components={props.components} />
+
+## Restart the application
+
+<DevelopCommand components={props.components} />


### PR DESCRIPTION
This short migration guide asks users to generate TypeScript typings again for Strapi v4.14.0.