### PR TITLE
Restore bigger font-size for categories title in sidebar

### DIFF
--- a/docusaurus/src/scss/sidebar.scss
+++ b/docusaurus/src/scss/sidebar.scss
@@ -162,6 +162,10 @@ $selector-color-mode-toggle-wrapper: 'div[class*="ColorModeToggle"]';
           > .menu__list-item-collapsible {
             font-weight: 700;
             font-size: var(--strapi-font-size-sm);
+
+            > .menu__link--sublist {
+              font-size: 16px;
+            }
           }
         }
       }


### PR DESCRIPTION
This PR fixes a bug that was inadvertently introduced sometimes during Strapi 5 docs creation.

Categories in the left sidebar should now have their bigger font back:

Before the fix:
![Screenshot 2024-10-14 at 15 55 45](https://github.com/user-attachments/assets/8dd3fbfc-7a34-4661-a31e-529b49482d12)

After the fix:
![Screenshot 2024-10-14 at 15 55 55](https://github.com/user-attachments/assets/f41b2376-7637-47de-9ac1-7a3c2b7671c7)

