### PR TITLE
[Strapi 5] Document breaking change for Admin RBAC updates

### DIFF
--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes.md
@@ -65,6 +65,7 @@ The beta version of Strapi 5 is not meant to be used in production yet.
 
 - [The `ContentManagerAppState` redux is modified](/dev-docs/migration/v4-to-v5/breaking-changes/redux-content-manager-app-state)
 - [The `EditViewLayout` and `ListViewLayout` have been refactored](/dev-docs/migration/v4-to-v5/breaking-changes/edit-view-layout-and-list-view-layout-rewritten)
+- [The Admin Panel RBAC redux store has been updated](/dev-docs/migration/v4-to-v5/breaking-changes/admin-panel-rbac-store-updated)
 
 ## Dependencies
 

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/admin-panel-rbac-store-updated.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/admin-panel-rbac-store-updated.md
@@ -11,12 +11,14 @@ tags:
 
 import Intro from '/docs/snippets/breaking-change-page-intro.md'
 import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
+import YesPlugins from '/docs/snippets/breaking-change-affecting-plugins.md'
 
 # The admin panel RBAC system has been updated
 
 In Strapi 5, the `content-manager_rbacManager`, which is a section of Strapi's redux store for the admin panel, is removed and the regular permissions system is used instead. Additionally, the `useRBAC` hook is updated.
 
 <Intro/>
+<YesPlugins/>
 
 ## Breaking change description
 

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/admin-panel-rbac-store-updated.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/admin-panel-rbac-store-updated.md
@@ -56,7 +56,8 @@ const canMain = allowedActions.canMain
 
 ### Notes
 
-A new RBAC API is available and users can utilise a middleware system to interact with calls. Additional information can be found in the Contributors Documentation, in the [Fetching permissions](https://contributor.strapi.io/docs/core/admin/permissions/frontend/fetching-permissions) and [Authentication](https://contributor.strapi.io/docs/core/admin/features/authentication) sections.
+* A new RBAC API is available and users can utilise a middleware system to interact with calls (see [contributors documentation](https://v5.contributor.strapi.io/exports/classes/StrapiApp#addrbacmiddleware)).
+* Additional information can be found in the Contributors Documentation, in the [Fetching permissions](https://contributor.strapi.io/docs/core/admin/permissions/frontend/fetching-permissions) and [Authentication](https://contributor.strapi.io/docs/core/admin/features/authentication) sections.
 
 ### Manual migration
 

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/admin-panel-rbac-store-updated.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/admin-panel-rbac-store-updated.md
@@ -56,6 +56,7 @@ const canMain = allowedActions.canMain
 
 ### Notes
 
+<!-- TODO: update links when v5.contributor.strapi.io is hosted at contributor.strapi.io -->
 * A new RBAC API is available and users can utilise a middleware system to interact with calls (see [contributors documentation](https://v5.contributor.strapi.io/exports/classes/StrapiApp#addrbacmiddleware)).
 * Additional information can be found in the Contributors Documentation, in the [Fetching permissions](https://contributor.strapi.io/docs/core/admin/permissions/frontend/fetching-permissions) and [Authentication](https://contributor.strapi.io/docs/core/admin/features/authentication) sections.
 

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/admin-panel-rbac-store-updated.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/admin-panel-rbac-store-updated.md
@@ -1,0 +1,61 @@
+---
+title: The admin panel RBAC system has been updated
+description: In Strapi 5, there is no `content-manager_rbacManager` anymore, and the regular permissions system is used instead.
+sidebar_label: content-manager_rbacManager removed
+displayed_sidebar: devDocsMigrationV5Sidebar
+tags:
+ - breaking changes
+ - content manager
+ - RBAC
+---
+
+import Intro from '/docs/snippets/breaking-change-page-intro.md'
+import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
+
+# The admin panel RBAC system has been updated
+
+In Strapi 5, the `content-manager_rbacManager`, which is a section of Strapi's redux store for the admin panel, is removed and the regular permissions system is used instead. Additionally, the `useRBAC` hook is updated.
+
+<Intro/>
+
+## Breaking change description
+
+**In Strapi v4**
+
+Permissions are handled with the `content-manager_rbacManager` section of the redux store, like in the following generic example:
+
+```tsx
+const cmPermissions useSelector(state => state['content-manager_rbacManager'])
+```
+
+```tsx
+const { allowedActions } = useRBAC({
+	main: [{ action: 'admin::something.main', subject: null }]
+})
+
+const canMain = allowedActions.canMain
+```
+
+**In Strapi 5**
+
+`content-manager_rbacManager` is removed and the regular permissions system is used instead, which implies the `useRBAC` hook is used differently, as in the following generic example:
+
+```tsx
+const { allowedActions } = useRBAC([
+  { action: 'admin::something.main', subject: null }
+])
+
+const canMain = allowedActions.canMain
+```
+
+## Migration
+
+<MigrationIntro />
+
+### Notes
+
+A new RBAC API is available and users can utilise a middleware system to interact with calls. Additional information can be found in the Contributors Documentation, in the [Fetching permissions](https://contributor.strapi.io/docs/core/admin/permissions/frontend/fetching-permissions) and [Authentication](https://contributor.strapi.io/docs/core/admin/features/authentication) sections.
+
+### Manual migration
+
+Plugin developers that are hooking into the redux store to tweak RBAC permissions in Strapi v4 need to update their code according to the described changes.

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -1189,6 +1189,7 @@ const sidebars = {
               items: [
                 'dev-docs/migration/v4-to-v5/breaking-changes/redux-content-manager-app-state',
                 'dev-docs/migration/v4-to-v5/breaking-changes/edit-view-layout-and-list-view-layout-rewritten',
+                'dev-docs/migration/v4-to-v5/breaking-changes/admin-panel-rbac-store-updated',
               ],
             },
             {


### PR DESCRIPTION
This PR documents changes related to `content-manager_rbacManager` and `useRBAC`.

Direct preview link 👉 [here](https://documentation-git-v5-bc-admin-rbac-strapijs.vercel.app/dev-docs/migration/v4-to-v5/breaking-changes/admin-panel-rbac-store-updated)