### PR TITLE
[Strapi 5] Breaking change for `strapi.container`

### DIFF
--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes.md
@@ -35,6 +35,7 @@ The following changes affect the databases interacting with your Strapi applicat
 
 - [`strapi.fetch` uses the native `fetch()` API](/dev-docs/migration/v4-to-v5/breaking-changes/fetch)
 - [The `isSupportedImage` method is removed in Strapi 5](/dev-docs/migration/v4-to-v5/breaking-changes/is-supported-image-removed)
+- [`Strapi` is a subclass of `Container`](/dev-docs/migration/v4-to-v5/breaking-changes/strapi-container)
 
 ## Dependencies
 

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes.md
@@ -6,7 +6,7 @@ tags:
  - breaking changes
 ---
 
-# Strapi v4 to v5 breaking changes
+# Strapi v4 to Strapi 5 breaking changes
 
 :::callout 🚧  Work in progress
 This page is a work-in-progress and the list of breaking changes will grow over time.

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/strapi-container.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/strapi-container.md
@@ -13,7 +13,7 @@ import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.
 
 # `Strapi` is a subclass of `Container`
 
-In Strapi v5, `Strapi` is a subclass of the `Container` to make it simpler to access services and unify the service access with one method. <Intro />
+In Strapi 5, `Strapi` is a subclass of the `Container` to make it simpler to access services and unify the service access with one method. <Intro />
 
 ## Breaking change description
 
@@ -34,7 +34,7 @@ strapi.container.get(...)
 
 <SideBySideColumn>
 
-**In Strapi v5**
+**In Strapi 5**
 
 Container methods are accessed like follows:
 

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/strapi-container.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/strapi-container.md
@@ -13,7 +13,7 @@ import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.
 
 # `Strapi` is a subclass of `Container`
 
-In Strapi 5, `Strapi` is a subclass of the `Container` to make it simpler to access services and unify the service access with one method. <Intro />
+In Strapi 5, `Strapi` is a subclass of the `Container` class to make it simpler to access services and unify the service access with one method. <Intro />
 
 ## Breaking change description
 

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/strapi-container.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/strapi-container.md
@@ -13,7 +13,9 @@ import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.
 
 # `Strapi` is a subclass of `Container`
 
-In Strapi 5, `Strapi` is a subclass of the `Container` class to make it simpler to access services and unify the service access with one method. <Intro />
+In Strapi 5, `Strapi` is a subclass of the `Container` class to make it simpler to access services and unify the service access with one method.
+
+<Intro />
 
 ## Breaking change description
 

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/strapi-container.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/strapi-container.md
@@ -1,0 +1,56 @@
+---
+title: Strapi is a subclass of Container
+description: In Strapi 5, container methods can be accessed directly from the strapi class.
+sidebar_label: Strapi subclass of Container
+displayed_sidebar: devDocsMigrationV5Sidebar
+tags:
+ - breaking changes
+ - strapi container
+---
+
+import Intro from '/docs/snippets/breaking-change-page-intro.md'
+import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
+
+# `Strapi` is a subclass of `Container`
+
+In Strapi v5, `Strapi` is a subclass of the `Container` to make it simpler to access services and unify the service access with one method. <Intro />
+
+## Breaking change description
+
+<SideBySideContainer>
+
+<SideBySideColumn>
+
+**In Strapi v4**
+
+Container methods are accessed like follows:
+
+```js
+strapi.container.register(....)
+strapi.container.get(...)
+```
+
+</SideBySideColumn>
+
+<SideBySideColumn>
+
+**In Strapi v5**
+
+Container methods are accessed like follows:
+
+```js
+strapi.add(....)
+strapi.get(...)
+```
+
+</SideBySideColumn>
+
+</SideBySideContainer>
+
+## Migration
+
+<MigrationIntro />
+
+### Manual procedure
+
+Ensure you update your method calls to `container`.

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -1052,6 +1052,7 @@ const sidebars = {
               items: [
                 'dev-docs/migration/v4-to-v5/breaking-changes/fetch',
                 'dev-docs/migration/v4-to-v5/breaking-changes/is-supported-image-removed',
+                'dev-docs/migration/v4-to-v5/breaking-changes/strapi-container',
               ]
             },
             {


### PR DESCRIPTION
In Strapi 5, `Strapi` is a subclass of the `Container` to make it simpler to access services and unify the service access with one method.

Direct preview link 👉  [here](https://documentation-git-v5-breaking-changes-strapi-container-strapijs.vercel.app/dev-docs/migration/v4-to-v5/breaking-changes/strapi-container)