### PR TITLE
[Strapi 5] Breaking change for no findPage() method in Document Service API

### DIFF
--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes.md
@@ -17,6 +17,7 @@ This page is part of the [Strapi v4 to v5 migration](/dev-docs/migration/v4-to-v
 ## Content API
 
 * [Draft & Publish is always enabled](/dev-docs/migration/v4-to-v5/breaking-changes/draft-and-publish-always-enabled)
+* [There is no `findPage()` method with the Document Service API](/dev-docs/migration/v4-to-v5/breaking-changes/no-find-page-in-document-service)
 
 ## Database
 

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/no-find-page-in-document-service.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/no-find-page-in-document-service.md
@@ -1,6 +1,6 @@
 ---
 title: No findPage() in Document Service API
-description: MySQL v5 is not supported in Strapi v5 anymore.
+description: In Strapi 5, the Entity Service API is deprecated, and for the findPage() method you should use the Document Service API's findMany() method instead.
 displayed_sidebar: devDocsMigrationV5Sidebar
 tags:
  - breaking changes
@@ -50,8 +50,6 @@ strapi.documents("api::article.article").findMany({
 </SideBySideColumn>
 
 </SideBySideContainer>
-
-<br />
 
 ## Migration
 

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/no-find-page-in-document-service.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/no-find-page-in-document-service.md
@@ -9,6 +9,7 @@ tags:
 ---
 
 import Intro from '/docs/snippets/breaking-change-page-intro.md'
+import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
 
 # No `findPage()` in Document Service API
 
@@ -53,5 +54,9 @@ strapi.documents("api::article.article").findMany({
 
 ## Migration
 
-<!-- TODO: update this part — will there be a codemod? -->
+<MigrationIntro />
 
+### Manual migration
+
+<!-- TODO: update this part — will there be a codemod? -->
+In your custom code, replace any occurences of the Entity Service API's `findPage()` method by the `findMany()` method from the Document Service API.

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/no-find-page-in-document-service.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/no-find-page-in-document-service.md
@@ -1,0 +1,59 @@
+---
+title: No findPage() in Document Service API
+description: MySQL v5 is not supported in Strapi v5 anymore.
+displayed_sidebar: devDocsMigrationV5Sidebar
+tags:
+ - breaking changes
+ - document service
+ - entity service
+---
+
+import Intro from '/docs/snippets/breaking-change-page-intro.md'
+
+# No `findPage()` in Document Service API
+
+In Strapi 5, the [Document Service API](/dev-docs/api/document-service) replaces the Entity Service API. There is no `findPage()` method available in the Document Service API and users should use the `findMany()` method instead.
+<Intro />
+
+## Breaking change description
+
+<SideBySideContainer>
+
+<SideBySideColumn>
+
+**In Strapi v4**
+
+In Strapi v4 you could use the `findPage()` method from the Entity Service API, for instance as follows: 
+
+```jsx
+strapi.entityService.findPage('api::article.article', {
+  start: 10,
+  limit: 15,
+});
+```
+
+</SideBySideColumn>
+
+<SideBySideColumn>
+
+**In Strapi 5**
+
+In Strapi 5 the Entity Service API is deprecated and you should use the Document Service API instead. The [`findMany()` method](/dev-docs/api/document-service/sort-pagination#pagination) can be used as follows:
+
+```jsx
+strapi.documents("api::article.article").findMany({
+  limit: 10,
+  start: 0,
+});
+```
+
+</SideBySideColumn>
+
+</SideBySideContainer>
+
+<br />
+
+## Migration
+
+<!-- TODO: update this part — will there be a codemod? -->
+

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -1029,7 +1029,8 @@ const sidebars = {
                 id: "dev-docs/migration/v4-to-v5/breaking-changes"
               },
               items: [
-                'dev-docs/migration/v4-to-v5/breaking-changes/draft-and-publish-always-enabled'
+                'dev-docs/migration/v4-to-v5/breaking-changes/draft-and-publish-always-enabled',
+                'dev-docs/migration/v4-to-v5/breaking-changes/no-find-page-in-document-service',
               ]
             },
             {


### PR DESCRIPTION
EntityService API: findPage() →  Document Service API: findMany()