### PR TITLE
Update names of removed mutations in GraphQL breaking change

### DIFF
--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/graphql-api-updated.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/graphql-api-updated.md
@@ -28,7 +28,7 @@ In Strapi 5, the GraphQL API has been updated. It handles the new, flattened res
 
 | Topic                        |  Description of the changes |
 |------------------------------|-----------------------------------------------------------------------------------------------------|
-| File upload support          | <ul><li>Removed `uploadFile` `uploadFiles` mutations</li><li>Removed `updateFileInfo` mutation in favor of using the `updateUploadFile` mutation</li><li>Removed `removeFile` mutation in favor of using the `deleteUploadFile` mutation</li><li>Removed `folder` queries & mutations</li><li>Removed `createUploadFile` mutation</li></ul> |
+| File upload support          | <ul><li>Removed `upload` `multipleUpload` mutations</li><li>Removed `updateFileInfo` mutation in favor of using the `updateUploadFile` mutation</li><li>Removed `removeFile` mutation in favor of using the `deleteUploadFile` mutation</li><li>Removed `folder` queries & mutations</li><li>Removed `createUploadFile` mutation</li></ul> |
 | Internationalization support | Removed the `createXXLocalization` mutations in favor of being able to update any locale from the main `updateXXX` mutation |
 | Draft & Publish support      | Removed `publicationState` in favor of `status` to align with the new Draft & Publish behavior |
 | Schema changes               | <ul><li>Simplified the basic queries with no `meta`/`pagination`</li><li>Introduced `Connection` to add pagination</li></ul> |


### PR DESCRIPTION
uploadFile and uploadFiles are the names of the queries, not the mutations.