### PR TITLE
Update Releases documentation for next release

### DIFF
--- a/docusaurus/docs/user-docs/content-manager/adding-content-to-releases.md
+++ b/docusaurus/docs/user-docs/content-manager/adding-content-to-releases.md
@@ -37,7 +37,7 @@ To add entries to a release:
 
 ## Adding an entry to a release
 
-An entry can be added to a [release](/user-docs/releases/introduction) while editing it from the edit view of the Content Manager. Only collection type entries can be added to a release, not single type entries.
+An entry can be added to a [release](/user-docs/releases/introduction) while editing it from the edit view of the Content Manager. 
 
 To add an entry to a release:
 


### PR DESCRIPTION
This tiny removes the mention about not being possible to add single type entries to Releases, as it will now be possible.