### PR TITLE
fix: set alpine linux version due to recent changes to `libvips`

### DIFF
--- a/docusaurus/docs/dev-docs/installation/docker.md
+++ b/docusaurus/docs/dev-docs/installation/docker.md
@@ -57,7 +57,7 @@ Sample `Dockerfile`:
 <TabItem value="yarn" label="yarn">
 
 ```dockerfile title="./Dockerfile"
-FROM node:18-alpine
+FROM node:18-alpine3.18
 # Installing libvips-dev for sharp Compatibility
 RUN apk update && apk add --no-cache build-base gcc autoconf automake zlib-dev libpng-dev nasm bash vips-dev git
 ARG NODE_ENV=development


### PR DESCRIPTION
### What does it do?

Fixed the version of the base image for the docker file to alpine 3.18

### Why is it needed?

Originally, I stumbled on an error with `../src/pipeline.cc` where it complained about an invalid struct type.
![CleanShot 2024-03-26 at 10 05 01@2x](https://github.com/strapi/documentation/assets/55560043/683dc147-f646-45eb-beff-02655b6a5504)

After some searching I found the issue:
The current image used as base in the Dockerfile example defaults to an alpine-linux version **later** than 3.18 (I think 3.19 when I look at the latest tags of the node docker image) due to the newer `latest` tag, which has made changes in `libvips`, as discussed in this PR: [Link](https://github.com/nodejs/docker-node/issues/2009)

The PR also mentions, that fixing the build to version 3.18 resolve the issue, which I also confirmed in my local setup when trying to deploy strapi through docker compose.

### Related issue(s)/PR(s)
I have not found any issue regarding this issue.