### PR TITLE
Add data-loss warning to top of docker instructions

### DIFF
--- a/docusaurus/docs/dev-docs/installation/docker.md
+++ b/docusaurus/docs/dev-docs/installation/docker.md
@@ -12,6 +12,10 @@ import DockerEnvTable from '/docs/snippets/docker-env-table.md'
 Strapi does not build any official container images. The following instructions are provided as a courtesy to the community. If you have any questions please reach out on [Discord](https://discord.strapi.io).
 :::
 
+:::warning
+ Strapi applications are not meant to be connected to a pre-existing database, not created by a Strapi application, nor connected to a Strapi v3 database. The Strapi team will not support such attempts. Attempting to connect to an unsupported database may, and most likely will, result in lost data such as dropped tables.
+:::
+
 The following documentation will guide you through building a custom [Docker](https://www.docker.com/) container with an existing Strapi project.
 
 Docker is an open platform that allows developing, shipping, and running applications by using containers (i.e. packages containing all the parts an application needs to function, such as libraries and dependencies). Containers are isolated from each other and bundle their own software, libraries, and configuration files; they can communicate with each other through well-defined channels.


### PR DESCRIPTION
### What does it do?

Some developers heavily using docker will refer first to a projects' Docker installation instructions. In the case of Strapi, this means that they might not realize that connecting Strapi to an existing database will `DROP` the existing database tables.

This PR adds a warning to the top of the `docker.md` readme.

### Why is it needed?

Docker developers will likely miss the warning when trying out Strapi.

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/12068
