### PR TITLE
[Strapi 5] Breaking change for the removed webpack aliases

### DIFF
--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes.md
@@ -55,7 +55,7 @@ This page is part of the [Strapi v4 to v5 migration](/dev-docs/migration/v4-to-v
 
 - [Vite is the default bundler in Strapi 5](/dev-docs/migration/v4-to-v5/breaking-changes/vite)
 - [Strapi 5 uses react-router-dom v6](/dev-docs/migration/v4-to-v5/breaking-changes/react-router-dom-6)
-- [Webpack Aliases are removed in Strapi v5](/dev-docs/migration/v4-to-v5/breaking-changes/webpack-aliases-removed)
+- [Webpack Aliases are removed in Strapi 5](/dev-docs/migration/v4-to-v5/breaking-changes/webpack-aliases-removed)
 
 ## Internal changes
 

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes.md
@@ -55,6 +55,7 @@ This page is part of the [Strapi v4 to v5 migration](/dev-docs/migration/v4-to-v
 
 - [Vite is the default bundler in Strapi 5](/dev-docs/migration/v4-to-v5/breaking-changes/vite)
 - [Strapi 5 uses react-router-dom v6](/dev-docs/migration/v4-to-v5/breaking-changes/react-router-dom-6)
+- [Webpack Aliases are removed in Strapi v5](/dev-docs/migration/v4-to-v5/breaking-changes/webpack-aliases-removed)
 
 ## Internal changes
 

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/webpack-aliases-removed.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/webpack-aliases-removed.md
@@ -26,7 +26,7 @@ In Strapi v5, webpack aliases are removed ensuring better compatibility and redu
 
 **In Strapi v4**
 
-- We maintained a specific list of dependencies that were aliased in webpack configuration. This ensured that plugins consistently used our versions of certain libraries like the design-system. <br/> <br/> However, this approach led to many bugs.
+- We maintained a specific list of dependencies that were aliased in webpack configuration. This ensured that plugins consistently used our versions of certain libraries like the design-system.
 
 </SideBySideColumn>
 

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/webpack-aliases-removed.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/webpack-aliases-removed.md
@@ -6,6 +6,7 @@ displayed_sidebar: devDocsMigrationV5Sidebar
 tags:
  - breaking changes
  - dependencies
+ - webpack
 ---
 
 import Intro from '/docs/snippets/breaking-change-page-intro.md'
@@ -51,6 +52,8 @@ In Strapi v5, webpack aliases are removed ensuring better compatibility and redu
 
 
 ### Manual procedure
+
+To migrate to Strapi 5:
 
 - Identify any configuration files (e.g., webpack configuration) that referenced the now-removed Webpack aliases in Strapi v4.
 - Ensure that any references to Webpack aliases in the code are replaced with appropriate imports or paths.

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/webpack-aliases-removed.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/webpack-aliases-removed.md
@@ -46,7 +46,7 @@ In Strapi v5, webpack aliases are removed ensuring better compatibility and redu
 
 ### Notes
 
-- If you encounter issues with third-party plugins, we recommend opening an issue on the respective plugin's repository. Encourage them to add their dependencies to their `package.json` file to resolve compatibility issues.
+- If you encounter issues with third-party plugins, we recommend opening an issue on the respective plugin's repository. Encourage the plugin maintainers to add their dependencies to their `package.json` file to resolve compatibility issues.
 
 - If you encounter issues with local plugins, you can fix them by amending the `resolve` option in your chosen bundler.
 

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/webpack-aliases-removed.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/webpack-aliases-removed.md
@@ -1,0 +1,56 @@
+---
+title: Webpack Aliases are removed
+description: A simplified approach of aliasing in Strapi v5. 
+sidebar_label: Webpack Aliases removed
+displayed_sidebar: devDocsMigrationV5Sidebar
+tags:
+ - breaking changes
+ - dependencies
+---
+
+import Intro from '/docs/snippets/breaking-change-page-intro.md'
+import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
+
+# Webpack Aliases are removed
+
+You can smoothly transition your Strapi project from v4 to v5, ensuring better compatibility and reduced dependency conflicts. <Intro />
+
+## Breaking change description
+
+<SideBySideContainer>
+
+<SideBySideColumn>
+
+**In Strapi v4**
+
+- We maintained a specific list of dependencies that were aliased in webpack configuration. This ensured that plugins consistently used our versions of certain libraries like the design-system. <br/> <br/> However, this approach led to many bugs.
+
+</SideBySideColumn>
+
+<SideBySideColumn>
+
+**In Strapi 5**
+
+- In Strapi v5, we have simplified the aliasing process. Now, we only alias essential dependencies like `react`, `react-dom`, `react-router-dom`, and `styled-components`.
+
+</SideBySideColumn>
+
+</SideBySideContainer>
+
+## Migration
+
+<MigrationIntro />
+
+### Notes
+
+- If you encounter issues with third-party plugins, we recommend opening an issue on the respective plugin's repository. Encourage them to add their dependencies to their `package.json` file to resolve compatibility issues.
+
+- If you encounter issues with local plugins, you can fix them by amending the `resolve` option in your chosen bundler.
+
+
+### Manual procedure
+
+- Identify any configuration files (e.g., webpack configuration) that referenced the now-removed Webpack aliases in Strapi v4.
+- Ensure that any references to Webpack aliases in the code are replaced with appropriate imports or paths.
+- If third-party plugins are used in the project, verify that they do not rely on Webpack aliases that are no longer present in Strapi v5.
+- If necessary, communicate with the plugin authors to update their dependencies or configurations accordingly.

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/webpack-aliases-removed.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/webpack-aliases-removed.md
@@ -13,7 +13,9 @@ import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.
 
 # Webpack Aliases are removed
 
-You can smoothly transition your Strapi project from v4 to v5, ensuring better compatibility and reduced dependency conflicts. <Intro />
+In Strapi v5, webpack aliases are removed ensuring better compatibility and reduced dependency conflicts. 
+
+<Intro />
 
 ## Breaking change description
 

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -1069,14 +1069,6 @@ const sidebars = {
               items: [
                 'dev-docs/migration/v4-to-v5/breaking-changes/removed-support-for-some-env-options',
                 'dev-docs/migration/v4-to-v5/breaking-changes/strict-requirements-config-files',
-                {
-                  type: 'doc',
-                  label: 'Webpack Aliases Removed',
-                  id: 'dev-docs/migration/v4-to-v5/breaking-changes/webpack-aliases-removed',
-                  customProps: {
-                    new: true,
-                  },
-                },
               ]
             },
             {
@@ -1147,6 +1139,14 @@ const sidebars = {
               items: [
                 'dev-docs/migration/v4-to-v5/breaking-changes/vite',
                 'dev-docs/migration/v4-to-v5/breaking-changes/react-router-dom-6',
+                {
+                  type: 'doc',
+                  label: 'Webpack Aliases Removed',
+                  id: 'dev-docs/migration/v4-to-v5/breaking-changes/webpack-aliases-removed',
+                  customProps: {
+                    new: true,
+                  },
+                },
               ]
             },
             {

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -564,7 +564,14 @@ const sidebars = {
               label: 'Introduction',
               id: 'dev-docs/migration/v4-to-v5/introduction'
             },
-            'dev-docs/migration/v4-to-v5/breaking-changes',
+            {
+              type: 'doc',
+              label: 'Breaking Changes',
+              id: 'dev-docs/migration/v4-to-v5/breaking-changes',
+              customProps: {
+                updated: true,
+              },
+            },
             'dev-docs/migration/v4-to-v5/migration-guides',
           ]
         }
@@ -1062,6 +1069,14 @@ const sidebars = {
               items: [
                 'dev-docs/migration/v4-to-v5/breaking-changes/removed-support-for-some-env-options',
                 'dev-docs/migration/v4-to-v5/breaking-changes/strict-requirements-config-files',
+                {
+                  type: 'doc',
+                  label: 'Webpack Aliases Removed',
+                  id: 'dev-docs/migration/v4-to-v5/breaking-changes/webpack-aliases-removed',
+                  customProps: {
+                    new: true,
+                  },
+                },
               ]
             },
             {


### PR DESCRIPTION
In this PR:
-Update information on the removal of the webpack aliases in Strapi v5.
