### PR TITLE
[Strapi 5] Breaking change for model config path uses uid

### DIFF
--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes.md
@@ -18,6 +18,7 @@ This page is part of the [Strapi v4 to v5 migration](/dev-docs/migration/v4-to-v
 
 * [Some `env`-only configuration options are handled by the server configuration](/dev-docs/migration/v4-to-v5/breaking-changes/removed-support-for-some-env-options)
 * [Configuration filenames should meet strict requirements](/dev-docs/migration/v4-to-v5/breaking-changes/strict-requirements-config-files)
+* [Model config path uses uid instead of dot notation](/dev-docs/migration/v4-to-v5/breaking-changes/model-config-path-uses-uid)
 
 ## Content API
 

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/model-config-path-uses-uid.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/model-config-path-uses-uid.md
@@ -1,0 +1,76 @@
+---
+title: Model config path uses uid instead of dot notation
+description: Modules like `api::myapi` and `plugin::upload` should no longer be accessed in the Strapi config using `api.myapi` and `plugin.upload`, but instead using `api::myapi` and `plugin::upload`.
+sidebar_label: Model config path uses uid
+displayed_sidebar: devDocsMigrationV5Sidebar
+tags:
+ - breaking changes
+ - database
+---
+
+import Intro from '/docs/snippets/breaking-change-page-intro.md'
+import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
+
+# Model config path uses uid instead of dot notation
+
+In Strapi 5, to retrieve config values you will need to use `config.get('plugin::upload.myconfigval')` or `config.get('api::myapi.myconfigval')`
+
+<Intro />
+
+<YesPlugins />
+
+## Breaking change description
+
+<SideBySideContainer>
+
+<SideBySideColumn>
+
+**In Strapi v4**
+
+Models are added to the configuration using `.` notation as follows:
+
+```jsx
+strapi.config.get('plugin.upload.somesetting');
+if ( strapi.config.has('plugin.upload.somesetting') ) {
+  strapi.config.set('plugin.upload.somesetting', false);
+}
+```
+
+</SideBySideColumn>
+
+<SideBySideColumn>
+
+**In Strapi 5**
+
+Models are added to the configuration using `::` replacing `.` notation as follows:
+```jsx
+strapi.config.get('plugin::upload.somesetting');
+if ( strapi.config.has('plugin::upload.somesetting') ) {
+  strapi.config.set('plugin::upload.somesetting', false);
+}
+```
+
+</SideBySideColumn>
+
+</SideBySideContainer>
+
+## Migration
+
+<MigrationIntro />
+
+### Notes
+
+- If an API has a configuration, it should also be accessed using `strapi.config.get(’api::myapi.myconfigval’)`.
+
+- The 'plugin' namespace has temporary support with a deprecation warning. This means that referencing `plugin.upload.somesetting` will emit a warning in the server log and check `plugin::upload.somesetting` instead.
+
+- A codemod has been created to assist in refactoring the strings in user code, replacing `plugin.` or `api.` with `plugin::` and `api::`.
+
+
+
+### Manual procedure
+
+A codemod will automatically handle the change in most cases.
+
+In cases were the codemod does not automatically handle the change, users will need to manually replace all their strings to target the new config paths.
+

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/model-config-path-uses-uid.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/model-config-path-uses-uid.md
@@ -5,7 +5,7 @@ sidebar_label: Model config path uses uid
 displayed_sidebar: devDocsMigrationV5Sidebar
 tags:
  - breaking changes
- - database
+ - configuration
 ---
 
 import Intro from '/docs/snippets/breaking-change-page-intro.md'

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/model-config-path-uses-uid.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/model-config-path-uses-uid.md
@@ -10,6 +10,7 @@ tags:
 
 import Intro from '/docs/snippets/breaking-change-page-intro.md'
 import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
+import YesPlugins from '/docs/snippets/breaking-change-affecting-plugins.md'
 
 # Model config path uses uid instead of dot notation
 

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -1062,6 +1062,14 @@ const sidebars = {
               items: [
                 'dev-docs/migration/v4-to-v5/breaking-changes/removed-support-for-some-env-options',
                 'dev-docs/migration/v4-to-v5/breaking-changes/strict-requirements-config-files',
+                {
+                  type: 'doc',
+                  label: 'Model config path uses uid',
+                  id: 'dev-docs/migration/v4-to-v5/breaking-changes/model-config-path-uses-uid',
+                  customProps: {
+                    new: true,
+                  },
+                }
               ]
             },
             {


### PR DESCRIPTION
In this PR:

Updated information on models config path using uid instead of the dot notation.