### PR TITLE
Fix broken nodejs releases documentation link

### DIFF
--- a/docusaurus/docs/snippets/installation-prerequisites.md
+++ b/docusaurus/docs/snippets/installation-prerequisites.md
@@ -1,6 +1,6 @@
 Before installing Strapi, the following requirements must be installed on your computer:
 
-- [Node.js](https://nodejs.org): Only [Active LTS or Maintenance LTS versions](https://nodejs.dev/en/about/releases/) are supported (currently `v18` and `v20`). Odd-number releases of Node, known as "current" versions of Node.js, are not supported (e.g. v19, v21).
+- [Node.js](https://nodejs.org): Only [Active LTS or Maintenance LTS versions](https://nodejs.org/en/about/previous-releases) are supported (currently `v18` and `v20`). Odd-number releases of Node, known as "current" versions of Node.js, are not supported (e.g. v19, v21).
 - Your preferred Node.js package manager:
     - [npm](https://docs.npmjs.com/cli/v6/commands/npm-install) (`v6` and above)
     - [yarn](https://yarnpkg.com/getting-started/install)


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

Fixes the broken link at [quick-start page](https://docs.strapi.io/dev-docs/quick-start) redirection to the nodejs version releases page, in nodejs documentation.

```diff
- https://nodejs.dev/en/about/releases/
+ https://nodejs.org/en/about/previous-releases 
```

### Why is it needed?

For easier user redirection.
