### PR TITLE
Fix dz populate example

### DIFF
--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/no-shared-population-strategy-components-dynamic-zones.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/no-shared-population-strategy-components-dynamic-zones.md
@@ -61,8 +61,8 @@ Users should ensure that components and dynamic zones are explicitly populated u
 
 - example generic syntax:
   
-    `populate[dynamic-zone-name][on][component-category.component-name][populate][relation-name][populate][0]=field-name`
+    `populate[dynamic-zone-name][on][component-category.component-name]=true`
 
 - example URL:
 
-  `/api/articles?populate[blocks][on][blocks.related-articles][populate][articles][populate][0]=image&populate[blocks][on][blocks.cta-command-line][populate]=*`
+  `/api/articles?populate[dynamic-zone-name][on][component-category.component-name]=true`


### PR DESCRIPTION
### What does it do?

simplifies and updates the dz example

### Why is it needed?

the original example was difficult to follow, and this shows just a simple population that would have been done in v4 with the shared population strategy being converted to the detailed `on` strategy

wildcard * in `on` statements is not supported in v5 (although)

we can improve this with a better example later, but for now this makes it correct

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
