### PR TITLE
Extend new/updated badges usage to sections

### DIFF
--- a/docusaurus/docs/cloud/cli/cloud-cli.md
+++ b/docusaurus/docs/cloud/cli/cloud-cli.md
@@ -4,7 +4,7 @@ displayed_sidebar: cloudSidebar
 sidebar_position: 3
 ---
 
-# Command Line Interface (CLI)
+# Command Line Interface (CLI) <NewBadge />
 
 Strapi Cloud comes with a Command Line Interface (CLI) which allows you to log in and out, and to deploy a local project without it having to be hosted on a remote git repository. The CLI works with both the `yarn` and `npm` package managers.
 

--- a/docusaurus/docs/cloud/getting-started/deployment.md
+++ b/docusaurus/docs/cloud/getting-started/deployment.md
@@ -6,7 +6,7 @@ canonicalUrl: https://docs.strapi.io/cloud/getting-started/deployment.html
 sidebar_position: 2
 ---
 
-# Project deployment with the Cloud dashboard
+# Project deployment with the Cloud dashboard <UpdatedBadge />
 
 This is a step-by-step guide for deploying your project on Strapi Cloud for the first time, using the Cloud dashboard.
 

--- a/docusaurus/docs/cloud/projects/settings.md
+++ b/docusaurus/docs/cloud/projects/settings.md
@@ -98,7 +98,7 @@ You can delete any Strapi Cloud project, but it will be permanent and irreversib
 2. In the dialog, select the reason why you are deleting your project. If selecting "Other" or "Missing feature", a textbox will appear to let you write additional information.
 3. Confirm the deletion of your project by clicking on the **Delete project** button at the bottom of the dialog.
 
-## Backups <CloudProBadge /> <CloudTeamBadge /> {#backups}
+## Backups <CloudProBadge /> <CloudTeamBadge /> <UpdatedBadge /> {#backups}
 
 The ![Backups icon](/img/assets/icons/ArrowClockwise.svg) *Backups* tab informs you of the status and date of the latest backup of your Strapi Cloud projects. The databases associated with all existing Strapi Cloud projects are indeed automatically backed up weekly and those backups are retained for a one-month period. Additionally, you can create a single manual backup.
 

--- a/docusaurus/docs/dev-docs/api/rest/guides/intro.md
+++ b/docusaurus/docs/dev-docs/api/rest/guides/intro.md
@@ -16,7 +16,7 @@ The following guides, officially maintained by the Strapi Documentation team, co
 <CustomDocCard emoji="🧠" title="Understanding populate" description="Learn what populating means and how you can use the populate parameter in your REST API queries to add additional fields to your responses." link="/dev-docs/api/rest/guides/understanding-populate" />
 <CustomDocCard emoji="🛠️" title="How to populate creator fields" description="Read step-by-step instructions on how to build a custom controller that leverages the populate parameter to add 'createdBy' and 'updatedBy' data to queries responses" link="/dev-docs/api/rest/guides/populate-creator-fields" />
 
-## Additional resources
+## Additional resources <UpdatedBadge />
 
 Additional tutorials and guides can be found in the following blog posts:
 

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -27,9 +27,6 @@ const sidebars = {
           type: "doc",
           label: "Quick Start Guide",
           id: "dev-docs/quick-start",
-          customProps: {
-            updated: true,
-          },
         },
         "dev-docs/faq",
         "dev-docs/usage-information",
@@ -63,9 +60,6 @@ const sidebars = {
             {
                 type: 'doc',
                 id: "dev-docs/installation/docker",
-                customProps: {
-                    updated: true
-                },
             },
           ],
         },
@@ -78,9 +72,6 @@ const sidebars = {
               type: "doc",
               label: "Introduction",
               id: "dev-docs/configurations",
-              customProps: {
-                updated: true,
-              },
             },
 
             'dev-docs/configurations/database',
@@ -91,9 +82,6 @@ const sidebars = {
             {
               type: 'doc',
               id: 'dev-docs/configurations/plugins',
-              customProps: {
-                updated: true,
-              },
             },
             'dev-docs/configurations/typescript',
             'dev-docs/configurations/api-tokens',
@@ -106,9 +94,6 @@ const sidebars = {
             {
               type: 'doc',
               id: 'dev-docs/configurations/features',
-              customProps: {
-                updated: true,
-              }
             },
           ],
         },
