### PR TITLE
chore: fix example request update (document-service) method

### DIFF
--- a/docusaurus/docs/dev-docs/api/document-service/status.md
+++ b/docusaurus/docs/dev-docs/api/document-service/status.md
@@ -198,8 +198,8 @@ To automatically publish a document while updating it, add `status: 'published'`
 
 ```js
 await strapi.documents('api::restaurant.restaurant').update({
+  documentId: 'a1b2c3d4e5f6g7h8i9j0klm',
   data: {
-    documentId: 'a1b2c3d4e5f6g7h8i9j0klm',
     name: "Biscotte Restaurant (closed)",
   },
   status: 'published',


### PR DESCRIPTION


### What does it do?

fix example requests of Update a draft and publish it on document-service

### Why is it needed?

the Update method need to pass the document_id on the root of object, instead of in `data` field

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
