### PR TITLE
[Strapi 5] Breaking change for U&P register.allowedFields

### DIFF
--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes.md
@@ -31,6 +31,10 @@ The following changes affect the databases interacting with your Strapi applicat
 - [MySQL v5 is not supported anymore](/dev-docs/migration/v4-to-v5/breaking-changes/mysql5-unsupported)
 - [Database identifiers can't be longer than 53 characters](/dev-docs/migration/v4-to-v5/breaking-changes/database-identifiers-shortened)
 
+## Plugins and their configuration
+
+- [Users & Permissions `register.allowedFields` defaults to `[]`](/dev-docs/migration/v4-to-v5/breaking-changes/register-allowed-fields)
+
 ## Strapi objects and methods
 
 - [`strapi.fetch` uses the native `fetch()` API](/dev-docs/migration/v4-to-v5/breaking-changes/fetch)

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/register-allowed-fields.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/register-allowed-fields.md
@@ -1,0 +1,51 @@
+---
+title: The Users & Permissions plugin's register.allowedFields configuration option defaults to []
+description: In Strapi 5, The Users & Permissions plugin's `register.allowedFields` configuration option defaults to [].
+sidebar_label: register.allowedFields defaults to []
+displayed_sidebar: devDocsMigrationV5Sidebar
+tags:
+ - breaking changes
+---
+
+import Intro from '/docs/snippets/breaking-change-page-intro.md'
+import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
+
+# The Users & Permissions plugin's `register.allowedFields` configuration option defaults to `[]`
+
+In Strapi 5, the Users & Permissions plugin's `register.allowedFields` configuration option defaults to `[]`.
+
+<Intro />
+
+## Breaking change description
+
+<SideBySideContainer>
+
+<SideBySideColumn>
+
+**In Strapi v4**
+
+Any new fields added to the User content type would be accepted by the registration form by default, and Strapi would warn about each field on startup.
+
+The users have the option to set `users-permissions.register.allowedFields` in the `config/plugins.js` file to an array of the fields they wanted to accept on their registration endpoint. For example, `[’picture’]` to accept a picture attribute on registration. Or an empty array `[]` if they do not want to accept anything else.
+
+However, if users did not set any value, that is, when `allowedFields` is undefined, all user fields are accepted.
+
+</SideBySideColumn>
+
+<SideBySideColumn>
+
+**In Strapi 5**
+
+An undefined `allowedFields` is treated as an empty array, and no fields are accepted by default. Users must explicitly choose to allow extra fields on registration.
+
+</SideBySideColumn>
+
+</SideBySideContainer>
+
+## Migration
+
+<MigrationIntro />
+
+### Manual procedure
+
+A codemod should handle this migration. If not, please refer to the documentation on how to [register allowed fields for the Users & Permissions plugin](/dev-docs/plugins/users-permissions#registration).

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -1047,6 +1047,18 @@ const sidebars = {
             },
             {
               type: "category",
+              collapsed: false,
+              label: "Plugins and their configuration",
+              link: {
+                type: 'doc',
+                id: "dev-docs/migration/v4-to-v5/breaking-changes"
+              },
+              items: [
+                'dev-docs/migration/v4-to-v5/breaking-changes/register-allowed-fields'
+              ]
+            },
+            {
+              type: "category",
               label: "Strapi objects and methods",
               collapsed: false,
               items: [


### PR DESCRIPTION
`register.allowedFields` defaults to an empty array.

Direct preview link 👉  [here](https://documentation-git-v5-breaking-changes-allowed-fields-strapijs.vercel.app/dev-docs/migration/v4-to-v5/breaking-changes/register-allowed-fields)