### PR TITLE
Add request timoutt section to upload documentation

### DIFF
--- a/docusaurus/docs/dev-docs/plugins/upload.md
+++ b/docusaurus/docs/dev-docs/plugins/upload.md
@@ -213,6 +213,7 @@ export default {
 
 </TabItem>
 
+</Tabs>
 
 
 ### Responsive Images

--- a/docusaurus/docs/dev-docs/plugins/upload.md
+++ b/docusaurus/docs/dev-docs/plugins/upload.md
@@ -172,6 +172,49 @@ export default {
 
 </Tabs>
 
+### Upload request timeout
+
+By default, the `strapi.server.httpServer.requestTimeout` is set to 330 seconds. This includes uploads. To make it possible for users with slow connections to upload large files, it might be required to increase this timeout limit by setting it in the bootstrapi function that runs before strapi gets started.
+
+
+<Tabs groupId="js-ts">
+
+<TabItem value="javascript" label="JAVASCRIPT">
+
+```js title="path: ./index.js"
+
+module.exports = {
+
+  //...
+
+  bootstrap({ strapi }) {
+    // Set the requestTimeout to 30 minutes:
+    strapi.server.httpServer.requestTimeout = 30 * 60 * 1000; 
+  },
+};
+```
+
+</TabItem>
+
+<TabItem value="typescript" label="TYPESCRIPT">
+
+```ts title="path: ./index.ts"
+
+export default {
+
+  //...
+
+  bootstrap({ strapi }) {
+    // Set the requestTimeout to 30 minutes:
+    strapi.server.httpServer.requestTimeout = 30 * 60 * 1000; 
+  },
+};
+```
+
+</TabItem>
+
+
+
 ### Responsive Images
 
 When the `Enable responsive friendly upload` setting is enabled in the settings panel the plugin will generate the following responsive image sizes:

--- a/docusaurus/docs/dev-docs/plugins/upload.md
+++ b/docusaurus/docs/dev-docs/plugins/upload.md
@@ -174,7 +174,7 @@ export default {
 
 ### Upload request timeout
 
-By default, the `strapi.server.httpServer.requestTimeout` is set to 330 seconds. This includes uploads. To make it possible for users with slow connections to upload large files, it might be required to increase this timeout limit by setting it in the bootstrapi function that runs before strapi gets started.
+By default, the `strapi.server.httpServer.requestTimeout` is set to 330 seconds. This includes uploads. To make it possible for users with slow connections to upload large files, it might be required to increase this timeout limit by setting it in the bootstrap function that runs before strapi gets started.
 
 
 <Tabs groupId="js-ts">


### PR DESCRIPTION
### What does it do?

Adds a section to the upload-plugin documentation about setting the maximum request timeout of `strapi.server.httpServer`

### Why is it needed?

In our team, whe had the problem that uploads would always timeout after 330 seconds. This was because the upload controller of the plugin apparently uses the `strapi.server.httpServer.requestTimeout` limit, which is set to 330 seconds by default. This took us ages to debug and we want to make this easier for other users to discover. I am however not sure, if this should rather be considered a bug. I'm not convinced that uploading files should use the default timeout at all.
