### PR TITLE
Update backend customization examples to Document Service API

### DIFF
--- a/docusaurus/docs/dev-docs/backend-customization/controllers.md
+++ b/docusaurus/docs/dev-docs/backend-customization/controllers.md
@@ -318,9 +318,9 @@ module.exports = {
     await validate.contentAPI.query(ctx.query, contentType, { auth: ctx.state.auth });
     const sanitizedQueryParams = await sanitize.contentAPI.query(ctx.query, contentType, { auth: ctx.state.auth });
 
-    const entities = await strapi.entityService.findMany(contentType.uid, sanitizedQueryParams);
+    const documents = await strapi.documents(contentType.uid).findMany(sanitizedQueryParams);
 
-    return await sanitize.contentAPI.output(entities, contentType, { auth: ctx.state.auth });
+    return await sanitize.contentAPI.output(documents, contentType, { auth: ctx.state.auth });
   }
 }
 ```
@@ -340,9 +340,9 @@ export default {
     await validate.contentAPI.query(ctx.query, contentType, { auth: ctx.state.auth });
     const sanitizedQueryParams = await sanitize.contentAPI.query(ctx.query, contentType, { auth: ctx.state.auth });
 
-    const entities = await strapi.entityService.findMany(contentType.uid, sanitizedQueryParams);
+    const documents = await strapi.documents(contentType.uid).findMany(sanitizedQueryParams);
 
-    return await sanitize.contentAPI.output(entities, contentType, { auth: ctx.state.auth });
+    return await sanitize.contentAPI.output(documents, contentType, { auth: ctx.state.auth });
   }
 }
 ```

--- a/docusaurus/docs/dev-docs/backend-customization/middlewares.md
+++ b/docusaurus/docs/dev-docs/backend-customization/middlewares.md
@@ -173,11 +173,7 @@ Proper implementation largely depends on your project's needs and custom code, b
          * the response includes author-related information
          */
         if (entryId) {
-          entry = await strapi.entityService.findOne(
-            // highlight-start
-            // replace the next line with your proper content-type identifier
-            "api::restaurant.restaurant",
-            // highlight-end
+          entry = await strapi.documents('api::restaurant.restaurant').findOne(
             entryId,
             { populate: "*" }
           );

--- a/docusaurus/docs/dev-docs/backend-customization/services.md
+++ b/docusaurus/docs/dev-docs/backend-customization/services.md
@@ -74,8 +74,8 @@ module.exports = createCoreService('api::restaurant.restaurant', ({ strapi }) =>
   },
 
   // Method 3: Replacing a core service
-  async findOne(entityId, params = {}) {
-    return strapi.entityService.findOne('api::restaurant.restaurant', entityId, this.getFetchParams(params));
+  async findOne(documentId, params = {}) {
+    return strapi.documents('api::restaurant.restaurant').findOne(documentId, this.getFetchParams(params));
   }
 }));
 ```
@@ -114,8 +114,8 @@ export default factories.createCoreService('api::restaurant.restaurant', ({ stra
   },
 
   // Method 3: Replacing a core service
-  async findOne(entityId, params = {}) {
-    return strapi.entityService.findOne('api::restaurant.restaurant', entityId, this.getFetchParams(params));
+  async findOne(documentId, params = {}) {
+     return strapi.documents('api::restaurant.restaurant').findOne(documentId, this.getFetchParams(params));
   }
 }));
 ```
@@ -299,9 +299,9 @@ async find(params) {
 <TabItem value="find-one" label="findOne()">
 
 ```js
-async findOne(entityId, params) {
+async findOne(documentId, params) {
   // some logic here
-  const result = await super.findOne(entityId, params);
+  const result = await super.findOne(documentId, params);
   // some more logic
 
   return result;
@@ -327,9 +327,9 @@ async create(params) {
 <TabItem value="update" label="update()">
 
 ```js
-async update(entityId, params) {
+async update(documentId, params) {
   // some logic here
-  const result = await super.update(entityId, params);
+  const result = await super.update(documentId, params);
   // some more logic
 
   return result;
@@ -341,9 +341,9 @@ async update(entityId, params) {
 <TabItem value="delete" label="delete()">
 
 ```js
-async delete(entityId, params) {
+async delete(documentId, params) {
   // some logic here
-  const result = await super.delete(entityId, params);
+  const result = await super.delete(documentId, params);
   // some more logic
 
   return result;
@@ -366,10 +366,10 @@ async delete(entityId, params) {
 ```js
 async find(params) {
   // some logic here
-  const entity = await super.find(params);
+  const document = await super.find(params);
   // some more logic
 
-  return entity;
+  return document;
 }
 ```
 
@@ -380,10 +380,10 @@ async find(params) {
 ```js
 async createOrUpdate({ data, ...params }) {
   // some logic here
-  const entity = await super.createOrUpdate({ data, ...params });
+  const document = await super.createOrUpdate({ data, ...params });
   // some more logic
 
-  return entity;
+  return document;
 }
 ```
 
@@ -394,10 +394,10 @@ async createOrUpdate({ data, ...params }) {
 ```js
 async delete(params) {
   // some logic here
-  const entity = await super.delete(params);
+  const document = await super.delete(params);
   // some more logic
 
-  return entity;
+  return document;
 }
 ```
 


### PR DESCRIPTION
This PR updates examples in backend customization > controllers, services, and middlewares, so they use the Document Service API instead of the Entity Service API.