### PR TITLE
Unhide breaking change entry about components not returning an id

### DIFF
--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes.md
@@ -99,4 +99,5 @@ You can click on the description of any breaking change in the following tables 
 | [There is no `findPage()` method with the Document Service API](/dev-docs/migration/v4-to-v5/breaking-changes/no-find-page-in-document-service) | Yes | No |
 | [Some attributes and content-types names are reserved by Strapi](/dev-docs/migration/v4-to-v5/breaking-changes/attributes-and-content-types-names-reserved) | Yes | No |
 | [Upload a file at entry creation is no longer possible](/dev-docs/migration/v4-to-v5/breaking-changes/no-upload-at-entry-creation) | Yes | No |
+| [Components and dynamic zones do not return an id](/dev-docs/migration/v4-to-v5/breaking-changes/components-and-dynamic-zones-do-not-return-id) | Yes | No |
 | [Components and dynamic zones should be populated using the detailed population strategy](/dev-docs/migration/v4-to-v5/breaking-changes/no-shared-population-strategy-components-dynamic-zones) | Yes | No |

--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/components-and-dynamic-zones-do-not-return-id.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/breaking-changes/components-and-dynamic-zones-do-not-return-id.md
@@ -3,7 +3,6 @@ title: Components and dynamic zones do not return an id
 description: In Strapi 5, components and dynamic zones do not return an `id` with REST API requests so it's not possible to partially update them.
 sidebar_label: Components and dynamic zones do not return an id
 displayed_sidebar: devDocsMigrationV5Sidebar
-unlisted: true
 tags:
  - breaking changes
  - content API
@@ -15,6 +14,7 @@ tags:
 import Intro from '/docs/snippets/breaking-change-page-intro.md'
 import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
 import YesPlugins from '/docs/snippets/breaking-change-affecting-plugins.md'
+import NoCodemods from '/docs/snippets/breaking-change-not-handled-by-codemod.md'
 
 # Components and dynamic zones do not return an `id`
 
@@ -23,6 +23,7 @@ In Strapi 5, components and dynamic zones do not return an `id` with REST API re
 <Intro />
 
 <YesPlugins/>
+<NoCodemods />
 
 ## Breaking change description
 


### PR DESCRIPTION
This PR "unhides" a breaking change entry from the table of content.