### PR TITLE
Fix start file TypeScript example in pm2 documentation

### DIFF
--- a/docusaurus/docs/dev-docs/deployment/process-manager.md
+++ b/docusaurus/docs/dev-docs/deployment/process-manager.md
@@ -62,9 +62,9 @@ strapi().start();
 <TabItem value="typescript" label="TypeScript">
 
 ```ts title="path: ./server.js"
-const strapi = require('@strapi/strapi');
-    const app = strapi({ distDir: '<path_to_your_out_dir>' });
-    app.start();
+const strapi = require("@strapi/strapi");
+const app = strapi({ distDir: "./dist" });
+app.start();
 ```
 
 </TabItem>


### PR DESCRIPTION
### What does it do?

Making the process manager example for the start file match the typescript page example:

- https://docs.strapi.io/dev-docs/deployment/process-manager#start-pm2-with-a-serverjs-file
- https://docs.strapi.io/dev-docs/typescript#start-strapi-programmatically

### Why is it needed?

Some people decided to copy/paste the example and not change the path (I guess some people can't read? :sweat_smile: )

### Related issue(s)/PR(s)

N/A
