### PR TITLE
Add breaking change for server.proxy config.

### DIFF
--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes.md
@@ -26,6 +26,7 @@ This page lists all the breaking changes introduced in Strapi 5.
 * [Model config path uses uid instead of dot notation](/dev-docs/migration/v4-to-v5/breaking-changes/model-config-path-uses-uid)
 * [The `webhooks.populateRelations` server configuration is removed](/dev-docs/migration/v4-to-v5/breaking-changes/remove-webhook-populate-relations)
 * [The `defaultIndex` option is removed from the `public` middleware](/dev-docs/migration/v4-to-v5/breaking-changes/default-index-removed)
+* [Server proxy configuration options are grouped under the `server.proxy` object](/dev-docs/migration/v4-to-v5/breaking-changes/server-proxy)
 
 ## Content API
 

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/server-proxy.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/server-proxy.md
@@ -1,0 +1,64 @@
+---
+title: Server proxy configuration
+description:  In Strapi 5, all proxy configuration options are now configured through the 'server.proxy' object in the '/config/server.js|ts' instead of having various option names such as 'globalProxy' and 'proxy' in Strapi v4.
+displayed_sidebar: devDocsMigrationV5Sidebar
+tags:
+ - breaking changes
+ - configuration
+ - server
+---
+
+import Intro from '/docs/snippets/breaking-change-page-intro.md'
+import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
+import NoPlugins from '/docs/snippets/breaking-change-not-affecting-plugins.md'
+import NoCodemods from '/docs/snippets/breaking-change-not-handled-by-codemod.md'
+
+#  Server proxy configurations are grouped under the `server.proxy` object
+
+In Strapi 5, all proxy configuration options are now configured through the `server.proxy` object in `/config/server.js|ts`, whether they are for requests made within `strapi.fetch` or for the global proxy agent for the [koa](https://koajs.com/) server.
+
+<Intro />
+<NoPlugins />
+<NoCodemods />
+
+## Breaking change description
+
+<SideBySideContainer>
+
+<SideBySideColumn>
+
+**In Strapi v4**
+
+* `server.globalProxy` is used to configure all requests through `strapi.fetch`.
+* `server.proxy` is used to set the value of koa server’s `proxy` option.
+
+</SideBySideColumn>
+
+<SideBySideColumn>
+
+**In Strapi 5**
+
+All configuration options are grouped under the `server.proxy` object.
+
+</SideBySideColumn>
+
+</SideBySideContainer>
+
+## Migration
+
+<MigrationIntro />
+
+### Notes
+
+Additional information about how the `server.proxy` configuration works in Strapi 5 is available in the [server configuration](/dev-docs/configurations/server) documentation.
+
+### Manual migration
+
+Users will need to manually update the code:
+
+- If `server.proxy` is used, it needs to move to `server.proxy.koa`.
+
+- If `server.globalProxy` is used, you have 2 choices:
+
+  - move it to `server.proxy.global` and be aware that it will now work for HTTP/HTTPS requests in addition to `strapi.fetch` requests,
+  - or move it to `server.proxy.fetch` to keep the exact same functionality as in Strapi v4, where only fetch was proxied.

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -1149,6 +1149,7 @@ const sidebars = {
                 },
                 'dev-docs/migration/v4-to-v5/breaking-changes/remove-webhook-populate-relations',
                 'dev-docs/migration/v4-to-v5/breaking-changes/default-index-removed',
+                'dev-docs/migration/v4-to-v5/breaking-changes/server-proxy',
               ]
             },
             {


### PR DESCRIPTION
This PR adds breaking change information regarding the `server.proxy` changes.

It is complementary of updates made to the server configuration documentation in #2124.