### PR TITLE
Add examples for middlewares context to Document Service API

### DIFF
--- a/docusaurus/docs/dev-docs/api/document-service/middlewares.md
+++ b/docusaurus/docs/dev-docs/api/document-service/middlewares.md
@@ -39,6 +39,206 @@ Syntax: `(context, next) => ReturnType<typeof next>`
 | `uid`         | Content type unique identifier                                                       | `string`      |
 | `contentType` | Content type                                                                         | `ContentType` |
 
+The following examples show what `context` might include:
+
+<Tabs>
+
+<TabItem value="find-many" label="findMany">
+
+```js
+{
+  uid: 'api::test.test',
+  contentType: {
+    kind: 'collectionType',
+    collectionName: 'tests',
+    info: { singularName: 'test', pluralName: 'tests', displayName: 'test' },
+    options: { comment: '', draftAndPublish: false },
+    attributes: {
+      test: [Object],
+      createdAt: [Object],
+      updatedAt: [Object],
+      publishedAt: [Object],
+      createdBy: [Object],
+      updatedBy: [Object],
+      locale: [Object]
+    },
+    apiName: 'test',
+    globalId: 'Test',
+    uid: 'api::test.test',
+    modelType: 'contentType',
+    modelName: 'test',
+    actions: {},
+    lifecycles: {}
+  },
+  action: 'findMany',
+  params: {
+    filters: { documentId: [Object] },
+    status: 'draft',
+    locale: null,
+    fields: [ 'documentId', 'locale', 'updatedAt', 'createdAt', 'publishedAt' ]
+  }
+}
+```
+</TabItem>
+
+<TabItem value="find-one" label="findOne">
+
+```js
+{
+  uid: 'api::test.test',
+  contentType: {
+    kind: 'collectionType',
+    collectionName: 'tests',
+    info: { singularName: 'test', pluralName: 'tests', displayName: 'test' },
+    options: { comment: '', draftAndPublish: false },
+    attributes: {
+      test: [Object],
+      createdAt: [Object],
+      updatedAt: [Object],
+      publishedAt: [Object],
+      createdBy: [Object],
+      updatedBy: [Object],
+      locale: [Object]
+    },
+    apiName: 'test',
+    globalId: 'Test',
+    uid: 'api::test.test',
+    modelType: 'contentType',
+    modelName: 'test',
+    actions: {},
+    lifecycles: {}
+  },
+  action: 'findOne',
+  params: {
+    populate: { createdBy: true, updatedBy: true },
+    locale: undefined,
+    status: 'published',
+    documentId: 'hp7hjvrbt8rcgkmabntu0aoq'
+  }
+}
+```
+
+</TabItem>
+
+<TabItem value="update" label="update">
+
+```js
+{
+  uid: 'api::test.test',
+  contentType: {
+    kind: 'collectionType',
+    collectionName: 'tests',
+    info: { singularName: 'test', pluralName: 'tests', displayName: 'test' },
+    options: { comment: '', draftAndPublish: false },
+    attributes: {
+      test: [Object],
+      createdAt: [Object],
+      updatedAt: [Object],
+      publishedAt: [Object],
+      createdBy: [Object],
+      updatedBy: [Object],
+      locale: [Object]
+    },
+    apiName: 'test',
+    globalId: 'Test',
+    uid: 'api::test.test',
+    modelType: 'contentType',
+    modelName: 'test',
+    actions: {},
+    lifecycles: {}
+  },
+  action: 'update',
+  params: {
+    data: { test: 'test1', updatedBy: 1 },
+    populate: { createdBy: true, updatedBy: true },
+    locale: undefined,
+    status: 'draft',
+    documentId: 'hp7hjvrbt8rcgkmabntu0aoq'
+  }
+}
+```
+
+</TabItem>
+
+<TabItem value="delete" label="delete">
+
+```js
+{
+  uid: 'api::test.test',
+  contentType: {
+    kind: 'collectionType',
+    collectionName: 'tests',
+    info: { singularName: 'test', pluralName: 'tests', displayName: 'test' },
+    options: { comment: '', draftAndPublish: false },
+    attributes: {
+      test: [Object],
+      createdAt: [Object],
+      updatedAt: [Object],
+      publishedAt: [Object],
+      createdBy: [Object],
+      updatedBy: [Object],
+      locale: [Object]
+    },
+    apiName: 'test',
+    globalId: 'Test',
+    uid: 'api::test.test',
+    modelType: 'contentType',
+    modelName: 'test',
+    actions: {},
+    lifecycles: {}
+  },
+  action: 'delete',
+  params: {
+    locale: '*',
+    documentId: 'hp7hjvrbt8rcgkmabntu0aoq',
+    populate: { createdBy: true, updatedBy: true }
+  }
+}
+```
+
+</TabItem>
+
+<TabItem value="create" label="create">
+
+```js
+{
+  uid: 'api::test.test',
+  contentType: {
+    kind: 'collectionType',
+    collectionName: 'tests',
+    info: { singularName: 'test', pluralName: 'tests', displayName: 'test' },
+    options: { comment: '', draftAndPublish: false },
+    attributes: {
+      test: [Object],
+      createdAt: [Object],
+      updatedAt: [Object],
+      publishedAt: [Object],
+      createdBy: [Object],
+      updatedBy: [Object],
+      locale: [Object]
+    },
+    apiName: 'test',
+    globalId: 'Test',
+    uid: 'api::test.test',
+    modelType: 'contentType',
+    modelName: 'test',
+    actions: {},
+    lifecycles: {}
+  },
+  action: 'create',
+  params: {
+    data: { test: 'test1', createdBy: 1, updatedBy: 1 },
+    locale: undefined,
+    status: 'draft',
+    populate: { createdBy: true, updatedBy: true }
+  }
+}
+```
+
+</TabItem>
+
+</Tabs>
+
 #### `next`
 
 `next` is a function without parameters that calls the next middleware in the stack and return its response.

