### PR TITLE
Update supported databases

### DIFF
--- a/docusaurus/docs/dev-docs/configurations/database.md
+++ b/docusaurus/docs/dev-docs/configurations/database.md
@@ -49,6 +49,7 @@ The `./config/database.js` (or `./config/database.ts` for TypeScript) accepts 2 
 Strapi only supports the following client values, and will automatically rewrite the 'client' value to the following options before passing the configuration to Knex
 
 | client       | actual package used |
+|----------|----------------------|
 | sqlite       | better-sqlite3      |
 | mysql        | mysql2              |
 | postgres     | pg                  |

--- a/docusaurus/docs/dev-docs/configurations/database.md
+++ b/docusaurus/docs/dev-docs/configurations/database.md
@@ -51,7 +51,7 @@ Strapi only supports the following client values, and will automatically rewrite
 | client       | actual package used |
 | sqlite       | better-sqlite3      |
 | mysql        | mysql2              |
-| postgres     | postgres            |
+| postgres     | pg                  |
 :::
 
 #### Connection parameters

--- a/docusaurus/docs/dev-docs/configurations/database.md
+++ b/docusaurus/docs/dev-docs/configurations/database.md
@@ -46,7 +46,12 @@ The `./config/database.js` (or `./config/database.ts` for TypeScript) accepts 2 
 | `acquireConnectionTimeout`<br /><br />_Optional_         | How long knex will wait before throwing a timeout error when acquiring a connection (in milliseconds) | `Integer` | `60000` |
 
 :::note
-A `client` value of 'sqlite' will be modified by Strapi to be 'better-sqlite3' if the package is available in your project, or 'sqlite3' if it is not.
+Strapi only supports the following client values, and will automatically rewrite the 'client' value to the following options before passing the configuration to Knex
+
+| client       | actual package used |
+| sqlite       | better-sqlite3      |
+| mysql        | mysql2              |
+| postgres     | postgres            |
 :::
 
 #### Connection parameters
@@ -543,12 +548,4 @@ $ \c my_strapi_db_name admin_user
 $ GRANT ALL ON SCHEMA public TO my_strapi_db_user;
 ```
 
-:::
-
-### Alternative database driver packages
-
-In addition to `client` values of '[postgres](https://www.npmjs.com/package/pg)', 'sqlite', and '[mysql](https://www.npmjs.com/package/mysql)', Strapi also allows a `client` value of '[mysql2](https://www.npmjs.com/package/mysql2)' for those who install and wish to use that package.
-
-:::note
-`mysql2` is required for the `caching_sha2_password` auth method used by default in MySQL v8+. If you receive an `"ER_NOT_SUPPORTED_AUTH_MODE"` error when using the `mysql` driver, try adding the `mysql2` package to your project. You should then remove the deprecated `connectionString` parameter from your connection configuration in favor of the `username` and `password` values.
 :::

--- a/docusaurus/docs/dev-docs/configurations/database.md
+++ b/docusaurus/docs/dev-docs/configurations/database.md
@@ -547,5 +547,3 @@ $ \c my_strapi_db_name admin_user
 # Grant schema privileges to the user
 $ GRANT ALL ON SCHEMA public TO my_strapi_db_user;
 ```
-
-:::

--- a/docusaurus/docs/dev-docs/installation/cli.md
+++ b/docusaurus/docs/dev-docs/installation/cli.md
@@ -20,12 +20,12 @@ Strapi CLI (Command Line Interface) installation scripts are the fastest way to 
 
 A supported database is also required for any Strapi project:
 
-| Database   | Minimum | Recommended |
-|------------|---------|-------------|
-| MySQL      | 5.7.8   | 8.0         |
-| MariaDB    | 10.3    | 10.6        |
-| PostgreSQL | 11.0    | 14.0        |
-| SQLite     | 3       | 3           |
+| Database   | Recommended | Minimum |
+| ---------- | ----------- | ------- |
+| MySQL      | 8.0         | 8.0     |
+| MariaDB    | 10.6        | 10.3    |
+| PostgreSQL | 14.0        | 12.0    |
+| SQLite     | 3           | 3       |
 
 :::caution
 Strapi v4 does not support MongoDB.

--- a/docusaurus/docs/snippets/database-require.md
+++ b/docusaurus/docs/snippets/database-require.md
@@ -1,6 +1,6 @@
 | Database   | Recommended | Minimum |
 | ---------- | ----------- | ------- |
-| MySQL      | 8.0         | 5.7.8   |
+| MySQL      | 8.0         | 8.0     |
 | MariaDB    | 10.6        | 10.3    |
-| PostgreSQL | 14.0        | 11.0    |
+| PostgreSQL | 14.0        | 12.0    |
 | SQLite     | 3           | 3       |

--- a/docusaurus/docs/snippets/operating-system-require.md
+++ b/docusaurus/docs/snippets/operating-system-require.md
@@ -1,8 +1,8 @@
 | Operating System |  Recommended |Minimum |
 |------------------|-------------|---------|
-| Ubuntu (LTS)     | 22.04       | 20.04   |
+| Ubuntu (LTS)     |  22.04      | 20.04   |
 | Debian           |  11.x       | 10.x    |
 | CentOS/RHEL      |  9.x        | 8.x     |
 | macOS            |  11.0       | 10.15   |
 | Windows Desktop  |  11         | 10      |
-| Windows Server   | 2022        | 2019    |
+| Windows Server   |  2022       | 2019    |


### PR DESCRIPTION
This is related to all these PRs (it was easier than doing separate docs):

https://github.com/strapi/strapi/pull/18499
https://github.com/strapi/strapi/pull/18500
https://github.com/strapi/strapi/pull/18503

The only thing remaining is if I may have missed somewhere that we list what database versions we support, because we no longer support MySQL v5 but I couldn't find it except in the contrib docs in the monorepo.