### PR TITLE
admin-panel-customization#favicon: Err code with `./extensions`

### DIFF
--- a/docusaurus/docs/dev-docs/admin-panel-customization.md
+++ b/docusaurus/docs/dev-docs/admin-panel-customization.md
@@ -452,7 +452,7 @@ To replace the favicon, use the following procedure:
 4. Update `./src/admin/app.js` with the following:
 
    ```js title="./src/admin/app.js"
-   import favicon from "./extensions/favicon.png";
+   import favicon from "../extensions/favicon.png";
 
    export default {
      config: {


### PR DESCRIPTION
Because I tested this example to replace the favicon, and I've got an error.

```bash
yarn run v1.22.19
$ strapi build
⠋ Building build context
[INFO] Including the following ENV variables as part of the JS bundle:
    - ADMIN_PATH
    - STRAPI_ADMIN_BACKEND_URL
    - STRAPI_TELEMETRY_DISABLED
✔ Building build context (73ms)
⠋ Building admin panel
⠴ Building admin panel[ERROR] Module not found: Error: Can't resolve './extensions/favicon.png' in '/var/www/strapi/src/admin'
✖ Building admin panel
[ERROR]  There seems to be an unexpected error, try again with --debug for more information

error Command failed with exit code 1.
```

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

I changed the example code at https://docs.strapi.io/dev-docs/admin-panel-customization#favicon

### Why is it needed?

Just adding a dot to `../extensions` 

