### PR TITLE
fix wrong import

### DIFF
--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/additional-resources/helper-plugin.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/additional-resources/helper-plugin.md
@@ -995,7 +995,7 @@ If you feel like you need this util, please open an issue on the Strapi reposito
 ### request
 
 This util has been removed and not replaced.
-You can use `useFetchClient` from `@strapi/admin/strapi-admin`.
+You can use `useFetchClient` from `@strapi/strapi/admin`.
 
 ```tsx
 // Before
@@ -1004,7 +1004,7 @@ import { request } from '@strapi/helper-plugin';
 request(`/${pluginId}/settings/config`, { method: 'GET' });
 
 // After
-import { useFetchClient } from '@strapi/admin/strapi-admin';
+import { useFetchClient } from `@strapi/strapi/admin`;
 
 const { get } = useFetchClient();
 get(`/${pluginId}/settings/config`);

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/additional-resources/helper-plugin.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/additional-resources/helper-plugin.md
@@ -1004,7 +1004,7 @@ import { request } from '@strapi/helper-plugin';
 request(`/${pluginId}/settings/config`, { method: 'GET' });
 
 // After
-import { useFetchClient } from `@strapi/strapi/admin`;
+import { useFetchClient } from '@strapi/strapi/admin';
 
 const { get } = useFetchClient();
 get(`/${pluginId}/settings/config`);


### PR DESCRIPTION
note seems like all imports with @strapi/(package)/strapi-admin are broken
### What does it do?

Changed an import

### Why is it needed?

The import used works but if used for any forntend hooks it would break the whole frontend (So it is better to only use the 1 import that works for everyting)

### Related issue(s)/PR(s)
https://github.com/strapi/strapi/issues/22162
