### PR TITLE
Update Node.js install snippet on AWS Deployment page

### DIFF
--- a/docusaurus/docs/dev-docs/deployment/amazon-aws.md
+++ b/docusaurus/docs/dev-docs/deployment/amazon-aws.md
@@ -257,9 +257,16 @@ Strapi currently supports `Node.js` `v16.x.x`, `v18.x.x`, and `v20.x.x`. The fol
 
 ```bash title="example using Node.js 20"
 cd ~
-curl -sL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+sudo apt-get update
 ...
-sudo apt-get install nodejs
+sudo apt-get install -y ca-certificates curl gnupg
+...
+sudo mkdir -p /etc/apt/keyrings
+curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+NODE_MAJOR=20
+sudo apt-get update
+...
+sudo apt-get install nodejs -y
 ...
 node -v && npm -v
 ```


### PR DESCRIPTION
### What does it do?

Updates snippet responsible for installing Node.js on AWS Deployment page according to https://github.com/nodesource/distributions#installation-instructions 

### Why is it needed?

![Screenshot 2023-10-07 at 18 56 44](https://github.com/strapi/documentation/assets/72109970/9506a5ee-7f9b-4273-89e4-2314f678b2e2)

### Related issue(s)/PR(s)

- none
