### PR TITLE
Fixes incorrect code example in providers.md

### DIFF
--- a/docusaurus/docs/dev-docs/providers.md
+++ b/docusaurus/docs/dev-docs/providers.md
@@ -263,7 +263,7 @@ module.exports = {
 <TabItem value="typescript" label="TypeScript">
 
 ```ts
-export {
+export default {
   init(providerOptions) {
     // init your provider if necessary
 


### PR DESCRIPTION
In the TypeScript example in providers.md the export should be a default export.