### PR TITLE
Current documentation leads to not functional `server.js`

### DIFF
--- a/docusaurus/docs/dev-docs/typescript/development.md
+++ b/docusaurus/docs/dev-docs/typescript/development.md
@@ -111,14 +111,14 @@ Types should only be imported from `@strapi/strapi` to avoid breaking changes. T
 
 To start Strapi programmatically in a TypeScript project the Strapi instance requires the compiled code location. This section describes how to set and indicate the compiled code directory.
 
-### Use the `strapi()` factory
+### Use the `createStrapi()` factory
 
-Strapi can be run programmatically by using the `strapi()` factory. Since the code of TypeScript projects is compiled in a specific directory, the parameter `distDir` should be passed to the factory to indicate where the compiled code should be read:
+Strapi can be run programmatically by using the `strapi.createStrapi()` factory. Since the code of TypeScript projects is compiled in a specific directory, the parameter `distDir` should be passed to the factory to indicate where the compiled code should be read:
 
 ```js title="./server.js"
 
 const strapi = require('@strapi/strapi');
-const app = strapi({ distDir: './dist' });
+const app = strapi.createStrapi({ distDir: './dist' });
 app.start(); 
 ```
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

Adding the correct function that works for starting the server by using `strapi()` function it resolves to an error like: `TypeError: strapi is not a function`

### Why is it needed?

Better documentation

### Related issue(s)/PR(s)

n/a