### PR TITLE
Fix pagination_next for first page of categories

### DIFF
--- a/docusaurus/docs/cloud/account/account-settings.md
+++ b/docusaurus/docs/cloud/account/account-settings.md
@@ -10,6 +10,7 @@ tags:
 - project settings
 - Strapi Cloud
 - Strapi Cloud project
+pagination_next: cloud/account/account-billing
 ---
 
 # Profile settings

--- a/docusaurus/docs/cloud/advanced/database.md
+++ b/docusaurus/docs/cloud/advanced/database.md
@@ -10,6 +10,7 @@ tags:
 - PostgreSQL
 - Strapi Cloud
 - Strapi Cloud project
+pagination_next: cloud/advanced/email
 ---
 
 # Database

--- a/docusaurus/docs/cloud/cli/cloud-cli.md
+++ b/docusaurus/docs/cloud/cli/cloud-cli.md
@@ -6,6 +6,7 @@ tags:
 - Strapi Cloud
 - CLI
 - deployment
+pagination_next: cloud/advanced/database
 ---
 
 # Command Line Interface (CLI) <NewBadge />

--- a/docusaurus/docs/cloud/getting-started/intro.md
+++ b/docusaurus/docs/cloud/getting-started/intro.md
@@ -8,6 +8,7 @@ tags:
 - introduction
 - deployment
 - Strapi Cloud
+pagination_next: cloud/getting-started/cloud-fundamentals
 ---
 
 # Welcome to the Strapi Cloud Docs!

--- a/docusaurus/docs/cloud/projects/deploys.md
+++ b/docusaurus/docs/cloud/projects/deploys.md
@@ -10,6 +10,7 @@ tags:
 - deploy, history and logs
 - Strapi Cloud
 - Strapi Cloud project
+pagination_next: cloud/projects/deploys-history
 ---
 
 # Deployments management

--- a/docusaurus/docs/cloud/projects/overview.md
+++ b/docusaurus/docs/cloud/projects/overview.md
@@ -7,6 +7,7 @@ sidebar_position: 1
 tags:
 - project status
 - Strapi Cloud
+pagination_next: cloud/projects/settings
 ---
 
 # Projects overview

--- a/docusaurus/docs/dev-docs/installation.md
+++ b/docusaurus/docs/dev-docs/installation.md
@@ -5,7 +5,7 @@ tags:
 - introduction
 - installation
 - Command Line Interface (CLI)
-
+pagination_next: dev-docs/installation/cli
 ---
 
 # Installation

--- a/docusaurus/docs/user-docs/content-type-builder/introduction-to-content-types-builder.md
+++ b/docusaurus/docs/user-docs/content-type-builder/introduction-to-content-types-builder.md
@@ -8,6 +8,7 @@ tags:
 - Content-type Builder
 - introduction
 - single type 
+pagination_next: user-docs/content-type-builder/creating-new-content-type
 ---
 
 import NotV5 from '/docs/snippets/_not-updated-to-v5.md'

--- a/docusaurus/docs/user-docs/intro.md
+++ b/docusaurus/docs/user-docs/intro.md
@@ -6,6 +6,7 @@ tags:
 - admin panel
 - guides
 - introduction
+pagination_next: user-docs/getting-started/user-guide-fundamentals
 ---
 
 # Welcome to the Strapi User Guide!

--- a/docusaurus/docs/user-docs/media-library/introduction-to-the-media-library.md
+++ b/docusaurus/docs/user-docs/media-library/introduction-to-the-media-library.md
@@ -9,7 +9,7 @@ tags:
 - filters
 - introduction
 - media library
-
+pagination_next: user-docs/media-library/adding-assets
 ---
 
 import NotV5 from '/docs/snippets/_not-updated-to-v5.md'

--- a/docusaurus/docs/user-docs/plugins/introduction-to-plugins.md
+++ b/docusaurus/docs/user-docs/plugins/introduction-to-plugins.md
@@ -9,6 +9,7 @@ tags:
 - provider
 - media library
 - upload plugin
+pagination_next: user-docs/plugins/installing-plugins-via-marketplace
 ---
 
 import NotV5 from '/docs/snippets/_not-updated-to-v5.md'

--- a/docusaurus/docs/user-docs/releases/introduction.md
+++ b/docusaurus/docs/user-docs/releases/introduction.md
@@ -7,6 +7,7 @@ tags:
 - introduction
 - Releases feature
 - Strapi Cloud
+pagination_next: user-docs/releases/creating-a-release
 ---
 
 # Releases <EnterpriseBadge /> <CloudTeamBadge/>

--- a/docusaurus/docs/user-docs/settings/introduction.md
+++ b/docusaurus/docs/user-docs/settings/introduction.md
@@ -6,6 +6,7 @@ tags:
 - admin panel
 - introduction
 - Users, Roles & Permissions
+pagination_next: user-docs/settings/configuring-users-permissions-plugin-settings
 ---
 
 The ![Settings icon](/img/assets/icons/v5/Cog.svg) _Settings_ section in the main navigation of the admin panel includes all the required set-up information that determines how an administrator interacts with and manages their Strapi application. 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

added `pagination_next` for most first pages of each categories

### Why is it needed?

The `next` navigation links of pages were not generated correctly when the page is the first page of a category.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
