### PR TITLE
Added caution message in CLI insatllation guide

### DIFF
--- a/docusaurus/docs/dev-docs/installation/cli.md
+++ b/docusaurus/docs/dev-docs/installation/cli.md
@@ -103,6 +103,10 @@ Follow the steps below to create a new Strapi project, being sure to use the app
 
 Once all questions have been answered, the script will start creating the Strapi project.
 
+:::caution
+If the browser didn't respond you might need to disable any razer processes running in the background.
+:::
+
 ### CLI installation options
 
 The above installation guide only covers the basic installation option using the CLI. There are other options that can be used when creating a new Strapi project, for example:


### PR DESCRIPTION

### What does it do? 
I have added a caution to the CLI installation guide 

Describe the technical changes you did.
A basic caution message

### Why is it needed?
It'll save an unexpected hour of research about it

### Describe the issue you are solving.
Notifying new users to end any razer processes that are running in the background, because they interfere with the DB connection port for some reason, which leads the browser to not respond to run strapi.

### Related issue(s)/PR(s)
No 