### PR TITLE
Fix link in user docs Content-type Builder section

### DIFF
--- a/docusaurus/docs/user-docs/content-type-builder/configuring-fields-content-type.md
+++ b/docusaurus/docs/user-docs/content-type-builder/configuring-fields-content-type.md
@@ -8,7 +8,7 @@ sidebar_position: 3
 The Content-type Builder is only accessible to create and update content-types when your Strapi application is in a development environment, else it will be in a read-only mode in other environments.
 :::
 
-Content-types are composed of one or several fields. Each field is designed to contain specific kind of data, filled up in the Content Manager (see [Writing content](#)).
+Content-types are composed of one or several fields. Each field is designed to contain specific kind of data, filled up in the Content Manager (see [Writing content](/user-docs/content-manager/writing-content.md)).
 
 In the Content-type Builder, fields can be added at the creation of a new content-type or component, or afterward when a content-type or component is edited or updated. The following documentation lists all existing regular fields but also tackles the specificities of components and dynamic zones. For each, you will find a definition, explanation of the form they take once in the Content Manager, and instructions to configure them.
 


### PR DESCRIPTION
### What does it do?

Add the missing link for Content Manager Writing Content section in  `/user-docs/content-type-builder/configuring-fields-content-type.md` 

### Why is it needed?

The current link is set to `#` 

### Related issue(s)/PR(s)

None
