### PR TITLE
Update attributes-and-content-types-names-reserved.md

### DIFF
--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/attributes-and-content-types-names-reserved.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/attributes-and-content-types-names-reserved.md
@@ -42,7 +42,9 @@ The following attribute names can be created on a content type:
 - `localizations`
 - `strapi_assignee`
 - `strapi_stage`
-- anything with the prefix `strapi`
+- `then`
+- `document`
+- anything with the prefix `strapi`, `_strapi`, or `__strapi`
 
 Any model name can be prefixed with `strapi`.
 
@@ -62,9 +64,11 @@ The following attribute names can **not** be created on a content type:
 - `localizations`
 - `strapi_assignee`
 - `strapi_stage`
-- `anything` with the prefix `strapi` or `__strapi`
+- `then`
+- `document`
+- anything with the prefix `strapi`, `_strapi`, or `__strapi`
 
-Model names can **not** be prefixed with `strapi` or `__strapi`.
+Model names can **not** be prefixed with `strapi`, `_strapi`, or `__strapi`.
 
 </SideBySideColumn>
 


### PR DESCRIPTION
### What does it do?

fixes list of reserved names

note: I'm not sure what was allowed in v4, but these are the current lists of restricted attributes and models directly from the code in v5

```
export const reservedAttributes = [
  // ID fields
  'id',
  'document_id',

  // Creator fields
  'created_at',
  'updated_at',
  'published_at',
  'created_by_id',
  'updated_by_id',
  // does not actually conflict because the fields are called *_by_id but we'll leave it to avoid confusion
  'created_by',
  'updated_by',

  // Used for Strapi functionality
  'entry_id',
  'status',
  'localizations',
  'meta',
  'locale',
  '__component',
  '__contentType',

  'strapi*',
  '_strapi*',
  '__strapi*',
];

export const reservedModels = [
  'boolean',
  'date',
  'date_time',
  'time',
  'upload',
  'document',
  'then', // no longer an issue but still restricting for being a javascript keyword

  'strapi*',
  '_strapi*',
  '__strapi*',
];
```

### Why is it needed?

Describe the issue you are solving.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
