### PR TITLE
Add new guides section to REST API

### DIFF
--- a/docusaurus/docs/dev-docs/api/rest/guides/intro.md
+++ b/docusaurus/docs/dev-docs/api/rest/guides/intro.md
@@ -7,11 +7,17 @@ pagination_next: dev-docs/api/rest/guides/understanding-populate
 
 # REST API Guides
 
-The [REST API reference](/dev-docs/api/rest) documentation is meant to provide a quick reference for all the endpoints and parameters available. The following guides cover dedicated topics and provide detailed explanations (guides indicated with 🧠) or step-by-step instructions (guides indicated with 🛠️) for some use cases.
+The [REST API reference](/dev-docs/api/rest) documentation is meant to provide a quick reference for all the endpoints and parameters available.
 
-<!-- <CustomDocCardsWrapper> -->
+## Guides
+
+The following guides, officially maintained by the Strapi Documentation team, cover dedicated topics and provide detailed explanations (guides indicated with 🧠) or step-by-step instructions (guides indicated with 🛠️) for some use cases:
 
 <CustomDocCard emoji="🧠" title="Understanding populate" description="Learn what populating means and how you can use the populate parameter in your REST API queries to add additional fields to your responses." link="/dev-docs/api/rest/guides/understanding-populate" />
 <CustomDocCard emoji="🛠️" title="How to populate creator fields" description="Read step-by-step instructions on how to build a custom controller that leverages the populate parameter to add 'createdBy' and 'updatedBy' data to queries responses" link="/dev-docs/api/rest/guides/populate-creator-fields" />
 
-<!-- </CustomDocCardsWrapper> -->
+## Additional resources
+
+Additional tutorials and guides can be found in the following blog posts:
+
+<CustomDocCard emoji="➕" title="Authenticating requests with the REST API" description="Learn how to authenticate your REST API queries with JSON Web Tokens and API tokens." link="https://strapi.io/blog/guide-on-authenticating-requests-with-the-rest-api" />


### PR DESCRIPTION
- Updates the new REST API guides section to include additional resources such as blog posts. 
- Add the link to the blog post about authenticating APIs