### PR TITLE
Fix grammar in the "TypeScript development" docs

### DIFF
--- a/docusaurus/docs/dev-docs/typescript.md
+++ b/docusaurus/docs/dev-docs/typescript.md
@@ -119,7 +119,7 @@ However, if you still want to use the generated types on your project but don't 
 aren't overwritten when the types are regenerated) and remove the `declare module '@strapi/types'` on the bottom of the file.
 
 :::warning
-Types should only be imported from `@strapi/strapi` to avoid breaking changes. The types in `@strapi/types` is for internal use only and is subject to change without notice.
+Types should only be imported from `@strapi/strapi` to avoid breaking changes. The types in `@strapi/types` are for internal use only and may change without notice.
 :::
 
 ## Develop a plugin using TypeScript


### PR DESCRIPTION
### What does it do?

Rewrites "is" to "are" in the warning about the right path to import types from in the TypeScript development documentation.

### Why is it needed?

To ensure clarity.

Note: This is also written in the same way in the [beta docs](https://docs-next.strapi.io/dev-docs/typescript/development#fix-build-issues-with-the-generated-types).
