### PR TITLE
Updated documentation for Nginx Proxying

### DIFF
--- a/docusaurus/docs/dev-docs/deployment/snippets-proxy/admin-redirect.md
+++ b/docusaurus/docs/dev-docs/deployment/snippets-proxy/admin-redirect.md
@@ -9,7 +9,7 @@ This sample configuration expects that the admin panel is accessible on `/admin`
 ```js title="./config/middlewares.js"
 module.exports = ({ env }) => [
 	// ...
-	{ resolve: '../src/middlewares/admin-redirect' },
+	{ resolve: './src/middlewares/admin-redirect' },
 ];
 
 ```


### PR DESCRIPTION
This PR updates the documentation. No new tests has been written. The PR should fix #2056 . The PR is ready to be reviewed and merged.

### What does it do?

The PR consists of changes to ~/documentation/docusaurus/docs/dev-docs/deployment/snippets-proxy/admin-redirect.md

### Why is it needed?

On the current live page [nginx deployment documentation](https://docs.strapi.io/dev-docs/deployment/nginx-proxy#) it incorrectly has two dots at the start (../) instead of one. creating confusion and may result in an error for someone trying to set up nginx redirect by directly copy-pasting from the documentation

### Related issue(s)/PR(s)

I found an OPEN PR regarding the same issue - [#2057](https://github.com/strapi/documentation/pull/2057) where changes were requested 2 weeks ago and have since been in the stale state I suppose.