--- a/docusaurus/docs/dev-docs/api/document-service/middlewares.md
+++ b/docusaurus/docs/dev-docs/api/document-service/middlewares.md
@@ -39,6 +39,9 @@ Syntax: `(context, next) => ReturnType<typeof next>`
 | `uid`         | Content type unique identifier                                                       | `string`      |
 | `contentType` | Content type                                                                         | `ContentType` |
 
+<details>
+<summary>Examples:</summary>
+
 The following examples show what `context` might include:
 
 <Tabs>
@@ -238,6 +241,7 @@ The following examples show what `context` might include:
 </TabItem>
 
 </Tabs>
+</details>
 
 #### `next`
 

--- a/docusaurus/docs/dev-docs/api/document-service/middlewares.md
+++ b/docusaurus/docs/dev-docs/api/document-service/middlewares.md
@@ -42,9 +42,57 @@ Syntax: `(context, next) => ReturnType<typeof next>`
 <details>
 <summary>Examples:</summary>
 
-The following examples show what `context` might include:
+The following examples show what `context` might include depending on the method called:
 
 <Tabs>
+
+
+<TabItem value="find-one" label="findOne">
+
+```js
+{
+  uid: "api::restaurant.restaurant",
+  contentType: {
+    kind: "collectionType",
+    collectionName: "restaurants",
+    info: {
+      singularName: "restaurant",
+      pluralName: "restaurants",
+      displayName: "restaurant"
+    },
+    options: {
+      draftAndPublish: true
+    },
+    pluginOptions: {},
+    attributes: {
+      name: { /*...*/ },
+      description: { /*...*/ },
+      createdAt: { /*...*/ },
+      updatedAt: { /*...*/ },
+      publishedAt: { /*...*/ },
+      createdBy: { /*...*/ },
+      updatedBy: { /*...*/ },
+      locale: { /*...*/ },
+    },
+    apiName: "restaurant",
+    globalId: "Restaurants",
+    uid: "api::restaurant.restaurant",
+    modelType: "contentType",
+    modelName: "restaurant",
+    actions: { /*...*/ },
+    lifecycles: { /*...*/ },
+  },
+  action: "findOne",
+  params: {
+    documentId: 'hp7hjvrbt8rcgkmabntu0aoq',
+    locale: undefined,
+    status: "publish"
+    populate: { /*...*/ },
+  }
+}
+```
+
+</TabItem>
 
 <TabItem value="find-many" label="findMany">
 
@@ -93,7 +141,7 @@ The following examples show what `context` might include:
 
 </TabItem>
 
