### PR TITLE
pr: chore - Improving routes page

### DIFF
--- a/docusaurus/docs/dev-docs/backend-customization/routes.md
+++ b/docusaurus/docs/dev-docs/backend-customization/routes.md
@@ -15,7 +15,7 @@ Requests sent to Strapi on any URL are handled by routes. By default, Strapi gen
 - with [policies](#policies), which are a way to block access to a route,
 - and with [middlewares](#middlewares), which are a way to control and change the request flow and the request itself.
 
-Once a route exists, reaching it executes some code handled by a controller (see [controllers documentation](/dev-docs/backend-customization/controllers)). To view all existing routes and their hierarchal order you can run `yarn strapi routes:list`.
+Once a route exists, reaching it executes some code handled by a controller (see [controllers documentation](/dev-docs/backend-customization/controllers)). To view all existing routes and their hierarchal order, you can run `yarn strapi routes:list` (see [CLI reference](/dev-docs/cli)).
 
 <figure style={imgStyle}>
   <img src="/img/assets/backend-customization/diagram-routes.png" alt="Simplified Strapi backend diagram with routes highlighted" />

--- a/docusaurus/docs/dev-docs/backend-customization/routes.md
+++ b/docusaurus/docs/dev-docs/backend-customization/routes.md
@@ -462,7 +462,7 @@ module.exports = {
     {
       method: 'GET',
       path: '/articles/customRoute',
-      handler: 'api::apiName.controllerName.functionName',
+      handler: 'api::api-name.controllerName.functionName', // or 'plugin::plugin-name.controllerName.functionName' for a plugin
       config: {
         middlewares: [
           // point to a registered middleware

--- a/docusaurus/docs/dev-docs/backend-customization/routes.md
+++ b/docusaurus/docs/dev-docs/backend-customization/routes.md
@@ -350,7 +350,7 @@ export default {
     {
       method: 'GET',
       path: '/articles/customRoute',
-      handler: 'api::apiName.controllerName.functionName',
+      handler: 'api::api-name.controllerName.functionName', // or 'plugin::plugin-name.controllerName.functionName' for a plugin
       config: {
         policies: [
           // point to a registered policy

--- a/docusaurus/docs/dev-docs/backend-customization/routes.md
+++ b/docusaurus/docs/dev-docs/backend-customization/routes.md
@@ -319,7 +319,7 @@ module.exports = {
     {
       method: 'GET',
       path: '/articles/customRoute',
-      handler: 'api::api-name.controllerName.functionName', // or 'plugin::plugin-name.controllerName.functionName' for a plugin
+      handler: 'api::api-name.controllerName.functionName', // or 'plugin::plugin-name.controllerName.functionName' for a plugin-scoped route
       config: {
         policies: [
           // point to a registered policy

--- a/docusaurus/docs/dev-docs/backend-customization/routes.md
+++ b/docusaurus/docs/dev-docs/backend-customization/routes.md
@@ -15,7 +15,7 @@ Requests sent to Strapi on any URL are handled by routes. By default, Strapi gen
 - with [policies](#policies), which are a way to block access to a route,
 - and with [middlewares](#middlewares), which are a way to control and change the request flow and the request itself.
 
-Once a route exists, reaching it executes some code handled by a controller (see [controllers documentation](/dev-docs/backend-customization/controllers)). To view all existing routes and their hierarchal order you can run `yarn strapi controllers:list`.
+Once a route exists, reaching it executes some code handled by a controller (see [controllers documentation](/dev-docs/backend-customization/controllers)). To view all existing routes and their hierarchal order you can run `yarn strapi routes:list`.
 
 <figure style={imgStyle}>
   <img src="/img/assets/backend-customization/diagram-routes.png" alt="Simplified Strapi backend diagram with routes highlighted" />

--- a/docusaurus/docs/dev-docs/backend-customization/routes.md
+++ b/docusaurus/docs/dev-docs/backend-customization/routes.md
@@ -350,7 +350,7 @@ export default {
     {
       method: 'GET',
       path: '/articles/customRoute',
-      handler: 'api::api-name.controllerName.functionName', // or 'plugin::plugin-name.controllerName.functionName' for a plugin
+      handler: 'api::api-name.controllerName.functionName', // or 'plugin::plugin-name.controllerName.functionName' for a plugin-scoped route
       config: {
         policies: [
           // point to a registered policy

--- a/docusaurus/docs/dev-docs/backend-customization/routes.md
+++ b/docusaurus/docs/dev-docs/backend-customization/routes.md
@@ -582,7 +582,7 @@ module.exports = {
     {
       method: 'GET',
       path: '/articles/customRoute',
-      handler: 'api::apiName.controllerName.functionName',
+      handler: 'api::api-name.controllerName.functionName', // or 'plugin::plugin-name.controllerName.functionName' for a plugin-specific controller
       config: {
         auth: false,
       },

--- a/docusaurus/docs/dev-docs/backend-customization/routes.md
+++ b/docusaurus/docs/dev-docs/backend-customization/routes.md
@@ -350,7 +350,7 @@ export default {
     {
       method: 'GET',
       path: '/articles/customRoute',
-      handler: 'api::api-name.controllerName.functionName', // or 'plugin::plugin-name.controllerName.functionName' for a plugin-scoped route
+      handler: 'api::api-name.controllerName.functionName', // or 'plugin::plugin-name.controllerName.functionName' for a plugin-specific controller
       config: {
         policies: [
           // point to a registered policy

--- a/docusaurus/docs/dev-docs/backend-customization/routes.md
+++ b/docusaurus/docs/dev-docs/backend-customization/routes.md
@@ -319,7 +319,7 @@ module.exports = {
     {
       method: 'GET',
       path: '/articles/customRoute',
-      handler: 'api::api-name.controllerName.functionName', // or 'plugin::plugin-name.controllerName.functionName' for a plugin-scoped route
+      handler: 'api::api-name.controllerName.functionName', // or 'plugin::plugin-name.controllerName.functionName' for a plugin-specific controller
       config: {
         policies: [
           // point to a registered policy

--- a/docusaurus/docs/dev-docs/backend-customization/routes.md
+++ b/docusaurus/docs/dev-docs/backend-customization/routes.md
@@ -602,7 +602,7 @@ export default  {
     {
       method: 'GET',
       path: '/articles/customRoute',
-      handler: 'api::apiName.controllerName.functionName',
+      handler: 'api::api-name.controllerName.functionName', // or 'plugin::plugin-name.controllerName.functionName' for a plugin-specific controller
       config: {
         auth: false,
       },

--- a/docusaurus/docs/dev-docs/backend-customization/routes.md
+++ b/docusaurus/docs/dev-docs/backend-customization/routes.md
@@ -493,7 +493,7 @@ export default  {
     {
       method: 'GET',
       path: '/articles/customRoute',
-      handler: 'api::apiName.controllerName.functionName',
+      handler: 'api::api-name.controllerName.functionName', // or 'plugin::plugin-name.controllerName.functionName' for a plugin-scoped route
       config: {
         middlewares: [
           // point to a registered middleware

--- a/docusaurus/docs/dev-docs/backend-customization/routes.md
+++ b/docusaurus/docs/dev-docs/backend-customization/routes.md
@@ -319,7 +319,7 @@ module.exports = {
     {
       method: 'GET',
       path: '/articles/customRoute',
-      handler: 'api::apiName.controllerName.functionName',
+      handler: 'api::api-name.controllerName.functionName', // or 'plugin::plugin-name.controllerName.functionName' for a plugin
       config: {
         policies: [
           // point to a registered policy

--- a/docusaurus/docs/dev-docs/backend-customization/routes.md
+++ b/docusaurus/docs/dev-docs/backend-customization/routes.md
@@ -493,7 +493,7 @@ export default  {
     {
       method: 'GET',
       path: '/articles/customRoute',
-      handler: 'api::api-name.controllerName.functionName', // or 'plugin::plugin-name.controllerName.functionName' for a plugin-scoped route
+      handler: 'api::api-name.controllerName.functionName', // or 'plugin::plugin-name.controllerName.functionName' for a plugin-specific controller
       config: {
         middlewares: [
           // point to a registered middleware

--- a/docusaurus/docs/dev-docs/backend-customization/routes.md
+++ b/docusaurus/docs/dev-docs/backend-customization/routes.md
@@ -462,7 +462,7 @@ module.exports = {
     {
       method: 'GET',
       path: '/articles/customRoute',
-      handler: 'controllerName.actionName',
+      handler: 'api::apiName.controllerName.functionName',
       config: {
         middlewares: [
           // point to a registered middleware
@@ -493,7 +493,7 @@ export default  {
     {
       method: 'GET',
       path: '/articles/customRoute',
-      handler: 'controllerName.actionName',
+      handler: 'api::apiName.controllerName.functionName',
       config: {
         middlewares: [
           // point to a registered middleware
@@ -582,7 +582,7 @@ module.exports = {
     {
       method: 'GET',
       path: '/articles/customRoute',
-      handler: 'controllerName.actionName',
+      handler: 'api::apiName.controllerName.functionName',
       config: {
         auth: false,
       },
@@ -602,7 +602,7 @@ export default  {
     {
       method: 'GET',
       path: '/articles/customRoute',
-      handler: 'controllerName.actionName',
+      handler: 'api::apiName.controllerName.functionName',
       config: {
         auth: false,
       },

--- a/docusaurus/docs/dev-docs/backend-customization/routes.md
+++ b/docusaurus/docs/dev-docs/backend-customization/routes.md
@@ -462,7 +462,7 @@ module.exports = {
     {
       method: 'GET',
       path: '/articles/customRoute',
-      handler: 'api::api-name.controllerName.functionName', // or 'plugin::plugin-name.controllerName.functionName' for a plugin
+      handler: 'api::api-name.controllerName.functionName', // or 'plugin::plugin-name.controllerName.functionName' for a plugin-specific controller
       config: {
         middlewares: [
           // point to a registered middleware

--- a/docusaurus/docs/dev-docs/backend-customization/routes.md
+++ b/docusaurus/docs/dev-docs/backend-customization/routes.md
@@ -15,7 +15,7 @@ Requests sent to Strapi on any URL are handled by routes. By default, Strapi gen
 - with [policies](#policies), which are a way to block access to a route,
 - and with [middlewares](#middlewares), which are a way to control and change the request flow and the request itself.
 
-Once a route exists, reaching it executes some code handled by a controller (see [controllers documentation](/dev-docs/backend-customization/controllers)).
+Once a route exists, reaching it executes some code handled by a controller (see [controllers documentation](/dev-docs/backend-customization/controllers)). To view all existing routes and their hierarchal order you can run `yarn strapi controllers:list`.
 
 <figure style={imgStyle}>
   <img src="/img/assets/backend-customization/diagram-routes.png" alt="Simplified Strapi backend diagram with routes highlighted" />
@@ -319,7 +319,7 @@ module.exports = {
     {
       method: 'GET',
       path: '/articles/customRoute',
-      handler: 'controllerName.actionName',
+      handler: 'api::apiName.controllerName.functionName',
       config: {
         policies: [
           // point to a registered policy
@@ -350,7 +350,7 @@ export default {
     {
       method: 'GET',
       path: '/articles/customRoute',
-      handler: 'controllerName.actionName',
+      handler: 'api::apiName.controllerName.functionName',
       config: {
         policies: [
           // point to a registered policy


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

Updated the handler names in the Configuration section and added a reference to a strapi command that allows you to view all existing routes and their current hierarchal order in the top-level/introductory section (above Implementation).

### Why is it needed?

I was told in office hours that the existing handler name I had was incorrect, but it matched the docs. I was then suggested to use the following format `api::whatever.whatever.yourFunction`. 

Knowing what the api::whatever.whatever part is can be kind of confusing -- when do I use singular/plural for my collection-types? Do I use my file name or the collection name? I was told of a really helpful command to see if my routes exist -- and what they're labeled as (e.g. api::whatever.whatever): `yarn strapi routes:list`

### Related issue(s)/PR(s)

It is something I discovered was an issue during office hours.
