### PR TITLE
Update transfer.md

### DIFF
--- a/docusaurus/docs/dev-docs/data-management/transfer.md
+++ b/docusaurus/docs/dev-docs/data-management/transfer.md
@@ -38,6 +38,8 @@ The CLI command consists of the following arguments:
 
 :::caution
 Exactly one remote source `--from` or destination `--to` option must be provided.
+
+If you want to transfer data from one remote Strapi to another you will have to go through your local instance to transfer the data.
 :::
 
 If you want to transfer data from one remote Strapi to another you will have to go through your local instance to transfer the data.

--- a/docusaurus/docs/dev-docs/data-management/transfer.md
+++ b/docusaurus/docs/dev-docs/data-management/transfer.md
@@ -42,7 +42,6 @@ Exactly one remote source `--from` or destination `--to` option must be provided
 If you want to transfer data from one remote Strapi to another you will have to go through your local instance to transfer the data.
 :::
 
-If you want to transfer data from one remote Strapi to another you will have to go through your local instance to transfer the data.
 
 :::tip
 Data transfers are authorized by transfer tokens, which are [managed from the admin panel](/user-docs/settings/transfer-tokens). From the admin panel, you can manage role-based permissions to tokens including `view`, `create`, `read`, `regenerate` and `delete`.

--- a/docusaurus/docs/dev-docs/data-management/transfer.md
+++ b/docusaurus/docs/dev-docs/data-management/transfer.md
@@ -37,8 +37,10 @@ The CLI command consists of the following arguments:
 | `--throttle`   | Time in milliseconds to inject an artificial delay between the "chunks" during a transfer.                                                   |
 
 :::caution
-Either `--to` or `--from` is required.
+Exactly one remote source `--from` or destination `--to` option must be provided.
 :::
+
+If you want to transfer data from one remote Strapi to another you will have to go through your local instance to transfer the data.
 
 :::tip
 Data transfers are authorized by transfer tokens, which are [managed from the admin panel](/user-docs/settings/transfer-tokens). From the admin panel, you can manage role-based permissions to tokens including `view`, `create`, `read`, `regenerate` and `delete`.


### PR DESCRIPTION
Clarified that no remote to remote transfer is possible.

### What does it do?

It's a simple enhancement of the documentation text. Nothing fancy.

### Why is it needed?

I tried to transfer data from one remote instance to another and found that the documentation does not say yet that you cannot use to and from at the same time but only one at a time.