-<TabItem value="find-one" label="findOne">
+<TabItem value="create" label="create">
 
 ```js
 {
@@ -128,11 +176,10 @@ The following examples show what `context` might include:
     actions: { /*...*/ },
     lifecycles: { /*...*/ },
   },
-  action: "findOne",
+  action: "create",
   params: {
-    documentId: 'hp7hjvrbt8rcgkmabntu0aoq',
-    locale: undefined,
-    status: "publish"
+    data: { /*...*/ },
+    status: "draft",
     populate: { /*...*/ },
   }
 }
@@ -234,53 +281,6 @@ The following examples show what `context` might include:
 ```
 
 </TabItem>
-
-<TabItem value="create" label="create">
-
-```js
-{
-  uid: "api::restaurant.restaurant",
-  contentType: {
-    kind: "collectionType",
-    collectionName: "restaurants",
-    info: {
-      singularName: "restaurant",
-      pluralName: "restaurants",
-      displayName: "restaurant"
-    },
-    options: {
-      draftAndPublish: true
-    },
-    pluginOptions: {},
-    attributes: {
-      name: { /*...*/ },
-      description: { /*...*/ },
-      createdAt: { /*...*/ },
-      updatedAt: { /*...*/ },
-      publishedAt: { /*...*/ },
-      createdBy: { /*...*/ },
-      updatedBy: { /*...*/ },
-      locale: { /*...*/ },
-    },
-    apiName: "restaurant",
-    globalId: "Restaurants",
-    uid: "api::restaurant.restaurant",
-    modelType: "contentType",
-    modelName: "restaurant",
-    actions: { /*...*/ },
-    lifecycles: { /*...*/ },
-  },
-  action: "create",
-  params: {
-    data: { /*...*/ },
-    status: "draft",
-    populate: { /*...*/ },
-  }
-}
-```
-
-</TabItem>
-
 </Tabs>
 </details>
 

--- a/docusaurus/docs/dev-docs/api/document-service/middlewares.md
+++ b/docusaurus/docs/dev-docs/api/document-service/middlewares.md
@@ -26,14 +26,14 @@ A middleware is a function that receives a context and a next function.
 Syntax: `(context, next) => ReturnType<typeof next>`
 
 | Parameter | Description                           | Type       |
-| --------- | ------------------------------------- | ---------- |
+|-----------|---------------------------------------|------------|
 | `context` | Middleware context                    | `Context`  |
 | `next`    | Call the next middleware in the stack | `function` |
 
 #### `context`
 
 | Parameter     | Description                                                                          | Type          |
-| ------------- | ------------------------------------------------------------------------------------ | ------------- |
+|---------------|--------------------------------------------------------------------------------------|---------------|
 | `action`      | The method that is running ([see available methods](/dev-docs/api/document-service)) | `string`      |
 | `params`      | The method params ([see available methods](/dev-docs/api/document-service))          | `Object`      |
 | `uid`         | Content type unique identifier                                                       | `string`      |
@@ -50,73 +50,90 @@ The following examples show what `context` might include:
 
 ```js
 {
-  uid: 'api::test.test',
+  uid: "api::restaurant.restaurant",
   contentType: {
-    kind: 'collectionType',
-    collectionName: 'tests',
-    info: { singularName: 'test', pluralName: 'tests', displayName: 'test' },
-    options: { comment: '', draftAndPublish: false },
-    attributes: {
-      test: [Object],
-      createdAt: [Object],
-      updatedAt: [Object],
-      publishedAt: [Object],
-      createdBy: [Object],
-      updatedBy: [Object],
-      locale: [Object]
+    kind: "collectionType",
+    collectionName: "restaurants",
+    info: {
+      singularName: "restaurant",
+      pluralName: "restaurants",
+      displayName: "restaurant"
     },
-    apiName: 'test',
-    globalId: 'Test',
-    uid: 'api::test.test',
-    modelType: 'contentType',
-    modelName: 'test',
-    actions: {},
-    lifecycles: {}
+    options: {
+      draftAndPublish: true
+    },
+    pluginOptions: {},
+    attributes: {
+      name: { /*...*/ },
+      description: { /*...*/ },
+      createdAt: { /*...*/ },
+      updatedAt: { /*...*/ },
+      publishedAt: { /*...*/ },
+      createdBy: { /*...*/ },
+      updatedBy: { /*...*/ },
+      locale: { /*...*/ },
+    },
+    apiName: "restaurant",
+    globalId: "Restaurants",
+    uid: "api::restaurant.restaurant",
+    modelType: "contentType",
+    modelName: "restaurant",
+    actions: { /*...*/ },
+    lifecycles: { /*...*/ },
   },
-  action: 'findMany',
+  action: "findMany",
   params: {
-    filters: { documentId: [Object] },
-    status: 'draft',
+    filters: { /*...*/ },
+    status: "draft",
     locale: null,
-    fields: [ 'documentId', 'locale', 'updatedAt', 'createdAt', 'publishedAt' ]
+    fields: ['name', 'description'],
   }
 }
 ```
