### PR TITLE
Update README introduction to mention issues vs. requests + various websites

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ Strapi is a free and open-source headless CMS delivering your content anywhere y
 - **Database agnostic**. You can choose the database you prefer. Strapi works with SQL databases: PostgreSQL, MySQL, MariaDB, and SQLite.
 - **Customizable**. You can quickly build your logic by fully customizing APIs, routes, or plugins to fit your needs perfectly.
 
+## Documentation websites
+
+The main official Strapi documentation website is hosted at [docs.strapi.io](https://docs.strapi.io).
+
+Additional official Strapi documentation websites cover different content:
+
+- Documentation for the older, unsupported version 3 of Strapi is hosted at [docs-v3.strapi.io](https://docs-v3.strapi.io).
+- Upcoming and/or experimental documentation is hosted at [docs-next.strapi.io](https://docs-next.strapi.io). It will soon start including in-progress documentation for Strapi v5.
+- Documentation for contributors, which include more in-depth and experimental content for developers who actively maintain and contribute to Strapi, is hosted at [contributor.strapi.io](https://contributor.strapi.io). This experimental documentation is maintained by Strapi engineers and any issue should be reported to the [`strapi/strapi`](https://github.com/strapi/strapi/issues/new/choose) repository.
+
 ## Contribution requirements
 
 The following are required if you are submitting pull requests to the documentation:
@@ -30,21 +40,21 @@ The following are required if you are submitting pull requests to the documentat
 
 👉 For more information on how to contribute, please read our [contribution guide](./CONTRIBUTING.md).
 
-## Requests
+## Issues
 
-Requests for new documentation are highly encouraged, this is not limited to new additions but also changes or more information requested on existing documentation. Please use our [request documentation](https://github.com/strapi/documentation/issues/new?template=DOC_REQUEST.md&title%5B%5D=REQUEST) issue template.
+Submitting issues help to improve the documentation. If you find incorrect screenshot(s), instructions, or code examples, or if you discover UX/UI bugs on the website, please use our [documentation issue](https://github.com/strapi/documentation/issues/new?template=BUG_REPORT.yml) template to report them. To submit an issue:
 
-## Bugs
-
-Bug reports help to improve the documentation. Please use our [documentation bug report](https://github.com/strapi/documentation/issues/new?template=BUG_REPORT.yml) template to report documentation bugs. To submit an issue:
-
-1. Verify the issue is only with the Strapi documentation, code issues should be directed at the main [strapi/strapi](https://github.com/strapi/strapi) repository.
+1. Verify the issue is only with one of the Strapi documentation websites. Product-related issues, missing Strapi features, and any issues not directly related to the documentation should be directed at the main [strapi/strapi](https://github.com/strapi/strapi) repository.
 2. Follow the issue template and fill out as much information as you can.
   
 Technical questions should be asked using the following resources:
 
 - Open a Q&A thread on our [official forum](https://forum.strapi.io).
 - Engage with other community members on our [community Discord server](https://discord.strapi.io).
+
+## Requests
+
+Requests for new documentation are highly encouraged. This is not limited to new additions but also changes or more information requested on existing documentation. Please use our [request documentation](https://github.com/strapi/documentation/issues/new?template=DOC_REQUEST.md&title%5B%5D=REQUEST) issue template. These requests will be checked by the Strapi Documentation team then transferred to another internal tool outside GitHub for priorization and subsequent actions.
 
 ## Releases
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The main official Strapi documentation website is hosted at [docs.strapi.io](htt
 Additional official Strapi documentation websites cover different content:
 
 - Documentation for the older, unsupported version 3 of Strapi is hosted at [docs-v3.strapi.io](https://docs-v3.strapi.io).
-- Upcoming and/or experimental documentation is hosted at [docs-next.strapi.io](https://docs-next.strapi.io). It will soon start including in-progress documentation for Strapi v5.
+- Upcoming and/or experimental documentation is hosted at [docs-next.strapi.io](https://docs-next.strapi.io). Starting autumn/winter 2023, this website will include in-progress documentation for Strapi v5.
 - Documentation for contributors, which include more in-depth and experimental content for developers who actively maintain and contribute to Strapi, is hosted at [contributor.strapi.io](https://contributor.strapi.io). This experimental documentation is maintained by Strapi engineers and any issue should be reported to the [`strapi/strapi`](https://github.com/strapi/strapi/issues/new/choose) repository.
 
 ## Contribution requirements


### PR DESCRIPTION
This PR updates the README to clarify the following:

- the various documentation websites available,
- and the issues vs. requests handling.