### PR TITLE
[Design revamp] Decrease base font size

### DIFF
--- a/docusaurus/.gitignore
+++ b/docusaurus/.gitignore
@@ -24,3 +24,4 @@ docs/.vuepress/config.js
 docs/node_modules/**
 
 release-notes.py
+release-notes-detailed.py

--- a/docusaurus/.gitignore
+++ b/docusaurus/.gitignore
@@ -24,4 +24,3 @@ docs/.vuepress/config.js
 docs/node_modules/**
 
 release-notes.py
-release-notes-detailed.py

--- a/docusaurus/src/scss/_tokens-overrides.scss
+++ b/docusaurus/src/scss/_tokens-overrides.scss
@@ -6,6 +6,7 @@
   --ifm-background-color: var(--strapi-neutral-0);
   --ifm-color-content: var(--strapi-neutral-800);
   --ifm-font-color-base: var(--strapi-neutral-800);
+  --ifm-font-size-base: var(--strapi-font-size-sm);
 
   --ifm-color-content-secondary: var(--strapi-neutral-600);
   --ifm-color-emphasis-100: var(--strapi-neutral-100);


### PR DESCRIPTION
This PR is the first of a list of upcoming initiatives aimed at improving the design of the documentation. These improvements will target Strapi 5 docs but might be backported to Strapi v4 docs.

The current PR simply reduces the base font size, as many users reported using the website at 90% zoom level.

Direct preview link 👉 [here](https://documentation-git-v5-improved-design-font-size-strapijs.vercel.app/dev-docs/intro)