### PR TITLE
fix : Navigation issue installation to cli

### DIFF
--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -49,7 +49,6 @@ const sidebars = {
         {
           type: 'category',
           label: 'Installation',
-          link: {type: 'doc', id: 'dev-docs/installation'},
           items: [
             {
               type: 'doc',


### PR DESCRIPTION
fix issue Navigation Issue

### What does it do?

I did remove a id from the installation so user can move on the installation and then cli docs

### Why is it needed?

Navigation problem between pages

<img width="1507" alt="Screenshot 2023-10-04 at 11 23 41 AM" src="https://github.com/strapi/documentation/assets/33973828/f2e7886f-39d4-41ae-9ca2-4396648c2cda">


