### PR TITLE
mention local file upload path

### DIFF
--- a/docusaurus/docs/dev-docs/plugins/upload.md
+++ b/docusaurus/docs/dev-docs/plugins/upload.md
@@ -8,7 +8,7 @@ description: Upload any kind of file on your server or external providers.
 
 The Upload plugin is the backend powering the Media Library plugin available by default in the Strapi admin panel. Using either the Media Library from the admin panel or the upload API directly, you can upload any kind of file for use in your Strapi application.
 
-By default Strapi provides a [provider](/dev-docs/providers) that uploads files to a local directory. Additional providers are available should you want to upload your files to another location.
+By default Strapi provides a [provider](/dev-docs/providers) that uploads files to a local directory, which by default will be `public/uploads/` in your Strapi project. Additional providers are available should you want to upload your files to another location.
 
 The providers maintained by Strapi include:
 


### PR DESCRIPTION
To save others time researching this information I just added where the standard upload plugin is writing the upload files.

### What does it do?

Specify in the docs where the standard file upload plugin is storing files locally.

### Why is it needed?

I could not find this information anywhere.
