### PR TITLE
[Strapi 5] Plugins migration summary

### DIFF
--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/guides/introduction.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/guides/introduction.md
@@ -8,6 +8,6 @@ displayed_sidebar: devDocsMigrationV5Sidebar
 
 The following pages cover some specific topics for migrating to Strapi 5 that have not been covered neither in the [CLI upgrade tool](/dev-docs/migration/v4-to-v5/use-the-upgrade-tool) guide nor in the list of [breaking changes](/dev-docs/migration/v4-to-v5/breaking-changes):
 
-<CustomDocCard emoji="💁" title="Helper-plugin deprecation reference" description="Learn how to develop plugins with the Strapi v4 helper-plugin that has been removed in Strapi 5." link="/dev-docs/migration/v4-to-v5/guides/helper-plugin" />
-<CustomDocCard emoji="🧩" title="Plugins migration reference" description="Find all resources and answers to your questions on how to migrate your plugins to Strapi 5." link="/dev-docs/migration/v4-to-v5/guides/plugins-migration" />
 <CustomDocCard emoji="📦" title="Entity Service API to Document Service API migration reference" description="Learn how to transition from the Entity Service API, deprecated in Strapi 5, to the new Document Service API." link="/dev-docs/migration/v4-to-v5/guides/from-entity-service-to-document-service" />
+<CustomDocCard emoji="🧩" title="Plugins migration summary" description="Find all resources and answers to your questions on how to migrate your plugins to Strapi 5." link="/dev-docs/migration/v4-to-v5/guides/plugins-migration" />
+<CustomDocCard emoji="💁" title="Helper-plugin deprecation reference" description="Learn how to develop plugins with the Strapi v4 helper-plugin that has been removed in Strapi 5." link="/dev-docs/migration/v4-to-v5/guides/helper-plugin" />

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/guides/introduction.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/guides/introduction.md
@@ -1,0 +1,13 @@
+---
+title: Additional resources for migrating to Strapi 5
+sidebar_label: Introduction
+displayed_sidebar: devDocsMigrationV5Sidebar
+---
+
+# Additional resources for migrating to Strapi 5
+
+The following pages cover some specific topics for migrating to Strapi 5 that have not been covered neither in the [CLI upgrade tool](/dev-docs/migration/v4-to-v5/use-the-upgrade-tool) guide nor in the list of [breaking changes](/dev-docs/migration/v4-to-v5/breaking-changes):
+
+<CustomDocCard emoji="💁" title="Helper-plugin deprecation reference" description="Learn how to develop plugins with the Strapi v4 helper-plugin that has been removed in Strapi 5." link="/dev-docs/migration/v4-to-v5/guides/helper-plugin" />
+<CustomDocCard emoji="🧩" title="Plugins migration reference" description="Find all resources and answers to your questions on how to migrate your plugins to Strapi 5." link="/dev-docs/migration/v4-to-v5/guides/plugins-migration" />
+<CustomDocCard emoji="📦" title="Entity Service API to Document Service API migration reference" description="Learn how to transition from the Entity Service API, deprecated in Strapi 5, to the new Document Service API." link="/dev-docs/migration/v4-to-v5/guides/from-entity-service-to-document-service" />

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/guides/plugins-migration.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/guides/plugins-migration.md
@@ -1,0 +1,55 @@
+---
+title: Plugins migration reference
+displayed_sidebar: devDocsMigrationV5Sidebar
+---
+
+# Plugins migration FAQ
+
+This page is intended to be used as a recap of everything to consider in Strapi 5 if you are a plugin developer intending to migrate your plugin from Strapi v4 to Strapi 5.
+
+## Back end changes
+
+- The Entity Service API from Strapi v4 is deprecated and Strapi 5 uses the Document Service API instead. There is a [migration guide](/dev-docs/migration/v4-to-v5/guides/from-entity-service-to-document-service) for this.
+- [Breaking changes](/dev-docs/migration/v4-to-v5/breaking-changes) might apply.
+- You can use the new [Plugin CLI](/dev-docs/plugins/guides/use-the-plugin-cli) to generate plugins and publish them on NPM and/or submit them to the Marketplace.
+    
+## Front-end changes
+
+    - Frontend Changes
+        - Design System?
+            - Not big changes visually (icons change)
+            - Can use v1 or v2 (advise using v2)
+            - Migration guide will exist
+            - Removed a couple but they were deprecated for a long time
+            - Breaking changes are in root of design system → moved into storybook later
+        - New APIs, all the normal breaking changes apply
+        - Helper plugin deprecated
+            - Has migration guide, in the repo for now → Piwi added to docs-next https://docs-next.strapi.io/dev-docs/migration/v4-to-v5/guides/helper-plugin
+            - Most have been moved to @strapi/admin
+            - Some were removed
+        - Aliasing dependencies → if not declared it will use ours (probably)
+        - Most everything is in the breaking change list (layouts, hooks, ect)
+    - General changes
+        - Building and packaging?
+            - They don’t have to do it (not tested)
+            - Recommended as a best practices (from npm)
+        - Pack up?
+            - Not required
+            - Is pack up specific to our packages or is it universal
+                - More for libraries
+            - Does the plugin need to be a TS one to use pack up (honestly no idea what pack up does)
+        - peerDepend requirement?
+            - Yes probably (ask emilie)
+            - As a peerDepend
+- Do we have an examples of plugins we have converted that could be reviewed?
+    - i18n → might be good for frontend, backend would be complicated (changed a ton)
+        - Cause of most of the breaking changes, using as an example would not be ideal
+    - review workflows → no v4 counterpart on it’s on own
+- Whats our plan for the following?
+    - https://github.com/strapi/strapi/tree/v5/main/packages/plugins/color-picker
+    - https://github.com/strapi/strapi/tree/v5/main/packages/plugins/sentry
+    - https://github.com/strapi/strapi-plugin-seo
+        - A lot of bad practice before we share it (after migrated) → need refactoring on the admin
+- What about custom providers?
+    - Does email/upload providers need any conversion?
+        - Mainly just getting rid of entityService → docsrv/queries

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/guides/plugins-migration.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/guides/plugins-migration.md
@@ -3,53 +3,49 @@ title: Plugins migration reference
 displayed_sidebar: devDocsMigrationV5Sidebar
 ---
 
