### PR TITLE
Breaking change for removing the "shared population strategy" for components & dynamic zones

### DIFF
--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes.md
@@ -102,3 +102,4 @@ You can click on the description of any breaking change in the following tables 
 | [The `localizations` field does not exist anymore](/dev-docs/migration/v4-to-v5/breaking-changes/no-localizations-field) | Yes | No |
 | [Some attributes and content-types names are reserved by Strapi](/dev-docs/migration/v4-to-v5/breaking-changes/attributes-and-content-types-names-reserved) | Yes | No |
 | [Upload a file at entry creation is no longer possible](/dev-docs/migration/v4-to-v5/breaking-changes/no-upload-at-entry-creation) | Yes | No |
+| [Components and dynamic zones should be populated using the detailed population strategy](/dev-docs/migration/v4-to-v5/breaking-changes/no-shared-population-strategy-components-dynamic-zones) | Yes | No |

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/no-shared-population-strategy-components-dynamic-zones.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/no-shared-population-strategy-components-dynamic-zones.md
@@ -1,0 +1,69 @@
+---
+title: No shared population strategy for components & dynamic zones
+description: In Strapi 5, the shared population strategy is not supported anymore, so components and dynamic zones must be explicitly populated using `on` fragments.
+sidebar_label: No shared population strategy
+displayed_sidebar: devDocsMigrationV5Sidebar
+tags:
+ - breaking changes
+ - content API
+ - population
+ - REST API
+ - upgrade to Strapi 5
+---
+
+import Intro from '/docs/snippets/breaking-change-page-intro.md'
+import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
+import YesPlugins from '/docs/snippets/breaking-change-affecting-plugins.md'
+import NoCodemods from '/docs/snippets/breaking-change-not-handled-by-codemod.md'
+
+# Components and dynamic zones should be populated using the detailed population strategy (`on` fragments)
+
+In Strapi 5, components and dynamic zones should be populated using the detailed population strategy, with `on` fragments. The shared population strategy possible in Strapi v4 is no longer supported.
+
+<Intro />
+
+<YesPlugins />
+<NoCodemods />
+
+## Breaking change description
+
+<SideBySideContainer>
+
+<SideBySideColumn>
+
+**In Strapi v4**
+
+<!-- TODO v5: Update this URL to docs-v4 -->
+You could use either [the shared or the detailed population strategy](https://docs.strapi.io/dev-docs/api/rest/guides/understanding-populate#populate-dynamic-zones) to populate components and dynamic zones in a REST API call.
+
+</SideBySideColumn>
+
+<SideBySideColumn>
+
+**In Strapi 5**
+
+You must use `on` fragments to explicitly detail which components and dynamic zones to [populate](/dev-docs/api/rest/populate-select#population).
+
+</SideBySideColumn>
+
+</SideBySideContainer>
+
+## Migration
+
+<MigrationIntro />
+
+### Notes
+
+Additional information on population is available in the [REST API documentation](/dev-docs/api/rest/populate-select#population).
+
+### Manual procedure
+
+Users should ensure that components and dynamic zones are explicitly populated using `on` fragments, such as in the following example syntax and URL:
+
+- example generic syntax:
+  
+    `populate[dynamic-zone-name][on][component-category.component-name][populate][relation-name][populate][0]=field-name`
+
+- example URL:
+
+  `/api/articles?populate[blocks][on][blocks.related-articles][populate][articles][populate][0]=image&populate[blocks][on][blocks.cta-command-line][populate]=*`


### PR DESCRIPTION
Now components & DZ must be populated explicitly with `on` fragments.