+
 </TabItem>
 
 <TabItem value="find-one" label="findOne">
 
 ```js
 {
-  uid: 'api::test.test',
+  uid: "api::restaurant.restaurant",
   contentType: {
-    kind: 'collectionType',
-    collectionName: 'tests',
-    info: { singularName: 'test', pluralName: 'tests', displayName: 'test' },
-    options: { comment: '', draftAndPublish: false },
-    attributes: {
-      test: [Object],
-      createdAt: [Object],
-      updatedAt: [Object],
-      publishedAt: [Object],
-      createdBy: [Object],
-      updatedBy: [Object],
-      locale: [Object]
+    kind: "collectionType",
+    collectionName: "restaurants",
+    info: {
+      singularName: "restaurant",
+      pluralName: "restaurants",
+      displayName: "restaurant"
     },
-    apiName: 'test',
-    globalId: 'Test',
-    uid: 'api::test.test',
-    modelType: 'contentType',
-    modelName: 'test',
-    actions: {},
-    lifecycles: {}
+    options: {
+      draftAndPublish: true
+    },
+    pluginOptions: {},
+    attributes: {
+      name: { /*...*/ },
+      description: { /*...*/ },
+      createdAt: { /*...*/ },
+      updatedAt: { /*...*/ },
+      publishedAt: { /*...*/ },
+      createdBy: { /*...*/ },
+      updatedBy: { /*...*/ },
+      locale: { /*...*/ },
+    },
+    apiName: "restaurant",
+    globalId: "Restaurants",
+    uid: "api::restaurant.restaurant",
+    modelType: "contentType",
+    modelName: "restaurant",
+    actions: { /*...*/ },
+    lifecycles: { /*...*/ },
   },
-  action: 'findOne',
+  action: "findOne",
   params: {
-    populate: { createdBy: true, updatedBy: true },
+    documentId: 'hp7hjvrbt8rcgkmabntu0aoq',
     locale: undefined,
-    status: 'published',
-    documentId: 'hp7hjvrbt8rcgkmabntu0aoq'
+    status: "publish"
+    populate: { /*...*/ },
   }
 }
 ```
@@ -127,36 +144,44 @@ The following examples show what `context` might include:
 
 ```js
 {
-  uid: 'api::test.test',
+  uid: "api::restaurant.restaurant",
   contentType: {
-    kind: 'collectionType',
-    collectionName: 'tests',
-    info: { singularName: 'test', pluralName: 'tests', displayName: 'test' },
-    options: { comment: '', draftAndPublish: false },
-    attributes: {
-      test: [Object],
-      createdAt: [Object],
-      updatedAt: [Object],
-      publishedAt: [Object],
-      createdBy: [Object],
-      updatedBy: [Object],
-      locale: [Object]
+    kind: "collectionType",
+    collectionName: "restaurants",
+    info: {
+      singularName: "restaurant",
+      pluralName: "restaurants",
+      displayName: "restaurant"
     },
-    apiName: 'test',
-    globalId: 'Test',
-    uid: 'api::test.test',
-    modelType: 'contentType',
-    modelName: 'test',
-    actions: {},
-    lifecycles: {}
+    options: {
+      draftAndPublish: true
+    },
+    pluginOptions: {},
+    attributes: {
+      name: { /*...*/ },
+      description: { /*...*/ },
+      createdAt: { /*...*/ },
+      updatedAt: { /*...*/ },
+      publishedAt: { /*...*/ },
+      createdBy: { /*...*/ },
+      updatedBy: { /*...*/ },
+      locale: { /*...*/ },
+    },
+    apiName: "restaurant",
+    globalId: "Restaurants",
+    uid: "api::restaurant.restaurant",
+    modelType: "contentType",
+    modelName: "restaurant",
+    actions: { /*...*/ },
+    lifecycles: { /*...*/ },
   },
-  action: 'update',
+  action: "update",
   params: {
-    data: { test: 'test1', updatedBy: 1 },
-    populate: { createdBy: true, updatedBy: true },
+    data: { /*...*/ },
+    documentId: 'hp7hjvrbt8rcgkmabntu0aoq',
     locale: undefined,
-    status: 'draft',
-    documentId: 'hp7hjvrbt8rcgkmabntu0aoq'
+    status: "draft"
+    populate: { /*...*/ },
   }
 }
 ```
