### PR TITLE
chore: fix relative paths on models page

### DIFF
--- a/docusaurus/docs/dev-docs/backend-customization/models.md
+++ b/docusaurus/docs/dev-docs/backend-customization/models.md
@@ -83,7 +83,7 @@ General settings for the model can be configured with the following parameters:
 | `kind`<br /><br />_Optional,<br/>only for content-types_ | String | Defines if the content-type is:<ul><li>a collection type (`collectionType`)</li><li>or a single type (`singleType`)</li></ul> |
 
 ```json
-// ./api/[api-name]/content-types/restaurant/schema.json
+// ./src/api/[api-name]/content-types/restaurant/schema.json
 
 {
   "kind": "collectionType",
@@ -653,7 +653,7 @@ Lifecycle hooks are functions that take an `event` parameter, an object with the
 
 ### Declarative and programmatic usage
 
-To configure a content-type lifecycle hook, create a `lifecycles.js` file in the `./api/[api-name]/content-types/[content-type-name]/` folder.
+To configure a content-type lifecycle hook, create a `lifecycles.js` file in the `./src/api/[api-name]/content-types/[content-type-name]/` folder.
 
 Each event listener is called sequentially. They can be synchronous or asynchronous.
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

change relative paths in documentation to point to the correct files
<img width="177" alt="Screenshot 2024-01-06 at 12 31 44" src="https://github.com/strapi/documentation/assets/17953978/43f749a6-c969-41bb-b83f-103b6f91e4f2">

### Why is it needed?

Consistency with other content on documentation page.
- https://docs.strapi.io/dev-docs/backend-customization/models all other paths seem to include the `/src/`

### Related issue(s)/PR(s)

none
