### PR TITLE
Strapi 5 templates

### DIFF
--- a/docusaurus/docs/dev-docs/advanced-features.md
+++ b/docusaurus/docs/dev-docs/advanced-features.md
@@ -25,6 +25,8 @@ Strapi provides advanced built-in features for developers who'd like to get the 
 
 <CustomDocCard title="Providers" description="Install, configure, and create providers to extend core capabilities of some plugins." link="/dev-docs/providers" />
 
+<CustomDocCard title="Templates" description="Use and create pre-made Strapi applications designed for a specific purpose." link="/dev-docs/templates" />
+
 <CustomDocCard title="Data management" description="Use Strapi's built-in data management system to import, export, or transfer data." link="/dev-docs/data-management" />
 
 <CustomDocCard title="Database migrations" description="Manage database migrations operations." link="/dev-docs/database-migrations" />

--- a/docusaurus/docs/dev-docs/advanced-features.md
+++ b/docusaurus/docs/dev-docs/advanced-features.md
@@ -25,8 +25,6 @@ Strapi provides advanced built-in features for developers who'd like to get the 
 
 <CustomDocCard title="Providers" description="Install, configure, and create providers to extend core capabilities of some plugins." link="/dev-docs/providers" />
 
-<CustomDocCard title="Templates" description="Use and create pre-made Strapi applications designed for a specific purpose." link="/dev-docs/templates" />
-
 <CustomDocCard title="Data management" description="Use Strapi's built-in data management system to import, export, or transfer data." link="/dev-docs/data-management" />
 
 <CustomDocCard title="Database migrations" description="Manage database migrations operations." link="/dev-docs/database-migrations" />

