### PR TITLE
Fix `CheckPagePermissions` code example in helper-plugin deprecation guide

### DIFF
--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/additional-resources/helper-plugin.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/additional-resources/helper-plugin.md
@@ -74,10 +74,10 @@ const MyProtectedPage = () => {
 import { Page } from '@strapi/strapi/admin';
 
 const MyProtectedPage = () => {
-  <Page.Protect permissions={[action: 'plugin::my-plugin.read']}>
   return (
-    </Page.Protect>
+    <Page.Protect permissions={[action: 'plugin::my-plugin.read']}>
       <MyPage />
+    </Page.Protect>
   );
 };
 ```


### PR DESCRIPTION
Change sequence of lines
I have amended the sequence of lines in the code example for the CheckPagePermissions migration to version 5 to ensure that the JavaScript XML syntax is correct.