### PR TITLE
Update users-permissions.md - Issue #1510

### DIFF
--- a/docusaurus/docs/dev-docs/plugins/users-permissions.md
+++ b/docusaurus/docs/dev-docs/plugins/users-permissions.md
@@ -828,7 +828,7 @@ The use of `ngrok` is not needed.
   - Client ID: `<Your Auth0 Client ID>`
   - Client Secret: `<Your Auth0 Client Secret>`
   - Subdomain: `<Your Auth0 tenant url>`, example it is the part in bold in the following url: https://**my-tenant.eu**.auth0.com/
-  - The redirect URL to your front-end app: `http://localhost:3000/connect/auth0`
+  - The redirect URL to your front-end app: `http://localhost:3000/connect/auth0/redirect`
 
 </TabItem>
 


### PR DESCRIPTION
Fixed url which did not match the route example at https://github.com/strapi/strapi-examples/blob/master/examples/login-react/src/App.js

### What does it do?

Fix incomplete url

### Why is it needed?

URL did not match the route provided in the examples repo

### Related issue(s)/PR(s)

#1510
