### PR TITLE
Plugin CLI update for @strapi/sdk-plugin package

### DIFF
--- a/docusaurus/docs/dev-docs/plugins/development/plugin-cli.md
+++ b/docusaurus/docs/dev-docs/plugins/development/plugin-cli.md
@@ -3,95 +3,92 @@ title: Plugin CLI
 description: Reference documentation for Strapi's Plugin CLI commands
 displayed_sidebar: devDocsSidebar
 tags:
-- backend server
-- plugin CLI
-- plugins
-- plugins development
-- strapi plugin
+  - backend server
+  - plugin CLI
+  - plugins
+  - plugins development
+  - strapi plugin
 ---
 
-import NotV5 from '/docs/snippets/_not-updated-to-v5.md'
+import NotV5 from '/docs/snippets/\_not-updated-to-v5.md'
 
 # Plugin CLI reference
 
 <NotV5/>
 
-:::caution
-The Plugin CLI is currently experimental.
-:::
+The Plugin CLI (@strapi/sdk-plugin) is set of commands orientated around developing plugins to use them as local plugins or to publish them on NPM and/or submit them to the Marketplace.
 
-The Plugin CLI is set of commands orientated around developing plugins to use them as local plugins or to publish them on NPM and/or submit them to the Marketplace.
-
+The commands are in their own repository called
 The present documentation lists the available Plugin CLI commands. The [associated guide](/dev-docs/plugins/guides/use-the-plugin-cli) illustrates how to use these commands to create a plugin from scratch, link it to an existing project, and publish it.
 
-## strapi plugin:init
+## npx @strapi/sdk-plugin init
 
 Create a new plugin at a given path.
 
 ```bash
-strapi plugin:init <path>
+npx @strapi/sdk-plugin init
 ```
 
-| Arguments |  Type  | Description         | Default                   |
-| --------- | :----: | --------------------| ------------------------- |
-| `path`    | string | Path to the plugin  | `./src/plugins/my-plugin` |
+| Arguments |  Type  | Description        | Default                   |
+| --------- | :----: | ------------------ | ------------------------- |
+| `path`    | string | Path to the plugin | `./src/plugins/my-plugin` |
 
-| Option        | Type | Description                              | Default |
-| ------------- | :--: | ---------------------------------------- |---------|
-| `-d, --debug` |  -   | Enable debugging mode with verbose logs  | false   |
-| `--silent`    |  -   | Do not log anything                      | false   |
+| Option        | Type | Description                             | Default |
+| ------------- | :--: | --------------------------------------- | ------- |
+| `-d, --debug` |  -   | Enable debugging mode with verbose logs | false   |
+| `--silent`    |  -   | Do not log anything                     | false   |
 
-## strapi plugin:build
+## strapi-plugin build
 
 Bundle the strapi plugin for publishing.
 
 ```bash
-strapi plugin:build
+strapi-plugin build
 ```
 
 | Option         |  Type  | Description                                                                                                       | Default |
-| -------------- | :----: | ----------------------------------------------------------------------------------------------------------------- | --------|
+| -------------- | :----: | ----------------------------------------------------------------------------------------------------------------- | ------- |
 | `--force`      | string | Automatically answer "yes" to all prompts, including potentially destructive requests, and run non-interactively. | -       |
 | `-d, --debug`  |   -    | Enable debugging mode with verbose logs                                                                           | false   |
 | `--silent`     |   -    | Do not log anything                                                                                               | false   |
 | `--minify`     |   -    | Minify the output                                                                                                 | true    |
 | `--sourcemaps` |   -    | Produce sourcemaps                                                                                                | false   |
 
-## strapi plugin:link-watch
+## strapi-plugin watch:link
 
 Recompiles the plugin automatically on changes and runs `yalc push --publish`.
 
 ```bash
-strapi plugin:link-watch
+strapi-plugin watch:link
 ```
 
-| Option        | Type | Description                                              | Default |
-| ------------- | :--: | -------------------------------------------------------- | --------|
-| `-d, --debug` |  -   | Enable debugging mode with verbose logs                  | false   |
-| `--silent`    |  -   | Do not log anything                                      | false   |
+| Option        | Type | Description                             | Default |
+| ------------- | :--: | --------------------------------------- | ------- |
+| `-d, --debug` |  -   | Enable debugging mode with verbose logs | false   |
+| `--silent`    |  -   | Do not log anything                     | false   |
 
