### PR TITLE
Add missing build script in webhook.js

### DIFF
--- a/docusaurus/docs/dev-docs/deployment/amazon-aws.md
+++ b/docusaurus/docs/dev-docs/deployment/amazon-aws.md
@@ -741,7 +741,7 @@ http
           .digest('hex');
 
       if (req.headers['x-hub-signature'] == sig) {
-        exec(`cd ${repo} && git pull && ${PM2_CMD}`, (error, stdout, stderr) => {
+        exec(`cd ${repo} && git pull && NODE_ENV=production npm run build && ${PM2_CMD}`, (error, stdout, stderr) => {
           if (error) {
             console.error(`exec error: ${error}`);
             return;

--- a/docusaurus/docs/dev-docs/deployment/digitalocean.md
+++ b/docusaurus/docs/dev-docs/deployment/digitalocean.md
@@ -452,7 +452,7 @@ More information can be found on webhooks in general in the [GitHub documentatio
               .digest('hex');
 
           if (req.headers['x-hub-signature'] == sig) {
-            exec(`cd ${repo} && git pull && ${PM2_CMD}`, (error, stdout, stderr) => {
+            exec(`cd ${repo} && git pull && NODE_ENV=production npm run build && ${PM2_CMD}`, (error, stdout, stderr) => {
               if (error) {
                 console.error(`exec error: ${error}`);
                 return;


### PR DESCRIPTION
### What does it do?

Adding building script to webhook.js example

### Why is it needed?

In the DigitalOcean deployment guide, I think that there's a missing building script in webhook.js example: [Set up a webhook on DigitalOcean/GitHub](https://docs.strapi.io/dev-docs/deployment/digitalocean#set-up-a-webhook-on-digitaloceangithub)

Without the re-build script, the server will serve the old build with no changes. From that, I think there should be a building script like `npm run build` after `git pull`.

### Additional context
Ps. I'm a newbie and this is my very first open source contribution, so please let me know if I did anything wrong.
