### PR TITLE
Add a cross-link to the "commonly asked questions" article in blog

### DIFF
--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/introduction-and-faq.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/introduction-and-faq.md
@@ -57,3 +57,7 @@ Strapi 5 docs also provide a [complete breaking changes database](/dev-docs/migr
 Strapi Cloud will deploy the updated code in Strapi 5 and will automatically run the data migration script.
 
 </details>
+
+:::strapi Why Strapi 5?
+The [Strapi blog](https://strapi.io/blog/commonly-asked-questions-transitioning-from-strapi-4-to-strapi-5) has some additional information about commonly asked questions, including why some changes were made.
+:::


### PR DESCRIPTION
This PR augments the v5 Introduction & FAQ page with a link to a nice blog article who adds more details and explains _why_ some changes were made.