### PR TITLE
Fix code examples in custom fields documentation

### DIFF
--- a/docusaurus/docs/dev-docs/custom-fields.md
+++ b/docusaurus/docs/dev-docs/custom-fields.md
@@ -148,7 +148,7 @@ export default {
       components: {
         Input: async () =>
           import(
-            /* webpackChunkName: "input-component" */ "./admin/src/components/Input"
+            /* webpackChunkName: "input-component" */ "./components/Input"
           ),
       },
       options: {
@@ -219,7 +219,7 @@ import * as React from "react";
 
 import { useIntl } from "react-intl";
 
-export const Input = React.forwardRef((props, ref) => {
+const Input = React.forwardRef((props, ref) => {
   const { attribute, disabled, intlLabel, name, onChange, required, value } =
     props; // these are just some of the props passed by the content-manager
 
@@ -233,7 +233,7 @@ export const Input = React.forwardRef((props, ref) => {
 
   return (
     <label>
-      {intlLabel}
+      {formatMessage(intlLabel)}
       <input
         ref={ref}
         name={name}
@@ -245,6 +245,8 @@ export const Input = React.forwardRef((props, ref) => {
     </label>
   );
 });
+
+export default Input;
 ```
 
 </details>

--- a/docusaurus/docs/dev-docs/custom-fields.md
+++ b/docusaurus/docs/dev-docs/custom-fields.md
@@ -11,7 +11,7 @@ import CustomFieldRequiresPlugin from '/docs/snippets/custom-field-requires-plug
 
 Custom fields extend Strapi’s capabilities by adding new types of fields to content-types and components. Once created or added to Strapi via plugins, custom fields can be used in the Content-Type Builder and Content Manager just like built-in fields.
 
-The present documentation is intended for custom field creators: it describes which APIs and functions developers must use to create a new custom field. The [user guide](/user-docs/plugins/introduction-to-plugins.md#custom-fields) describes how to add and use custom fields from Strapi's admin panel.
+The present documentation is intended for custom field creators: it describes which APIs and functions developers must use to create a new custom field. The [User Guide](/user-docs/plugins/introduction-to-plugins.md#custom-fields) describes how to add and use custom fields from Strapi's admin panel.
 
 It is recommended that you develop a dedicated [plugin](/dev-docs/plugins-development) for custom fields. Custom field plugins include both a server and admin panel part. The custom field must be registered in both parts before it is usable in Strapi's admin panel.
 

--- a/docusaurus/docs/user-docs/plugins/introduction-to-plugins.md
+++ b/docusaurus/docs/user-docs/plugins/introduction-to-plugins.md
@@ -42,6 +42,6 @@ Currently, the only plugins designed to work with providers are the:
 
 ## Custom fields
 
-Some plugins can add _custom fields_ to Strapi. Custom fields are a way to extend Strapi’s capabilities by adding new types of fields to content-types or components.
+Some plugins can add custom fields to Strapi (for additional information about creating custom fields plugins, see [Developer Docs](/dev-docs/custom-fields)). Custom fields are a way to extend Strapi’s capabilities by adding new types of fields to content-types or components.
 
 Once added to Strapi (see [Marketplace](./installing-plugins-via-marketplace.md)), custom fields can be created in the [Content-type Builder](/user-docs/content-type-builder/configuring-fields-content-type#custom-fields) and used in the [Content Manager](/user-docs/content-manager/writing-content/).


### PR DESCRIPTION
Fixes a few errors in code examples for the custom fields documentation:
- missing export for Input component
- invalid use of formatMessage
- invalid path for dynamic import of Input component

 +also slightly improves the user guide