-## strapi plugin:watch
+## strapi-plugin watch
 
 Watch and compile the Strapi plugin for local development.
 
 ```bash
-strapi plugin:watch
+strapi-plugin watch
 ```
 
-| Option        | Type | Description                                              | Default |
-| ------------- | :--: | -------------------------------------------------------- |---------|
-| `-d, --debug` |  -   | Enable debugging mode with verbose logs                  | false   |
-| `--silent`    |  -   | Do not log anything                                      | false   |
+| Option        | Type | Description                             | Default |
+| ------------- | :--: | --------------------------------------- | ------- |
+| `-d, --debug` |  -   | Enable debugging mode with verbose logs | false   |
+| `--silent`    |  -   | Do not log anything                     | false   |
 
-## strapi plugin:verify
+## strapi-plugin verify
 
 Verify the output of the plugin before publishing it.
 
 ```bash
-strapi plugin:verify
+strapi-plugin verify
 ```
 
-| Option        | Type | Description                                              | Default |
-| ------------- | :--: | -------------------------------------------------------- | --------|
-| `-d, --debug` |  -   | Enable debugging mode with verbose logs                  | false   |
-| `--silent`    |  -   | Do not log anything                                      | false   |
+| Option        | Type | Description                             | Default |
+| ------------- | :--: | --------------------------------------- | ------- |
+| `-d, --debug` |  -   | Enable debugging mode with verbose logs | false   |
+| `--silent`    |  -   | Do not log anything                     | false   |

--- a/docusaurus/docs/dev-docs/plugins/development/plugin-cli.md
+++ b/docusaurus/docs/dev-docs/plugins/development/plugin-cli.md
@@ -16,9 +16,8 @@ import NotV5 from '/docs/snippets/\_not-updated-to-v5.md'
 
 <NotV5/>
 
-The Plugin CLI (@strapi/sdk-plugin) is set of commands orientated around developing plugins to use them as local plugins or to publish them on NPM and/or submit them to the Marketplace.
+The Plugin CLI is set of commands provided by the package [@strapi/sdk-plugin](https://github.com/strapi/sdk-plugin) orientated around developing plugins to use them as local plugins or to publish them on NPM and/or submit them to the Marketplace.
 
-The commands are in their own repository called
 The present documentation lists the available Plugin CLI commands. The [associated guide](/dev-docs/plugins/guides/use-the-plugin-cli) illustrates how to use these commands to create a plugin from scratch, link it to an existing project, and publish it.
 
 ## npx @strapi/sdk-plugin init

--- a/docusaurus/docs/dev-docs/plugins/guides/use-the-plugin-cli.md
+++ b/docusaurus/docs/dev-docs/plugins/guides/use-the-plugin-cli.md
@@ -4,14 +4,14 @@ description: Learn how to use the Plugin CLI to build and publish a Strapi plugi
 sidebar_label: Use the Plugin CLI
 displayed_sidebar: devDocsSidebar
 tags:
-- guides
-- plugins
-- plugin CLI
-- plugins development guides
-- Strapi plugin
+  - guides
+  - plugins
+  - plugin CLI
+  - plugins development guides
+  - Strapi plugin
 ---
 
-import NotV5 from '/docs/snippets/_not-updated-to-v5.md'
+import NotV5 from '/docs/snippets/\_not-updated-to-v5.md'
 
 # How to use the Plugin CLI to create and publish a Strapi plugin
 
@@ -36,7 +36,7 @@ To create your plugin, ensure you are in the parent directory of where you want 
 <TabItem value="yarn" label="Yarn">
 
 ```bash
-yarn dlx @strapi/strapi plugin:init my-strapi-plugin
+yarn dlx @strapi/sdk-plugin init my-strapi-plugin
 ```
 
 </TabItem>
@@ -44,7 +44,7 @@ yarn dlx @strapi/strapi plugin:init my-strapi-plugin
 <TabItem value="npm" label="NPM">
 
 ```bash
-npx @strapi/strapi plugin:init my-strapi-plugin
+npx @strapi/sdk-plugin:init my-strapi-plugin
 ```
 
 </TabItem>


### PR DESCRIPTION
### What does it do?

Explain the use of the new standalone plugin CLI now that the strapi commands for plugins have been moved there

### Related issue(s)/PR(s)

[The new plugin-sdk](https://github.com/strapi/sdk-plugin)

[Removes Plugin CLI](https://github.com/strapi/strapi/pull/20303) from strapi

DX-1405