### PR TITLE
Update Dockerfile for production

### DIFF
--- a/docusaurus/docs/dev-docs/installation/docker.md
+++ b/docusaurus/docs/dev-docs/installation/docker.md
@@ -338,7 +338,6 @@ The following `Dockerfile` can be used to build a production Docker image for a 
 FROM node:18-alpine as build
 RUN apk update && apk add --no-cache build-base gcc autoconf automake zlib-dev libpng-dev vips-dev git > /dev/null 2>&1
 ENV NODE_ENV=production
-ENV NODE_ENV=${NODE_ENV}
 
 WORKDIR /opt/
 COPY package.json yarn.lock ./
@@ -353,7 +352,6 @@ RUN yarn build
 FROM node:18-alpine
 RUN apk add --no-cache vips-dev
 ENV NODE_ENV=production
-ENV NODE_ENV=${NODE_ENV}
 WORKDIR /opt/
 COPY --from=build /opt/node_modules ./node_modules
 WORKDIR /opt/app


### PR DESCRIPTION
Proposition: when you are building for production you need to be sure that the NODE_ENV is going to be production. Thus the removal of these two lines is required (For Security).


