### PR TITLE
[Strapi 5️⃣] Removal of `isSupportedImage`

### DIFF
--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes.md
@@ -3,7 +3,7 @@ title: Breaking changes
 description: View the list of all breaking changes introduced between Strapi v4 and v5.
 displayed_sidebar: devDocsMigrationV5Sidebar
 tags:
- - breaking-changes
+ - breaking changes
 ---
 
 # Strapi v4 to v5 breaking changes
@@ -34,3 +34,4 @@ The following changes affect the databases interacting with your Strapi applicat
 ## Strapi objects and methods
 
 - [`strapi.fetch` uses the native `fetch()` API](/dev-docs/migration/v4-to-v5/breaking-changes/fetch)
+- [The `isSupportedImage` method is removed](/dev-docs/migration/v4-to-v5/breaking-changes/is-supported-image-removed)

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/is-supported-image-removed.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/is-supported-image-removed.md
@@ -1,7 +1,7 @@
 ---
-title: Strapi 5 uses React Router DOM 6
+title: The isSupportedImage method is removed in Strapi 5
 description: Database identifiers are shortened in Strapi v5 and can't be longer than 53 characters to avoid issues with identifiers that are too long.
-sidebar_label: Database identifiers shortened
+sidebar_label: isSupportedImage removed
 displayed_sidebar: devDocsMigrationV5Sidebar
 tags:
  - breaking changes

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/is-supported-image-removed.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/is-supported-image-removed.md
@@ -1,0 +1,50 @@
+---
+title: Strapi 5 uses React Router DOM 6
+description: Database identifiers are shortened in Strapi v5 and can't be longer than 53 characters to avoid issues with identifiers that are too long.
+sidebar_label: Database identifiers shortened
+displayed_sidebar: devDocsMigrationV5Sidebar
+tags:
+ - breaking changes
+ - upload plugin
+---
+
+import Intro from '/docs/snippets/breaking-change-page-intro.md'
+import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
+
+# The `isSupportedImage` method is removed
+
+The `isSupportedImage` method has been issuing a deprecation warning ever since v4, and is finally being removed in Strapi 5.
+
+ <Intro />
+
+## Breaking change description
+
+<SideBySideContainer>
+
+<SideBySideColumn>
+
+**In Strapi v4**
+
+The `isSupportedImage` method is supported, but deprecated.
+
+</SideBySideColumn>
+
+<SideBySideColumn>
+
+**In Strapi v5**
+
+The `isSupportedImage` method is removed.
+
+Developers must use either `isImage` to check if a file is an image, or `isOptimizableImage` to check if the file is an image that can be optimized.
+
+</SideBySideColumn>
+
+</SideBySideContainer>
+
+## Migration
+
+<MigrationIntro />
+
+### Manual procedure
+
+Replace occurences of the `isSupportedImage` method in your code by the appropriate method, `isImage` or `isOptimizableImage`, depending on your needs.

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/is-supported-image-removed.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/is-supported-image-removed.md
@@ -1,6 +1,6 @@
 ---
 title: The isSupportedImage method is removed in Strapi 5
-description: Database identifiers are shortened in Strapi v5 and can't be longer than 53 characters to avoid issues with identifiers that are too long.
+description: The `isSupportedImage` method is removed in Strapi 5. Users should use `isImage` or `isOptimizableImage` instead.
 sidebar_label: isSupportedImage removed
 displayed_sidebar: devDocsMigrationV5Sidebar
 tags:

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -1050,7 +1050,8 @@ const sidebars = {
               label: "Strapi objects and methods",
               collapsed: false,
               items: [
-                'dev-docs/migration/v4-to-v5/breaking-changes/fetch'
+                'dev-docs/migration/v4-to-v5/breaking-changes/fetch',
+                'dev-docs/migration/v4-to-v5/breaking-changes/is-supported-image-removed',
               ]
             },
           ]


### PR DESCRIPTION
This documents the breaking change related to the removal of `isSupportedImage()` in Strapi 5

Direct preview link 👉 [here](https://documentation-git-v5-breaking-changes-is-suppor-c1adc7-strapijs.vercel.app/dev-docs/migration/v4-to-v5/breaking-changes/is-supported-image-removed)