### PR TITLE
Add useTypescriptMigrations

### DIFF
--- a/docusaurus/docs/dev-docs/configurations/database.md
+++ b/docusaurus/docs/dev-docs/configurations/database.md
@@ -98,10 +98,15 @@ When using Docker, change the pool `min` value to `0` as Docker will kill any id
 
 The `settings` object found in `./config/database.js` (or `./config/database.ts` for TypeScript) is used to configure Strapi-specific database settings and accepts the following parameters:
 
-| Parameter        | Description                                                     | Type      | Default |
-| ---------------- | --------------------------------------------------------------- | --------- | ------- |
-| `forceMigration` | Enable or disable the forced database migration.                | `Boolean` | `true`  |
-| `runMigrations`  | Enable or disable database migrations from running on start up. | `Boolean` | `true`  |
+| Parameter                 | Description                                                     | Type      | Default |
+| ----------------          | --------------------------------------------------------------- | --------- | ------- |
+| `forceMigration`          | Enable or disable the forced database migration.                | `Boolean` | `true`  |
+| `runMigrations`           | Enable or disable database migrations from running on start up. | `Boolean` | `true`  |
+| `useTypescriptMigrations` | Look for migrations in the build dir instead of the src dir     | `Boolean` | `false` |
+
+:::note
+When using `useTypescriptMigrations` you can continue to use existing javascript migrations by setting `compilerOptions { allowJs: true }` in your tsconfig file.
+:::
 
 <!-- TODO: Open and track a feature request for autoMigration as it doesn't exist in v4 -->
 

--- a/docusaurus/docs/dev-docs/configurations/database.md
+++ b/docusaurus/docs/dev-docs/configurations/database.md
@@ -105,7 +105,7 @@ The `settings` object found in `./config/database.js` (or `./config/database.ts`
 | `useTypescriptMigrations` | Look for migrations in the build dir instead of the src dir     | `Boolean` | `false` |
 
 :::note
-When using `useTypescriptMigrations` you can continue to use existing javascript migrations by setting `compilerOptions { allowJs: true }` in your tsconfig file.
+When using `useTypescriptMigrations` you can continue to use existing JavaScript migrations by setting `compilerOptions { allowJs: true }` in your tsconfig file.
 :::
 
 <!-- TODO: Open and track a feature request for autoMigration as it doesn't exist in v4 -->


### PR DESCRIPTION
### What does it do?

Adds new config option `database.settings.useTypescriptMigrations`

### Why is it needed?

to support new feature

### Related issue(s)/PR(s)

Pending release of https://github.com/strapi/strapi/pull/21374