### PR TITLE
Removing the note about unmodified fields on the update

### DIFF
--- a/docusaurus/docs/dev-docs/api/rest.md
+++ b/docusaurus/docs/dev-docs/api/rest.md
@@ -349,7 +349,6 @@ Partially updates a document by `id` and returns its value.
 Send a `null` value to clear fields.
 
 :::note NOTES
-* Even unmodified fields must be included in the request's body.
 * Even with the [Internationalization (i18n) plugin](/dev-docs/i18n) installed, it's currently not possible to [update the locale of a document](/dev-docs/i18n#rest-update).
 * While updating a document, you can define its relations and their order (see [Managing relations through the REST API](/dev-docs/api/rest/relations) for more details).
 :::


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?
There's a note in the REST API documentation that includes the unmodified fields in the update. I think it's not correct, the update works also without including the unmodified fields.

### Why is it needed?
The note is not true.

