### PR TITLE
Mention Preview is under a feature flag

### DIFF
--- a/docusaurus/docs/dev-docs/configurations/features.md
+++ b/docusaurus/docs/dev-docs/configurations/features.md
@@ -31,7 +31,7 @@ To enable a future flag:
 
 1. (_optional_) If the server is running, stop it with `Ctrl-C`.
 2. Open the `config/features.js|ts` file or create it if the file does not exist yet. The file will export a `future` object with all the future flags to enable.
-3. To enable a future flag, add its property name (see [full list](#available-future-flags)) to the `future` object and ensure the property's value is set to `true`. The following example shows how to enable the `contentReleasesScheduling` future flag:
+3. To enable a future flag, add its property name (see [full list](#available-future-flags)) to the `future` object and ensure the property's value is set to `true`. The following example shows how to enable the `preview` future flag:
 
   <Tabs groupId='js-ts'>
 
@@ -40,8 +40,8 @@ To enable a future flag:
   ```ts title="/config/features.ts"
   module.export = ({ env }) => ({
     future: {
-      // You could also simply write: contentReleases: true
-      contentReleasesScheduling: env.bool('STRAPI_FUTURE_CONTENT_RELEASES_SCHEDULING', false),
+      // You could also simply write: preview: true
+      preview: env.bool('STRAPI_FUTURE_PREVIEW', false),
     },
   })
 
@@ -50,10 +50,10 @@ To enable a future flag:
   This example assumes that you have an `.env` environment file at the root of your application and that the file includes the following line:
 
   ```json title=".env"
-  STRAPI_FUTURE_CONTENT_RELEASES_SCHEDULING=true
+  STRAPI_FUTURE_PREVIEW=true
   ```
 
-  If your environment file does not include this value, the `contentReleasesScheduling` future flag property value  will default to `false` and the experimental feature will not be enabled.
+  If your environment file does not include this value, the `preview` future flag property value  will default to `false` and the experimental feature will not be enabled.
 
   </TabItem>
 
@@ -62,8 +62,8 @@ To enable a future flag:
   ```ts title="/config/features.ts"
   export default {
     future: {
-      // You could also simply write: contentReleases: true
-      contentReleasesScheduling: env.bool('STRAPI_FUTURE_CONTENT_RELEASES_SCHEDULING', false),
+      // You could also simply write: preview: true
+      preview: env.bool('STRAPI_FUTURE_PREVIEW', false),
     },
   };
   ```
@@ -71,10 +71,10 @@ To enable a future flag:
   This example assumes that you have an `.env` environment file at the root of your application and that the file includes the following line:
 
   ```json title=".env"
-  STRAPI_FUTURE_CONTENT_RELEASES_SCHEDULING=true
+  STRAPI_FUTURE_PREVIEW=true
   ```
 
-  If your environment file does not include this value, the `contentReleases` future flag property value will default to `false` and the experimental feature will not be enabled.
+  If your environment file does not include this value, the `preview` future flag property value will default to `false` and the experimental feature will not be enabled.
 
   </TabItem>
   </Tabs>
@@ -109,8 +109,8 @@ Developers can use the following APIs to interact with future flags:
 
 There are currently no available future flags. This section will be updated once new experimental features are available for testing.
 
-<!-- The following future flags are currently available and can be used in the `future` object of the `config/features` configuration file:
+The following future flags are currently available and can be used in the `future` object of the `config/features` configuration file:
 
 | Property name     | Related feature                              | Suggested environment variable name       |
 | ----------------- | -------------------------------------------- | ----------------------------------------- |
-| `contentReleasesScheduling` | [Releases Scheduling](/user-docs/releases/managing-a-release#scheduling-a-release-) | `STRAPI_FUTURE_CONTENT_RELEASES_SCHEDULING` | -->
+| `preview` | [Preview](/user-docs/content-manager/previewing-content) | `STRAPI_FUTURE_PREVIEW` |

--- a/docusaurus/docs/user-docs/content-manager/previewing-content.md
+++ b/docusaurus/docs/user-docs/content-manager/previewing-content.md
@@ -22,7 +22,8 @@ With the Preview feature, you can preview your front end application directly fr
 
 :::prerequisites
 - The Strapi admin panel user should have read permissions for the content-type.
-- The Preview feature should be configured in the code of the `config/admin` file (see [Developer Docs](/dev-docs/preview) for details).
+- While the Preview feature is in beta, it should be enabled with the `future.preview` feature flag set to `true` in `config/features` (see [Developer Docs](/dev-docs/configurations/features)).
+- The Preview feature should be configured in the code of the `config/admin` file (see [Developer Docs](/dev-docs/preview)).
 - A front-end application should already be created and running so you can preview it.
 :::
 

--- a/docusaurus/docs/user-docs/content-manager/previewing-content.md
+++ b/docusaurus/docs/user-docs/content-manager/previewing-content.md
@@ -20,10 +20,6 @@ With the Preview feature, you can preview your front end application directly fr
   }}
 />
 
-<!-- <div style={{position: 'relative', paddingBottom: 'calc(54.43121693121693% + 50px)', height: '0'}}>
-<iframe id="zpen5g4t8p" src="https://app.guideflow.com/embed/zpen5g4t8p" width="100%" height="100%" style={{overflow:'hidden', position:'absolute', border:'none'}} scrolling="no" allow="clipboard-read; clipboard-write" webkitallowfullscreen mozallowfullscreen allowfullscreen allowtransparency="true"></iframe>
-</div> -->
-
 :::prerequisites
 - The Strapi admin panel user should have read permissions for the content-type.
 - The Preview feature should be configured in the code of the `config/admin` file (see [Developer Docs](/dev-docs/preview) for details).


### PR DESCRIPTION
This PR updates the existing user guide & dev docs for the Preview feature because Preview is still under a feature flag until its stable release.