### PR TITLE
Fix parameter name in database configuration for MySQL2

### DIFF
--- a/docusaurus/docs/dev-docs/configurations/database.md
+++ b/docusaurus/docs/dev-docs/configurations/database.md
@@ -550,5 +550,5 @@ $ GRANT ALL ON SCHEMA public TO my_strapi_db_user;
 In addition to `client` values of '[postgres](https://www.npmjs.com/package/pg)', 'sqlite', and '[mysql](https://www.npmjs.com/package/mysql)', Strapi also allows a `client` value of '[mysql2](https://www.npmjs.com/package/mysql2)' for those who install and wish to use that package.
 
 :::note
-`mysql2` is required for the `caching_sha2_password` auth method used by default in MySQL v8+. If you receive an `"ER_NOT_SUPPORTED_AUTH_MODE"` error when using the `mysql` driver, try adding the `mysql2` package to your project. You should then remove the deprecated `connectionString` parameter from your connection configuration in favor of the `username` and `password` values.
+`mysql2` is required for the `caching_sha2_password` auth method used by default in MySQL v8+. If you receive an `"ER_NOT_SUPPORTED_AUTH_MODE"` error when using the `mysql` driver, try adding the `mysql2` package to your project. You should then remove the deprecated `connectionString` parameter from your connection configuration in favor of the `user` and `password` values.
 :::


### PR DESCRIPTION
The configuration parameters required by mysql2 are "name" and "password". The parameter "username" rises a warning.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

I changed the name of mysql2 configuration from "username" to "user" since the first one rises a warning.

### Why is it needed?

It provides updated information about mysq2 configuration

### Related issue(s)/PR(s)

none
