### PR TITLE
Updates the loading order to load logger middleware first 

### DIFF
--- a/docusaurus/docs/dev-docs/configurations/middlewares.md
+++ b/docusaurus/docs/dev-docs/configurations/middlewares.md
@@ -35,6 +35,7 @@ The `./config/middlewares.js` file exports an array, where order matters and con
 
 module.exports = [
   // The array is pre-populated with internal, built-in middlewares, prefixed by `strapi::`
+  'strapi::logger',
   'strapi::errors',
   'strapi::security',
   'strapi::cors',
@@ -67,7 +68,6 @@ module.exports = [
   },
 
   // remaining internal & built-in middlewares
-  'strapi::logger',
   'strapi::query',
   'strapi::body',
   'strapi::session',
@@ -84,6 +84,7 @@ module.exports = [
 
 export default [
   // The array is pre-populated with internal, built-in middlewares, prefixed by `strapi::`
+  'strapi::logger',
   'strapi::cors',
   'strapi::body',
   'strapi::errors',

--- a/docusaurus/docs/dev-docs/migration-guides.md
+++ b/docusaurus/docs/dev-docs/migration-guides.md
@@ -29,6 +29,7 @@ If there is no specific migration guide between your current version and the lat
 - [Migration guide from 4.6.1 to 4.7.0](/dev-docs/migration/v4/migration-guide-4.6.1-to-4.7.0)
 - [Migration guide from 4.7.0 to 4.11.4](/dev-docs/migration/v4/migration-guide-4.7.0-to-4.11.4)
 - [Migration guide from 4.11.4 to 4.14.0](/dev-docs/migration/v4/migration-guide-4.11.4-to-4.14.0)
+- [Migration guide from 4.14.0 to 4.15.6](/dev-docs/migration/v4/migration-guide-4.14.0-to-4.15.6)
 
 ## v3 to v4 migration guides
 

--- a/docusaurus/docs/dev-docs/migration/v4/migration-guide-4.14.0-to-4.15.6.md
+++ b/docusaurus/docs/dev-docs/migration/v4/migration-guide-4.14.0-to-4.15.6.md
@@ -1,0 +1,92 @@
+---
+title: Migrate from 4.14.0 to 4.15.6
+displayed_sidebar: devDocsSidebar
+description: Learn how you can migrate your Strapi application from 4.14.0 to 4.15.6.
+---
+
+import PluginsCaution from '/docs/snippets/migrate-plugins-extension-caution.md'
+import BuildCommand from '/docs/snippets/build-npm-yarn.md'
+import DevelopCommand from '/docs/snippets/develop-npm-yarn.md'
+import InstallCommand from '/docs/snippets/install-npm-yarn.md'
+
+# v4.14.0 to v4.15.6 migration guide
+
+The present migration guide upgrades Strapi v4.14.0 to v4.15.6. Strapi v4.15.6 updated the [loading order](/dev-docs/configurations/middlewares#loading-order) of the middlewares, ensuring the [`logger` middleware](/dev-docs/configurations/middlewares#logger) is loaded first. The migration guide consists of:
+
+- Upgrading the application dependencies
+- Manually updating the loading order of middlewares in the configuration file
+- Reinitializing the application
+
+<PluginsCaution components={props.components} />
+
+
+## Upgrading the application dependencies to 4.15.6
+
+:::prerequisites
+Stop the server before starting the upgrade.
+:::
+
+1. Upgrade all of the Strapi packages in `package.json` to `4.15.6`:
+
+   ```json title="path: package.json"
+   {
+     // ...
+     "dependencies": {
+       "@strapi/strapi": "4.15.6",
+       "@strapi/plugin-users-permissions": "4.15.6",
+       "@strapi/plugin-i18n": "4.15.6"
+       // ...
+     }
+   }
+   ```
+
+2. Save the edited `package.json` file.
+
+3. Run the install command:
+   <InstallCommand components={props.components} />
+
+## Manually update the loading order of middlewares
+
+Manually update the [`config/middlewares.js` configuration file](/dev-docs/configurations/middlewares) to ensure that `strapi::logger` is the first item in the array:
+
+<Tabs groupId="js-ts">
+
+<TabItem value="javascript" label="JavaScript">
+
+```js title="./config/middlewares.js" {3}
+
+module.exports = [
+  'strapi::logger',
+  'strapi::errors',
+  'strapi::security',
+  'strapi::cors',
+  // …
+];
+```
+
+</TabItem>
+
+<TabItem value="typescript" label="TypeScript">
+
+```ts title="./config/middlewares.ts" {3}
+
+export default [
+  'strapi::logger',
+  'strapi::cors',
+  'strapi::body',
+  'strapi::errors',
+  // …
+]
+```
+
+</TabItem>
+
+</Tabs>
+
+## Rebuild the application
+
+<BuildCommand components={props.components} />
+
+## Restart the application
+
+<DevelopCommand components={props.components} />


### PR DESCRIPTION
This PR:

- updates the code examples in the config/middleware documentation
- adds a migration guide to handle the change

Related community PR: https://github.com/strapi/strapi/pull/16921