### PR TITLE
Adding documentation for the integration between the Releases and Review Workflows features

### DIFF
--- a/docusaurus/docs/user-docs/releases/managing-a-release.md
+++ b/docusaurus/docs/user-docs/releases/managing-a-release.md
@@ -86,8 +86,10 @@ Publishing a release means that all the actions (publish or unpublish) defined f
 The _Status_ column displays the status of each entry:
 
    - ![Success icon](/img/assets/icons/v5/CheckCircle.svg) Already published: the entry is already published and publishing the release will not affect this entry 
+   - ![Success icon](/img/assets/icons/v5/CheckCircle.svg) Already unpublished: the entry is already unpublished, and publishing the release will not affect this entry.
    - ![Success icon](/img/assets/icons/v5/CheckCircle.svg) Ready to publish: the entry is ready to  be published with the release
-   - ![Fail icon](/img/assets/icons/v5/CrossCircle2.svg) "[field name] is required", "[field name] is too short" or "[field name] is too long": the entry cannot be published because of the issue stated in the red warning message. In this case, the release will be indicated as *Blocked* until all issues have been fixed.
+   - ![Success icon](/img/assets/icons/v5/CheckCircle.svg) Ready to unpublish: the entry is ready to  be unpublished with the release
+   - ![Fail icon](/img/assets/icons/v5/CrossCircle2.svg) Not ready to publish: the entry cannot be published because some fields are incorrectly filled, or it hasn't reached the required stage for publishing. In this case, the release will be indicated as *Blocked* until all issues have been fixed.
    
 If some of your entries have a ![Fail icon](/img/assets/icons/v5/CrossCircle2.svg) status, click the ![More icon](/img/assets/icons/v5/More.svg) and the **Edit the entry** button to fix the issues until all entries have the ![Success icon](/img/assets/icons/v5/CheckCircle.svg) status. Note that you will have to click on the **Refresh** button to update the release page as you fix the various entries issues.
 

--- a/docusaurus/docs/user-docs/settings/review-workflows.md
+++ b/docusaurus/docs/user-docs/settings/review-workflows.md
@@ -24,7 +24,7 @@ The Review Workflows feature allows you to create and manage workflows for your 
 
 In many organizations different teams review different parts of content. By using different review workflows for different content-types, it is possible to adjust each workflow to the needs of each team involved.
 
-The default workflow is configured to have 4 stages: To do, In progress, Ready to review, and Reviewed. All 4 stages can be edited, reordered or deleted as needed, and it is also possible to add new stages.
+The default workflow is configured to have 4 stages: To do, In progress, Ready to review, and Reviewed. All 4 stages can be edited, reordered or deleted as needed, and it is also possible to add new stages. Additionally, any stage can be defined as a required stage for publishing, ensuring content must pass through that stage before it can be published.
 
 Before being available in the [Content Manager](/user-docs/content-manager/reviewing-content), review workflows must be configured from ![Settings icon](/img/assets/icons/v5/Cog.svg) *Settings > Global settings > Review Workflows*. The Review workflows settings are only available to users with the Super Admin role by default. Other roles must be granted the **Review workflows** permissions. See [Users, Roles, & Permissions](/user-docs/users-roles-permissions) for more information.
 
@@ -46,6 +46,7 @@ Before being available in the [Content Manager](/user-docs/content-manager/revie
     | Workflow name  | Write a unique name of workflow.                                         |
     | Associated to  | (optional) Assign this workflow to one or more existing content-types.   |
     | Stages         | Add review stages (see [Adding a new stage](#adding-a-new-stage)).       |
+    | Required stage | Define any stage as required for publishing.       |
 
 3. Click on the **Save** button. The new workflow will be displayed in the list-view and for every content-type assigned.
 


### PR DESCRIPTION
### What does it do?

Adds comprehensive documentation for the Releases and Review Workflows features following the implementation of a new setting that allows users to define a required stage for publishing.

### Why is it needed?

This update addresses anticipated gaps in the user guide related to setting up Releases and Review Workflows, in preparation for an upcoming improvement to these features.

### Related issue(s)/PR(s)

The next CMS release will include the improvement.