-# Plugins migration FAQ
+# Plugins migration summary
 
-This page is intended to be used as a recap of everything to consider in Strapi 5 if you are a plugin developer intending to migrate your plugin from Strapi v4 to Strapi 5.
+:::callout 🚧  Work in progress
+This page is a work-in-progress and some links are currently missing.
+:::
 
-## Back end changes
+The present page is intended to be used as a short summary of everything to consider if you are a plugin developer intending to migrate your plugin from Strapi v4 to Strapi 5. The page quickly describes the changes affecting plugins and link to additional resources where necessary.
 
-- The Entity Service API from Strapi v4 is deprecated and Strapi 5 uses the Document Service API instead. There is a [migration guide](/dev-docs/migration/v4-to-v5/guides/from-entity-service-to-document-service) for this.
-- [Breaking changes](/dev-docs/migration/v4-to-v5/breaking-changes) might apply.
+## Back-end changes
+
+- The Entity Service API from Strapi v4 is deprecated and Strapi 5 uses the [Document Service API](/dev-docs/api/document-service) instead. A [migration guide](/dev-docs/migration/v4-to-v5/guides/from-entity-service-to-document-service) is available to help you transition to the Document Service API.
+- General Strapi v4 to Strapi 5 [breaking changes](/dev-docs/migration/v4-to-v5/breaking-changes) might apply.
 - You can use the new [Plugin CLI](/dev-docs/plugins/guides/use-the-plugin-cli) to generate plugins and publish them on NPM and/or submit them to the Marketplace.
-    
+
 ## Front-end changes
 
