### PR TITLE
Add the --verbose option to the data transfer command description

### DIFF
--- a/docusaurus/docs/dev-docs/data-management/transfer.md
+++ b/docusaurus/docs/dev-docs/data-management/transfer.md
@@ -37,6 +37,7 @@ The CLI command consists of the following arguments:
 | `--exclude`    | Exclude data using comma-separated data types. The available types are: `content`, `files`, and `config`.                                    |
 | `--only`       | Include only these data. The available types are: `content`, `files`, and `config`.                                                          |
 | `--throttle` | Time in milliseconds to inject an artificial delay between the "chunks" during a transfer. |
+| `--verbose` | Enable verbose logs. |
 
 :::caution
 Either `--to` or `--from` is required.


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?
Just adding the --verbose option description to the CLI command options for the data transfer documentation

### Why is it needed?
The verbose option description is missing.