### PR TITLE
Add link to ms package for examples for JWT expiresIn

### DIFF
--- a/docusaurus/docs/dev-docs/plugins/users-permissions.md
+++ b/docusaurus/docs/dev-docs/plugins/users-permissions.md
@@ -161,7 +161,7 @@ Available options:
 
 - `jwtSecret`: random string used to create new JWTs, typically set using the `JWT_SECRET` [environment variable](/dev-docs/configurations/environment#strapi-s-environment-variables).
 - `jwt.expiresIn`: expressed in seconds or a string describing a time span.<br/>
-  Eg: 60, "45m", "10h", "2 days", "7d", "2y". A numeric value is interpreted as a seconds count. If you use a string be sure you provide the time units (minutes, hours, days, years, etc), otherwise milliseconds unit is used by default ("120" is equal to "120ms").
+  Eg: 60, "45m", "10h", "2 days", "7d", "2y". A numeric value is interpreted as a seconds count. If you need more advanced examples please see the [ms package](https://github.com/vercel/ms).
 
 <Tabs groupId="js-ts">
 


### PR DESCRIPTION
### What does it do?

Changes the examples for the users-permissions plugin to link to the package that actually parses the expiresIn string syntax

### Why is it needed?

Community member on Discord was a bit confused and it's probably best to link to the package that actually parses this for more advanced examples

### Related issue(s)/PR(s)

N/A
