### PR TITLE
Update cross-link to U&P plugin from dev docs routes documentation

### DIFF
--- a/docusaurus/docs/dev-docs/backend-customization/routes.md
+++ b/docusaurus/docs/dev-docs/backend-customization/routes.md
@@ -526,7 +526,7 @@ export default  {
 
 ### Public routes
 
-By default, routes are protected by Strapi's authentication system, which is based on [API tokens](/dev-docs/configurations/api-tokens) or on the use of the [Users & Permissions plugin](/user-docs/plugins/strapi-plugins#users-permissions-plugin).
+By default, routes are protected by Strapi's authentication system, which is based on [API tokens](/dev-docs/configurations/api-tokens) or on the use of the [Users & Permissions plugin](/user-docs/users-roles-permissions/configuring-end-users-roles).
 
 In some scenarios, it can be useful to have a route publicly available and control the access outside of the normal Strapi authentication system. This can be achieved by setting the `auth` configuration parameter of a route to `false`:
 


### PR DESCRIPTION
This PR improves backlinking from routes dev docs to U&P user guide, as mentioned in [a reader's comment](https://github.com/strapi/strapi/issues/22002#issuecomment-2499217275) on the annual main pain points issue.