### PR TITLE
Fix outdated mention of Gold plan in SSO docs

### DIFF
--- a/docusaurus/docs/dev-docs/configurations/sso.md
+++ b/docusaurus/docs/dev-docs/configurations/sso.md
@@ -2,7 +2,7 @@
 title: SSO configuration
 sidebar_label: Single Sign-On (SSO)
 displayed_sidebar: devDocsConfigSidebar
-description: Strapi's SSO allows you to configure additional sign-in and sign-up methods for your administration panel. It requires an Enterprise Edition with a Gold plan.
+description: Strapi's SSO allows you to configure additional sign-in and sign-up methods for your administration panel. It requires an Enterprise Edition.
 canonicalUrl: https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/configurations/optional/sso.html
 tags:
 - additional configuration
@@ -19,7 +19,7 @@ Single Sign-On on Strapi allows you to configure additional sign-in and sign-up 
 :::prerequisites
 
 - A Strapi application running on version 3.5.0 or higher is required.
-- To configure SSO on your application, you will need an EE license with a [Gold plan](https://strapi.io/pricing-self-hosted).
+- To configure SSO on your application, you will need an <EnterpriseBadge /> license.
 - Make sure the SSO feature is [enabled in the admin panel](/user-docs/settings/single-sign-on).
 - Make sure Strapi is part of the applications you can access with your provider. For example, with Microsoft (Azure) Active Directory, you must first ask someone with the right permissions to add Strapi to the list of allowed applications. Please refer to your provider(s) documentation to learn more about that.
 :::


### PR DESCRIPTION
Users only need an EE license