### PR TITLE
fix: v5 has different API

### DIFF
--- a/docusaurus/docs/dev-docs/deployment.md
+++ b/docusaurus/docs/dev-docs/deployment.md
@@ -174,7 +174,7 @@ If you need a server.js file to be able to run `node server.js` instead of `npm 
 ```js title="path: ./server.js"
 
 const strapi = require('@strapi/strapi');
-strapi(/* {...} */).start();
+strapi.createStrapi(/* {...} */).start();
 ```
 
 :::caution


### PR DESCRIPTION
`createStrapi()` needs to be called before `start()`

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

Describe the technical changes you did.

### Why is it needed?

Describe the issue you are solving.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
