### PR TITLE
docs: add codemods command

### DIFF
--- a/docusaurus/docs/dev-docs/upgrade-tool.md
+++ b/docusaurus/docs/dev-docs/upgrade-tool.md
@@ -85,13 +85,27 @@ npx @strapi/upgrade patch
 
 During the upgrade process, the project dependencies are updated and installed, and the related codemods are executed (if any).
 
-<!-- ## Run codemods only
+## Run codemods only
 
 Run the upgrade tool with the `codemods` parameter to execute a utility that allows selecting the codemods to be executed. With this command, only the codemods are run, the dependencies are not updated nor installed.
 
+If you just wish to view a list of the available codemods, use the `ls` command:
+
 ```bash
-npx @strapi/upgrade codemods
-``` -->
+npx @strapi/upgrade codemods ls
+```
+
+To select from a list of available codemods and run them, use the `run` command:
+
+```bash
+npx @strapi/upgrade codemods run
+```
+
+To run only a specific codemod, use `run` followed by a UID found from the `ls` command:
+
+```bash
+npx @strapi/upgrade codemods run 5.0.0-strapi-codemod-uid
+```
 
 ## Options
 

--- a/docusaurus/docs/dev-docs/upgrade-tool.md
+++ b/docusaurus/docs/dev-docs/upgrade-tool.md
@@ -89,7 +89,7 @@ During the upgrade process, the project dependencies are updated and installed, 
 
 Run the upgrade tool with the `codemods` parameter to execute a utility that allows selecting the codemods to be executed. With this command, only the codemods are run, the dependencies are not updated nor installed.
 
-If you just wish to view a list of the available codemods, use the `ls` command:
+To view a list of the available codemods, use the `ls` command:
 
 ```bash
 npx @strapi/upgrade codemods ls


### PR DESCRIPTION
### What does it do?

Adds docs for the ugprade tool `codemods` command

### Why is it needed?

it was missing

### Related issue(s)/PR(s)

DX-1395
