### PR TITLE
Fix #2052: Clarify that you need to use .ts files when extending plugins if you use TypeScript 

### DIFF
--- a/docusaurus/docs/dev-docs/plugins-extension.md
+++ b/docusaurus/docs/dev-docs/plugins-extension.md
@@ -21,14 +21,14 @@ Plugin extensions code is located in the `./src/extensions` folder (see [project
 ```bash
 /extensions
   /some-plugin-to-extend
-    strapi-server.js
+    strapi-server.js|ts
     /content-types
       /some-content-type-to-extend
         model.json
       /another-content-type-to-extend
         model.json
   /another-plugin-to-extend
-    strapi-server.js
+    strapi-server.js|ts
 ```
 </details>
 
@@ -39,13 +39,13 @@ Plugins can be extended in 2 ways:
 
 ## Extending a plugin's content-types
 
-A plugin's Content-Types can be extended in 2 ways: using the programmatic interface within `strapi-server.js` and by overriding the content-types schemas.
+A plugin's Content-Types can be extended in 2 ways: using the programmatic interface within `strapi-server.js|ts` and by overriding the content-types schemas.
 
 The final schema of the content-types depends on the following loading order:
 
 1. the content-types of the original plugin,
 2. the content-types overridden by the declarations in the [schema](/dev-docs/backend-customization/models#model-schema) defined in `./src/extensions/plugin-name/content-types/content-type-name/schema.json`
-3. the content-types declarations in the [`content-types` key exported from `strapi-server.js`](/dev-docs/api/plugins/server-api#content-types)
+3. the content-types declarations in the [`content-types` key exported from `strapi-server.js|ts`](/dev-docs/api/plugins/server-api#content-types)
 4. the content-types declarations in the [`register()` function](/dev-docs/configurations/functions#register) of the Strapi application
 
 To overwrite a plugin's [content-types](/dev-docs/backend-customization/models):
@@ -63,9 +63,13 @@ When a Strapi application is initializing, plugins, extensions and global lifecy
 
 1. Plugins are loaded and their interfaces are exposed.
 2. Files in `./src/extensions` are loaded.
-3. The `register()` and `bootstrap()` functions in `./src/index.js` are called.
+3. The `register()` and `bootstrap()` functions in `./src/index.js|ts` are called.
 
-A plugin's interface can be extended at step 2 (i.e. within `./src/extensions`) or step 3 (i.e. inside `./src/index.js`).
+A plugin's interface can be extended at step 2 (i.e. within `./src/extensions`) or step 3 (i.e. inside `./src/index.js|ts`).
+
+:::note
+If your Strapi project is TypeScript-based, please ensure that the `index` file has a TypeScript extension (i.e., `src/index.ts`) otherwise it will not be compiled.
+:::
 
 ### Within the extensions folder
 
@@ -73,13 +77,13 @@ To extend a plugin's server interface using the `./src/extensions` folder:
 
 1. _(optional)_ Create the `./src/extensions` folder at the root of the app, if the folder does not already exist.
 2. Create a subfolder with the same name as the plugin to be extended.
-3. Create a `strapi-server.js` file to extend a plugin's back end using the [Server API](/dev-docs/api/plugins/server-api).
+3. Create a `strapi-server.js|ts` file to extend a plugin's back end using the [Server API](/dev-docs/api/plugins/server-api).
 4. Within this file, define and export a function. The function receives the `plugin` interface as an argument so it can be extended.
 
 <details>
 <summary>Example of backend extension</summary>
 
-```js title="./src/extensions/some-plugin-to-extend/strapi-server.js"
+```js title="./src/extensions/some-plugin-to-extend/strapi-server.js|ts"
 
 module.exports = (plugin) => {
   plugin.controllers.controllerA.find = (ctx) => {};
@@ -99,12 +103,12 @@ module.exports = (plugin) => {
 
 ### Within the register and bootstrap functions
 
-To extend a plugin's interface within `./src/index.js`, use the `bootstrap()` and `register()` [functions](/dev-docs/configurations/functions) of the whole project, and access the interface programmatically with [getters](/dev-docs/api/plugins/server-api#usage).
+To extend a plugin's interface within `./src/index.js|ts`, use the `bootstrap()` and `register()` [functions](/dev-docs/configurations/functions) of the whole project, and access the interface programmatically with [getters](/dev-docs/api/plugins/server-api#usage).
 
 <details>
-<summary>Example of extending a plugin's content-type within ./src/index.js</summary>
+<summary>Example of extending a plugin's content-type within ./src/index.js|ts</summary>
 
-```js title="./src/index.js"
+```js title="./src/index.js|ts"
 
 module.exports = {
   register({ strapi }) {


### PR DESCRIPTION
Fixes #2052 