### PR TITLE
[Strapi 5] Entity Service → Document Service: Breaking change + migration reference

### DIFF
--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes.md
@@ -40,6 +40,7 @@ The beta version of Strapi 5 is not meant to be used in production yet.
 * [The `locale` attribute name is reserved by Strapi](/dev-docs/migration/v4-to-v5/breaking-changes/locale-attribute-reserved)
 <!-- * [Components and dynamic zones do not return an `id` with REST API requests](/dev-docs/migration/v4-to-v5/breaking-changes/components-and-dynamic-zones-do-not-return-id) not implemented yet -->
 * [The GraphQL API has been updated](/dev-docs/migration/v4-to-v5/breaking-changes/graphql-api-updated)
+* [The Entity Service API is deprecated and replaced by the Document Service API](/dev-docs/migration/v4-to-v5/breaking-changes/entity-service-deprecated)
 
 ## Database
 

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/entity-service-deprecated.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/entity-service-deprecated.md
@@ -1,0 +1,68 @@
+---
+title: Entity Service deprecated
+description: In Strapi 5, the Entity Service API is deprecated in favor of the new Document Service API.
+sidebar_label: Entity Service deprecated
+displayed_sidebar: devDocsMigrationV5Sidebar
+tags:
+ - breaking changes
+ - Entity Service API
+ - Document Service API
+---
+
+import Intro from '/docs/snippets/breaking-change-page-intro.md'
+import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
+import YesPlugins from '/docs/snippets/breaking-change-affecting-plugins.md'
+
+# Entity Service deprecated
+
+The Entity Service that was used in Strapi v4 is deprecated and replaced by the new [Document Service API](/dev-docs/api/document-service) in Strapi 5. <MigrationIntro/>
+
+<YesPlugins/>
+
+## Breaking change description
+
+<SideBySideContainer>
+
+<SideBySideColumn>
+
+**In Strapi v4**
+
+The Entity Service API is the go-to API to use to interact with your content-types.
+
+</SideBySideColumn>
+
+<SideBySideColumn>
+
+**In Strapi 5**
+
+The [Document Service API](/dev-docs/api/document-service) replaces the Entity Service API from Strapi v4.
+
+</SideBySideColumn>
+
+</SideBySideContainer>
+
+## Migration
+
+<MigrationIntro />
+
+### Notes
+
+The following are the main topics to take into account when using the Document Service API instead of the Entity Service API from Strapi v4:
+
+* The Document Service API expects a `documentId` property.<br/>This breaking change also affects the REST and GraphQL APIs (see [the related entry](/dev-docs/migration/v4-to-v5/breaking-changes/use-document-id)).
+* The response returned by the `findMany()` function is different in Strapi v4 and Strapi 5:
+  - In Strapi v4, the `findMany()` function from the Entity Service API returns a single item for single types.
+  - In Strapi 5, the [`findMany()` function from the Document Service API](/dev-docs/api/document-service#findmany) always returns arrays. To get a single item, extract the first item from the returned array, or use [the `findFirst()` function](/dev-docs/api/document-service#findfirst).
+* There is no `findPage()` method anymore in Strapi 5 (see [the related breaking change entry](/dev-docs/migration/v4-to-v5/breaking-changes/no-find-page-in-document-service))
+* The [Draft & Publish](/user-docs/content-manager/saving-and-publishing-content) feature has been updated in Strapi 5 and this is reflected in the Document Service API:
+  - `publicationState` is replaced by `status` (see [the related breaking change entry](/dev-docs/migration/v4-to-v5/breaking-changes/publication-state-removed)).
+  - New methods are introduced to handle the updated [Draft & Publish](/user-docs/content-manager/saving-and-publishing-content) feature: [`publish()`](/dev-docs/api/document-service#publish), [`unpublish()`](/dev-docs/api/document-service#unpublish), and [`discardDraft()`](/dev-docs/api/document-service#discarddraft).
+  - The `published_at` property can not be used anymore to trigger the publication of content.
+* The `delete()` function of the Document Service API returns a list of affected entries (multiple locales can be deleted all at once), while the `delete()` function from Strapi v4 returns only the deleted entry.
+* Entity Service decorators can not be used anymore, and [Document Service middlewares](/dev-docs/api/document-service/middlewares) must be used instead.
+* The Document Service API does not support file uploads.
+
+
+### Migration procedure
+
+The migration is partially handled by a codemod when using the [upgrade tool](/dev-docs/upgrade-tool). The [Entity Service API to Document Service API migration reference](/dev-docs/migration/v4-to-v5/guides/from-entity-service-to-document-service) gives additional information about which aspects are handled by the codemod and which use cases require manual migration.

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/publication-state-removed.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/publication-state-removed.md
@@ -61,4 +61,5 @@ There are no fallbacks to return by default the published version, and return th
 
 ### Migration procedure
 
-No manual migration is required. A codemod will automatically handle the change (see [Entity Service to Document Service migration reference](/dev-docs/migration/v4-to-v5/guides/from-entity-service-to-document-service) for additional details).
+* API calls initiated from the front end (REST API, GraphQL API) that used `publicationState` need to be manually updated.
+* If `publicationState` is used in your custom back-end code with the Entity Service API in Strapi v4, a codemod will automatically handle the change for Strapi 5 (see [Entity Service to Document Service migration reference](/dev-docs/migration/v4-to-v5/guides/from-entity-service-to-document-service) for additional details).

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/publication-state-removed.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/publication-state-removed.md
@@ -59,7 +59,6 @@ In Strapi 5, the [Draft & Publish feature](/user-docs/content-manager/saving-and
 
 There are no fallbacks to return by default the published version, and return the draft version if no published version is found.
 
-### Migration procedure 
+### Migration procedure
 
-<!-- TODO: to be confirmed -->
-A codemod will automatically handle the change.
+No manual migration is required. A codemod will automatically handle the change (see [Entity Service to Document Service migration reference](/dev-docs/migration/v4-to-v5/guides/from-entity-service-to-document-service) for additional details).

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/guides/from-entity-service-to-document-service.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/guides/from-entity-service-to-document-service.md
@@ -8,4 +8,265 @@ tags:
 - document service API
 ---
 
-_Coming soon…_
+# Entity Service API to Document Service API migration reference
+
+In Strapi 5, the [Document Service API](/dev-docs/api/document-service) replaces the Entity Service API from Strapi v4. The present page is intended to give developers an idea of how to migrate away from the Entity Service API, by describing which changes in custom code will be handled by codemods from the [upgrade tool](/dev-docs/upgrade-tool) and which will have to be handled manually.
+
+## Changes handled by the upgrade tool
+
+When using the [upgrade tool](/dev-docs/upgrade-tool), a codemod is run and handles some parts of the `entityService` migration.
+
+:::caution
+The codemod is only changing the function calls and some parameters. This can not be considered as a complete migration as the codemod will never be able to convert an `entityId` into a `documentId`.
+:::
+
+When using the codemod from the upgrade tool:
+
+- The code structure is automatically migrated.
+- `publicationState` is automatically transformed into `status`
+
+The following examples show how the codemod from the upgrade tool updates the code from various function calls.
+
+### `findOne`
+
+<Columns>
+<ColumnLeft>
+
+**Before:**
+
+```tsx
+strapi.entityService.findOne(uid, entityId);
+
+
+```
+
+</ColumnLeft>
+
+<ColumnRight>
+
+**After:**
+
+```tsx
+strapi.documents(uid).findOne({
+  documentId: "__TODO__"
+});
+```
+
+</ColumnRight>
+
+</Columns>
+
+### `findMany`
+
+<Columns>
+<ColumnLeft>
+
+**Before:**
+
+```tsx
+strapi.entityService.findMany(uid, {
+  fields: ["id", "name", "description"],
+  populate: ["author", "comments"],
+  publicationState: "preview",
+});
+```
+
+</ColumnLeft>
+
+<ColumnRight>
+
+**After:**
+
+```tsx
+strapi.documents(uid).findMany({
+  fields: ["id", "name", "description"],
+  populate: ["author", "comments"],
+  status: "draft",
+});
+```
+
+</ColumnRight>
+</Columns>
+
+### `create`
+
+<Columns>
+<ColumnLeft>
+
+**Before:**
+
+```tsx
+strapi.entityService.create(uid, {
+  data: {
+    name: "John Doe",
+    age: 30,
+  },
+});
+```
+
+</ColumnLeft>
+<ColumnRight>
+
+**After:**
+
+```tsx
+strapi.documents(uid).create({
+  data: {
+    name: "John Doe",
+    age: 30,
+  },
+});
+```
+
+</ColumnRight>
+</Columns>
+
+### `update`
+
+<Columns>
+<ColumnLeft>
+
+**Before:**
+
+```tsx
+strapi.entityService.update(uid, entityId, {
+  data: {
+    name: "John Doe",
+    age: 30,
+  }
+});
+
+```
+
+</ColumnLeft>
+<ColumnRight>
+
+**After:**
+
+```tsx
+strapi.documents(uid).update({
+  documentId: "__TODO__",
+  data: {
+    name: "John Doe",
+    age: 30,
+  }
+});
+```
+
+</ColumnRight>
+</Columns>
+
+### `delete`
+
+<Columns>
+<ColumnLeft>
+
+**Before:**
+
+```tsx
+strapi.entityService.delete(uid, entityId);
+
+
+```
+
+</ColumnLeft>
+<ColumnRight>
+
+**After:**
+
+```tsx
+strapi.documents(uid).delete({
+  documentId: "__TODO__"
+});
+```
+
+</ColumnRight>
+</Columns>
+
+### `count`
+
+<Columns>
+<ColumnLeft>
+
+**Before:**
+
+```tsx
+strapi.entityService.count(uid);
+```
+
+</ColumnLeft>
+<ColumnRight>
+
+**After:**
+
+```tsx
+strapi.documents(uid).count();
+```
+
+</ColumnRight>
+</Columns>
+
+
+
+## Changes to handle manually
+
+- We cannot guess the document id so we add a `__TODO__` to make it easily searchable and replacable by users
+- Previsouly they where changing the published_at to publish now they have to use the publis/unpublish/discardraft methods and we cannot auto migrate that
+
+***
+
+- The delete function returns a list of entries affected (multiple locales can be deleted at once) before it was just returning the deleted entry
+
+Depending on where we run that code they might have already access to the documentId after migrating (e.g when using the core services 
+
+**Manual migration**
+
+---
+
+- User can manually do the migration the codemod operates too if they prefer it.
+- If they where using other non-documented methods they will have to refactor their code to use doc service methods
+
+**Decorators (For plugin developers)**
+
+- The entity service decorators have been replaced by the document service middlewares
+
+**Before**
+
+```tsx
+strapi.entityService.decorate((service) => {
+
+	return Object.assign(service, {
+	
+		findOne(entityId, params = {}) {
+			// e.g soft exclude soft deleted content
+			params.filters = { ...params.filters, deletedAt: { $notNull: true } } 
+			return service.findOne(entityId, params)
+		}
+	});
+})
+```
+
+**After** (full doc in the doc-service documentation)
+
+```tsx
+strapi.documents.use((ctx, next) => {
+	if (ctx.uid !== "api::myct.myct") {
+		return next();
+	}
+	
+	if (ctx.action === 'findOne') {
+		// customization
+		ctx.params.filters = { ...params.filters, deletedAt: { $notNull: true } } 
+		const res = await next();
+		// do sth with the res if you want
+		return res;
+	}
+	
+	return next();
+});
+```
+
+**SingleTypes**
+
+- In v4 the findMany function was returning a single item when called for a single type.
+- In v5 the findMany is generic and only returns arrays. user will have to extra the 1st item from the array

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -1157,6 +1157,7 @@ const sidebars = {
                 'dev-docs/migration/v4-to-v5/breaking-changes/locale-attribute-reserved',
                 // 'dev-docs/migration/v4-to-v5/breaking-changes/components-and-dynamic-zones-do-not-return-id', // not implemented yet
                 'dev-docs/migration/v4-to-v5/breaking-changes/graphql-api-updated',
+                'dev-docs/migration/v4-to-v5/breaking-changes/entity-service-deprecated',
               ]
             },
             {


### PR DESCRIPTION
This PR:
- adds a breaking change entry for the Entity Service being deprecated and replaced by the Document Service.
- adds a migration reference which explains what the codemod does and what users still need to manually handle.

Direct preview links
👉 [Breaking change entry](https://documentation-git-v5-entity-document-migration-strapijs.vercel.app/dev-docs/migration/v4-to-v5/breaking-changes/entity-service-deprecated)
👉 [Migration reference](https://documentation-git-v5-entity-document-migration-strapijs.vercel.app/dev-docs/migration/v4-to-v5/guides/from-entity-service-to-document-service)