### PR TITLE
Add information about Vue Strapi Blocks Renderer

### DIFF
--- a/docusaurus/docs/user-docs/content-type-builder/configuring-fields-content-type.md
+++ b/docusaurus/docs/user-docs/content-type-builder/configuring-fields-content-type.md
@@ -112,8 +112,14 @@ The Rich Text (Blocks) field displays an editor with live rendering and various 
 
 </Tabs>
 
-:::strapi React renderer
-If using the Blocks editor, we recommend that you also use the [Strapi Blocks React Renderer](https://github.com/strapi/blocks-react-renderer) to easily render the content in a React frontend.
+:::Strapi Frontend Renderer
+
+When leveraging the Blocks editor within Strapi, it is highly advisable to complement your workflow with the following tools for seamless content rendering on the frontend:
+
+* [Strapi Blocks React Renderer](https://github.com/strapi/blocks-react-renderer) - The official React library designed for optimal integration.
+* [Vue Strapi Blocks Renderer](https://github.com/niklasfjeldberg/vue-strapi-blocks-renderer) - A community-backed library, serving as a backport for the Vue framework.
+
+Enhance your development experience with these libraries to unlock the full potential of the Strapi Blocks editor.
 :::
 
 ### <img width="28" src="/img/assets/icons/ctb_number.svg" /> Number

--- a/docusaurus/docs/user-docs/content-type-builder/configuring-fields-content-type.md
+++ b/docusaurus/docs/user-docs/content-type-builder/configuring-fields-content-type.md
@@ -112,7 +112,7 @@ The Rich Text (Blocks) field displays an editor with live rendering and various 
 
 </Tabs>
 
-:::Strapi Frontend Renderer
+:::strapi Frontend Renderer
 
 When leveraging the Blocks editor within Strapi, it is highly advisable to complement your workflow with the following tools for seamless content rendering on the frontend:
 


### PR DESCRIPTION
### What does it do?

This pull request enhances the documentation for the Strapi Frontend Renderer. Specifically, it provides detailed information on utilizing the Blocks editor and recommends using two libraries for optimal frontend content rendering:

1. [Strapi Blocks React Renderer](https://github.com/strapi/blocks-react-renderer): The official React library tailored for seamless integration.
2. [Vue Strapi Blocks Renderer](https://github.com/niklasfjeldberg/vue-strapi-blocks-renderer): A community-supported library serving as a backport for the Vue framework.

### Why is it needed?

This enhancement is crucial for developers using the Strapi Blocks editor. It offers clear guidance on leveraging the recommended libraries, ensuring a smoother workflow and improved rendering of content on the frontend. By following these suggestions, developers can enhance their development experience with Strapi.

### Related issue(s)/PR(s)

This pull request is in reference to the documentation enhancement and does not directly relate to any specific issue or pull request.