### PR TITLE
Init. breaking changes pages for Strapi v4 → v5 migration

### DIFF
--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes.md
@@ -28,5 +28,5 @@ The following changes affect the `schema.json` file of your content-types:
 
 The following changes affect the databases interacting with your Strapi application:
 
-- [MySQL v5 support is dropped](/dev-docs/migration/v4-to-v5/breaking-changes/mysql5-unsupported)
+- [MySQL v5 is not supported anymore](/dev-docs/migration/v4-to-v5/breaking-changes/mysql5-unsupported)
 

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes.md
@@ -16,7 +16,7 @@ This page is part of the [Strapi v4 to v5 migration](/dev-docs/migration/v4-to-v
 
 ## Content API
 
-The following changes affect the Content API of your Strapi application.
+The following changes affect the Content API of your Strapi application:
 
 ### Schemas
 
@@ -26,7 +26,7 @@ The following changes affect the `schema.json` file of your content-types:
 
 ## Database
 
-The following changes affect the databases interacting with your Strapi application.
+The following changes affect the databases interacting with your Strapi application:
 
 - [MySQL v5 support is dropped](/dev-docs/migration/v4-to-v5/breaking-changes/mysql5-unsupported)
 

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes.md
@@ -29,4 +29,5 @@ The following changes affect the `schema.json` file of your content-types:
 The following changes affect the databases interacting with your Strapi application:
 
 - [MySQL v5 is not supported anymore](/dev-docs/migration/v4-to-v5/breaking-changes/mysql5-unsupported)
+- [Database identifiers can't be longer than 53 characters](/dev-docs/migration/v4-to-v5/breaking-changes/database-identifiers-shortened)
 

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes.md
@@ -1,9 +1,23 @@
 ---
 title: Breaking changes
 # description: todo
-displayed_sidebar: devDocsSidebar
+displayed_sidebar: devDocsMigrationV5Sidebar
 ---
 
 # Strapi v4 to v5 breaking changes
 
-_Coming soon…_
+:::callout 🚧  Work in progress
+This page is a work-in-progress and the list of breaking changes will grow over time.
+:::
+
+This page is part of the [Strapi v4 to v5 migration](/dev-docs/migration/v4-to-v5/introduction) and lists all the breaking changes introduced in Strapi v5.
+
+## Content API
+
+The following changes affect the Content API of your Strapi application.
+
+### Schemas
+
+The following changes affect the `schema.json` file of your content-types:
+
+* [Draft & Publish is always enabled](/dev-docs/migration/v4-to-v5/breaking-changes/draft-and-publish-always-enabled)

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/database-identifiers-shortened.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/database-identifiers-shortened.md
@@ -1,0 +1,72 @@
+---
+title: Database identifiers shortened in v5
+description: Database identifiers are shortened in Strapi v5 and can't be longer than 53 characters to avoid issues with identifiers that are too long.
+sidebar_label: Database identifiers shortened
+displayed_sidebar: devDocsMigrationV5Sidebar
+tags:
+ - breaking changes
+ - database
+---
+
+import Intro from '/docs/snippets/breaking-change-page-intro.md'
+import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
+
+# Database identifiers shortened in v5
+
+In Strapi v5, database identifiers can't be longer than 53 characters. <Intro />
+
+## Breaking change description
+
+<SideBySideContainer>
+
+<SideBySideColumn>
+
+**In Strapi v4**
+
+Database identifiers could be longer than 53 characters, potentially causing issues with some databases.
+
+</SideBySideColumn>
+
+<SideBySideColumn>
+
+**In Strapi v5**
+
+<!-- TODO: update sentence "also will be changing" → define what changed once we know -->
+Database identifiers can't be longer than 53 characters.
+
+</SideBySideColumn>
+
+</SideBySideContainer>
+
+## Migration
+
+<MigrationIntro />
+
+### Notes
+
+- A hashing key will be added when shortening database identifiers to avoid conflicts. It will consist in the first 6 characters of SHA-256.
+- Some suffixes will be used:
+
+  | Suffix                 | Short version |
+  | ---------------------- | ------------- |
+  | `fk`                   | `fk`          |
+  | `unique`               | `unq`         |
+  | `primary`              | `pk`          |
+  | `index`                | `idx`         |
+  | `component`            | `cmp`         |
+  | `components`           | `cmps`        |
+  | `component_type_index` | `cmpix`       |
+  | `entity_fk`            | `etfk`        |
+  | `field_index`          | `flix`        |
+  | `order`                | `ord`         |
+  | `order_fk`             | `ofk`         |
+  | `order_inv_fk`         | `oifk`        |
+  | `order_index`          | `oidx`        |
+  | `inv_fk`               | `ifk`         |
+  | `morphs`               | `mph`         |
+  | `links`                | `lnk`         |
+  | `id_column_index`      | `idix`        |
+
+### Manual procedure
+
+No manual migration is required. Strapi will handle everything when starting the application in Strapi v5.

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/database-identifiers-shortened.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/database-identifiers-shortened.md
@@ -31,8 +31,7 @@ Database identifiers could be longer than 53 characters, potentially causing iss
 
 **In Strapi v5**
 
-<!-- TODO: update sentence "also will be changing" → define what changed once we know -->
-Database identifiers can't be longer than 53 characters.
+Database identifiers can't be longer than 53 characters and will be shortened.
 
 </SideBySideColumn>
 
@@ -44,7 +43,7 @@ Database identifiers can't be longer than 53 characters.
 
 ### Notes
 
-- A hashing key will be added when shortening database identifiers to avoid conflicts. It will consist in the first 6 characters of SHA-256.
+- A hashing key will be added when shortening database identifiers to avoid conflicts. It will consist in the first 6 characters of SHA-256. For example, `my_very_very_very_very_very_very_very_too_long_identifier_unique` will be shortened to `my_very_very_very_very_very_very_very_very_a2d3x3_unq` in Strapi v5.
 - Some suffixes will be used:
 
   | Suffix                 | Short version |

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/database-identifiers-shortened.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/database-identifiers-shortened.md
@@ -43,7 +43,7 @@ Database identifiers can't be longer than 53 characters and will be shortened.
 
 ### Notes
 
-- A hashing key will be added when shortening database identifiers to avoid conflicts. It will consist in the first 6 characters of SHA-256. For example, `my_very_very_very_very_very_very_very_too_long_identifier_unique` will be shortened to `my_very_very_very_very_very_very_very_very_a2d3x3_unq` in Strapi v5.
+- A hashing key will be added when shortening database identifiers to avoid conflicts. It will consist in the first 6 characters of SHA-256. For example, `my_very_very_very_very_very_very_very_too_long_identifier_unique` will be shortened to `my_very_very_very_very_very_very_very_very_06a6ab_unq` in Strapi v5.
 - Some suffixes will be used:
 
   | Suffix                 | Short version |

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/draft-and-publish-always-enabled.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/draft-and-publish-always-enabled.md
@@ -1,0 +1,72 @@
+---
+title: Draft & Publish always enabled in v5
+description: Draft & Publish is always enabled in Strapi v5 and this is reflected in the Content API models.
+sidebar_label: Draft & Publish always enabled
+displayed_sidebar: devDocsMigrationV5Sidebar
+tags:
+ - breaking changes
+ - content API
+ - draft & publish
+---
+
+import Intro from '/docs/snippets/breaking-change-page-intro.md'
+import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
+
+# Draft & Publish always enabled in v5
+
+In Strapi v5, the Draft & Publish feature is always enabled. <Intro />
+
+## Breaking change description
+
+<SideBySideContainer>
+
+<SideBySideColumn>
+
+**In Strapi v4**
+
+Content types had a `draftAndPublish` option in their schema. The database schema and admin panel interface changed depending on that option.
+
+</SideBySideColumn>
+
+<SideBySideColumn>
+
+**In Strapi v5**
+
+All content-types now have Draft & publish enabled in the database and in the admin panel interface. The admin panel interface also will be changing.
+
+</SideBySideColumn>
+
+</SideBySideContainer>
+
+## Migration
+
+<MigrationIntro />
+
+### Notes
+
+<!-- TODO: add codemod link -->
+<!-- TODO: add link to strapi upgrade CLI tool documentation -->
+- Strapi provides a [codemod](#) to automatically update all the content-type schemas that are detected by the [`strapi upgrade` tool](#).
+- Plugin developers and users with custom content-types should update content-types.
+- A safety net is provided to avoid breaking changes that would force manual intervention and to avoid breaking the whole Strapi plugins ecosystem:
+
+  - A default `publishedAt` value is set.
+  - The `draftAndPublish: true` option can still be present in v5 content-types schemas, but will be ignored.
+
+### Manual procedure
+
+:::note
+This procedure is only required if the codemod failed to remove the line automatically.
+:::
+
+To manually update Strapi v4 code to Strapi v5, update the `schema.json` files of your content-types to remove the `draftAndPublish: true` option line:
+
+```json title="/src/api/my-api-name/content-types/my-content-type-name/schema.json"
+
+{
+  "options": {
+    "draftAndPublish": true // delete the entire line
+   }
+}
+```
+    

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/draft-and-publish-always-enabled.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/draft-and-publish-always-enabled.md
@@ -12,7 +12,7 @@ tags:
 import Intro from '/docs/snippets/breaking-change-page-intro.md'
 import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
 
-# Draft & Publish always enabled in v5
+# Draft & Publish is always enabled in Strapi v5
 
 In Strapi v5, the Draft & Publish feature is always enabled. <Intro />
 

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/draft-and-publish-always-enabled.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/draft-and-publish-always-enabled.md
@@ -32,6 +32,7 @@ Content types had a `draftAndPublish` option in their schema. The database schem
 
 **In Strapi v5**
 
+<!-- TODO: update sentence "also will be changing" → define what changed once we know -->
 All content-types now have Draft & publish enabled in the database and in the admin panel interface. The admin panel interface also will be changing.
 
 </SideBySideColumn>

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/mysql5-unsupported.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/mysql5-unsupported.md
@@ -8,7 +8,11 @@ tags:
  - mysql
 ---
 
+import Intro from '/docs/snippets/breaking-change-page-intro.md'
+
 # MySQL v5 is not supported in Strapi v5 anymore
+
+In Strapi v5, MySQL version 5 is not supported.<Intro />
 
 ## Breaking change description
 
@@ -26,7 +30,8 @@ MySQL v5 was supported.
 
 **In Strapi v5**
 
-MySQL v5 is not supported anymore.
+MySQL v5 is not supported anymore.<br />
+MySQL v8 is the minimum required version (see [CLI installation guide](/dev-docs/installation/cli)).
 
 </SideBySideColumn>
 
@@ -36,6 +41,8 @@ MySQL v5 is not supported anymore.
 
 ## Migration
 
-No manual migration steps required.
-
+<!-- TODO: update this sentence -->
+No manual migration is required for the codebase of your Strapi application.
 Connection information will probably stay the same as in Strapi v4.
+
+However, to use Strapi v5, you must upgrade your MySQL database to version 8.0 (see additional information in the official [MySQL documentation](https://dev.mysql.com/doc/relnotes/mysql/8.0/en/)).

--- a/docusaurus/docs/snippets/breaking-change-page-intro.md
+++ b/docusaurus/docs/snippets/breaking-change-page-intro.md
@@ -1,0 +1,1 @@
+This page is part of the [breaking changes database](/dev-docs/migration/v4-to-v5/breaking-changes) and provides information about the breaking change and additional instructions to migrate from Strapi v4 to Strapi v5.

--- a/docusaurus/docs/snippets/breaking-change-page-migration-intro.md
+++ b/docusaurus/docs/snippets/breaking-change-page-migration-intro.md
@@ -1,0 +1,1 @@
+This section regroups useful notes and procedures about the introduced breaking change.

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -943,8 +943,13 @@ const sidebars = {
             {
               type: "category",
               label: "Database",
+              link: {
+                type: 'doc',
+                id: "dev-docs/migration/v4-to-v5/breaking-changes"
+              },
               items: [
-                'dev-docs/migration/v4-to-v5/breaking-changes/mysql5-unsupported'
+                'dev-docs/migration/v4-to-v5/breaking-changes/mysql5-unsupported',
+                'dev-docs/migration/v4-to-v5/breaking-changes/database-identifiers-shortened'
               ]
             },
           ]

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -932,6 +932,10 @@ const sidebars = {
             {
               type: "category",
               label: "Content API",
+              link: {
+                type: 'doc',
+                id: "dev-docs/migration/v4-to-v5/breaking-changes"
+              },
               items: [
                 'dev-docs/migration/v4-to-v5/breaking-changes/draft-and-publish-always-enabled'
               ]

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -901,8 +901,46 @@ const sidebars = {
       ]
     },
   ],
-  devDocsPluginsSidebar: [
-
+  devDocsMigrationV5Sidebar: [
+    {
+      type: 'link',
+      label: '⬅️ Back to Dev Docs content',
+      href: '/dev-docs/intro'
+    },
+    {
+      type: 'category',
+      collapsed: false,
+      link: {
+        type: 'doc',
+        id: 'dev-docs/migration/v4-to-v5/introduction'
+      },
+      label: 'v4 to v5 migration',
+      items: [
+        {
+          type: "doc",
+          label: "Introduction",
+          id: "dev-docs/migration/v4-to-v5/introduction"
+        },
+        {
+          type: "category",
+          label: "Breaking changes",
+          link: {
+            type: "doc",
+            id: "dev-docs/migration/v4-to-v5/breaking-changes",
+          },
+          items: [
+            {
+              type: "category",
+              label: "Content API",
+              items: [
+                'dev-docs/migration/v4-to-v5/breaking-changes/draft-and-publish-always-enabled'
+              ]
+            },
+          ]
+        },
+        "dev-docs/migration/v4-to-v5/migration-guides",
+      ]
+    }
   ]
 };
 


### PR DESCRIPTION
This PR initializes the breaking changes database that will be part of the v4 → v5 migration documentation, and more specifically:

- Create a new sidebar dedicated to the migration
- Creates a breaking changes database page and adds the first 2 entries
- Adds 2 breaking changes pages (content is still subject to modification in further PRs) as examples of how we could possibly document these
- Introduces the use of tags to add another layer of documentation classification. I mean to use tags only for breaking changes and migration, but if it appears useful to readers, we could eventually extend its usage.

Direct preview link: 👉 [list page](https://documentation-git-v5-breaking-changes-strapijs.vercel.app/dev-docs/migration/v4-to-v5/breaking-changes)