### PR TITLE
Add callout to lifecycle hooks to cross-link to error handling docs

### DIFF
--- a/docusaurus/docs/dev-docs/backend-customization/models.md
+++ b/docusaurus/docs/dev-docs/backend-customization/models.md
@@ -619,6 +619,10 @@ Lifecycle hooks can be customized declaratively or programmatically.
 Lifecycles hooks are not triggered when using directly the [knex](https://knexjs.org/) library instead of Strapi functions.
 :::
 
+:::tip
+Check our [error handling](/dev-docs/error-handling#services-and-models-lifecycles) documentation to resolve any errors you may encounter while using the lifecycle hooks.
+:::
+
 ### Available lifecycle events
 
 The following lifecycle events are available:

--- a/docusaurus/docs/dev-docs/backend-customization/models.md
+++ b/docusaurus/docs/dev-docs/backend-customization/models.md
@@ -620,7 +620,7 @@ Lifecycles hooks are not triggered when using directly the [knex](https://knexjs
 :::
 
 :::tip
-Check our [error handling](/dev-docs/error-handling#services-and-models-lifecycles) documentation to resolve any errors you may encounter while using the lifecycle hooks.
+Please refer to the [error handling](/dev-docs/error-handling#services-and-models-lifecycles) documentation to learn how to throw errors from lifecycle hooks.
 :::
 
 ### Available lifecycle events


### PR DESCRIPTION
In this PR:

Included link to the error handling section of Strapi documentation in the Models file.