--- a/docusaurus/docs/dev-docs/installation/cli.md
+++ b/docusaurus/docs/dev-docs/installation/cli.md
@@ -118,7 +118,15 @@ The above installation guide only covers the basic installation option using the
 | `--use-npm` | Force the usage of [npm](https://www.npmjs.com/) as the project package manager |
 | `--use-yarn` | Force the usage of [yarn](https://yarnpkg.com/) as the project package manager |
 | `--use-pnpm` | Force the usage of [pnpm](https://pnpm.io/) as the project package manager |
+| `--install`  | Install all dependencies, skipping the related CLI prompt |
+| `--no-install`  | Do not install all dependencies, skipping the related CLI prompt |
+| `--git-init` | Initialize a git repository, skipping the related CLI prompt |
+| `--no-git-init` | Do not initialize a git repository, skipping the related CLI prompt |
+| `--example`  | Add example data, skipping the related CLI prompt |
+| `--no-example`  | Do not add example data, skipping the related CLI prompt |
 | `--skip-cloud` |  Skip [Strapi Cloud login and project creation steps](#skipping-the-strapi-cloud-login-step) |
+| `--skip-db` | Skip all database-related prompts and create a project with the default (SQLite) database |
+| `--template <template-name-or-url>` | Create the application based on a given template.<br/>Additional options for templates are available, see the [templates documentation](/dev-docs/templates) for details. |
 | `--dbclient <dbclient>` | Define the database client to use by replacing `<dbclient>` in the command by one of the these values:<ul><li>`sql` for a SQLite database (default)</li><li>`postgres` for a PostgreSQL database</li><li>`mysql` for a MySQL database</li></ul> |
 | `--dbhost <dbhost>` | Define the database host to use by replacing `<dbclient>` in the command by the value of your choice |
 | `--dbport <dbport>` | Define the database port to use by replacing `<dbclient>` in the command by the value of your choice |
@@ -127,7 +135,7 @@ The above installation guide only covers the basic installation option using the
 | `--dbpassword <dbpassword>` | Define the database password to use by replacing `<dbclient>` in the command by the value of your choice |
 | `--dbssl <dbssl>` | Define that SSL is used with the database, by passing `--dbssl=true` (No SSL by default) |
 | `--dbfile <dbfile>` | For SQLite databases, define the database file path to use by replacing `<dbclient>` in the command by the value of your choice |
-| `--quickstart` | (**Deprecated in Strapi 5**)<br/>Directly create the project in quickstart mode. |
+| `--quickstart` | (**Deprecated in Strapi 5**)<br/>Directly create the project in quickstart mode, including adding example data. |
 
 :::note Notes
 * If you do not pass a `--use-yarn|npm|pnpm` option, the installation script will use whatever package manager was used with the create command to install all dependencies (e.g., `npm create strapi` will install all the project's dependencies with npm).

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes.md
@@ -70,6 +70,7 @@ You can click on the description of any breaking change in the following tables 
 | [`strapi-utils` has been refactored](/dev-docs/migration/v4-to-v5/breaking-changes/strapi-utils-refactored) | Yes | ✅ Yes |
 | [Core service methods use the Document Service API](/dev-docs/migration/v4-to-v5/breaking-changes/core-service-methods-use-document-service) | Yes | No |
 | [i18n is now part of the strapi core](/dev-docs/migration/v4-to-v5/breaking-changes/i18n-content-manager-locale) | Yes | ✅ Yes |
+| [Templates are now regular, standalone Strapi applications](/dev-docs/migration/v4-to-v5/breaking-changes/templates) | No | No |
 
 ## Plugins, providers, and admin panel customization
 

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/templates.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/templates.md
@@ -1,6 +1,6 @@
 ---
 title: Templates are now regular, standalone Strapi applications
-description: Strapi 5 has strict requirements on the configuration filenames allowed to be loaded.
+description: Templates have been fully rewritten in Strapi 5 and now are standalone, regular Strapi applications, making it easier to create, distribute, and re-use them.
 displayed_sidebar: devDocsMigrationV5Sidebar
 tags:
  - breaking changes

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/templates.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/templates.md
@@ -1,0 +1,59 @@
+---
+title: Templates are now typical Strapi applications
+description: Strapi 5 has strict requirements on the configuration filenames allowed to be loaded.
+displayed_sidebar: devDocsMigrationV5Sidebar
+tags:
+ - breaking changes
+ - templates
+ - upgrade to Strapi 5
+---
+
+import Intro from '/docs/snippets/breaking-change-page-intro.md'
+import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
+import NoPlugins from '/docs/snippets/breaking-change-not-affecting-plugins.md'
+import NoCodemods from '/docs/snippets/breaking-change-not-handled-by-codemod.md'
+
+# Templates are now standalone, regular Strapi applications
+
+Templates have been fully rewritten in Strapi 5 and now are standalone, regular Strapi applications, making it much easier to create, distribute, and re-use them.
+<Intro />
+<NoPlugins />
+<NoCodemods />
+
+## Breaking change description
+
+<SideBySideContainer>
+
+<SideBySideColumn>
+
+**In Strapi v4**
+
+<!-- TODO: update this link with docs-v4 just before the stable -->
+Templates were npm packages with strict requirements (see [v4 documentation](https://docs.strapi.io/dev-docs/templates)).
+
+</SideBySideColumn>
+
+<SideBySideColumn>
+
+**In Strapi 5**
+
+Templates are now just regular Strapi 5 applications, which can be run on their own.
+
+</SideBySideColumn>
+
+</SideBySideContainer>
+
+## Migration
+
+<MigrationIntro />
+
+### Notes
+
+* For additional information about creating a new Strapi application based on an existing template, see the [templates documentation](/dev-docs/templates).
+* Creating a Strapi template is now as simple as creating a new Strapi 5 application and adjusting its codebase to your needs.
+
+### Manual migration
+
+Templates in Strapi v4 were only useful if applied on top of a default Strapi application. Strapi 5 templates are now standalone Strapi 5 applications. 
+
+To convert your Strapi v4 template into a usable Strapi 5 template, ensure the template includes all files required for Strapi to work. Your folder containing the v4 template applied on top of a full-blown Strapi application should be enough to be a Strapi 5 template.

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/templates.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/templates.md
@@ -1,5 +1,5 @@
 ---
-title: Templates are now typical Strapi applications
+title: Templates are now regular, standalone Strapi applications
 description: Strapi 5 has strict requirements on the configuration filenames allowed to be loaded.
 displayed_sidebar: devDocsMigrationV5Sidebar
 tags:

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/templates.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/templates.md
@@ -15,7 +15,7 @@ import NoCodemods from '/docs/snippets/breaking-change-not-handled-by-codemod.md
 
 # Templates are now standalone, regular Strapi applications
 
-Templates have been fully rewritten in Strapi 5 and now are standalone, regular Strapi applications, making it much easier to create, distribute, and re-use them.
+Templates have been fully rewritten in Strapi 5 and now are standalone, regular Strapi applications, making it easier to create, distribute, and reuse them.
 <Intro />
 <NoPlugins />
 <NoCodemods />

--- a/docusaurus/docs/dev-docs/plugins/server-api.md
+++ b/docusaurus/docs/dev-docs/plugins/server-api.md
@@ -147,45 +147,6 @@ Once defined, the configuration can be accessed:
 Run `yarn strapi console` or `npm run strapi console` to access the strapi object in a live console.
 :::
 
-## Cron
-
-The `cron` object allows you to add cron jobs to the Strapi instance.
-
-```js title="./src/plugins/my-plugin/strapi-server.js"
-module.exports = () => ({
-  bootstrap({ strapi }) {
-    strapi.cron.add({
-      // runs every second
-      myJob: {
-        task: ({ strapi }) => {
-          console.log("hello from plugin");
-        },
-        options: {
-          rule: "* * * * * *",
-        },
-      },
-    });
-  },
-});
-```
-
-To remove a CRON job you can call the remove function on the `strapi.cron` object and pass in the key corresponding to the CRON job you want to remove.
-
-:::note
-Cron jobs that are using the key as the rule can not be removed.
-:::
-
-```js
-strapi.cron.remove("myJob");
-```
-
-### List cron jobs
-
-To list all the cron jobs that are currently running you can call the `jobs` array on the `strapi.cron` object.
-
-```js
-strapi.cron.jobs
-```
 
 ## Backend customization
 

--- a/docusaurus/docs/dev-docs/plugins/server-api.md
+++ b/docusaurus/docs/dev-docs/plugins/server-api.md
@@ -147,6 +147,45 @@ Once defined, the configuration can be accessed:
 Run `yarn strapi console` or `npm run strapi console` to access the strapi object in a live console.
 :::
 
+## Cron
+
+The `cron` object allows you to add cron jobs to the Strapi instance.
+
+```js title="./src/plugins/my-plugin/strapi-server.js"
+module.exports = () => ({
+  bootstrap({ strapi }) {
+    strapi.cron.add({
+      // runs every second
+      myJob: {
+        task: ({ strapi }) => {
+          console.log("hello from plugin");
+        },
+        options: {
+          rule: "* * * * * *",
+        },
+      },
+    });
+  },
+});
+```
+
+To remove a CRON job you can call the remove function on the `strapi.cron` object and pass in the key corresponding to the CRON job you want to remove.
+
+:::note
+Cron jobs that are using the key as the rule can not be removed.
+:::
+
+```js
+strapi.cron.remove("myJob");
+```
+
+### List cron jobs
+
+To list all the cron jobs that are currently running you can call the `jobs` array on the `strapi.cron` object.
+
+```js
+strapi.cron.jobs
+```
 
 ## Backend customization
 

--- a/docusaurus/docs/dev-docs/templates.md
+++ b/docusaurus/docs/dev-docs/templates.md
@@ -1,24 +1,18 @@
 ---
 title: Templates
-description: Quickly create a pre-made Strapi application designed for a specific use case. It allows you to quickly bootstrap a custom Strapi application.
+description: Use and create pre-made Strapi applications designed for a specific use case.
 displayed_sidebar: devDocsSidebar
-
+tags:
+- installation
+- templates
+- CLI
 ---
 
 # Templates
 
-:::caution
-Templates are currently not usable with Strapi 5 pre-releases versions (beta or release candidate versions). Templates will be available again with the Strapi 5 stable release.
-:::
+Templates in Strapi 5 are pre-made Strapi applications designed for specific use cases.
 
-Templates are pre-made Strapi configurations designed for specific use cases. They allow bootstrapping a custom Strapi application. A template can configure [collection types and single types](/user-docs/content-type-builder), [components](/dev-docs/backend-customization/models.md#components-2) and [dynamic zones](/dev-docs/backend-customization/models.md#dynamic-zones), and [plugins](/dev-docs/plugins).
-
-:::strapi Templates vs. Starters
-
-- A template is only useful once applied on top of a default Strapi application via the CLI. It is not a configured application and cannot be run on its own since it lacks many files (e.g. database configurations, `package.json`, etc.).
-- A starter is a pre-made frontend application that consumes a Strapi API. Only one starter is currently available, the [Next.js starter](https://strapi.io/starters).
-
-:::
+Strapi 5 templates are folders that include all files and folders that you would find in a typical Strapi application (see [project structure](/dev-docs/project-structure)).
 
 ## Using a template
 
@@ -29,7 +23,7 @@ To create a new Strapi project based on a template, run the following command:
 <TabItem value="yarn" label="Yarn">
 
 ```sh
-yarn create strapi-app my-project --template <template-package>
+yarn create strapi-app my-project --template <template-name-or-url>
 ```
 
 </TabItem>
@@ -37,115 +31,29 @@ yarn create strapi-app my-project --template <template-package>
 <TabItem value="npm" label="NPM">
 
 ```sh
-npx create-strapi-app@latest my-project --template <template-package>
+npx create-strapi-app@latest my-project --template <template-name-or-url>
 ```
 
 </TabItem>
 
 </Tabs>
 
-npm is used to install template packages, so `<template-package>` can match [any format](https://docs.npmjs.com/cli/v8/commands/npm-install) supported by `npm install`. This includes npm packages, scoped packages, packages with a precise version or tag, and local directories for development.
+In addition to the mandatory `--template` parameter, you can pass the optional `--template-path` and `--template-branch` options to more precisely define the template to use.
 
-:::tip
-For convenience, official Strapi templates also have a shorthand, making it possible to omit the `@strapi/template-` prefix from the template npm package name:
+The following table lists all the possible ways to define which template to use:
 
-```sh
-# use the full template name
-yarn create strapi-app my-project --template @strapi/template-blog
-
-# use the shorthand
-yarn create strapi-app my-project --template blog
-```
-
-:::
-
-The `--template` option can be used in combination with all other `create-strapi-app` options (e.g. `--quickstart` or `--no-run`).
+| Syntax | Description |
+|--------|-------------|
+| `--template website` | Using one of the [Strapi-maintained templates](https://github.com/strapi/strapi/tree/v5/main/templates) calling it by its (folder) name. |
+| `--template strapi/strapi` | Using the template's GitHub repository shorthand.<br/>This will use the default repository branch. |
+| `--template strapi/strapi/some/sub/path` | Using the template's GitHub repository shorthand and specifying a subpath.<br/>This will use the default repository branch. |
+| `--template strapi/strapi`<br/>`--template-branch=xxx`<br/>`--template-path=some/sub/path` | The most verbose way, explicitly defining a template branch and a subpath. |
+| `--template https://github.com/owner/some-template-repo` | Using a full repository URL.<br/>This will use the default repository branch. |
+| `--template https://github.com/owner/some-template-repo --template-branch=xxx --template-path=sub/path` | Using a full repository URL, and specifying both the branch and the subpath for the template. |
+| `--template https://github.com/strapi/strapi/tree/branch/sub/path` | Using a repository, branch, and subpath directly.<br/><br/>⚠️ _Warning: This won't work with branch names that include a `/`. In such cases, it's best to explicitly define `--template-branch` and `--template-path`._ |
 
 ## Creating a template
 
-Templates are generated from a customized Strapi application and published to the npm package registry. Before creating a template make sure you have a Strapi application that matches your use case and that you have read the [template requirements](#requirements).
+Creating a Strapi 5 template is as simple as creating a Strapi application. Create the application (see [CLI installation](/dev-docs/installation/cli)) and the generated folder containing your Strapi 5 application can serve as a template. You can then pass it to the `--template` flag when creating a new Strapi 5 application to use it as a template.
 
-### Requirements
-
-Keep the following requirements in mind when creating a template:
-
-* Templates should not deal with environment-specific configurations (e.g. databases or upload and email providers). This keeps templates maintainable and avoids conflicts with other CLI options (e.g. `--quickstart`).
-
-* Templates must follow a specific file structure, containing the following at the repository's root:
-    * [`template` directory](#template-directory)
-    * [`package.json` file](https://docs.npmjs.com/creating-a-package-json-file)
-    * [`template.json` file](#template-json-file)
-
-This structure can be created manually or automatically generated with the [`strapi templates:generate` command](/dev-docs/cli#strapi-templates-generate):
-
-<Tabs groupId="yarn-npm">
-
-<TabItem value="yarn" label="Yarn">
-
-```sh
-yarn strapi templates:generate <path>
-```
-
-</TabItem>
-
-<TabItem value="npm" label="NPM">
-  
-```sh
-npx strapi templates:generate [path]
-```
-  
-</TabItem>
-
-</Tabs>
-
-The repository root can contain any other files or directories desired, but must include the `template` directory, `package.json` file, and `template.json` file at a minimum.
-
-#### `template` directory
-
-The `template` directory is used to extend the file contents of a Strapi project and should only include the files that will overwrite the default Strapi application.
-
-Only the following contents are allowed inside the `template` directory:
-
-- `README.md`: the readme of an application made with this template
-- `.env.example` to specify required environment variables
-- `src/`
-- `data/` to store the data imported by a seed script
-- `public/` to serve files
-- `scripts/` for custom scripts
-
-:::caution
-If any unexpected file or directory is found, the installation will crash.
-:::
-
-#### `template.json` file
-
-The `template.json` is used to extend the Strapi application's default `package.json`. All properties overwriting the default `package.json` should be included in a root `package` property:
-
-```json title="./template.json"
-
-{
-  "package": {
-    "dependencies": {
-      "@strapi/plugin-graphql": "^4.0.0"
-    },
-    "scripts": {
-      "custom": "node ./scripts/custom.js"
-    }
-  }
-}
-```
-
-### Packaging and publishing
-
-With the above [requirements](#requirements) in mind, follow these steps to create and publish a template:
-
-1. [Create a standard Strapi application](/dev-docs/quick-start) with `create-strapi-app`, using the `--quickstart` option.
-2. Customize your application to match the needs of your use case.
-3. Generate your template using the [CLI](/dev-docs/cli#strapi-templates-generate) by running `strapi templates:generate <path>`
-4. Navigate to this path to see your generated template.
-5. If you have modified your application's `package.json`, include these changes (and _only_ these changes) in `template.json` in a `package` property. If not, leave it as an empty object.
-6. Enter `npm publish` to make your template available on the npm package registry.
-
-:::strapi List of templates
-[Strapi-maintained](https://github.com/strapi/starters-and-templates) templates and [community-maintained](https://github.com/strapi/community-content/tree/master/templates) templates can be found on GitHub.
-:::
+An example of what a template could look like is the [Strapi-maintained `website` template](https://github.com/strapi/strapi/tree/v5/main/templates/website).

--- a/docusaurus/docs/dev-docs/templates.md
+++ b/docusaurus/docs/dev-docs/templates.md
@@ -1,18 +1,24 @@
 ---
 title: Templates
-description: Use and create pre-made Strapi applications designed for a specific use case.
+description: Quickly create a pre-made Strapi application designed for a specific use case. It allows you to quickly bootstrap a custom Strapi application.
 displayed_sidebar: devDocsSidebar
-tags:
-- installation
-- templates
-- CLI
+
 ---
 
 # Templates
 
-Templates in Strapi 5 are pre-made Strapi applications designed for specific use cases.
+:::caution
+Templates are currently not usable with Strapi 5 pre-releases versions (beta or release candidate versions). Templates will be available again with the Strapi 5 stable release.
+:::
 
-Strapi 5 templates are folders that include all files and folders that you would find in a typical Strapi application (see [project structure](/dev-docs/project-structure)).
+Templates are pre-made Strapi configurations designed for specific use cases. They allow bootstrapping a custom Strapi application. A template can configure [collection types and single types](/user-docs/content-type-builder), [components](/dev-docs/backend-customization/models.md#components-2) and [dynamic zones](/dev-docs/backend-customization/models.md#dynamic-zones), and [plugins](/dev-docs/plugins).
+
+:::strapi Templates vs. Starters
+
+- A template is only useful once applied on top of a default Strapi application via the CLI. It is not a configured application and cannot be run on its own since it lacks many files (e.g. database configurations, `package.json`, etc.).
+- A starter is a pre-made frontend application that consumes a Strapi API. Only one starter is currently available, the [Next.js starter](https://strapi.io/starters).
+
+:::
 
 ## Using a template
 
@@ -23,7 +29,7 @@ To create a new Strapi project based on a template, run the following command:
 <TabItem value="yarn" label="Yarn">
 
 ```sh
-yarn create strapi-app my-project --template <template-name-or-url>
+yarn create strapi-app my-project --template <template-package>
 ```
 
 </TabItem>
@@ -31,29 +37,115 @@ yarn create strapi-app my-project --template <template-name-or-url>
 <TabItem value="npm" label="NPM">
 
 ```sh
-npx create-strapi-app@latest my-project --template <template-name-or-url>
+npx create-strapi-app@latest my-project --template <template-package>
 ```
 
 </TabItem>
 
 </Tabs>
 
-In addition to the mandatory `--template` parameter, you can pass the optional `--template-path` and `--template-branch` options to more precisely define the template to use.
+npm is used to install template packages, so `<template-package>` can match [any format](https://docs.npmjs.com/cli/v8/commands/npm-install) supported by `npm install`. This includes npm packages, scoped packages, packages with a precise version or tag, and local directories for development.
 
-The following table lists all the possible ways to define which template to use:
+:::tip
+For convenience, official Strapi templates also have a shorthand, making it possible to omit the `@strapi/template-` prefix from the template npm package name:
 
-| Syntax | Description |
-|--------|-------------|
-| `--template website` | Using one of the [Strapi-maintained templates](https://github.com/strapi/strapi/tree/v5/main/templates) calling it by its (folder) name. |
-| `--template strapi/strapi` | Using the template's GitHub repository shorthand.<br/>This will use the default repository branch. |
-| `--template strapi/strapi/some/sub/path` | Using the template's GitHub repository shorthand and specifying a subpath.<br/>This will use the default repository branch. |
-| `--template strapi/strapi`<br/>`--template-branch=xxx`<br/>`--template-path=some/sub/path` | The most verbose way, explicitly defining a template branch and a subpath. |
-| `--template https://github.com/owner/some-template-repo` | Using a full repository URL.<br/>This will use the default repository branch. |
-| `--template https://github.com/owner/some-template-repo --template-branch=xxx --template-path=sub/path` | Using a full repository URL, and specifying both the branch and the subpath for the template. |
-| `--template https://github.com/strapi/strapi/tree/branch/sub/path` | Using a repository, branch, and subpath directly.<br/><br/>⚠️ _Warning: This won't work with branch names that include a `/`. In such cases, it's best to explicitly define `--template-branch` and `--template-path`._ |
+```sh
+# use the full template name
+yarn create strapi-app my-project --template @strapi/template-blog
+
+# use the shorthand
+yarn create strapi-app my-project --template blog
+```
+
+:::
+
+The `--template` option can be used in combination with all other `create-strapi-app` options (e.g. `--quickstart` or `--no-run`).
 
 ## Creating a template
 
-Creating a Strapi 5 template is as simple as creating a Strapi application. Create the application (see [CLI installation](/dev-docs/installation/cli)) and the generated folder containing your Strapi 5 application can serve as a template. You can then pass it to the `--template` flag when creating a new Strapi 5 application to use it as a template.
+Templates are generated from a customized Strapi application and published to the npm package registry. Before creating a template make sure you have a Strapi application that matches your use case and that you have read the [template requirements](#requirements).
 
-An example of what a template could look like is the [Strapi-maintained `website` template](https://github.com/strapi/strapi/tree/v5/main/templates/website).
+### Requirements
+
+Keep the following requirements in mind when creating a template:
+
+* Templates should not deal with environment-specific configurations (e.g. databases or upload and email providers). This keeps templates maintainable and avoids conflicts with other CLI options (e.g. `--quickstart`).
+
+* Templates must follow a specific file structure, containing the following at the repository's root:
+    * [`template` directory](#template-directory)
+    * [`package.json` file](https://docs.npmjs.com/creating-a-package-json-file)
+    * [`template.json` file](#template-json-file)
+
+This structure can be created manually or automatically generated with the [`strapi templates:generate` command](/dev-docs/cli#strapi-templates-generate):
+
+<Tabs groupId="yarn-npm">
+
+<TabItem value="yarn" label="Yarn">
+
+```sh
+yarn strapi templates:generate <path>
+```
+
+</TabItem>
+
+<TabItem value="npm" label="NPM">
+  
+```sh
+npx strapi templates:generate [path]
+```
+  
+</TabItem>
+
+</Tabs>
+
+The repository root can contain any other files or directories desired, but must include the `template` directory, `package.json` file, and `template.json` file at a minimum.
+
+#### `template` directory
+
+The `template` directory is used to extend the file contents of a Strapi project and should only include the files that will overwrite the default Strapi application.
+
+Only the following contents are allowed inside the `template` directory:
+
+- `README.md`: the readme of an application made with this template
+- `.env.example` to specify required environment variables
+- `src/`
+- `data/` to store the data imported by a seed script
+- `public/` to serve files
+- `scripts/` for custom scripts
+
+:::caution
+If any unexpected file or directory is found, the installation will crash.
+:::
+
+#### `template.json` file
+
+The `template.json` is used to extend the Strapi application's default `package.json`. All properties overwriting the default `package.json` should be included in a root `package` property:
+
+```json title="./template.json"
+
+{
+  "package": {
+    "dependencies": {
+      "@strapi/plugin-graphql": "^4.0.0"
+    },
+    "scripts": {
+      "custom": "node ./scripts/custom.js"
+    }
+  }
+}
+```
+
+### Packaging and publishing
+
+With the above [requirements](#requirements) in mind, follow these steps to create and publish a template:
+
+1. [Create a standard Strapi application](/dev-docs/quick-start) with `create-strapi-app`, using the `--quickstart` option.
+2. Customize your application to match the needs of your use case.
+3. Generate your template using the [CLI](/dev-docs/cli#strapi-templates-generate) by running `strapi templates:generate <path>`
+4. Navigate to this path to see your generated template.
+5. If you have modified your application's `package.json`, include these changes (and _only_ these changes) in `template.json` in a `package` property. If not, leave it as an empty object.
+6. Enter `npm publish` to make your template available on the npm package registry.
+
+:::strapi List of templates
+[Strapi-maintained](https://github.com/strapi/starters-and-templates) templates and [community-maintained](https://github.com/strapi/community-content/tree/master/templates) templates can be found on GitHub.
+:::

--- a/docusaurus/docs/dev-docs/templates.md
+++ b/docusaurus/docs/dev-docs/templates.md
@@ -10,7 +10,7 @@ tags:
 
 # Templates
 
-Templates in Strapi 5 are pre-made Strapi applications designed for specific use cases.
+Templates in Strapi 5 are standalone, pre-made Strapi applications designed for specific use cases.
 
 Strapi 5 templates are folders that include all files and folders that you would find in a typical Strapi application (see [project structure](/dev-docs/project-structure)).
 

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -310,14 +310,6 @@ const sidebars = {
           id: 'dev-docs/providers',
         },
         {
-          type: 'doc',
-          label: 'Templates',
-          id: 'dev-docs/templates',
-          customProps: {
-            updated: true,
-          }
-        },
-        {
           type: 'category',
           label: 'Data management',
           link: {

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -310,6 +310,14 @@ const sidebars = {
           id: 'dev-docs/providers',
         },
         {
+          type: 'doc',
+          label: 'Templates',
+          id: 'dev-docs/templates',
+          customProps: {
+            updated: true,
+          }
+        },
+        {
           type: 'category',
           label: 'Data management',
           link: {


### PR DESCRIPTION
This PR:

- Completely rewrites the Templates documentation with the latest updates from [strapi/strapi #20913](https://github.com/strapi/strapi/pull/20913)
- Updates the CLI installation reference with the newly added options
- Adds a short breaking change entry

Direct preview links
👉 [Templates](https://documentation-git-v5-templates-strapijs.vercel.app/dev-docs/templates)
👉 [CLI installation options](https://documentation-git-v5-templates-strapijs.vercel.app/dev-docs/installation/cli#cli-installation-options)
👉 [Breaking change](https://documentation-git-v5-templates-strapijs.vercel.app/dev-docs/migration/v4-to-v5/breaking-changes/templates)

Notes: 
- Another PR will update the Quick Start Guide to reflect the new CLI prompts when creating a project. Probably next week.
