### PR TITLE
Improve the Plugins configuration section to mention Upload/Media Library configuration

### DIFF
--- a/docusaurus/docs/dev-docs/configurations.md
+++ b/docusaurus/docs/dev-docs/configurations.md
@@ -36,7 +36,7 @@ Some specific features require additional configuration:
 
 | Feature | Location | Required or optional |
 |---------|------|------|
-| [Plugins](/dev-docs/configurations/plugins) | In the `config/plugins` file | <ul><li>Optional if using only built-in plugins with default presets.</li><li>Required to enable, configure, or disable plugins.</li></ul> |
+| [Plugins](/dev-docs/configurations/plugins) | In the `config/plugins` file | <ul><li>Optional if using only built-in plugins with default presets.</li><li>Required to enable, configure, or disable plugins.</li></ul>Can also be used to configure the Upload plugin (which handles the Media Library feature) and GraphQL. |
 | [TypeScript](/dev-docs/configurations/typescript) | <ul><li>In `tsconfig.json` for general [TypeScript-related configuration](/dev-docs/configurations/typescript#project-structure-and-typescript-specific-configuration-files)</li><li>In the `config/typescript` file for [dedicated TypeScript features](/dev-docs/configurations/typescript#strapi-specific-configuration-for-typescript) specific to Strapi</li></ul> | Required to use TypeScript efficiently |
 | [API tokens](/dev-docs/configurations/api-tokens) | In the `config/admin` file | Required if using API tokens for authentication instead of the [Users & Permissions plugin](/dev-docs/plugins/users-permissions) |
 | [Lifecycle functions](/dev-docs/configurations/functions) | In the `/src/index` file | Optionally used to perform various actions that happen during the server lifecycle. Includes the `register`, `bootstrap`, and `destroy` functions. |

--- a/docusaurus/docs/dev-docs/configurations/plugins.md
+++ b/docusaurus/docs/dev-docs/configurations/plugins.md
@@ -147,3 +147,81 @@ export default () => ({
 </TabItem>
 
 </Tabs>
+
+## Upload configuration
+
+The [Upload plugin](/dev-docs/plugins/upload) handles the [Media Library](/user-docs/media-library). When using the default upload provider, the following specific configuration options can be declared in an `upload.config` object within the `config/plugins` file. All parameters are optional:
+
+| Parameter                                   | Description                                                                                                         | Type    | Default |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ------- | ------- |
+| `providerOptions.localServer`        | Options that will be passed to [koa-static](https://github.com/koajs/static) upon which the Upload server is build.<br/><br/>(See [local server configuration](/dev-docs/plugins/upload#local-server) in Upload documentation for additional details) | Object  | -       |
+| `sizeLimit`                                  | Maximum file size in bytes.<br/><br/>(See [max file size configuration](/dev-docs/plugins/upload#max-file-size) in Upload plugin documentation for additional information) | Integer | `209715200`<br/><br/>(200 MB in bytes, i.e., 200 x 1024 x 1024 bytes) |
+| `breakpoints`             | Allows to override the breakpoints sizes at which responsive images are generated when the "Responsive friendly upload" option is set to `true`.<br/><br/>(See [responsive images configuration](/dev-docs/plugins/upload#responsive-images) in Upload plugin documentation for additional information) | Object | `{ large: 1000, medium: 750, small: 500 }` |
+
+:::note Notes
+* Some configuration options can also be set directly from the Admin Panel (see [User Guide](/user-docs/settings/media-library-settings)).
+* The Upload request timeout is defined in the server options, not in the Upload plugin options, as it's not specific to the Upload plugin but is applied to the whole Strapi server instance. See [upload request timeout configuration](/dev-docs/plugins/upload#upload-request-timeout) in the Upload documentation for additional details.
+* When using a different upload provider, additional configuration options might be available. For Upload providers maintained by Strapi, see the [Amazon S3 provider](https://market.strapi.io/providers/@strapi-provider-upload-aws-s3) and [Cloudinary provider](https://market.strapi.io/providers/@strapi-provider-upload-cloudinary) documentations for additional information about available options.
+:::
+
+**Example custom configuration**:
+
+The following is an example of a custom configuration for the Upload plugin when using the default upload provider:
+
+<Tabs groupId="js-ts">
+
+<TabItem value="javascript" label="JavaScript">
+
+```js title="/config/plugins.js"
+
+module.exports = ({ env })=>({
+  upload: {
+    config: {
+      providerOptions: {
+        localServer: {
+          maxage: 300000
+        },
+      },
+      sizeLimit: 250 * 1024 * 1024, // 256mb in bytes
+      breakpoints: {
+        xlarge: 1920,
+        large: 1000,
+        medium: 750,
+        small: 500,
+        xsmall: 64
+      },
+    },
+  },
+});
+```
+
+</TabItem>
+
+<TabItem value="typescript" label="TypeScript">
+
+```ts title="/config/plugins.ts"
+
+export default () => ({
+  upload: {
+    config: {
+      providerOptions: {
+        localServer: {
+          maxage: 300000
+        },
+      },
+      sizeLimit: 250 * 1024 * 1024, // 256mb in bytes
+      breakpoints: {
+        xlarge: 1920,
+        large: 1000,
+        medium: 750,
+        small: 500,
+        xsmall: 64
+      },
+    },
+  },
+})
+```
+
+</TabItem>
+
+</Tabs>

--- a/docusaurus/docs/dev-docs/configurations/plugins.md
+++ b/docusaurus/docs/dev-docs/configurations/plugins.md
@@ -8,13 +8,19 @@ description: Strapi plugins have a single entry point file to define their confi
 
 # Plugins configuration
 
-Plugin configurations are stored in `./config/plugins.js|ts` (see [project structure](/dev-docs/project-structure)). Each plugin can be configured with the following available parameters:
+Plugin configurations are stored in `/config/plugins.js|ts` (see [project structure](/dev-docs/project-structure)). Each plugin can be configured with the following available parameters:
 
 | Parameter                  | Description                                                                                                                                                            | Type    |
 | -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
 | `enabled`                  | Enable (`true`) or disable (`false`) an installed plugin                                                                                                               | Boolean |
 | `config`<br/><br/>_Optional_ | Used to override default plugin configuration ([defined in strapi-server.js](/dev-docs/api/plugins/server-api#configuration)) | Object  |
 | `resolve`<br/> _Optional, only required for local plugins_             | Path to the plugin's folder                                                                                                                                            | String  |
+
+:::note
+Some features of Strapi are provided by plugins and the following plugins can also have specific configuration options: [GraphQL](#graphql-configuration) and [Upload](#upload-configuration).
+:::
+
+**Basic example custom configuration for plugins:**
 
 <Tabs groupId="js-ts">
 

--- a/docusaurus/docs/dev-docs/configurations/plugins.md
+++ b/docusaurus/docs/dev-docs/configurations/plugins.md
@@ -86,7 +86,7 @@ If no specific configuration is required, a plugin can also be declared with the
 
 ## GraphQL configuration
 
-The [GraphQL plugin](/dev-docs/plugins/graphql) has the following specific configuration options that should be declared in a `graphql.config` object. All parameters are optional:
+The [GraphQL plugin](/dev-docs/plugins/graphql) has the following specific configuration options that should be declared in a `graphql.config` object within the `config/plugins` file. All parameters are optional:
 
 | Parameter          | Description                                                                                                                                                   | Type    | Default |
 | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- | ------- |
@@ -99,6 +99,8 @@ The [GraphQL plugin](/dev-docs/plugins/graphql) has the following specific confi
 | `maxLimit`         | Maximum value for [the `pagination[limit]` parameter](/dev-docs/api/graphql#pagination-by-offset) used in API calls                                                                                                              | Integer  | `-1`    |
 | `playgroundAlways` | Whether the playground should be publicly exposed.<br/><br/>Enabled by default in if `NODE_ENV` is set to `development`.                                        | Boolean | `false`  |
 | `shadowCRUD`       | Whether type definitions for queries, mutations and resolvers based on models should be created automatically (see [Shadow CRUD documentation](/dev-docs/plugins/graphql#shadow-crud)). | Boolean | `true` |
+
+**Example custom configuration**:
 
 <Tabs groupId="js-ts">
 

--- a/docusaurus/docs/dev-docs/configurations/plugins.md
+++ b/docusaurus/docs/dev-docs/configurations/plugins.md
@@ -43,7 +43,7 @@ module.exports = ({ env }) => ({
   },
 
   // disable a plugin
-  myotherplugin: {
+  'my-other-plugin': {
     enabled: false, // plugin installed but disabled
   },
 });
@@ -70,7 +70,7 @@ export default ({ env }) => ({
   },
 
   // disable a plugin
-  myotherplugin: {
+  'my-other-plugin': {
     enabled: false, // plugin installed but disabled
   },
 });

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -80,7 +80,13 @@ const sidebars = {
             'dev-docs/configurations/admin-panel',
             'dev-docs/configurations/middlewares',
             'dev-docs/configurations/api',
-            'dev-docs/configurations/plugins',
+            {
+              type: 'doc',
+              id: 'dev-docs/configurations/plugins',
+              customProps: {
+                updated: true,
+              },
+            },
             'dev-docs/configurations/typescript',
             'dev-docs/configurations/api-tokens',
             'dev-docs/configurations/functions',
@@ -1024,7 +1030,13 @@ const sidebars = {
             id: 'dev-docs/configurations'
           },
           items: [
-            'dev-docs/configurations/plugins',
+            {
+              type: 'doc',
+              id: 'dev-docs/configurations/plugins',
+              customProps: {
+                updated: true,
+              },
+            },
             'dev-docs/configurations/typescript',
             'dev-docs/configurations/api-tokens',
             'dev-docs/configurations/functions',


### PR DESCRIPTION
This PR: 
- clarifies that config/plugins is also used to configure GraphQL and Upload
- adds an Upload plugin configuration section to the Plugins configuration page, with cross-reference to the Upload plugin docs and to some other providers' documentations