### PR TITLE
Fix discardDraft() Document Service API example

### DIFF
--- a/docusaurus/docs/dev-docs/api/document-service.md
+++ b/docusaurus/docs/dev-docs/api/document-service.md
@@ -634,7 +634,7 @@ If no `locale` parameter is passed, `discardDraft()` discards draft data and ove
 <Request title="Discard draft for the default locale of a document">
 
 ```js
-strapi.documents.discardDraft({
+strapi.documents('api::restaurant.restaurant').discardDraft({
   documentId: 'a1b2c3d4e5f6g7h8i9j0klm', 
 });
 ```


### PR DESCRIPTION
The example was missing the API UID