### PR TITLE
Fixed file structure alignment

### DIFF
--- a/docusaurus/src/components/ProjectStructure.js
+++ b/docusaurus/src/components/ProjectStructure.js
@@ -129,7 +129,6 @@ export default function InteractiveProjectStructure() {
       │     │           ├──── <a href="/dev-docs/backend-customization/routes">routes</a><br/>
       │     │           ├──── <a href="/dev-docs/backend-customization/services">services</a><br/>
       │     │           └ index.ts<br/>
-      │     │
       │     ├──── <a href="/dev-docs/backend-customization/models">components</a><br/>
       │     │     └──── (category-name)<br/>
       │     │           ├ (componentA).json<br/>


### PR DESCRIPTION
The components folder was pushed too far to the right because of duplicate hierarchy columns.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

Removed duplicate file hierarchy column.

### Why is it needed?

The components folder was miss-aligned.

Before
<img width="778" alt="before" src="https://github.com/strapi/documentation/assets/23349127/fcbe220b-7fcf-495c-8f89-c5152b133370">

After
<img width="778" alt="after" src="https://github.com/strapi/documentation/assets/23349127/7bc2d43b-3588-4255-b533-406d8b33bd42">

### Related issue(s)/PR(s)

Unknown
