### PR TITLE
Adding notes about GitLab groups

### DIFF
--- a/docusaurus/docs/cloud/account/account-settings.md
+++ b/docusaurus/docs/cloud/account/account-settings.md
@@ -43,6 +43,10 @@ To connect a new Google, GitLab or GitHub account to your Strapi Cloud account, 
 
 You can also click on the three dots button of a connected account and click on the "Manage on" button to manage your GitHub, GitLab or Google account directly on the corresponding website.
 
+:::caution
+For GitLab, Groups and Subgroups habilitations are not supported at the moment.
+:::
+
 ### Deleting Strapi Cloud account
 
 You can delete your Strapi Cloud account, but it will be permanent and irreversible. All associated projects and their data will be deleted as well and the subscriptions for the projects will automatically be canceled.

--- a/docusaurus/docs/cloud/account/account-settings.md
+++ b/docusaurus/docs/cloud/account/account-settings.md
@@ -44,7 +44,7 @@ To connect a new Google, GitLab or GitHub account to your Strapi Cloud account, 
 You can also click on the three dots button of a connected account and click on the "Manage on" button to manage your GitHub, GitLab or Google account directly on the corresponding website.
 
 :::caution
-For GitLab, Groups and Subgroups habilitations are not supported at the moment.
+For GitLab, Groups and Subgroups organizations are not supported at the moment.
 :::
 
 ### Deleting Strapi Cloud account

--- a/docusaurus/docs/cloud/getting-started/deployment-cli.md
+++ b/docusaurus/docs/cloud/getting-started/deployment-cli.md
@@ -18,7 +18,7 @@ This is a step-by-step guide for deploying your project on Strapi Cloud for the 
 Before you can deploy your Strapi application on Strapi Cloud using the Command Line Interface, you need to have the following prerequisites:
 
 - Have remaining free trials.
-- Have a Google, GitHub or GitLab account. For GitLab, Groups and Subgroups habilitations are not supported at the moment.
+- Have a Google, GitHub or GitLab account. For GitLab, Groups and Subgroups organizations are not supported at the moment.
 - Have an already created Strapi project (see [Installing from CLI in the Developer Documentation](/dev-docs/installation/cli)), stored locally. The project must be less than 100MB.
 - Have available storage in your hard drive where the temporary folder of your operating system is stored.
 :::

--- a/docusaurus/docs/cloud/getting-started/deployment-cli.md
+++ b/docusaurus/docs/cloud/getting-started/deployment-cli.md
@@ -17,8 +17,8 @@ This is a step-by-step guide for deploying your project on Strapi Cloud for the 
 :::prerequisites
 Before you can deploy your Strapi application on Strapi Cloud using the Command Line Interface, you need to have the following prerequisites:
 
-- Be a first-time Strapi Cloud user: you must never have deployed a project with Strapi Cloud before, and your free trial must still be available.
-- Have a Google, GitHub or GitLab account.
+- Have remaining free trials.
+- Have a Google, GitHub or GitLab account. For GitLab, Groups and Subgroups habilitations are not supported at the moment.
 - Have an already created Strapi project (see [Installing from CLI in the Developer Documentation](/dev-docs/installation/cli)), stored locally. The project must be less than 100MB.
 - Have available storage in your hard drive where the temporary folder of your operating system is stored.
 :::

--- a/docusaurus/docs/cloud/getting-started/deployment.md
+++ b/docusaurus/docs/cloud/getting-started/deployment.md
@@ -26,7 +26,7 @@ Before you can deploy your Strapi application on Strapi Cloud using the Cloud da
 * Project(s) source code hosted on [GitHub](https://github.com) or [GitLab](https://about.gitlab.com/). The connected repository can contain multiple Strapi applications. Each Strapi app must be in a separate directory.
 * Specifically for GitLab:
   * at least have "[Maintainer](https://docs.gitlab.com/ee/user/permissions.html)" permissions for the project to import on Strapi Cloud.
-  * Groups and Subgroups habilitations are not supported at the moment.
+  * Groups and Subgroups organizations are not supported at the moment.
 :::
 
 ## Logging in to Strapi Cloud

--- a/docusaurus/docs/cloud/getting-started/deployment.md
+++ b/docusaurus/docs/cloud/getting-started/deployment.md
@@ -24,7 +24,9 @@ Before you can deploy your Strapi application on Strapi Cloud using the Cloud da
 * Strapi version `4.8.2` or higher
 * Project database must be compatible with PostgreSQL. Strapi does not support and does not recommend using any external databases, though it's possible to configure one (see [advanced database configuration](/cloud/advanced/database)).
 * Project(s) source code hosted on [GitHub](https://github.com) or [GitLab](https://about.gitlab.com/). The connected repository can contain multiple Strapi applications. Each Strapi app must be in a separate directory.
-* Specifically for GitLab: at least have "[Maintainer](https://docs.gitlab.com/ee/user/permissions.html)" permissions for the project to import on Strapi Cloud.
+* Specifically for GitLab:
+  * at least have "[Maintainer](https://docs.gitlab.com/ee/user/permissions.html)" permissions for the project to import on Strapi Cloud.
+  * Groups and Subgroups habilitations are not supported at the moment.
 :::
 
 ## Logging in to Strapi Cloud


### PR DESCRIPTION
### What does it do?

The idea is to add a note about: `GitLab groups and Subgroups habilitations are not supported at the moment.`

I updated 3 places:
- Project deployment - Dashboard (screenshot 1)
- Project deployment - CLI (screenshot 2) (+ a leftover about free trials - as right now people can have several)
- Profil settings (screenshot 3)

Screenshot 1:
![image](https://github.com/user-attachments/assets/bc1ecb49-6f49-40d1-bf0c-4b5266a48e15)

Screenshot 2:
![image](https://github.com/user-attachments/assets/0cf198f8-17be-47f6-967a-aec63e77efd9)

Screenshot 3:
![image](https://github.com/user-attachments/assets/0ca7b08d-7c8c-4d36-8879-eaf385bce2d1)
