### PR TITLE
fix locale prerequisites

### DIFF
--- a/docusaurus/docs/dev-docs/api/rest/filters-locale-publication.md
+++ b/docusaurus/docs/dev-docs/api/rest/filters-locale-publication.md
@@ -365,7 +365,6 @@ await request(`/api/restaurants?${query}`);
 
 :::prerequisites
 
-- The [Internationalization (i18n) feature](/dev-docs/i18n) should be installed.
 - [Localization should be enabled for the content-type](/user-docs/content-type-builder/creating-new-content-type.md#creating-a-new-content-type).
 :::
 


### PR DESCRIPTION


### What does it do?

removed install prerequisite since it is not in core so you can't uninstall it and it is always installed

### Why is it needed?

since people would think they need to install it and install the v4 plugin since there is no V5 version

### Related issue(s)/PR(s)
