### PR TITLE
[Strapi 5] Breaking change: Vite as default bundler

### DIFF
--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes.md
@@ -38,8 +38,8 @@ The following changes affect the databases interacting with your Strapi applicat
 
 ## Dependencies
 
+- [Vite is the default bundler in Strapi 5](/dev-docs/migration/v4-to-v5/breaking-changes/vite)
 - [Strapi 5 uses react-router-dom v6](/dev-docs/migration/v4-to-v5/breaking-changes/react-router-dom-6)
-- [The `isSupportedImage` method is removed](/dev-docs/migration/v4-to-v5/breaking-changes/is-supported-image-removed)
 
 ## Internal changes
 

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/vite.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/vite.md
@@ -1,0 +1,50 @@
+---
+title: Vite is the default bundler
+description: In Strapi 5, Vite is the default bundler and replaces webpack.
+sidebar_label: Vite bundling
+displayed_sidebar: devDocsMigrationV5Sidebar
+tags:
+ - breaking changes
+ - vite
+ - front end
+---
+
+import Intro from '/docs/snippets/breaking-change-page-intro.md'
+import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
+
+# Vite is the default bundler
+
+In Strapi 5, Vite is the default bundler.
+
+<Intro />
+
+## Breaking change description
+
+<SideBySideContainer>
+
+<SideBySideColumn>
+
+**In Strapi v4**
+
+Webpack is the default bundler.
+
+</SideBySideColumn>
+
+<SideBySideColumn>
+
+**In Strapi 5**
+
+[Vite](https://vitejs.dev/) is the default bundler.
+
+
+</SideBySideColumn>
+
+</SideBySideContainer>
+
+## Migration
+
+<MigrationIntro />
+
+### Manual procedure
+
+Users with custom webpack configurations need to convert to [Vite](https://vitejs.dev/) configurations, or alternatively set `--bundler=webpack` when starting the development server to keep the Strapi v4 behaviour; in the latter case, the terminal will issue a warning. Please refer to the [bundlers](/dev-docs/admin-panel-customization#bundlers-experimental) documentation for additional details.

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -1056,6 +1056,15 @@ const sidebars = {
             },
             {
               type: "category",
+              label: "Dependencies",
+              collapsed: false,
+              items: [
+                'dev-docs/migration/v4-to-v5/breaking-changes/vite',
+                'dev-docs/migration/v4-to-v5/breaking-changes/react-router-dom-6',
+              ]
+            },
+            {
+              type: "category",
               label: "Internal changes",
               collapsed: false,
               items: [


### PR DESCRIPTION
Webpack → Vite