### PR TITLE
Add openapi.json route documentation (#2143)

### DIFF
--- a/docusaurus/docs/dev-docs/plugins/documentation.md
+++ b/docusaurus/docs/dev-docs/plugins/documentation.md
@@ -10,7 +10,9 @@ The Documentation plugin is useful to document the available endpoints once you 
 
 If installed, the Documentation plugin will inspect content types and routes found on all APIs in your project and any plugin specified in the configuration. The plugin will then programmatically generate documentation to match the [OpenAPI specification](https://swagger.io/specification/). The Documentation plugin generates the [paths objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#paths-object) and [schema objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#schema-object) and converts all Strapi types to [OpenAPI data types](https://swagger.io/docs/specification/data-models/data-types/).
 
-The generated documentation can be found in your application at the following path: `src/extensions/documentation/documentation/<version>/full_documentation.json`
+The generated documentation can be accessed either through your application's source code or through the running application itself:
+- **Source code**: The documentation is located at <br/>`src/extensions/documentation/documentation/<version>/full_documentation.json`
+- **Running application**: Use the URL <br/>`<server-url>:<server-port>/documentation/<version>/openapi.json`
 
 ## Installation
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

Adds documentation for new route `/documentation/<version>/openapi.json` provided by the documentation plugin.

**Preview:**
![image](https://github.com/user-attachments/assets/86b23111-556d-4bf0-8b86-3d8581af0654)

### Why is it needed?

This is needed to inform devs that there is a way to access the `full_documentation.json` via endpoint of the documentation plugin.

### Related issue(s)/PR(s)

- https://github.com/strapi/strapi/pull/20871
- https://github.com/strapi/documentation/issues/2143
- https://github.com/strapi/documentation/issues/590
- https://github.com/strapi/documentation/issues/366
- https://github.com/strapi/strapi/issues/10734
