### PR TITLE
fix: create plugin: npm init command documentation

### DIFF
--- a/docusaurus/docs/dev-docs/plugins/development/create-a-plugin.md
+++ b/docusaurus/docs/dev-docs/plugins/development/create-a-plugin.md
@@ -50,7 +50,7 @@ yarn dlx @strapi/sdk-plugin init my-strapi-plugin
 <TabItem value="npm" label="NPM">
 
 ```bash
-npx @strapi/sdk-plugin:init my-strapi-plugin
+npx @strapi/sdk-plugin init my-strapi-plugin
 ```
 
 </TabItem>


### PR DESCRIPTION
### What does it do?

fix the documentation about to create a plugin with npm 

### Why is it needed?

to not get insane because the beautiful docs propose a wrong cli command
