### PR TITLE
Update custom-fields.md options description type

### DIFF
--- a/docusaurus/docs/dev-docs/custom-fields.md
+++ b/docusaurus/docs/dev-docs/custom-fields.md
@@ -275,7 +275,7 @@ Each object in the `items` array can contain the following parameters:
 | Items parameter | Description                                                        | Type                                                 |
 | --------------- | ------------------------------------------------------------------ | ---------------------------------------------------- |
 | `name`          | Label of the input.<br/>Must use the `options.settingName` format. | `String`                                             |
-| `description`   | Description of the input to use in the Content-type Builder        | `String`                                             |
+| `description`   | Description of the input to use in the Content-type Builder        | [`IntlObject`](https://formatjs.io/docs/react-intl/) |
 | `intlLabel`     | Translation for the label of the input                             | [`IntlObject`](https://formatjs.io/docs/react-intl/) |
 | `type`          | Type of the input (e.g., `select`, `checkbox`)                     | `String`                                             |
 


### PR DESCRIPTION
Update the type for the description field for custom field option items to reflect actual implementation.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

Updates the `description` field type to reflect the actual implementation. The `description` field type is still documented as expecting a `String` type, but according to the actual options structure (e.g. [FormModal/attributes/advancedForm.ts](https://github.com/strapi/strapi/blob/develop/packages/core/content-type-builder/admin/src/components/FormModal/attributes/advancedForm.ts)), this should actually be the `IntlObject` type instead.

### Why is it needed?

As documented, the `description` field will not output for custom field options in the Content-Type Builder UI.
