### PR TITLE
Fix locale param. example in Interactive Query Builder

### DIFF
--- a/docusaurus/docs/dev-docs/api/rest/interactive-query-builder.md
+++ b/docusaurus/docs/dev-docs/api/rest/interactive-query-builder.md
@@ -47,7 +47,7 @@ Please refer to the [REST API parameters table](/dev-docs/api/rest/parameters) a
     page: 1,
   },
   status: 'published',
-  locale: ['en'],
+  locale: 'en',
 }
   `}
 />


### PR DESCRIPTION
Locale should be a string (not in an array)