### PR TITLE
Add a note on how to work around a version clash in the 4.2.x to 4.3.x migration when on node v16

### DIFF
--- a/docusaurus/docs/dev-docs/migration/v4/migration-guide-4.2.x-to-4.3.x.md
+++ b/docusaurus/docs/dev-docs/migration/v4/migration-guide-4.2.x-to-4.3.x.md
@@ -46,6 +46,25 @@ Stop the server before starting the upgrade. At the time of writing this, the la
 
 3. <InstallCommand components={props.components} />
 
+  :::note
+  If you are on a Node <=16.x version, you might get an error stating that the `cheerio` sub-dependency of of `@strapi/plugin-documentation` requires node >=18.17.
+
+  The reason is that the version specifier for `cheerio` in Strapi >=4.2.x is `^1.0.0-rc.12`, which used to resolve to the version `1.0.0-rc.12` that supported Node v16, but now it resolves to `1.0.0` (non-rc) which has a requirement for Node >=18.17.
+  
+  As a workaround in yarn, you can add a resolution to your `package.json` that pins cheerio at the exact release candidate that still supports Node v16:
+
+  ```json title="path: ./package.json"
+  {
+    // ...
+    "resolutions": {
+      "@strapi/plugin-documentation/**/cheerio": "1.0.0-rc.12"
+    },
+    // ...
+  }
+  ```
+  Next, run `yarn` again. When you upgrade to a later Strapi version that supports Node 18, remove this resolution.
+  :::
+
 ## Updating the database configuration script
 
 This step is only required if you use the default SQLite database configuration in a TypeScript project.


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

Add a note for users on node v16 that explains how to work around a sub dependency engine version compatibility issue, in the 4.2.x to 4.3.x migration guide. See my docs addition for more details, it explains the reason.

### Why is it needed?

Over the last two hours, I've upgraded Strapi from 4.2.2 to 4.25.10 on a personal project using Strapi, running through all the relevant migration guides.

It was all mostly smooth sailing (thanks!), the only issue encountered however is the one I describe in this docs update.

I believe this note is relevant for all users that do this migration, since AFAICS from the git history, versions 4.2.x and 4.3.x, wherein the upgrade  to `cheerio@^1.0.0-rc.12` was done, supported only node v16 maximally:

https://github.com/strapi/strapi/blob/1b23af22454afe389ed47fbe9edc37f27f82643d/packages/plugins/documentation/package.json#L52

When trying to do this migration with node v18, you get error messages that v18 is not supported.

### Related issue(s)/PR(s)

None.
