### PR TITLE
Revert "Clarify Role parameter usage for Users & Permissions plugin"

### DIFF
--- a/docusaurus/docs/user-docs/users-roles-permissions/managing-end-users.md
+++ b/docusaurus/docs/user-docs/users-roles-permissions/managing-end-users.md
@@ -39,6 +39,6 @@ To create a new end-user account:
 | Password  | (optional) Write a new password in the textbox. You can click on the eye icon for the password to be shown. |
 | Confirmed | (optional) Click **ON** for the end-user account to be confirmed.                                           |
 | Blocked   | (optional) Click **ON** to block the account of the end user, to prevent them to access content.            |
-| Role      | (optional) Indicate the role that should be granted to the new end user, by either providing the name or the ID of the role. If this field is not filled in, the end user will be attributed the role set as default (see [Managing Users & Permissions plugin settings](../settings/configuring-users-permissions-plugin-settings.md)). |
+| Role      | (optional) Indicate the role that should be granted to the new end user. If this field is not filled in, the end user will be attributed the role set as default (see [Managing Users & Permissions plugin settings](../settings/configuring-users-permissions-plugin-settings.md)). |
 
 4. Click on the **Save** button.


### PR DESCRIPTION
Reverts strapi/documentation#2157

I made a mistake. It's only possible to provide the role ID here, not the name. The workaround is to search for the role's name first. I will give it another run, sorry guys.