### PR TITLE
Fixed sso okta caution block placement

### DIFF
--- a/docusaurus/docs/dev-docs/configurations/sso.md
+++ b/docusaurus/docs/dev-docs/configurations/sso.md
@@ -767,10 +767,6 @@ npm install --save passport-keycloak-oauth2-oidc
 
 </Tabs>
 
-:::caution
-When setting the `OKTA_DOMAIN` environment variable, make sure to include the protocol (e.g. `https://example.okta.com`). If you do not, you will end up in a redirect loop.
-:::
-
 <details>
   <summary>Configuration example for Keycloak (OpenID Connect):</summary>
   <div>
@@ -892,6 +888,11 @@ npm install --save passport-okta-oauth20
 </TabItem>
 
 </Tabs>
+
+:::caution
+When setting the `OKTA_DOMAIN` environment variable, make sure to include the protocol (e.g. `https://example.okta.com`). If you do not, you will end up in a redirect loop.
+:::
+
 <details>
   <summary>Configuration example for Okta:</summary>
   <div>


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

Fixes the misplaced Okta caution block on [Single Sign-on](https://docs.strapi.io/dev-docs/configurations/sso) page. It was misplaced under keycloak heading and users were unable to see if they visited https://docs.strapi.io/dev-docs/configurations/sso#okta url.

**Before:**
![Screenshot from 2024-01-15 13-18-28](https://github.com/strapi/documentation/assets/55325434/68154bad-cfbd-4acc-ab54-dfad7532a905)



**After:**
![Screenshot from 2024-01-15 13-18-47](https://github.com/strapi/documentation/assets/55325434/5034b882-7979-4b60-966b-38b927742750)


### Why is it needed?

Improves visibility and relevancy of the caution block.