### PR TITLE
Document using strapi instance for migrations

### DIFF
--- a/docusaurus/docs/dev-docs/database-migrations.md
+++ b/docusaurus/docs/dev-docs/database-migrations.md
@@ -80,7 +80,9 @@ module.exports = {
 
 ### Using Strapi Instance for migrations
 
+:::danger
 If a user opts not to use Knex directly for migrations and instead utilizes the Strapi instance, it is important to wrap the migration code with `strapi.db.transaction()`. Failure to do so may result in migrations not rolling back if an error occurs.
+:::
 
 <details>
 <summary>Example of migration file with Strapi instance</summary>

--- a/docusaurus/docs/dev-docs/database-migrations.md
+++ b/docusaurus/docs/dev-docs/database-migrations.md
@@ -74,3 +74,36 @@ module.exports = {
 ```
 
 </details>
+
+
+## Additional considerations
+
+### Using Strapi Instance for migrations
+
+If a user opts not to use Knex directly for migrations and instead utilizes the Strapi instance, it is important to wrap the migration code with `strapi.db.transaction()`. Failure to do so may result in migrations not rolling back if an error occurs.
+
+<details>
+<summary>Example of migration file with Strapi instance</summary>
+
+```jsx title="./database/migrations/2022.05.10T00.00.00.name-of-my-migration.js"
+module.exports = {
+  async up() {
+    await strapi.db.transaction(async () => {
+      // Your migration code here
+
+      // Example: creating new entries
+      await strapi.entityService.create('api::article.article', {
+        data: {
+          title: 'My Article',
+        },
+      });
+
+      // Example: custom service method
+      await strapi.service('api::article.article').updateRelatedArticles();
+    });
+  },
+};
+```
+
+</details>
+

--- a/docusaurus/docs/dev-docs/database-migrations.md
+++ b/docusaurus/docs/dev-docs/database-migrations.md
@@ -75,9 +75,6 @@ module.exports = {
 
 </details>
 
-
-## Additional considerations
-
 ### Using Strapi Instance for migrations
 
 :::danger


### PR DESCRIPTION
### What does it do?

Updated documentation for developers that decide to use `strapi` instead of `knex` to perform data migrations. 

### Why is it needed?

Often developers may want to use their custom strapi service methods to perform migrations.

> [!Important]
This serves as a caution for new Strapi developers who might overlook the lack of atomicity when using the `strapi` instance, unlike `knex`, which operates within a transaction state by default when received in the `up()` function.

Source: this happened to my team😄 

### Related issue(s)/PR(s)

N/A