@@ -167,34 +192,43 @@ The following examples show what `context` might include:
 
 ```js
 {
-  uid: 'api::test.test',
+  uid: "api::restaurant.restaurant",
   contentType: {
-    kind: 'collectionType',
-    collectionName: 'tests',
-    info: { singularName: 'test', pluralName: 'tests', displayName: 'test' },
-    options: { comment: '', draftAndPublish: false },
-    attributes: {
-      test: [Object],
-      createdAt: [Object],
-      updatedAt: [Object],
-      publishedAt: [Object],
-      createdBy: [Object],
-      updatedBy: [Object],
-      locale: [Object]
+    kind: "collectionType",
+    collectionName: "restaurants",
+    info: {
+      singularName: "restaurant",
+      pluralName: "restaurants",
+      displayName: "restaurant"
     },
-    apiName: 'test',
-    globalId: 'Test',
-    uid: 'api::test.test',
-    modelType: 'contentType',
-    modelName: 'test',
-    actions: {},
-    lifecycles: {}
+    options: {
+      draftAndPublish: true
+    },
+    pluginOptions: {},
+    attributes: {
+      name: { /*...*/ },
+      description: { /*...*/ },
+      createdAt: { /*...*/ },
+      updatedAt: { /*...*/ },
+      publishedAt: { /*...*/ },
+      createdBy: { /*...*/ },
+      updatedBy: { /*...*/ },
+      locale: { /*...*/ },
+    },
+    apiName: "restaurant",
+    globalId: "Restaurants",
+    uid: "api::restaurant.restaurant",
+    modelType: "contentType",
+    modelName: "restaurant",
+    actions: { /*...*/ },
+    lifecycles: { /*...*/ },
   },
-  action: 'delete',
+  action: "delete",
   params: {
-    locale: '*',
+    data: { /*...*/ },
     documentId: 'hp7hjvrbt8rcgkmabntu0aoq',
-    populate: { createdBy: true, updatedBy: true }
+    locale: "*",
+    populate: { /*...*/ },
   }
 }
 ```
@@ -205,35 +239,42 @@ The following examples show what `context` might include:
 
 ```js
 {
-  uid: 'api::test.test',
+  uid: "api::restaurant.restaurant",
   contentType: {
-    kind: 'collectionType',
-    collectionName: 'tests',
-    info: { singularName: 'test', pluralName: 'tests', displayName: 'test' },
-    options: { comment: '', draftAndPublish: false },
-    attributes: {
-      test: [Object],
-      createdAt: [Object],
-      updatedAt: [Object],
-      publishedAt: [Object],
-      createdBy: [Object],
-      updatedBy: [Object],
-      locale: [Object]
+    kind: "collectionType",
+    collectionName: "restaurants",
+    info: {
+      singularName: "restaurant",
+      pluralName: "restaurants",
+      displayName: "restaurant"
     },
-    apiName: 'test',
-    globalId: 'Test',
-    uid: 'api::test.test',
-    modelType: 'contentType',
-    modelName: 'test',
-    actions: {},
-    lifecycles: {}
+    options: {
+      draftAndPublish: true
+    },
+    pluginOptions: {},
+    attributes: {
+      name: { /*...*/ },
+      description: { /*...*/ },
+      createdAt: { /*...*/ },
+      updatedAt: { /*...*/ },
+      publishedAt: { /*...*/ },
+      createdBy: { /*...*/ },
+      updatedBy: { /*...*/ },
+      locale: { /*...*/ },
+    },
+    apiName: "restaurant",
+    globalId: "Restaurants",
+    uid: "api::restaurant.restaurant",
+    modelType: "contentType",
+    modelName: "restaurant",
+    actions: { /*...*/ },
+    lifecycles: { /*...*/ },
   },
-  action: 'create',
+  action: "create",
   params: {
-    data: { test: 'test1', createdBy: 1, updatedBy: 1 },
-    locale: undefined,
-    status: 'draft',
-    populate: { createdBy: true, updatedBy: true }
+    data: { /*...*/ },
+    status: "draft",
+    populate: { /*...*/ },
   }
 }
 ```


### PR DESCRIPTION
This PR adds examples so that users know what they get with `context` for the most common methods.