-    - Frontend Changes
-        - Design System?
-            - Not big changes visually (icons change)
-            - Can use v1 or v2 (advise using v2)
-            - Migration guide will exist
-            - Removed a couple but they were deprecated for a long time
-            - Breaking changes are in root of design system → moved into storybook later
-        - New APIs, all the normal breaking changes apply
-        - Helper plugin deprecated
-            - Has migration guide, in the repo for now → Piwi added to docs-next https://docs-next.strapi.io/dev-docs/migration/v4-to-v5/guides/helper-plugin
-            - Most have been moved to @strapi/admin
-            - Some were removed
-        - Aliasing dependencies → if not declared it will use ours (probably)
-        - Most everything is in the breaking change list (layouts, hooks, ect)
-    - General changes
-        - Building and packaging?
-            - They don’t have to do it (not tested)
-            - Recommended as a best practices (from npm)
-        - Pack up?
-            - Not required
-            - Is pack up specific to our packages or is it universal
-                - More for libraries
-            - Does the plugin need to be a TS one to use pack up (honestly no idea what pack up does)
-        - peerDepend requirement?
-            - Yes probably (ask emilie)
-            - As a peerDepend
-- Do we have an examples of plugins we have converted that could be reviewed?
-    - i18n → might be good for frontend, backend would be complicated (changed a ton)
-        - Cause of most of the breaking changes, using as an example would not be ideal
-    - review workflows → no v4 counterpart on it’s on own
-- Whats our plan for the following?
-    - https://github.com/strapi/strapi/tree/v5/main/packages/plugins/color-picker
-    - https://github.com/strapi/strapi/tree/v5/main/packages/plugins/sentry
-    - https://github.com/strapi/strapi-plugin-seo
-        - A lot of bad practice before we share it (after migrated) → need refactoring on the admin
-- What about custom providers?
-    - Does email/upload providers need any conversion?
-        - Mainly just getting rid of entityService → docsrv/queries
+- The Design System is upgraded to v2 in Strapi 5:
+  <!-- TODO: add link to icons in Design System v2 -->
+  - There are no big visual changes, except for [icons](#).<br/>(_the link will be added in the upcoming weeks_)
+  <!-- TODO: add link to migration guide -->
+  - A migration guide will be [available](#).<br/>(_the link will be added in the upcoming weeks_)
+  <!-- TODO: add link to breaking changes -->
+  - A list of breaking changes specific to the Design System will be available in the [Design System documentation](#).<br/>(_the link will be added in the upcoming weeks_)
+  - General Strapi v4 to Strapi 5 [breaking changes](/dev-docs/migration/v4-to-v5/breaking-changes) might apply.
+- The `helper-plugin` is deprecated. A [migration reference](/dev-docs/migration/v4-to-v5/guides/helper-plugin) is available to help you transition away from the `helper-plugin`.
+  <!-- TODO: clarify the next line 👇 -->
+  <!-- - Aliasing dependencies → if not declared it will use ours (probably) -->
+
+<!-- TODO: clarify these 👇-->
+<!-- ## General changes
+
+- Building and packaging?
+  - They don’t have to do it (not tested)
+  - Recommended as a best practices (from npm)
+- Pack up?
+  - Not required
+  - Is pack up specific to our packages or is it universal
+      - More for libraries
+  - Does the plugin need to be a TS one to use pack up (honestly no idea what pack up does)
+- peerDepend requirement?
+  - Yes probably (ask emilie)
+  - As a peerDepend -->
+
+## Custom providers
+
+Custom [providers](/dev-docs/providers) for the Email and Upload plugins need conversion only if they were using the Entity Service API (please refer to the [Entity Service API to Document Service API migration guide](/dev-docs/migration/v4-to-v5/guides/from-entity-service-to-document-service)).

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/introduction.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/introduction.md
@@ -14,10 +14,10 @@ It is currently strongly advised that you refrain from migrating from Strapi v4 
 The beta version of Strapi 5 is not meant to be used in production yet.
 :::
 
-The [upgrade tool](/dev-docs/upgrade-tool) and its codemods should automate some parts of the migration from v4 to Strapi 5. Additional information is also given below about breaking changes.
+The [upgrade tool](/dev-docs/upgrade-tool) and its codemods should automate some parts of the migration from v4 to Strapi 5. Additional information is also given below about breaking changes and dedicated migration resources for specific topics.
 
 <CustomDocCardsWrapper>
 <CustomDocCard emoji="" title="Use the upgrade tool" description="Learn how you can use the CLI upgrade tool to migrate from v4 to Strapi 5." link="/dev-docs/migration/v4-to-v5/use-the-upgrade-tool" />
-<CustomDocCard emoji="" title="v4 to v5 Breaking changes" description="Read more about the differences between Strapi v4 and v5 and the resulting breaking changes." link="/dev-docs/migration/v4-to-v5/breaking-changes" />
-<CustomDocCard emoji="" title="v4 to v5 migration guides" description="Handle specific use cases: Plugins migration, helper-plugin deprecation, Entity Service API deprecation." link="/dev-docs/migration/v4-to-v5/guides/introduction" />
+<CustomDocCard emoji="" title="Breaking changes list" description="Read more about the differences between Strapi v4 and v5 and the resulting breaking changes." link="/dev-docs/migration/v4-to-v5/breaking-changes" />
+<CustomDocCard emoji="" title="Specific migration resources" description="Handle specific use cases: Plugins migration, helper-plugin deprecation, Entity Service API deprecation." link="/dev-docs/migration/v4-to-v5/guides/introduction" />
 </CustomDocCardsWrapper>

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/introduction.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/introduction.md
@@ -17,5 +17,7 @@ The beta version of Strapi 5 is not meant to be used in production yet.
 The [upgrade tool](/dev-docs/upgrade-tool) and its codemods should automate some parts of the migration from v4 to Strapi 5. Additional information is also given below about breaking changes.
 
 <CustomDocCardsWrapper>
+<CustomDocCard emoji="" title="Use the upgrade tool" description="Learn how you can use the CLI upgrade tool to migrate from v4 to Strapi 5." link="/dev-docs/migration/v4-to-v5/use-the-upgrade-tool" />
 <CustomDocCard emoji="" title="v4 to v5 Breaking changes" description="Read more about the differences between Strapi v4 and v5 and the resulting breaking changes." link="/dev-docs/migration/v4-to-v5/breaking-changes" />
+<CustomDocCard emoji="" title="v4 to v5 migration guides" description="Handle specific use cases: Plugins migration, helper-plugin deprecation, Entity Service API deprecation." link="/dev-docs/migration/v4-to-v5/guides/introduction" />
 </CustomDocCardsWrapper>

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/use-the-upgrade-tool.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/use-the-upgrade-tool.md
@@ -1,0 +1,6 @@
+---
+title: Migrate to Strapi 5 with the CLI upgrade tool
+displayed_sidebar: devDocsMigrationV5Sidebar
+---
+
+_Coming soon…_

--- a/docusaurus/docs/dev-docs/plugins/guides/use-the-plugin-cli.md
+++ b/docusaurus/docs/dev-docs/plugins/guides/use-the-plugin-cli.md
@@ -9,12 +9,6 @@ import NotV5 from '/docs/snippets/_not-updated-to-v5.md'
 
 # How to use the Plugin CLI to create and publish a Strapi plugin
 
-<NotV5/>
-
-:::caution
-The Plugin CLI is currently experimental.
-:::
-
 The Plugin CLI is set of commands orientated around developing plugins to use them as local plugins or to publish them on NPM and/or submit them to the Marketplace.
 
 As opposed to the `strapi generate plugin` command (see [plugin creation and setup](/dev-docs/plugins/development/create-a-plugin)) you do not need to set up a Strapi project to use the Plugin CLI.

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -1227,7 +1227,10 @@ const sidebars = {
         {
           type: 'category',
           label: 'Migration guides',
+          link: { type: 'doc', id: 'dev-docs/migration/v4-to-v5/guides/introduction' },
           items: [
+            'dev-docs/migration/v4-to-v5/guides/introduction',
+            'dev-docs/migration/v4-to-v5/guides/plugins-migration',
             'dev-docs/migration/v4-to-v5/guides/helper-plugin',
             'dev-docs/migration/v4-to-v5/guides/from-entity-service-to-document-service',
           ]


### PR DESCRIPTION
This PR adds a short summary about plugins migration and cross-references many other documentation resources, inside and outside docs.strapi.io.