### PR TITLE
Add link to article about REST API and CDN

### DIFF
--- a/docusaurus/docs/dev-docs/api/rest/guides/intro.md
+++ b/docusaurus/docs/dev-docs/api/rest/guides/intro.md
@@ -21,4 +21,7 @@ The following guides, officially maintained by the Strapi Documentation team, co
 Additional tutorials and guides can be found in the following blog posts:
 
 <CustomDocCard emoji="➕" title="Authenticating requests with the REST API" description="Learn how to authenticate your REST API queries with JSON Web Tokens and API tokens." link="https://strapi.io/blog/guide-on-authenticating-requests-with-the-rest-api" />
+
 <CustomDocCard emoji="➕" title="Using Fetch with Strapi's Content API" description="Explore how to use the fetch() method of the Fetch API to interact with Strapi's Content API." link="https://strapi.io/blog/mastering-api-requests-using-fetch-with-strapi-content-api" />
+
+<CustomDocCard emoji="➕" title="Requesting Strapi's REST API behind a Content Delivery Network (CDN)" description="Learn how to overcome network latency issues when requesting large numbers of media assets by leveraging the usage of a CDN with Strapi's REST API." link="https://strapi.io/blog/request-strapi-s-rest-api-behind-a-content-delivery-network-cdn" />


### PR DESCRIPTION
This PR adds another link in the additional resources section of the REST API guides, to highlight the [new article about using Strapi's content API behind a CDN](https://strapi.io/blog/request-strapi-s-rest-api-behind-a-content-delivery-network-cdn).