### PR TITLE
[Strapi 5] Document better-sqlite3 breaking change

### DIFF
--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes.md
@@ -45,6 +45,7 @@ The beta version of Strapi 5 is not meant to be used in production yet.
 
 - [MySQL v5 is not supported anymore](/dev-docs/migration/v4-to-v5/breaking-changes/mysql5-unsupported)
 - [Database identifiers can't be longer than 55 characters](/dev-docs/migration/v4-to-v5/breaking-changes/database-identifiers-shortened)
+- [Only the `better-sqlite3` package is supported for the sqlite client](/dev-docs/migration/v4-to-v5/breaking-changes/only-better-sqlite3-for-sqlite)
 
 ## Plugins, plugins configuration, and plugins development
 

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/only-better-sqlite3-for-sqlite.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/only-better-sqlite3-for-sqlite.md
@@ -14,7 +14,7 @@ import NoPlugins from '/docs/snippets/breaking-change-not-affecting-plugins.md'
 
 # Only the `better-sqlite3` package is supported for the sqlite client
 
-Strapi 5 can only use the `better-sqlite3` package for SQLite databases, and the `client` value for it must be set to `sqlite`
+Strapi 5 can only use the `better-sqlite3` package for SQLite databases, and the `client` value for it must be set to `sqlite`.
 
 <Intro />
 

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/only-better-sqlite3-for-sqlite.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/only-better-sqlite3-for-sqlite.md
@@ -14,7 +14,7 @@ import NoPlugins from '/docs/snippets/breaking-change-not-affecting-plugins.md'
 
 # Only the `better-sqlite3` package is supported for the sqlite client
 
-Strapi 5 can only use the `better-sqlite3` package for SQLite databases.
+Strapi 5 can only use the `better-sqlite3` package for SQLite databases, and the `client` value for it must be set to `sqlite`
 
 <Intro />
 

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/only-better-sqlite3-for-sqlite.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/only-better-sqlite3-for-sqlite.md
@@ -1,0 +1,60 @@
+---
+title: Only the `better-sqlite3` package is supported for the sqlite client
+description: In Strapi 5, 
+sidebar_label: Only better-sqlite3 for sqlite 
+displayed_sidebar: devDocsMigrationV5Sidebar
+unlisted: true
+tags:
+ - breaking changes
+---
+
+import Intro from '/docs/snippets/breaking-change-page-intro.md'
+import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
+import NoPlugins from '/docs/snippets/breaking-change-not-affecting-plugins.md'
+
+# Only the `better-sqlite3` package is supported for the sqlite client
+
+Strapi 5 can only use the `better-sqlite3` package for SQLite databases.
+
+<Intro />
+
+<NoPlugins/>
+
+## Breaking change description
+
+<SideBySideContainer>
+
+<SideBySideColumn>
+
+**In Strapi v4**
+
+The database configuration `client` option for SQLite databases accepts several values such as `sqlite3`, `vscode/sqlite3`, `sqlite-legacy`, and `better-sqlite3`.
+
+</SideBySideColumn>
+
+<SideBySideColumn>
+
+**In Strapi 5**
+
+The database configuration `client` option for SQLite database only accepts `sqlite`.
+
+</SideBySideColumn>
+
+</SideBySideContainer>
+
+## Migration
+
+<MigrationIntro />
+
+### Notes
+
+Strapi 5 uses the `better-sqlite3` package for SQLite databases under the hood. Knex rewrites the `sqlite` option as `better-sqlite3`.
+
+### Manual procedure
+
+No manual migration should be required as codemods from the [upgrade tool](/dev-docs/upgrade-tool) will handle this change.
+
+In case you want to manually migrate, run the following commands in the terminal:
+
+1. Run `yarn remove sqlite3` to remove the sqlite 3 package.
+2. Run `yarn add better-sqlite3` to install the `better-sqlite3` package.

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -1152,7 +1152,8 @@ const sidebars = {
               },
               items: [
                 'dev-docs/migration/v4-to-v5/breaking-changes/mysql5-unsupported',
-                'dev-docs/migration/v4-to-v5/breaking-changes/database-identifiers-shortened'
+                'dev-docs/migration/v4-to-v5/breaking-changes/database-identifiers-shortened',
+                'dev-docs/migration/v4-to-v5/breaking-changes/only-better-sqlite3-for-sqlite',
               ]
             },
             {


### PR DESCRIPTION
This PR documents the database config `client` option restrictions for SQLite in Strapi 5.