### PR TITLE
Remove beta badge for React Renderer (stable release)

### DIFF
--- a/docusaurus/docs/user-docs/content-type-builder/configuring-fields-content-type.md
+++ b/docusaurus/docs/user-docs/content-type-builder/configuring-fields-content-type.md
@@ -113,7 +113,7 @@ The Rich Text (Blocks) field displays an editor with live rendering and various 
 </Tabs>
 
 :::strapi React renderer
-If using the Blocks editor, we recommend that you also use the [Strapi Blocks React Renderer](https://github.com/strapi/blocks-react-renderer) <BetaBadge /> to easily render the content in a React frontend.
+If using the Blocks editor, we recommend that you also use the [Strapi Blocks React Renderer](https://github.com/strapi/blocks-react-renderer) to easily render the content in a React frontend.
 :::
 
 ### <img width="28" src="/img/assets/icons/ctb_number.svg" /> Number


### PR DESCRIPTION
Remove Beta Badge in React Renderer callout (Configuring fields for content-types).