### PR TITLE
Add badges for Cloud-related plans

### DIFF
--- a/docusaurus/docs/cloud/getting-started/usage-billing.md
+++ b/docusaurus/docs/cloud/getting-started/usage-billing.md
@@ -4,7 +4,7 @@ displayed_sidebar: cloudSidebar
 sidebar_position: 3
 ---
 
-# Usage & Billing
+# Usage & Billing <CloudProBadge /> <CloudTeamBadge />
 
 This page contains general information related to the usage and billing of your Strapi Cloud account and applications. Strapi Cloud offers a free 7-day trial for all new accounts and two paid plans: **Pro** and **Team**.
 

--- a/docusaurus/docs/cloud/getting-started/usage-billing.md
+++ b/docusaurus/docs/cloud/getting-started/usage-billing.md
@@ -4,7 +4,7 @@ displayed_sidebar: cloudSidebar
 sidebar_position: 3
 ---
 
-# Usage & Billing <CloudProBadge /> <CloudTeamBadge />
+# Usage & Billing
 
 This page contains general information related to the usage and billing of your Strapi Cloud account and applications. Strapi Cloud offers a free 7-day trial for all new accounts and two paid plans: **Pro** and **Team**.
 

--- a/docusaurus/src/components/Badge.js
+++ b/docusaurus/src/components/Badge.js
@@ -62,6 +62,25 @@ export function EnterpriseBadge(props) {
   );
 }
 
+export function CloudProBadge(props) {
+  return (
+    <Badge
+      variant="Strapi Cloud Pro"
+      link="https://strapi.io/pricing-cloud"
+      {...props}
+    />
+  );
+}
+
+export function CloudTeamBadge(props) {
+  return (
+    <Badge
+      variant="Strapi Cloud Team"
+      link="https://strapi.io/pricing-cloud"
+      {...props}
+    />
+  );
+}
 
 export function NewBadge(props) {
   return (

--- a/docusaurus/src/scss/badge.scss
+++ b/docusaurus/src/scss/badge.scss
@@ -43,6 +43,16 @@
     --custom-badge-color: rgb(229, 136, 41);
   }
 
+  &--strapicloudpro {
+    --custom-badge-background-color: rgb(55, 34, 254);
+    --custom-badge-color: #fff;
+  }
+
+  &--strapicloudteam {
+    --custom-badge-background-color: rgb(154, 53, 242);
+    --custom-badge-color: #fff;
+  }
+
   &--new {
     --custom-badge-background-color: var(--strapi-warning-100);
     --custom-badge-border-color: var(--strapi-warning-200);

--- a/docusaurus/src/theme/MDXComponents.js
+++ b/docusaurus/src/theme/MDXComponents.js
@@ -18,7 +18,7 @@ import FeedbackPlaceholder from '../components/FeedbackPlaceholder';
 import CustomDocCard from '../components/CustomDocCard';
 import CustomDocCardsWrapper from '../components/CustomDocCardsWrapper';
 import { InteractiveQueryBuilder } from '../components/InteractiveQueryBuilder/InteractiveQueryBuilder';
-import { AlphaBadge, BetaBadge, EnterpriseBadge } from '../components/Badge';
+import { AlphaBadge, BetaBadge, EnterpriseBadge, CloudProBadge, CloudTeamBadge } from '../components/Badge';
 import { SideBySideColumn, SideBySideContainer } from '../components';
 import ThemedImage from '@theme/ThemedImage';
 import {
@@ -48,6 +48,8 @@ export default {
   AlphaBadge,
   BetaBadge,
   EnterpriseBadge,
+  CloudProBadge,
+  CloudTeamBadge,
   Columns,
   ColumnLeft,
   ColumnRight,


### PR DESCRIPTION
Adds some badges to more efficiently communicate which Strapi Cloud feature(s) are tied to which plan(s). Similar behavior to the `<EnterpriseBadge />` we have for the EE licence.

- Adds `<CloudProBadge />` and `<CloudTeamBadge />`
- Add these badges to the "Update & billing" page H1, just for the sake of illustrating their usage

Names (both component name + display name) and designs can be discussed 😊

👉 [Direct preview link](https://documentation-bj6zd597l-strapijs.vercel.app/cloud/getting-started/usage-billing)