### PR TITLE
docs: Fix typo in retro-compatibility flag value

### DIFF
--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/step-by-step.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/step-by-step.md
@@ -119,4 +119,4 @@ Follow the steps below and leverage retro-compatibility flags and guided migrati
 1. Enable the retro-compatibility flag by setting `v4CompatibilityMode` to `true` in the `graphl.config` object of [the `/config/plugins.js|ts` file](/dev-docs/configurations/plugins#graphql).
 2. Update your queries and mutations only, guided by the dedicated [breaking change entry for GraphQL](/dev-docs/migration/v4-to-v5/breaking-changes/graphql-api-updated).
 3. Validate that your client is running correctly.
-4. Disable the retro-compatibily flag by setting `v4CompatibilityMode` to `true` and start using the new response format.
+4. Disable the retro-compatibily flag by setting `v4CompatibilityMode` to `false` and start using the new response format.


### PR DESCRIPTION
### What does it do?

This PR corrects a typo in the documentation.
The step to disable the retro-compatibility flag currently instructs setting v4CompatibilityMode to true. However, the correct value should be false to disable retro-compatibility and start using the new response format.
This PR updates the documentation to correctly state that disabling the retro-compatibility flag requires setting v4CompatibilityMode to false.

### Why is it needed?

The current documentation contains incorrect information, which may lead to confusion or improper configuration by users. This fix ensures clarity and accuracy.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
