### PR TITLE
Fix SDK plugin init command example in the SDK reference

### DIFF
--- a/docusaurus/docs/dev-docs/plugins/development/plugin-sdk.md
+++ b/docusaurus/docs/dev-docs/plugins/development/plugin-sdk.md
@@ -20,7 +20,7 @@ The present documentation lists the available Plugin SDK commands. The [associat
 Create a new plugin at a given path.
 
 ```bash
-npx @strapi/sdk-plugin init
+npx @strapi/sdk-plugin init /path/to/my-plugin
 ```
 
 | Arguments |  Type  | Description        | Default                   |


### PR DESCRIPTION
This PR fixes the missing `path` argument example.