### PR TITLE
chore: update confirmation modal text in Cloud Update Repository

### DIFF
--- a/docusaurus/docs/cloud/projects/settings.md
+++ b/docusaurus/docs/cloud/projects/settings.md
@@ -74,7 +74,7 @@ Updating the git repository could result in the loss of the project and its data
     | Auto-deploy     | Tick the box to automatically trigger a new deployment whenever a new commit is pushed to the selected branch. Untick it to disable the option. |
 
 5. Click on the **Update repository** button at the bottom of the *Update repository* interface.
-6. In the *Manage repository* dialog, confirm your changes by clicking on the **Relink repository** button.
+6. In the *Update repository* dialog, confirm your changes by clicking on the **Confirm** button.
 
 #### Deleting Strapi Cloud project
 


### PR DESCRIPTION
### What does it do?

Updates the wording of the confirmation dialog when updating a repository in the Cloud Project settings.

### Why is it needed?

The dialog will be updated and the Doc should reflect the new wording.

### Related issue(s)/PR(s)

Jira Ref CLOUD-1045
