### PR TITLE
SDK beta callout

### DIFF
--- a/docusaurus/docs/dev-docs/api/rest.md
+++ b/docusaurus/docs/dev-docs/api/rest.md
@@ -30,6 +30,10 @@ By default, the REST API responses only include top-level fields and does not po
 The Upload plugin (which handles media found in the [Media Library](/user-docs/media-library)) has a specific API described in the [Upload plugin documentation](/dev-docs/plugins/upload).
 :::
 
+:::strapi Strapi SDK
+Strapi has just released a new SDK, currently in beta. Early documentation is available on the [Contributor Docs](https://contributor.strapi.io/) website while we are integrating it into the official REST API reference.
+:::
+
 ## Endpoints
 
 For each Content-Type, the following endpoints are automatically generated:

--- a/docusaurus/docs/dev-docs/api/rest.md
+++ b/docusaurus/docs/dev-docs/api/rest.md
@@ -31,7 +31,7 @@ The Upload plugin (which handles media found in the [Media Library](/user-docs/m
 :::
 
 :::strapi Strapi SDK
-Strapi has just released a new SDK, currently in beta. Early documentation is available on the [Contributor Docs](https://contributor.strapi.io/) website while we are integrating it into the official REST API reference.
+Strapi has just released a new SDK, currently in alpha. Early documentation is available on the [repository](https://github.com/strapi/sdk-js) while we are integrating it into the official REST API reference.
 :::
 
 ## Endpoints

--- a/docusaurus/docs/dev-docs/api/rest.md
+++ b/docusaurus/docs/dev-docs/api/rest.md
@@ -31,7 +31,7 @@ The Upload plugin (which handles media found in the [Media Library](/user-docs/m
 :::
 
 :::strapi Strapi SDK
-Strapi has just released a new SDK, currently in beta. Early documentation is available on the [repository](https://github.com/strapi/sdk-js) while we are integrating it into the official REST API reference.
+Strapi has just released a new SDK, currently in alpha. Early documentation is available on the [repository](https://github.com/strapi/sdk-js) while we are integrating it into the official REST API reference.
 :::
 
 ## Endpoints

--- a/docusaurus/docs/dev-docs/api/rest.md
+++ b/docusaurus/docs/dev-docs/api/rest.md
@@ -31,7 +31,7 @@ The Upload plugin (which handles media found in the [Media Library](/user-docs/m
 :::
 
 :::strapi Strapi SDK
-Strapi has just released a new SDK, currently in alpha. Early documentation is available on the [repository](https://github.com/strapi/sdk-js) while we are integrating it into the official REST API reference.
+Strapi has just released a new SDK, currently in beta. Early documentation is available on the [repository](https://github.com/strapi/sdk-js) while we are integrating it into the official REST API reference.
 :::
 
 ## Endpoints


### PR DESCRIPTION
This PR adds a callout highlighting the release of the beta SDK and provides a link to the contributor docs.

Next steps will be to prepare an extensive documentation included in the REST API reference.

Edit: You could use the package's README, we'll just need to slightly update the text 😊 