### PR TITLE
Add link to blog post about using `fetch()` with the REST API

### DIFF
--- a/docusaurus/docs/dev-docs/api/rest/guides/intro.md
+++ b/docusaurus/docs/dev-docs/api/rest/guides/intro.md
@@ -21,3 +21,4 @@ The following guides, officially maintained by the Strapi Documentation team, co
 Additional tutorials and guides can be found in the following blog posts:
 
 <CustomDocCard emoji="➕" title="Authenticating requests with the REST API" description="Learn how to authenticate your REST API queries with JSON Web Tokens and API tokens." link="https://strapi.io/blog/guide-on-authenticating-requests-with-the-rest-api" />
+<CustomDocCard emoji="➕" title="Using Fetch with Strapi's Content API" description="Explore how to use the fetch() method of the Fetch API to interact with Strapi's Content API." link="https://strapi.io/blog/guide-on-authenticating-requests-with-the-rest-api" />


### PR DESCRIPTION
This PR highlights the [Mastering API Requests: Using Fetch with Strapi's Content API](https://strapi.io/blog/mastering-api-requests-using-fetch-with-strapi-content-api) blog post in the REST API additional resources list.