### PR TITLE
Add links to v4 docs

### DIFF
--- a/docusaurus/docs/dev-docs/api/document-service.md
+++ b/docusaurus/docs/dev-docs/api/document-service.md
@@ -17,8 +17,7 @@ The Document Service API is built on top of the **Query Engine API** <Annotation
 With the Document Service API, you can also [count](#count) documents and, if [Draft & Publish](/user-docs/content-manager/saving-and-publishing-content) is enabled on the content-type, perform Strapi-specific features such as [publishing](#publish)/[unpublishing](#unpublish) documents and [discarding drafts](#discarddraft).
 
 :::strapi Entity Service API is deprecated in Strapi 5
-<!-- TODO v5: update this link to start with docs-v4 once stable is out -->
-The Document Service API is meant to replace the Entity Service API used in Strapi v4 ([see Strapi v4 documentation](https://docs.strapi.io/dev-docs/api/entity-service)). Additional information on how to transition away from the Entity Service API to the Document Service API can be found in the related [migration reference](/dev-docs/migration/v4-to-v5/additional-resources/from-entity-service-to-document-service).
+The Document Service API is meant to replace the Entity Service API used in Strapi v4 ([see Strapi v4 documentation](https://docs-v4.strapi.io/dev-docs/api/entity-service)). Additional information on how to transition away from the Entity Service API to the Document Service API can be found in the related [migration reference](/dev-docs/migration/v4-to-v5/additional-resources/from-entity-service-to-document-service).
 :::
 
 :::note

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/lifecycle-hooks-document-service.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/lifecycle-hooks-document-service.md
@@ -36,8 +36,7 @@ However, the Document Service API might not suit all your use cases; the databas
 
 **In Strapi v4**
 
-<!-- TODO v5: update this link to start with docs-v4 once stable is out -->
-In Strapi v4, lifecycle hooks work as documented in the [Strapi v4 documentation](https://docs.strapi.io/dev-docs/backend-customization/models#lifecycle-hooks).
+In Strapi v4, lifecycle hooks work as documented in the [Strapi v4 documentation](https://docs-v4.strapi.io/dev-docs/backend-customization/models#lifecycle-hooks).
 
 </SideBySideColumn>
 

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/no-shared-population-strategy-components-dynamic-zones.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/no-shared-population-strategy-components-dynamic-zones.md
@@ -33,8 +33,7 @@ In Strapi 5, components and dynamic zones should be populated using the detailed
 
 **In Strapi v4**
 
-<!-- TODO v5: Update this URL to docs-v4 -->
-You could use either [the shared or the detailed population strategy](https://docs.strapi.io/dev-docs/api/rest/guides/understanding-populate#populate-dynamic-zones) to populate components and dynamic zones in a REST API call.
+You could use either [the shared or the detailed population strategy](https://docs-v4.strapi.io/dev-docs/api/rest/guides/understanding-populate#populate-dynamic-zones) to populate components and dynamic zones in a REST API call.
 
 </SideBySideColumn>
 

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/no-upload-at-entry-creation.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/no-upload-at-entry-creation.md
@@ -29,8 +29,7 @@ In Strapi 5, it is not possible to upload a file while creating an entry, so thi
 
 **In Strapi v4**
 
-<!-- TODO v5: update this link for Strapi v4 once moved to the new URL -->
-It was possible to upload a file while creating an entry, as [documented for Strapi v4](https://docs.strapi.io/dev-docs/plugins/upload#upload-files-at-entry-creation).
+It was possible to upload a file while creating an entry, as [documented for Strapi v4](https://docs-v4.strapi.io/dev-docs/plugins/upload#upload-files-at-entry-creation).
 
 </SideBySideColumn>
 


### PR DESCRIPTION
This PR adds cross-links to v4 docs for some topics that will soon be documented only there.