### PR TITLE
Fix incorrect examples of PolicyError

### DIFF
--- a/docusaurus/docs/dev-docs/error-handling.md
+++ b/docusaurus/docs/dev-docs/error-handling.md
@@ -405,6 +405,8 @@ The `ForbiddenError` class is a specific error class used when a user either doe
 | --- | --- | --- | --- |
 | `message` | `string` | The error message | `Forbidden access` |
 
+Note: `ForbiddenError` message contents will not be displayed to the Content API and will be returned to the user as an empty `UnauthorizedError`
+
 ```js
 throw new ForbiddenError('Ah ah ah, you didn\'t say the magic word');
 ```
@@ -418,6 +420,8 @@ The `UnauthorizedError` class is a specific error class used when a user doesn't
 | Parameter | Type | Description | Default |
 | --- | --- | --- | --- |
 | `message` | `string` | The error message | `Unauthorized` |
+
+Note: `UnauthorizedError` message contents will not be displayed to the Content API and will be returned to the user as an empty `UnauthorizedError`
 
 ```js
 throw new UnauthorizedError('You shall not pass!');
@@ -465,6 +469,8 @@ The `PolicyError` class is a specific error designed to be used with [route poli
 ```js
 throw new PolicyError('Something went wrong', { policy: 'my-policy' });
 ```
+
+Note: Because `PolicyError` extends `ForbiddenError`, it will not be displayed to the Content API and will be returned to the user as an empty `ForbiddenError` and you will need to use a different error type in your policy if you want it to be visible in the Content API.
 
 </TabItem>
 


### PR DESCRIPTION
### What does it do?

PolicyErrors are not visible in the content api in Strapi v4, so we need to update the documentation to reflect that.

See https://github.com/strapi/strapi/pull/19092 for discussion

Note that in v5 this will change, very likely to allow PolicyErrors to be visible in the content API

### Why is it needed?

Docs are incorrect

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/pull/19092
