### PR TITLE
Strapi Cloud: removing one-time password in "Managing subscriptions"

### DIFF
--- a/docusaurus/docs/cloud/account/account-billing.md
+++ b/docusaurus/docs/cloud/account/account-billing.md
@@ -25,19 +25,13 @@ The Payment method section can only be accessible once the mandatory fields of t
 
 ## Managing subscriptions
 
-Using the **Manage subscriptions** button, you can view and manage your subscriptions, account and billing information, and payment method.
+Using the **Manage subscriptions** button in the *Billing* tab, you can:
 
-1. Click the **Manage subscriptions** button. A login modal will appear.
-
-2. Enter the billing email address associated with your account and click **Continue**.
-
-3. The **Manage Subscriptions** modal will appear. From here, you can:
-
-   - view and edit your subscriptions by clicking on the active subscription(s) tile(s): change project name, update shipping details, [edit current subscription](#edit-subscription) and [cancel current subscription](#cancel-subscription)
-   - view and edit your Account Information: email, password, company name
-   - view and edit your Billing & Shipping Addresses
-   - view and edit your Payment Methods and add new ones
-   - access your Billing History and download your invoices
+- view and edit your subscriptions by clicking on the active subscription(s) tile(s): change project name, update shipping details, [edit current subscription](#edit-subscription) and [cancel current subscription](#cancel-subscription),
+- view and edit your Account Information: email, password and company name,
+- view and edit your Billing & Shipping Addresses,
+- view and edit your Payment Methods and add new ones,
+- access your Billing History and download your invoices.
 
 <ThemedImage
   alt="Subscriptions management modal"

--- a/docusaurus/docs/cloud/account/account-billing.md
+++ b/docusaurus/docs/cloud/account/account-billing.md
@@ -29,9 +29,9 @@ Using the **Manage subscriptions** button, you can view and manage your subscrip
 
 1. Click the **Manage subscriptions** button. A login modal will appear.
 
-2. Enter the billing email address associated with your account and click **Continue**. A one-time password will be sent to the email address.
+2. Enter the billing email address associated with your account and click **Continue**.
 
-3. Enter the one-time password and click **Continue**. The **Manage Subscriptions** modal will appear. From here, you can:
+3. The **Manage Subscriptions** modal will appear. From here, you can:
 
    - view and edit your subscriptions by clicking on the active subscription(s) tile(s): change project name, update shipping details, [edit current subscription](#edit-subscription) and [cancel current subscription](#cancel-subscription)
    - view and edit your Account Information: email, password, company name


### PR DESCRIPTION
Remove mention of one-time password to manage subscriptions, in "Account billing details".