### PR TITLE
[Strapi 5] Breaking change for CM redux store

### DIFF
--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes.md
@@ -36,6 +36,10 @@ The following changes affect the databases interacting with your Strapi applicat
 - [`strapi.fetch` uses the native `fetch()` API](/dev-docs/migration/v4-to-v5/breaking-changes/fetch)
 - [The `isSupportedImage` method is removed in Strapi 5](/dev-docs/migration/v4-to-v5/breaking-changes/is-supported-image-removed)
 
+## Content Manager
+
+- [The `ContentManagerAppState` redux is modified](/dev-docs/migration/v4-to-v5/breaking-changes/redux-content-manager-app-state)
+
 ## Dependencies
 
 - [Strapi 5 uses react-router-dom v6](/dev-docs/migration/v4-to-v5/breaking-changes/react-router-dom-6)

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/redux-content-manager-app-state.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/redux-content-manager-app-state.md
@@ -32,6 +32,18 @@ The redux store can fire the following actions:
 - `'ContentManager/App/GET_INIT_DATA’`
 - `'ContentManager/App/SET_INIT_DATA’`
 
+The payload nests attributes inside the `data` object. For instance, for the `SET_INIT_DATA` action, the payload is of the following format:
+
+```json
+  data: {
+    authorizedCollectionTypeLinks: ContentManagerAppState['collectionTypeLinks'];
+    authorizedSingleTypeLinks: ContentManagerAppState['singleTypeLinks'];
+    components: ContentManagerAppState['components'];
+    contentTypeSchemas: ContentManagerAppState['models'];
+    fieldSizes: ContentManagerAppState['fieldSizes'];
+  };
+```
+
 </SideBySideColumn>
 
 <SideBySideColumn>
@@ -42,6 +54,18 @@ The redux store no longer fires the following actions:
 
 - `'ContentManager/App/RESET_INIT_DATA’`
 - `'ContentManager/App/GET_INIT_DATA’`
+
+The payload data does not nest attributes within a `data` object anymore. For instance, for the `SET_INIT_DATA` action, the payload is of the following format:
+
+```json
+{
+  authorizedCollectionTypeLinks: ContentManagerAppState['collectionTypeLinks'];
+  authorizedSingleTypeLinks: ContentManagerAppState['singleTypeLinks'];
+  components: ContentManagerAppState['components'];
+  contentTypeSchemas: ContentManagerAppState['models'];
+  fieldSizes: ContentManagerAppState['fieldSizes'];
+}
+```
 
 </SideBySideColumn>
 
@@ -54,3 +78,5 @@ The redux store no longer fires the following actions:
 ### Manual procedure
 
 The redux store in Strapi 5 continues to fire `'ContentManager/App/SET_INIT_DATA’`, so users should instead listen for this action in their middlewares only.
+
+Additionally, adjustments to your custom code might need to be done based on the new payload format.

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/redux-content-manager-app-state.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/redux-content-manager-app-state.md
@@ -1,0 +1,56 @@
+---
+title: The ContentManagerAppState redux is modified
+description: In Strapi 5, the redux store for the Content Manager has been changed and some redux actions were removed.
+sidebar_label: ContentManagerAppState redux modified
+displayed_sidebar: devDocsMigrationV5Sidebar
+tags:
+ - breaking changes
+ - Content Manager
+ - redux
+---
+
+import Intro from '/docs/snippets/breaking-change-page-intro.md'
+import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
+
+# The ContentManagerAppState redux is modified
+
+In Strapi 5, the redux store for the Content Manager has been changed and some redux actions were removed. Notably, the `useContentManagerInitData` redux state for the Content Manager has been refactored to remove `ModelsContext`. Users might be relying on the original structure in a middleware or subscriber; doing so this will break their application.
+
+<Intro />
+
+## Breaking change description
+
+<SideBySideContainer>
+
+<SideBySideColumn>
+
+**In Strapi v4**
+
+The redux store can fire the following actions:
+
+- `'ContentManager/App/RESET_INIT_DATA’`
+- `'ContentManager/App/GET_INIT_DATA’`
+- `'ContentManager/App/SET_INIT_DATA’`
+
+</SideBySideColumn>
+
+<SideBySideColumn>
+
+**In Strapi 5**
+
+The redux store no longer fires the following actions:
+
+- `'ContentManager/App/RESET_INIT_DATA’`
+- `'ContentManager/App/GET_INIT_DATA’`
+
+</SideBySideColumn>
+
+</SideBySideContainer>
+
+## Migration
+
+<MigrationIntro />
+
+### Manual procedure
+
+The redux store in Strapi 5 continues to fire `'ContentManager/App/SET_INIT_DATA’`, so users should instead listen for this action in their middlewares only.

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -1056,6 +1056,14 @@ const sidebars = {
             },
             {
               type: "category",
+              label: "Content Manager",
+              collapsed: false,
+              items: [
+                'dev-docs/migration/v4-to-v5/breaking-changes/redux-content-manager-app-state',
+              ]
+            },
+            {
+              type: "category",
               label: "Internal changes",
               collapsed: false,
               items: [


### PR DESCRIPTION
This PR documents the breaking change for Strapi 5 introduced in https://github.com/strapi/strapi/pull/19042

Direct preview link 👉 [here](https://documentation-git-v5-breaking-changes-redux-cm-strapijs.vercel.app/dev-docs/migration/v4-to-v5/breaking-changes/redux-content-manager-app-state)