### PR TITLE
Add `strapi cloud environment link` to Cloud CLI

### DIFF
--- a/docusaurus/docs/cloud/cli/cloud-cli.md
+++ b/docusaurus/docs/cloud/cli/cloud-cli.md
@@ -51,10 +51,6 @@ The terminal will inform you when the project is successfully deployed on Strapi
 
 Once the project is first deployed on Strapi Cloud with the CLI, the `deploy` command can be reused to trigger a new deployment of the same project.
 
-:::caution
-The `deploy` command can only be used by new users who have never created a Strapi Cloud project, and for which the free trial is still available. Once a project is deployed with the CLI, it isn't possible to deploy another project on the same Strapi Cloud account with the CLI.
-:::
-
 :::note
 Once you deployed your project, if you visit the Strapi Cloud dashboard, you may see some limitations as well as impacts due to creating a Strapi Cloud project that is not in a remote repository and which was deployed with the CLI.
 

--- a/docusaurus/docs/cloud/cli/cloud-cli.md
+++ b/docusaurus/docs/cloud/cli/cloud-cli.md
@@ -70,6 +70,7 @@ Links project in current folder to an existing project in Strapi Cloud.
 
 :::note
 Linking a project to Strapi Cloud doesn't limit it to Strapi Cloud alone; you can still deploy and manage it in your own self-hosted environment as needed.
+:::
 
 ```bash
 strapi link

--- a/docusaurus/docs/cloud/cli/cloud-cli.md
+++ b/docusaurus/docs/cloud/cli/cloud-cli.md
@@ -41,7 +41,13 @@ Deploy a new local project (< 100MB) in Strapi Cloud.
 strapi deploy
 ```
 
-This command must be used after the `login` one. It deploys a local Strapi project on Strapi Cloud, without having to host it on a remote git repository beforehand. The terminal will inform you when the project is successfully deployed on Strapi Cloud.
+This command must be used after the `login` one. It deploys a local Strapi project on Strapi Cloud, without having to host it on a remote git repository beforehand. 
+
+When you use this command, you’ll be asked to select a target environment. To skip this prompt, you can either:
+- Use the `-env` flag (e.g., `strapi deploy -env <environment-name>`)
+- Set a default environment with `strapi cloud environment link` [command](#cloud-environment-link), so deployments automatically go to that environment.
+
+The terminal will inform you when the project is successfully deployed on Strapi Cloud.
 
 Once the project is first deployed on Strapi Cloud with the CLI, the `deploy` command can be reused to trigger a new deployment of the same project.
 
@@ -96,6 +102,16 @@ strapi cloud environments
 ```
 
 This command retrieves and displays a list of all environments belonging to your Strapi Cloud project.
+
+## strapi cloud environment link <NewBadge /> {#cloud-environment-link}
+
+Links your local project to a specific environment in your Strapi Cloud project.
+
+```bash
+strapi cloud environment link
+```
+
+This command shows a list of all environments in your Strapi Cloud project and lets you choose one. The selected environment will then be the default for direct deployments.
 
 ## strapi logout
 

--- a/docusaurus/docs/cloud/cli/cloud-cli.md
+++ b/docusaurus/docs/cloud/cli/cloud-cli.md
@@ -44,7 +44,7 @@ strapi deploy
 This command must be used after the `login` one. It deploys a local Strapi project on Strapi Cloud, without having to host it on a remote git repository beforehand. 
 
 When you use this command, you’ll be asked to select a target environment. To skip this prompt, you can either:
-- Use the `-env` flag (e.g., `strapi deploy -env <environment-name>`)
+- Use the `--env` flag (e.g., `strapi deploy --env <environment-name>`)
 - Set a default environment with `strapi cloud environment link` [command](#cloud-environment-link), so deployments automatically go to that environment.
 
 The terminal will inform you when the project is successfully deployed on Strapi Cloud.

--- a/docusaurus/docs/cloud/cli/cloud-cli.md
+++ b/docusaurus/docs/cloud/cli/cloud-cli.md
@@ -45,6 +45,7 @@ This command must be used after the `login` one. It deploys a local Strapi proje
 
 :::note
 If you have any free trial available, the deploy command will create automatically a new project on Strapi Cloud, unless you previously link your local project to an existing project by using the `strapi link` command.
+:::
 
 When you use this command, you’ll be asked to select a target environment. To skip this prompt, you can either:
 - Use the `--env` flag (e.g., `strapi deploy --env <environment-name>`)

--- a/docusaurus/docs/cloud/cli/cloud-cli.md
+++ b/docusaurus/docs/cloud/cli/cloud-cli.md
@@ -41,7 +41,10 @@ Deploy a new local project (< 100MB) in Strapi Cloud.
 strapi deploy
 ```
 
-This command must be used after the `login` one. It deploys a local Strapi project on Strapi Cloud, without having to host it on a remote git repository beforehand. 
+This command must be used after the `login` one. It deploys a local Strapi project on Strapi Cloud, without having to host it on a remote git repository beforehand.
+
+:::note
+If you have any free trial available, the deploy command will create automatically a new project on Strapi Cloud, unless you previously link your local project to an existing project by using the `strapi link` command.
 
 When you use this command, you’ll be asked to select a target environment. To skip this prompt, you can either:
 - Use the `--env` flag (e.g., `strapi deploy --env <environment-name>`)
@@ -63,6 +66,9 @@ Once you deployed your project, if you visit the Strapi Cloud dashboard, you may
 **Alias:** `strapi cloud:link`
 
 Links project in current folder to an existing project in Strapi Cloud.
+
+:::note
+Linking a project to Strapi Cloud doesn't limit it to Strapi Cloud alone; you can still deploy and manage it in your own self-hosted environment as needed.
 
 ```bash
 strapi link


### PR DESCRIPTION
### What does it do?

This PR introduces documentation about `strapi cloud environment link` command.

### Why is it needed?

The new command to allow users to link a target environment to deploy their projects is being introduced in the next release.

