### PR TITLE
Fixing the table of links in the rest api documentation

### DIFF
--- a/docusaurus/docs/dev-docs/api/rest.md
+++ b/docusaurus/docs/dev-docs/api/rest.md
@@ -300,6 +300,8 @@ In Strapi 5, a specific document is reached by its `documentId`.
 
 Creates a document and returns its value.
 
+By default, a document is created with a published status. To create a document as a draft, pass the [`status`](/dev-docs/api/rest/filters-locale-publication#status) parameter with the value `draft`.
+
 If the Internationalization (i18n) feature is enabled on the content-type, it's possible to use POST requests to the REST API to [create localized documents](/dev-docs/i18n#creating-a-new-localized-entry).
 
 :::note

--- a/docusaurus/docs/dev-docs/api/rest.md
+++ b/docusaurus/docs/dev-docs/api/rest.md
@@ -300,7 +300,7 @@ In Strapi 5, a specific document is reached by its `documentId`.
 
 Creates a document and returns its value.
 
-By default, a document is created with a published status. To create a document as a draft, pass the [`status`](/dev-docs/api/rest/filters-locale-publication#status) parameter with the value `draft`.
+By default, a document is created with a published status. To create a document as a draft, pass the [`?status=draft`](/dev-docs/api/rest/filters-locale-publication#status) query parameter.
 
 If the Internationalization (i18n) feature is enabled on the content-type, it's possible to use POST requests to the REST API to [create localized documents](/dev-docs/i18n#creating-a-new-localized-entry).
 

--- a/docusaurus/docs/dev-docs/api/rest.md
+++ b/docusaurus/docs/dev-docs/api/rest.md
@@ -62,11 +62,11 @@ sources={{
 
 | Method   | URL                             | Description                           |
 | -------- | ------------------------------- | ------------------------------------- |
-| `GET`    | `/api/:pluralApiId`             | [Get a list of document](#get-documents) |
-| `POST`   | `/api/:pluralApiId`             | [Create a document](#create-an-entry)   |
-| `GET`    | `/api/:pluralApiId/:documentId` | [Get a document](#get-an-entry)         |
-| `PUT`    | `/api/:pluralApiId/:documentId` | [Update a document](#update-an-entry)   |
-| `DELETE` | `/api/:pluralApiId/:documentId` | [Delete a document](#delete-an-entry)   |
+| `GET`    | `/api/:pluralApiId`             | [Get a list of document](#get-all) |
+| `POST`   | `/api/:pluralApiId`             | [Create a document](#create)   |
+| `GET`    | `/api/:pluralApiId/:documentId` | [Get a document](#get)         |
+| `PUT`    | `/api/:pluralApiId/:documentId` | [Update a document](#update)   |
+| `DELETE` | `/api/:pluralApiId/:documentId` | [Delete a document](#delete)   |
 
 </TabItem>
 
@@ -300,7 +300,7 @@ In Strapi 5, a specific document is reached by its `documentId`.
 
 Creates a document and returns its value.
 
-If the [Internationalization (i18n) plugin](/dev-docs/i18n) is installed, it's possible to use POST requests to the REST API to [create localized documents](/dev-docs/i18n#creating-a-new-localized-entry).
+If the Internationalization (i18n) feature is enabled on the content-type, it's possible to use POST requests to the REST API to [create localized documents](/dev-docs/i18n#creating-a-new-localized-entry).
 
 :::note
 While creating a document, you can define its relations and their order (see [Managing relations through the REST API](/dev-docs/api/rest/relations.md) for more details).

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -978,27 +978,27 @@ const sidebars = {
             {
               type: 'link',
               label: 'Get documents',
-              href: '/dev-docs/api/rest#get-documents'
+              href: '/dev-docs/api/rest#get-all'
             },
             {
               type: 'link',
               label: 'Get a document',
-              href: '/dev-docs/api/rest#get-a-document'
+              href: '/dev-docs/api/rest#get'
             },
             {
               type: 'link',
               label: 'Create a document',
-              href: '/dev-docs/api/rest#create-a-document'
+              href: '/dev-docs/api/rest#create'
             },
             {
               type: 'link',
               label: 'Update a document',
-              href: '/dev-docs/api/rest#update-a-document'
+              href: '/dev-docs/api/rest#update'
             },
             {
               type: 'link',
               label: 'Delete a document',
-              href: '/dev-docs/api/rest#delete-a-document'
+              href: '/dev-docs/api/rest#delete'
             },
           ]
         },


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

It just fixes the links on the table that we have in the rest api documentation.
And I added a sentence to describe the default behavior on document creation with the rest API (document is created in published status unless the status=draft parameter is passed to the query)

### Why is it needed?

Links are links; if they don't link... 🤷🏼‍♂️😄

