### PR TITLE
Fix : Align navbar search box with 100% width

### DIFF
--- a/docusaurus/src/scss/custom-search-bar.scss
+++ b/docusaurus/src/scss/custom-search-bar.scss
@@ -43,6 +43,7 @@
   }
 
   .kapa-widget-button {
+    width: 100%;
     appearance: none;
     background: none;
     border: none;
@@ -133,7 +134,6 @@
         top: 0;
       }
     }
-
   }
 }
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

Applies a CSS fix to align the navbar search box by setting the width of the .kapa-widget-button class to 100%. This adjustment ensures that the search box is properly aligned with other navbar elements, improving the overall visual consistency.

### Why is it needed?

The navbar search box was misaligned and visually inconsistent with other elements in the navbar. This issue impacted the user experience by making the search box appear out of place. The fix improves the alignment, creating a more cohesive and polished look.

### Related issue(s)/PR(s)

This resolves the issue reported in #2279

For a visual demonstration of the fix, see [Video](https://drive.google.com/file/d/1pz6StsV4j7bnw7jIJk8hlTSu2PnOJvoK/view?usp=sharing)
