### PR TITLE
Fix grammar in the "TypeScript development" docs

### DIFF
--- a/docusaurus/docs/dev-docs/typescript/development.md
+++ b/docusaurus/docs/dev-docs/typescript/development.md
@@ -104,7 +104,7 @@ To do that, edit the `tsconfig.json` of the Strapi project and add `types/genera
 However, if you still want to use the generated types on your project, but don't want Strapi to use them, a workaround could be to copy those generated types and paste them outside of the `generated` directory (so that they aren't overwritten when the types are regenerated) and remove the `declare module '@strapi/types'` from the bottom of the file.
 
 :::warning
-Types should only be imported from `@strapi/strapi` to avoid breaking changes. The types in `@strapi/types` is for internal use only and is subject to change without notice.
+Types should only be imported from `@strapi/strapi` to avoid breaking changes. The types in `@strapi/types` are for internal use only and may change without notice.
 :::
 
 ## Start Strapi programmatically


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

Rewrites "is" to "are" in the warning about the right path to import types from in the TypeScript development documentation.

### Why is it needed?

To ensure clarity.

### Related issue(s)/PR(s)

The change has already been made in the v4 documentation #2184. 
