### PR TITLE
Update docs content for Preview switching from beta to stable

### DIFF
--- a/docusaurus/docs/dev-docs/configurations/features.md
+++ b/docusaurus/docs/dev-docs/configurations/features.md
@@ -108,9 +108,9 @@ Developers can use the following APIs to interact with future flags:
 ## Available future flags
 
 There are currently no available future flags. This section will be updated once new experimental features are available for testing.
-
+<!-- 
 The following future flags are currently available and can be used in the `future` object of the `config/features` configuration file:
 
 | Property name     | Related feature                              | Suggested environment variable name       |
 | ----------------- | -------------------------------------------- | ----------------------------------------- |
-| `preview` | [Preview](/user-docs/content-manager/previewing-content) | `STRAPI_FUTURE_PREVIEW` |
+| `preview` | [Preview](/user-docs/content-manager/previewing-content) | `STRAPI_FUTURE_PREVIEW` | -->

--- a/docusaurus/docs/dev-docs/preview.md
+++ b/docusaurus/docs/dev-docs/preview.md
@@ -8,7 +8,7 @@ tags:
 - configuration
 ---
 
-# Setting up the Preview feature <BetaBadge /> <FutureBadge />
+# Setting up the Preview feature
 
 Strapi's Preview feature enables previewing content in a frontend application directly from the Strapi admin panel. 
 

--- a/docusaurus/docs/user-docs/content-manager/previewing-content.md
+++ b/docusaurus/docs/user-docs/content-manager/previewing-content.md
@@ -7,7 +7,7 @@ tags:
 - preview
 ---
 
-# Previewing content <BetaBadge /> <FutureBadge />
+# Previewing content 
 
 With the Preview feature, you can preview your front end application directly from Strapi's admin panel. This is helpful to see how updates to your content in the Edit View of the Content Manager will affect the final result.
 
@@ -22,7 +22,6 @@ With the Preview feature, you can preview your front end application directly fr
 
 :::prerequisites
 - The Strapi admin panel user should have read permissions for the content-type.
-- While the Preview feature is in beta, it should be enabled with the `future.preview` feature flag set to `true` in `config/features` (see [Developer Docs](/dev-docs/configurations/features)).
 - The Preview feature should be configured in the code of the `config/admin` file (see [Developer Docs](/dev-docs/preview)).
 - A front-end application should already be created and running so you can preview it.
 :::

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -100,7 +100,7 @@ const sidebars = {
             'dev-docs/configurations/cron',
             'dev-docs/configurations/environment',
             'dev-docs/configurations/sso',
-            'dev-docs/configurations/features',
+            // 'dev-docs/configurations/features',
             'dev-docs/configurations/guides/rbac',
             'dev-docs/configurations/guides/public-assets',
             'dev-docs/configurations/guides/access-cast-environment-variables',


### PR DESCRIPTION
This PR slightly update Preview-related pages:
- removes badges
- hides feature flags page as there will be no future flags available once Preview is out as stable