### PR TITLE
Digital Ocean Droplet Deployment Edit: Add info about nginx max file size to config instructions

### DIFF
--- a/docusaurus/docs/dev-docs/deployment/digitalocean.md
+++ b/docusaurus/docs/dev-docs/deployment/digitalocean.md
@@ -273,7 +273,7 @@ Your Strapi project is now installed on your DigitalOcean Droplet. Before being 
         proxy_set_header Host $host;
         proxy_cache_bypass $http_upgrade;
         ```
-    * Nginx has a [config setting](http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size) called `client_max_body_size` that will prevent file uploads greater than the specified amount. This will need to be adjusted since its default is only 1MB. Note that strapi middleware is already in charge of parsing requests of file sizes up to 200MB.
+    * Nginx has a [configuration setting](http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size) called `client_max_body_size` that will prevent file uploads greater than the specified amount. This will need to be adjusted since its default is only 1MB. Note that strapi middleware is already in charge of parsing requests of file sizes up to 200MB.
       ```
       ...
       http {

--- a/docusaurus/docs/dev-docs/deployment/digitalocean.md
+++ b/docusaurus/docs/dev-docs/deployment/digitalocean.md
@@ -273,6 +273,16 @@ Your Strapi project is now installed on your DigitalOcean Droplet. Before being 
         proxy_set_header Host $host;
         proxy_cache_bypass $http_upgrade;
         ```
+    * Nginx has a [config setting](http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size) called `client_max_body_size` that will prevent file uploads greater than the specified amount. This will need to be adjusted since its default is only 1MB. Note that strapi middleware is already in charge of parsing requests of file sizes up to 200MB.
+      ```
+      ...
+      http {
+        ...
+        client_max_body_size 200m; # Or 0 to disable
+        ...
+      }
+      ...
+      ```
 
 2. Close the port to outside traffic by running the following commands:
 


### PR DESCRIPTION
- Fixes #1941 > #1900
- Ready to be merged

### What does it do?

Add another bullet + code block in "Install and configure Nginx web server" to mention that nginx has a "client_max_body_size" property that prevents uploads greater than 1MB by default, and to provide instructions on how to change it.

### Why is it needed?

I was running into errors uploading media over 1MB to the admin panel and it took a bit to figure out that it was an Nginx problem.

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/9301

https://github.com/strapi/strapi/issues/13743

