### PR TITLE
Updates for the stable version of Releases 

### DIFF
--- a/docusaurus/docs/user-docs/content-manager/adding-content-to-releases.md
+++ b/docusaurus/docs/user-docs/content-manager/adding-content-to-releases.md
@@ -4,7 +4,7 @@ description: Instructions to include content in a release
 displayed_sidebar: userDocsSidebar
 ---
 
-# Including content in a release  <EnterpriseBadge /> <CloudTeamBadge /> <FutureBadge /> <BetaBadge />
+# Including content in a release  <EnterpriseBadge /> <CloudTeamBadge />
 
 Using the [Releases](/user-docs/releases/introduction) feature, you can group several entries to publish them altogether. Adding entries to a release is done from the Content Manager. You can also remove an entry from a release while updating the entry.
 

--- a/docusaurus/docs/user-docs/releases/creating-a-release.md
+++ b/docusaurus/docs/user-docs/releases/creating-a-release.md
@@ -3,7 +3,7 @@ title: Creating a release
 description: Instructions to create a release from the admin panel
 ---
 
-# Creating a release  <EnterpriseBadge /> <CloudTeamBadge /> <FutureBadge /> <BetaBadge />
+# Creating a release  <EnterpriseBadge /> <CloudTeamBadge />
 
 The [Releases](/user-docs/releases/introduction) page allows creating new releases that will be used to organize entries.
 

--- a/docusaurus/docs/user-docs/releases/creating-a-release.md
+++ b/docusaurus/docs/user-docs/releases/creating-a-release.md
@@ -26,7 +26,7 @@ To create a new release:
 
 Adding entries to a release must be done from the Content Manager. You can add a single entry to a release while creating or editing the entry [in the edit view](/user-docs/content-manager/adding-content-to-releases).
 
-<!-- TODO: for later, when multiple addition is implemented -->
+<!-- TODO: for later, when multiple addition is implemented, probably in 4.20 -->
 <!-- 
 Adding entries to a release must be done from the Content Manager:
 

--- a/docusaurus/docs/user-docs/releases/introduction.md
+++ b/docusaurus/docs/user-docs/releases/introduction.md
@@ -3,12 +3,9 @@ title: Introduction to Releases
 description: Introduction to the Releases feature that enables content managers to organize entries to publish/unpublish simultaneously
 ---
 
-# Releases <EnterpriseBadge /> <CloudTeamBadge/> <FutureBadge /> <BetaBadge/>
+# Releases <EnterpriseBadge /> <CloudTeamBadge/>
 
 Releases enables content managers to organize entries into containers that can perform publish and unpublish actions simultaneously. A release can contain entries from different content types and can mix locales.
-
-
-Releases is currently only available as an experimental feature. To enable it, set the appropriate future flag. See <a href="/dev-docs/configurations/features">future flags</a> documentation for instructions on how to enable a future flag.
 
 <ThemedImage
   alt="List of Releases"

--- a/docusaurus/docs/user-docs/releases/managing-a-release.md
+++ b/docusaurus/docs/user-docs/releases/managing-a-release.md
@@ -4,7 +4,7 @@ description: Instructions on how to manage a Release from the admin panel
 ---
 
 
-# Managing a release <EnterpriseBadge /> <CloudTeamBadge /> <FutureBadge />  <BetaBadge />
+# Managing a release <EnterpriseBadge /> <CloudTeamBadge />
 
 Adding entries to a [release](/user-docs/releases/introduction) allow viewing them altogether on a single page.
 

--- a/docusaurus/docs/user-docs/releases/managing-a-release.md
+++ b/docusaurus/docs/user-docs/releases/managing-a-release.md
@@ -53,6 +53,10 @@ Entries can be removed from a release. To do so, click the ![More icon](/img/ass
 
 Publishing a release means that all the actions (publish or unpublish) defined for each entry included in the release will be performed simultaneously. To publish a release, click the **Publish** button in the top right corner of the admin panel.
 
+:::note
+If a validation error occurs in the status of an entry, you will need to fix this before being able to publish the release. This usually happens when a required field is empty in a given entry.
+:::
+
 :::caution
 Once a release is published, the release itself cannot be updated. You can not re-release that specific release with the same group of entries with some modifications; you must create another release.
 :::

--- a/docusaurus/docs/user-docs/releases/managing-a-release.md
+++ b/docusaurus/docs/user-docs/releases/managing-a-release.md
@@ -36,12 +36,7 @@ You can rename a release. To do so, while on a release page:
 3. In the modal, change the name of the release in the _Name_ field.
 4. Click **Continue** to save the change.
 
-## Choose how entries are grouped
-
-:::callout 🚧 Beta feature
-Use the following command to install the latest version of this feature:
-`npx create-strapi-app@beta`
-:::
+## Choosing how entries are grouped
 
 A release page can display entries either grouped by locale, content-type, or action (publish or unpublish). To change how entries are grouped, click the **Group by …** dropdown and select an option from the list.
 

--- a/docusaurus/docs/user-docs/releases/managing-a-release.md
+++ b/docusaurus/docs/user-docs/releases/managing-a-release.md
@@ -40,11 +40,11 @@ You can rename a release. To do so, while on a release page:
 
 A release page can display entries either grouped by locale, content-type, or action (publish or unpublish). To change how entries are grouped, click the **Group by …** dropdown and select an option from the list.
 
-## Publish or unpublish entries
+## Publishing or unpublishing entries
 
 A release includes multiple entries. You can set the state of each entry with the **Publish** and **Unpublish** action buttons. When the release itself is “published” then the desired actions will be simultaneously performed on each entry.
 
-<!-- TODO: re-add when implemented -->
+## Removing entries from a release
 <!-- ## Remove entries from a release
 
 Entries can be removed from a release. To do so, click the three dots **…** at the end of the line of an entry and select the **Remove from release** button. -->

--- a/docusaurus/docs/user-docs/releases/managing-a-release.md
+++ b/docusaurus/docs/user-docs/releases/managing-a-release.md
@@ -45,7 +45,6 @@ A release page can display entries either grouped by locale, content-type, or ac
 A release includes multiple entries. You can set the state of each entry with the **Publish** and **Unpublish** action buttons. When the release itself is “published” then the desired actions will be simultaneously performed on each entry.
 
 ## Removing entries from a release
-<!-- ## Remove entries from a release
 
 Entries can be removed from a release. To do so, click the ![More icon](/img/assets/icons/more.svg) at the end of the line of an entry and select the **Remove from release** button.
 

--- a/docusaurus/docs/user-docs/releases/managing-a-release.md
+++ b/docusaurus/docs/user-docs/releases/managing-a-release.md
@@ -47,7 +47,7 @@ A release includes multiple entries. You can set the state of each entry with th
 ## Removing entries from a release
 <!-- ## Remove entries from a release
 
-Entries can be removed from a release. To do so, click the three dots **…** at the end of the line of an entry and select the **Remove from release** button. -->
+Entries can be removed from a release. To do so, click the ![More icon](/img/assets/icons/more.svg) at the end of the line of an entry and select the **Remove from release** button.
 
 ## Publishing a release
 


### PR DESCRIPTION
This PR updates the Releases and CM docs:
- removes beta and future flags badges and mentions
- mentions ability to remove an entry from a release (releases page)
- mentions validaiton errors