### PR TITLE
feat: add more before examples for helper plugin migration

### DIFF
--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/additional-resources/helper-plugin.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/additional-resources/helper-plugin.md
@@ -53,7 +53,8 @@ const MyPage = () => {
 ### CheckPermissions
 
 This component has been removed and not replaced. If you feel like you need this component, please open an issue on the Strapi repository to discuss your usecase.
-We recommend using the `Page.Protect` component from `@strapi/strapi/admin` instead. See `CheckPagePermissions`below for an example. If you need to check permissions for a lower level component you can use the useRBAC hook.
+
+We recommend using the `Page.Protect` component from `@strapi/strapi/admin` instead (see [`CheckPagePermissions`](#checkpagepermissions) for an example). If you need to check permissions for a lower level component you can use [the `useRBAC` hook](#userbac).
 
 
 ### CheckPagePermissions

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/additional-resources/helper-plugin.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/additional-resources/helper-plugin.md
@@ -26,6 +26,16 @@ This component has been removed and refactored to be part of the `Page` componen
 // Before
 import { AnErrorOccurred } from '@strapi/helper-plugin';
 
+const MyPage = () => {
+  // ...
+
+  if (error) {
+    return <AnErrorOccurred />;
+  }
+
+  // ...
+};
+
 // After
 import { Page } from '@strapi/strapi/admin';
 
@@ -43,8 +53,8 @@ const MyPage = () => {
 ### CheckPermissions
 
 This component has been removed and not replaced. If you feel like you need this component, please open an issue on the Strapi repository to discuss your usecase.
+We recommend using the `Page.Protect` component from `@strapi/strapi/admin` instead. See `CheckPagePermissions`below for an example. If you need to check permissions for a lower level component you can use the useRBAC hook.
 
-We recommend using the `Page.Protect` component from `@strapi/strapi/admin` instead. See below for an example. If you need to check permissions for a lower level component you can use the useRBAC hook.
 
 ### CheckPagePermissions
 
@@ -54,14 +64,24 @@ This component has been removed and refactored to be part of the `Page` componen
 // Before
 import { CheckPagePermissions } from '@strapi/helper-plugin';
 
+const MyProtectedPage = () => {
+  return (
+    <CheckPagePermissions
+        permissions={[action: 'plugin::my-plugin.read']}
+    >
+      <MyPag />
+    </CheckPagePermissions>
+  );
+};
+
 // After
 import { Page } from '@strapi/strapi/admin';
 
 const MyProtectedPage = () => {
+  <Page.Protect permissions={[action: 'plugin::my-plugin.read']}>
   return (
-    <Page.Protect permissions={[action: 'plugin::my-plugin.read']}>
-      <MyPage />
     </Page.Protect>
+      <MyPage />
   );
 };
 ```
@@ -102,9 +122,13 @@ import { DateTimePicker } from '@strapi/design-system';
 
 This component was previously deprecated and has now been removed. Similar to the deprecation notice, we recommend using the `Table` component from `@strapi/strapi/admin`.
 
+Please see the contributors [documentation for the `Table` component](https://v5.contributor.strapi.io/exports/namespaces/Table) for more information.
+
 ### EmptyBodyTable
 
 This component has been removed and is part of the `Table` component.
+
+Please see the contributors [documentation for the `Table` component](https://v5.contributor.strapi.io/exports/namespaces/Table) for more information.
 
 ### EmptyStateLayout
 
@@ -129,6 +153,13 @@ This component was moved to the `admin` package and can now be imported via the 
 ```tsx
 // Before
 import { FilterListURLQuery } from '@strapi/helper-plugin';
+
+const MyComponent = () => {
+  return (
+    <FilterListURLQuery filtersSchema={[{name: 'name', metadatas: {label: 'Name'}, fieldSchema: {type: 'string'}}]} />
+  );
+};
+
 
 // After
 import { Filters } from '@strapi/strapi/admin';
@@ -184,6 +215,19 @@ This component has been removed and refactored to become the `InputRenderer` com
 ```tsx
 // Before
 import { GenericInput } from '@strapi/helper-plugin';
+
+const MyComponent = () => {
+  return (
+    <GenericInput
+      type={'type'}
+      hint={'hint'}
+      label={'label'}
+      name={'name'}
+      onChange={onMetaChange}
+      value={'value'}
+    />
+  );
+};
 
 // After
 import { InputRenderer } from '@strapi/strapi/admin';
@@ -264,6 +308,16 @@ This component has been removed and refactored to be part of the `Page` componen
 // Before
 import { LoadingIndicatorPage } from '@strapi/helper-plugin';
 
+const MyPage = () => {
+  // ...
+
+  if (isLoading) {
+    return <LoadingIndicatorPage />;
+  }
+
+  // ...
+};
+
 // After
 import { Page } from '@strapi/strapi/admin';
 
@@ -283,6 +337,7 @@ const MyPage = () => {
 This component has been removed and not replaced, you should use the `EmptyStateLayout` component from `@strapi/design-system`.
 
 ```tsx
+// Before
 import { NoContent } from '@strapi/helper-plugin';
 
 <NoContent
@@ -314,6 +369,16 @@ This component has been removed and refactored to be part of the `Page` componen
 ```tsx
 // Before
 import { NoPermissions } from '@strapi/helper-plugin';
+
+const MyPage = () => {
+  // ...
+
+  if (!canRead) {
+    return <NoPermissions />;
+  }
+
+  // ...
+};
 
 // After
 import { Page } from '@strapi/strapi/admin';
@@ -355,6 +420,12 @@ This component was moved to the `admin` package and can now be imported via the 
 ```tsx
 // Before
 import { PageSizeURLQuery } from '@strapi/helper-plugin';
+
+const MyComponent = () => {
+  return (
+    <PageSizeURLQuery options={['12', '24', '50', '100']} defaultValue="24" />
+  );
+};
 
 // After
 import { Pagination } from '@strapi/strapi/admin';
@@ -424,6 +495,16 @@ This component should be imported from the `@strapi/design-system` package:
 // Before
 import { Status } from '@strapi/helper-plugin';
 
+const MyComponent = () => {
+  return (
+    <Status variant={statusColor} showBullet={false} size="S">
+      <Typography fontWeight="bold" textColor={`${statusColor}700`}>
+        {stateMessage[status]}
+      </Typography>
+    </Status>
+  );
+};
+
 // After
 import { Status } from '@strapi/design-system';
 ```
@@ -435,6 +516,46 @@ This component should be imported from the `@strapi/strapi/admin` package:
 ```tsx
 // Before
 import { Table } from '@strapi/helper-plugin';
+
+const MyComponent = () => {
+  return (
+    <Table colCount={2} rowCount={2}>
+      <Thead>
+        <Tr>
+          <Th>
+            <Typography variant="sigma" textColor="neutral600">
+              {`Name`}
+            </Typography>
+          </Th>
+          <Th>
+            <Typography variant="sigma" textColor="neutral600">
+              {`Description`}
+            </Typography>
+          </Th>
+        </Tr>
+      </Thead>
+      <Tbody>
+        {data?.map(({ name, description }) => {
+          return (
+            <Tr key={name}>
+              <Td>
+                <Typography textColor="neutral800" variant="omega" fontWeight="bold">
+                  {name}
+                </Typography>
+              </Td>
+              <Td>
+                <Typography textColor="neutral800">
+                  {description}
+                </Typography>
+              </Td>
+            </Tr>
+          );
+        })}
+      </Tbody>
+    </Table>
+  );
+};
+
 
 // After
 import { Table } from '@strapi/strapi/admin';
@@ -789,6 +910,11 @@ This util has been removed. If you need to use it, you should use the `checkUser
 // Before
 import { hasPermissions } from '@strapi/helper-plugin';
 
+
+const permissions = await Promise.all(
+  generalSectionRawLinks.map(({ permissions }) => hasPermissions(userPermissions, permissions))
+);
+
 // After
 import { useAuth } from '@strapi/strapi/admin';
 
@@ -826,6 +952,8 @@ const prefixPluginTranslations = (
   }, {} as TradOptions);
 };
 ```
+
+If you feel like you need this util, please open an issue on the Strapi repository to discuss your usecase.
 
 ### pxToRem
 


### PR DESCRIPTION
This PR updates the helper plugin deprecation guide with more before examples