@@ -198,9 +183,6 @@ const sidebars = {
             {
               type: 'doc',
               id: "dev-docs/api/rest/populate-select",
-              customProps: {
-                updated: true,
-              },
             },
             "dev-docs/api/rest/filters-locale-publication",
             "dev-docs/api/rest/sort-pagination",
@@ -211,7 +193,7 @@ const sidebars = {
               id: "dev-docs/api/rest/guides/intro",
               label: "Guides",
               customProps: {
-                new: true,
+                updated: true,
               }
             }
           ],
@@ -260,9 +242,6 @@ const sidebars = {
         {
           type: "category",
           label: "Back-end customization",
-          customProps: {
-            updated: true,
-          },
           items: [
             {
               type: "doc",
@@ -282,9 +261,6 @@ const sidebars = {
             {
               type: "doc",
               id: "dev-docs/backend-customization/controllers",
-              customProps: {
-                updated: true,
-              },
             },
             "dev-docs/backend-customization/services",
             "dev-docs/backend-customization/models",
@@ -618,9 +594,6 @@ const sidebars = {
   userDocsSidebar: [
     {
       type: 'category',
-      customProps: {
-        updated: true,
-      },
       collapsed: false,
       label: 'Getting Started',
       items: [
@@ -660,9 +633,6 @@ const sidebars = {
         {
           type: 'doc',
           id: 'user-docs/content-type-builder/configuring-fields-content-type',
-          customProps: {
-            updated: true,
-          },
         },
         'user-docs/content-type-builder/managing-content-types',
       ],
@@ -741,9 +711,6 @@ const sidebars = {
               type: 'doc',
               label: 'Review Workflows',
               id: 'user-docs/settings/review-workflows',
-              customProps: {
-                updated: true,
-              },
             },
             'user-docs/settings/single-sign-on',
             'user-docs/settings/transfer-tokens',
@@ -818,7 +785,7 @@ const sidebars = {
           label: "Project settings",
           id: "cloud/projects/settings",
           customProps: {
-            updated: false,
+            updated: true,
           },
         },
         "cloud/projects/collaboration",
@@ -1081,6 +1048,11 @@ const sidebars = {
           label: "How to populate creator fields",
           id: 'dev-docs/api/rest/guides/populate-creator-fields',
         },
+        {
+          type: "link",
+          label: "Additional resources",
+          href: '/dev-docs/api/rest/guides/intro#additional-resources',
+        },
       ],
     }
   ],
@@ -1133,9 +1105,6 @@ const sidebars = {
             {
               type: 'doc',
               id: 'dev-docs/configurations/plugins',
-              customProps: {
-                updated: true,
-              },
             },
             'dev-docs/configurations/typescript',
             'dev-docs/configurations/api-tokens',
@@ -1146,9 +1115,6 @@ const sidebars = {
             {
               type: 'doc',
               id: 'dev-docs/configurations/features',
-              customProps: {
-                updated: true
-              }
             }
           ]
         },

--- a/docusaurus/src/theme/MDXComponents.js
+++ b/docusaurus/src/theme/MDXComponents.js
@@ -18,7 +18,7 @@ import FeedbackPlaceholder from '../components/FeedbackPlaceholder';
 import CustomDocCard from '../components/CustomDocCard';
 import CustomDocCardsWrapper from '../components/CustomDocCardsWrapper';
 import { InteractiveQueryBuilder } from '../components/InteractiveQueryBuilder/InteractiveQueryBuilder';
-import { AlphaBadge, BetaBadge, EnterpriseBadge, FutureBadge, CloudProBadge, CloudTeamBadge, CloudDevBadge } from '../components/Badge';
+import { AlphaBadge, BetaBadge, EnterpriseBadge, FutureBadge, CloudProBadge, CloudTeamBadge, CloudDevBadge, NewBadge, UpdatedBadge } from '../components/Badge';
 import { SideBySideColumn, SideBySideContainer } from '../components';
 import ThemedImage from '@theme/ThemedImage';
 import ScreenshotNumberReference from '../components/ScreenshotNumberReference';
@@ -55,6 +55,8 @@ export default {
   CloudProBadge,
   CloudTeamBadge,
   CloudDevBadge,
+  NewBadge,
+  UpdatedBadge,
   Columns,
   ColumnLeft,
   ColumnRight,


### PR DESCRIPTION
This PR offers the ability to extend the usage of `✨ New` and 🖋️ Updated` badges outside the table of content, and uses them in place in new or recently updated sections.