### PR TITLE
Refactor SSO Configuration (docs v6)

### DIFF
--- a/docusaurus/docs/dev-docs/configurations/sso-providers/auth0.md
+++ b/docusaurus/docs/dev-docs/configurations/sso-providers/auth0.md
@@ -1,9 +1,9 @@
 ---
-title: Keycloak - Admin SSO Provider
-description: Steps to configure Keycloak as a Strapi Admin SSO Provider
+title: Auth0 - Admin SSO Provider
+description: Steps to configure Auth0 as a Strapi Admin SSO Provider
 displayed_sidebar: cmsSidebar
-tags: 
-- keycloak
+tags:
+- auth0
 - additional configuration
 - admin panel
 - configuration

--- a/docusaurus/docs/dev-docs/configurations/sso-providers/github.md
+++ b/docusaurus/docs/dev-docs/configurations/sso-providers/github.md
@@ -1,24 +1,99 @@
 ---
-title: GitHub SSO provider
-description: Learn how to configure the SSO provider to sign in and sign up into your Strapi application through GitHub.
+title: GitHub - Admin SSO Provider
+description: Steps to configure GitHub as a Strapi Admin SSO Provider
 displayed_sidebar: cmsSidebar
 tags: 
-- SSO
-- providers
+- github
+- additional configuration
+- admin panel
 - configuration
+- Enterprise feature
+- SSO
 ---
 
-# GitHub provider SSO configuration
-
-The present page explains how to setup the GitHub provider for the [Single Sign-On (SSO) feature](/user-docs/features/sso).
+import SSOServerConfig from '/docs/snippets/configuration-sso-server.md'
+import SSOAdminConfig from '/docs/snippets/configuration-sso-admin.md'
+import SSOMiddlewaresConfig from '/docs/snippets/configuration-sso-middlewares.md'
 
 :::prerequisites
-You have read the [How to configure SSO guide](/dev-docs/configurations/guides/configure-sso).
+
+- [Properly configure Strapi for SSO](#required-configuration-before-setting-up-sso)
+- Create your GitHub OAuth2 application by following the steps in the [GitHub Developer Settings](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/creating-an-oauth-app).
+- Gather the required information to set as environment variables in your Strapi project:
+  - GITHUB_CLIENT_ID
+  - GITHUB_CLIENT_SECRET
+
 :::
 
-## Installation
+## Required configuration before setting up SSO
 
-Install [passport-github](https://github.com/cfsghost/passport-github):
+### Server Configuration
+
+<SSOServerConfig />
+
+### Admin Configuration
+
+<SSOAdminConfig />
+
+### Middlewares Configuration
+
+<SSOMiddlewaresConfig />
+
+## Provider Specific Notes
+
+### Scopes
+
+The GitHub OAuth2 provider requires the following scopes, however additional scopes can be added as needed depending on your use case and the data you need returned:
+
+- `user:email`
+
+### Profile Data
+
+Data returned from the provider is dependent on how your GitHub OAuth2 application is configured. The example below assumes that the GitHub OAuth2 application is configured to return the user's email and username. Fields returned by the provider can change based on the scopes requested and the user's GitHub account settings.
+
+If you aren't sure what data is being returned by the provider, you can log the `profile` object in the `createStrategy` function to see what data is available as seen in the following example.
+
+<details>
+  <summary>Configuration Example with Logging</summary>
+
+```js
+(request, accessToken, refreshToken, profile, done) => {
+  // See what is returned by the provider
+  console.log(profile);
+
+  done(null, {
+    // Map the data returned by the provider to the Strapi user object
+    email: profile.emails[0].value,
+    username: profile.username,
+  });
+}
+```
+
+</details>
+
+### Redirect URL/URI
+
+The redirect URL/URI will be dependent on your provider configuration however in most cases should combine your application's public URL and the provider's callback URL. The example below shows how to combine the public URL with the provider's callback URL.
+
+```js
+callbackURL:
+  env('PUBLIC_URL', "https://api.example.com") +
+  strapi.admin.services.passport.getStrategyCallbackURL("github"),
+```
+
+In this example the redirect URL/URI used by the provider will be `https://api.example.com/admin/connect/github`.
+
+This is broken down as follows:
+
+- `https://api.example.com` is the public URL of your Strapi application
+- `/admin/connect` is the general path for SSO callbacks in Strapi
+- `/github` is the specific provider UID for GitHub
+
+## Strapi Configuration
+
+Using: [passport-github](https://github.com/cfsghost/passport-github)
+
+### Install the Provider Package
 
 <Tabs groupId="yarn-npm">
 
@@ -40,15 +115,13 @@ npm install --save passport-github2
 
 </Tabs>
 
-## Configuration example
-
-The GitHub SSO provider is configured in the `auth.providers` array of [the `config/admin` file](/dev-docs/configurations/admin-panel):
+### Adding the Provider to Strapi
 
 <Tabs groupId="js-ts">
 
 <TabItem value="javascript" label="JavaScript">
 
-```js title="/config/admin.js"
+```js title="./config/admin.js"
 
 const GithubStrategy = require("passport-github2");
 
@@ -67,6 +140,7 @@ module.exports = ({ env }) => ({
               clientSecret: env("GITHUB_CLIENT_SECRET"),
               scope: ["user:email"],
               callbackURL:
+                env('PUBLIC_URL') +
                 strapi.admin.services.passport.getStrategyCallbackURL("github"),
             },
             (accessToken, refreshToken, profile, done) => {
@@ -87,7 +161,7 @@ module.exports = ({ env }) => ({
 
 <TabItem value="typescript" label="TypeScript">
 
-```ts title="/config/admin.ts"
+```ts title="./config/admin.ts"
 
 import { Strategy as GithubStrategy } from "passport-github2";
 
@@ -106,6 +180,7 @@ export default ({ env }) => ({
               clientSecret: env("GITHUB_CLIENT_SECRET"),
               scope: ["user:email"],
               callbackURL:
+                env('PUBLIC_URL') +
                 strapi.admin.services.passport.getStrategyCallbackURL("github"),
             },
             (accessToken, refreshToken, profile, done) => {
@@ -125,4 +200,3 @@ export default ({ env }) => ({
 </TabItem>
 
 </Tabs>
-

--- a/docusaurus/docs/dev-docs/configurations/sso-providers/gitlab.md
+++ b/docusaurus/docs/dev-docs/configurations/sso-providers/gitlab.md
@@ -1,9 +1,9 @@
 ---
-title: Keycloak - Admin SSO Provider
-description: Steps to configure Keycloak as a Strapi Admin SSO Provider
+title: Gitlab - Admin SSO Provider
+description: Steps to configure Gitlab as a Strapi Admin SSO Provider
 displayed_sidebar: cmsSidebar
-tags: 
-- keycloak
+tags:
+- gitlab
 - additional configuration
 - admin panel
 - configuration

--- a/docusaurus/docs/dev-docs/configurations/sso-providers/google.md
+++ b/docusaurus/docs/dev-docs/configurations/sso-providers/google.md
@@ -1,24 +1,101 @@
 ---
-title: Google SSO provider
-description: Learn how to configure the SSO provider to sign in and sign up into your Strapi application through Google.
+title: Google - Admin SSO Provider
+description: Steps to configure Google as a Strapi Admin SSO Provider
 displayed_sidebar: cmsSidebar
 tags: 
-- SSO
-- providers
+- google
+- additional configuration
+- admin panel
 - configuration
+- Enterprise feature
+- SSO 
 ---
 
-# Google provider SSO configuration
-
-The present page explains how to setup the Google provider for the [Single Sign-On (SSO) feature](/user-docs/features/sso).
+import SSOServerConfig from '/docs/snippets/configuration-sso-server.md'
+import SSOAdminConfig from '/docs/snippets/configuration-sso-admin.md'
+import SSOMiddlewaresConfig from '/docs/snippets/configuration-sso-middlewares.md'
 
 :::prerequisites
-You have read the [How to configure SSO guide](/dev-docs/configurations/guides/configure-sso).
+
+- [Properly configure Strapi for SSO](#required-configuration-before-setting-up-sso)
+- Create your Google OAuth2 app by following the steps in the [Google Console](https://developers.google.com/workspace/guides/create-credentials#oauth-client-id).
+- Gather the required information to set as environment variables in your Strapi project:
+  - GOOGLE_CLIENT_ID
+  - GOOGLE_CLIENT_SECRET
+
 :::
 
-## Installation
+## Required configuration before setting up SSO
 
-Install [passport-google-oauth2](https://github.com/mstade/passport-google-oauth2):
+### Server Configuration
+
+<SSOServerConfig />
+
+### Admin Configuration
+
+<SSOAdminConfig />
+
+### Middlewares Configuration
+
+<SSOMiddlewaresConfig />
+
+## Provider Specific Notes
+
+### Scopes
+
+The Google OAuth2 provider requires the following scopes, however additional scopes can be added as needed depending on your use case and the data you need returned:
+
+- `https://www.googleapis.com/auth/userinfo.email`
+- `https://www.googleapis.com/auth/userinfo.profile`
+
+### Profile Data
+
+Data returned from the provider is dependent on how your Google OAuth2 application is configured. The example below assumes that the Google OAuth2 application is configured to return the user's email, first name, and last name. Fields returned by the provider can change based on the scopes requested and the user's Google account settings.
+
+If you aren't sure what data is being returned by the provider, you can log the `profile` object in the `createStrategy` function to see what data is available as seen in the following example.
+
+<details>
+  <summary>Configuration Example with Logging</summary>
+
+```js
+(request, accessToken, refreshToken, profile, done) => {
+  // See what is returned by the provider
+  console.log(profile);
+
+  done(null, {
+    // Map the data returned by the provider to the Strapi user object
+    email: profile.email,
+    firstname: profile.given_name,
+    lastname: profile.family_name,
+  });
+}
+```
+
+</details>
+
+### Redirect URL/URI
+
+The redirect URL/URI will be dependent on your provider configuration however in most cases should combine your application's public URL and the provider's callback URL. The example below shows how to combine the public URL with the provider's callback URL.
+
+```js
+callbackURL:
+  env('PUBLIC_URL', "https://api.example.com") +
+  strapi.admin.services.passport.getStrategyCallbackURL("google"),
+```
+
+In this example the redirect URL/URI used by the provider will be `https://api.example.com/admin/connect/google`.
+
+This is broken down as follows:
+
+- `https://api.example.com` is the public URL of your Strapi application
+- `/admin/connect` is the general path for SSO callbacks in Strapi
+- `/google` is the specific provider UID for Google
+
+## Strapi Configuration
+
+Using: [passport-google-oauth2](https://github.com/mstade/passport-google-oauth2)
+
+### Install the Provider Package
 
 <Tabs groupId="yarn-npm">
 
@@ -40,15 +117,13 @@ npm install --save passport-google-oauth2
 
 </Tabs>
 
-## Configuration example
-
-The Google SSO provider is configured in the `auth.providers` array of [the `config/admin` file](/dev-docs/configurations/admin-panel):
+### Adding the Provider to Strapi
 
 <Tabs groupId="js-ts">
 
 <TabItem value="javascript" label="JavaScript">
 
-```js title="/config/admin.js"
+```js title="./config/admin.js"
 
 const GoogleStrategy = require("passport-google-oauth2");
 
@@ -70,6 +145,7 @@ module.exports = ({ env }) => ({
                 "https://www.googleapis.com/auth/userinfo.profile",
               ],
               callbackURL:
+                env('PUBLIC_URL') +
                 strapi.admin.services.passport.getStrategyCallbackURL("google"),
             },
             (request, accessToken, refreshToken, profile, done) => {
@@ -90,7 +166,7 @@ module.exports = ({ env }) => ({
 
 <TabItem value="typescript" label="TypeScript">
 
-```ts title="/config/admin.ts"
+```ts title="./config/admin.ts"
 
 import {Strategy as GoogleStrategy } from "passport-google-oauth2";
 
@@ -112,6 +188,7 @@ export default ({ env }) => ({
                 "https://www.googleapis.com/auth/userinfo.profile",
               ],
               callbackURL:
+                env('PUBLIC_URL') +
                 strapi.admin.services.passport.getStrategyCallbackURL("google"),
             },
             (request, accessToken, refreshToken, profile, done) => {
@@ -131,4 +208,3 @@ export default ({ env }) => ({
 </TabItem>
 
 </Tabs>
-

--- a/docusaurus/docs/dev-docs/configurations/sso-providers/microsoft.md
+++ b/docusaurus/docs/dev-docs/configurations/sso-providers/microsoft.md
@@ -1,24 +1,111 @@
 ---
-title: Microsoft SSO provider
-description: Learn how to configure the SSO provider to sign in and sign up into your Strapi application through Microsoft.
+title: Microsoft Entra ID - Admin SSO Provider
+description: Steps to configure Microsoft Entra ID as a Strapi Admin SSO Provider
 displayed_sidebar: cmsSidebar
 tags: 
-- SSO
-- providers
+- microsoft
+- entra id
+- azure active directory
+- active directory
+- additional configuration
+- admin panel
 - configuration
+- Enterprise feature
+- SSO 
 ---
 
-# Microsoft provider SSO configuration
-
-The present page explains how to setup the Microsoft provider for the [Single Sign-On (SSO) feature](/user-docs/features/sso).
+import SSOServerConfig from '/docs/snippets/configuration-sso-server.md'
+import SSOAdminConfig from '/docs/snippets/configuration-sso-admin.md'
+import SSOMiddlewaresConfig from '/docs/snippets/configuration-sso-middlewares.md'
 
 :::prerequisites
-You have read the [How to configure SSO guide](/dev-docs/configurations/guides/configure-sso).
+
+- [Properly configure Strapi for SSO](#required-configuration-before-setting-up-sso)
+- Create your EntraID OAuth2 app by following the steps in the [EntraID/Azure Portal](https://learn.microsoft.com/en-us/entra/architecture/auth-oauth2).
+  - It's important to review the [OAuth application types](https://learn.microsoft.com/en-us/entra/identity-platform/v2-app-types#web-apps) as Strapi only supports "web" applications.
+- Gather the required information to set as environment variables in your Strapi project:
+  - MICROSOFT_CLIENT_ID
+  - MICROSOFT_CLIENT_SECRET
+  - MICROSOFT_TENANT_ID
+
 :::
 
-## Installation
+## Required configuration before setting up SSO
 
-Install [passport-azure-ad-oauth2](https://github.com/auth0/passport-azure-ad-oauth2#readme):
+### Server Configuration
+
+<SSOServerConfig />
+
+### Admin Configuration
+
+<SSOAdminConfig />
+
+### Middlewares Configuration
+
+<SSOMiddlewaresConfig />
+
+## Provider Specific Notes
+
+### Scopes
+
+The EntraID OAuth2 provider requires the following scopes, however additional scopes can be added as needed depending on your use case and the data you need returned:
+
+- [`user:email`](https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#the-email-scope)
+
+### Profile Data
+
+:::warning
+It is extremely likely that the below example will not work directly for you as the fields returned by the EntraID instance are extremely subjective to each individual setup. For example some instances will have a `upn` field, others will not and the value type of the `upn` may be different for each instance or even between different users in the same instance.
+:::
+
+Data returned from the provider is dependent on how your EntraID OAuth2 application is configured. The example below assumes that the EntraID OAuth2 application is configured to return the user's email, first name, and last name. Fields returned by the provider can change based on the scopes requested and the user's EntraID account settings.
+
+If you aren't sure what data is being returned by the provider, you can log the `waadProfile` object in the `createStrategy` function to see what data is available as seen in the following example.
+
+<details>
+  <summary>Configuration Example with Logging</summary>
+
+```js
+(accessToken, refreshToken, params, profile, done) => {
+  let waadProfile = jwt.decode(params.id_token, "", true);
+
+  // See what is returned by the provider
+  console.log(waadProfile);
+
+  done(null, {
+    email: waadProfile.email,
+    username: waadProfile.email,
+    firstname: waadProfile.given_name, // optional if email and username exist
+    lastname: waadProfile.family_name, // optional if email and username exist
+  });
+}
+```
+
+</details>
+
+### Redirect URL/URI
+
+The redirect URL/URI will be dependent on your provider configuration however in most cases should combine your application's public URL and the provider's callback URL. The example below shows how to combine the public URL with the provider's callback URL.
+
+```js
+callbackURL:
+  env('PUBLIC_URL', "https://api.example.com") +
+  strapi.admin.services.passport.getStrategyCallbackURL("azure_ad_oauth2"),
+```
+
+In this example the redirect URL/URI used by the provider will be `https://api.example.com/admin/connect/azure_ad_oauth2`.
+
+This is broken down as follows:
+
+- `https://api.example.com` is the public URL of your Strapi application
+- `/admin/connect` is the general path for SSO callbacks in Strapi
+- `/azure_ad_oauth2` is the specific provider UID for Mircosoft Entra ID / Azure Active Directory
+
+## Strapi Configuration
+
+Using: [passport-azure-ad-oauth2](https://github.com/auth0/passport-azure-ad-oauth2#readme)
+
+### Install the Provider Package
 
 <Tabs groupId="yarn-npm">
 
@@ -40,15 +127,13 @@ npm install --save passport-azure-ad-oauth2 jsonwebtoken
 
 </Tabs>
 
-## Configuration example
-
-The Microsoft SSO provider is configured in the `auth.providers` array of [the `config/admin` file](/dev-docs/configurations/admin-panel):
+### Adding the Provider to Strapi
 
 <Tabs groupId="js-ts">
 
 <TabItem value="javascript" label="JavaScript">
 
-```js title="/config/admin.js"
+```js title="./config/admin.js"
 
 const AzureAdOAuth2Strategy = require("passport-azure-ad-oauth2");
 const jwt = require("jsonwebtoken");
@@ -69,6 +154,7 @@ module.exports = ({ env }) => ({
               scope: ["user:email"],
               tenant: env("MICROSOFT_TENANT_ID", ""),
               callbackURL:
+                env('PUBLIC_URL') +
                 strapi.admin.services.passport.getStrategyCallbackURL(
                   "azure_ad_oauth2"
                 ),
@@ -93,7 +179,7 @@ module.exports = ({ env }) => ({
 
 <TabItem value="typescript" label="TypeScript">
 
-```ts title="/config/admin.ts"
+```ts title="./config/admin.ts"
 
 import { Strategy as AzureAdOAuth2Strategy} from "passport-azure-ad-oauth2";
 import jwt from "jsonwebtoken";
@@ -114,6 +200,7 @@ export default ({ env }) => ({
               scope: ["user:email"],
               tenant: env("MICROSOFT_TENANT_ID", ""),
               callbackURL:
+                env('PUBLIC_URL') +
                 strapi.admin.services.passport.getStrategyCallbackURL(
                   "azure_ad_oauth2"
                 ),

--- a/docusaurus/docs/dev-docs/configurations/sso-providers/okta.md
+++ b/docusaurus/docs/dev-docs/configurations/sso-providers/okta.md
@@ -1,24 +1,105 @@
 ---
-title: Okta SSO provider
-description: Learn how to configure the SSO provider to sign in and sign up into your Strapi application through Okta.
+title: Okta - Admin SSO Provider
+description: Steps to configure Okta as a Strapi Admin SSO Provider
 displayed_sidebar: cmsSidebar
 tags: 
-- SSO
-- providers
+- okta
+- additional configuration
+- admin panel
 - configuration
+- Enterprise feature
+- SSO 
 ---
 
-# Okta provider SSO configuration
-
-The present page explains how to setup the Okta provider for the [Single Sign-On (SSO) feature](/user-docs/features/sso).
+import SSOServerConfig from '/docs/snippets/configuration-sso-server.md'
+import SSOAdminConfig from '/docs/snippets/configuration-sso-admin.md'
+import SSOMiddlewaresConfig from '/docs/snippets/configuration-sso-middlewares.md'
 
 :::prerequisites
-You have read the [How to configure SSO guide](/dev-docs/configurations/guides/configure-sso).
+
+- [Properly configure Strapi for SSO](#required-configuration-before-setting-up-sso)
+- Create your Okta OAuth2 app by following the steps in the [Okta portal](https://developer.okta.com/docs/guides/implement-oauth-for-okta/main/).
+- Gather the required information to set as environment variables in your Strapi project:
+  - OKTA_CLIENT_ID
+  - OKTA_CLIENT_SECRET
+  - OKTA_DOMAIN
+
 :::
 
-## Installation
+:::warning
+When setting the `OKTA_DOMAIN` environment variable, make sure to include the protocol (e.g. `https://example.okta.com`). If you do not, you will end up in a redirect loop.
+:::
 
-Install [passport-okta-oauth20](https://github.com/antoinejaussoin/passport-okta-oauth20/#readme):
+## Required configuration before setting up SSO
+
+### Server Configuration
+
+<SSOServerConfig />
+
+### Admin Configuration
+
+<SSOAdminConfig />
+
+### Middlewares Configuration
+
+<SSOMiddlewaresConfig />
+
+## Provider Specific Notes
+
+### Scopes
+
+The Okta OAuth2 provider requires the following scopes, however additional scopes can be added as needed depending on your use case and the data you need returned:
+
+- [`openid`](https://developer.okta.com/docs/api/oauth2/)
+- [`profile`](https://developer.okta.com/docs/api/oauth2/)
+- [`email`](https://developer.okta.com/docs/api/oauth2/)
+
+### Profile Data
+
+Data returned from the provider is dependent on how your Okta OAuth2 application is configured. The example below assumes that the Okta OAuth2 application is configured to return the user's email, first name, and last name. Fields returned by the provider can change based on the scopes requested and the user's Okta account settings.
+
+If you aren't sure what data is being returned by the provider, you can log the `profile` object in the `createStrategy` function to see what data is available as seen in the following example.
+
+<details>
+  <summary>Configuration Example with Logging</summary>
+
+```js
+(accessToken, refreshToken, profile, done) => {
+  // See what is returned by the provider
+  console.log(profile);
+
+  done(null, {
+    email: profile.email,
+    username: profile.username,
+  });
+}
+```
+
+</details>
+
+### Redirect URL/URI
+
+The redirect URL/URI will be dependent on your provider configuration however in most cases should combine your application's public URL and the provider's callback URL. The example below shows how to combine the public URL with the provider's callback URL.
+
+```js
+callbackURL:
+  env('PUBLIC_URL', "https://api.example.com") +
+  strapi.admin.services.passport.getStrategyCallbackURL("okta"),
+```
+
+In this example the redirect URL/URI used by the provider will be `https://api.example.com/admin/connect/okta`.
+
+This is broken down as follows:
+
+- `https://api.example.com` is the public URL of your Strapi application
+- `/admin/connect` is the general path for SSO callbacks in Strapi
+- `/okta` is the specific provider UID for Okta
+
+## Strapi Configuration
+
+Using: [passport-okta-oauth20](https://github.com/antoinejaussoin/passport-okta-oauth20/#readme)
+
+### Install the Provider Package
 
 <Tabs groupId="yarn-npm">
 
@@ -40,20 +121,13 @@ npm install --save passport-okta-oauth20
 
 </Tabs>
 
-## Configuration example
-
-The Okta SSO provider is configured in the `auth.providers` array of [the `config/admin` file](/dev-docs/configurations/admin-panel):
-
-:::caution
-When setting the `OKTA_DOMAIN` environment variable, make sure to include the protocol (e.g., `https://example.okta.com`). If you do not, you will end up in a redirect loop.
-:::
+### Adding the Provider to Strapi
 
 <Tabs groupId="js-ts">
 
 <TabItem value="javascript" label="JavaScript">
 
-```js title="/config/admin.js"
-
+```js title="./config/admin.js"
 const OktaOAuth2Strategy = require("passport-okta-oauth20").Strategy;
 
 module.exports = ({ env }) => ({
@@ -72,6 +146,7 @@ module.exports = ({ env }) => ({
               audience: env("OKTA_DOMAIN"),
               scope: ["openid", "email", "profile"],
               callbackURL:
+                env('PUBLIC_URL') +
                 strapi.admin.services.passport.getStrategyCallbackURL("okta"),
             },
             (accessToken, refreshToken, profile, done) => {
@@ -91,8 +166,7 @@ module.exports = ({ env }) => ({
 
 <TabItem value="typescript" label="TypeScript">
 
-```ts title="/config/admin.ts"
-
+```ts title="./config/admin.ts"
 import { Strategy as OktaOAuth2Strategy } from "passport-okta-oauth20";
 
 export default ({ env }) => ({
@@ -111,6 +185,7 @@ export default ({ env }) => ({
               audience: env("OKTA_DOMAIN"),
               scope: ["openid", "email", "profile"],
               callbackURL:
+                env('PUBLIC_URL') +
                 strapi.admin.services.passport.getStrategyCallbackURL("okta"),
             },
             (accessToken, refreshToken, profile, done) => {

--- a/docusaurus/docs/snippets/configuration-sso-admin.md
+++ b/docusaurus/docs/snippets/configuration-sso-admin.md
@@ -1,0 +1,57 @@
+There are some optional configurations that you can set should it be necessary, for more information on available options please see the [Admin Configuration](/dev-docs/configurations/admin-panel) documentation.
+
+- **`url`**: The public facing URL of your Strapi administration panel. (e.g. `https://admin.example.com`)
+- **`auth.domain`**: Setting a custom domain for cookie storage. (e.g. `.example.com`)
+
+:::note
+When deploying the admin panel to a different location or on a different subdomain, an additional configuration is required to set the common domain for the cookies. This is required to ensure the cookies are shared across the domains.
+:::
+
+:::caution
+Deploying the admin and backend on entirely different unrelated domains is not possible at this time when using SSO due to restrictions in cross-domain cookies.
+:::
+
+<details>
+  <summary>Admin Optional Configuration Example</summary>
+
+<Tabs groupId="js-ts">
+
+<TabItem value="javascript" label="JavaScript">
+
+```js title="./config/admin.js"
+
+module.exports = ({ env }) => ({
+  // ...
+  url: env('PUBLIC_ADMIN_URL', 'https://admin.example.com'),
+  auth: {
+    domain: env("ADMIN_SSO_DOMAIN", ".example.com"),
+    providers: [
+      // ...
+    ],
+  },
+  // ...
+});
+```
+
+</TabItem>
+
+<TabItem value="typescript" label="TypeScript">
+
+```ts title="./config/admin.ts"
+
+export default ({ env }) => ({
+  // ...
+  url: env('PUBLIC_ADMIN_URL', 'https://admin.example.com'),
+  auth: {
+    domain: env("ADMIN_SSO_DOMAIN", ".example.com"),
+    providers: [
+      // ...
+    ],
+  },
+  // ...
+});
+```
+
+</TabItem>
+</Tabs>
+</details>

--- a/docusaurus/docs/snippets/configuration-sso-middlewares.md
+++ b/docusaurus/docs/snippets/configuration-sso-middlewares.md
@@ -1,0 +1,87 @@
+The following middleware configurations are required when using SSO, for more information on available options please see the [Middlewares Configuration](/dev-docs/configurations/middlewares) documentation.
+
+- **`contentSecurityPolicy`**: Allows you to configure the Content Security Policy (CSP) for your Strapi application. This is used to prevent cross-site scripting attacks by allowing you to control what resources can be loaded by your application.
+
+:::note
+By default, Strapi security policy does not allow loading images from external URLs, so provider logos will not show up on the [login screen](/user-docs/intro#accessing-the-admin-panel) of the admin panel unless [a security exception is added](/dev-docs/configurations/middlewares#security) or you use a file uploaded directly on your Strapi application.
+:::
+
+<details>
+  <summary>Middlewares Configuration Example</summary>
+
+<Tabs groupId="js-ts">
+<TabItem value="js" label="JavaScript">
+
+```jsx title="./config/middlewares.js"
+module.exports = [
+  // ...
+  {
+    name: 'strapi::security',
+    config: {
+      contentSecurityPolicy: {
+        useDefaults: true,
+        directives: {
+          'connect-src': ["'self'", 'https:'],
+          'img-src': [
+            "'self'",
+            'data:',
+            'blob:',
+            'market-assets.strapi.io',
+            'cdn2.iconfinder.com', // Base URL of the provider's logo without the protocol
+          ],
+          'media-src': [
+            "'self'",
+            'data:',
+            'blob:',
+            'market-assets.strapi.io',
+            'cdn2.iconfinder.com', // Base URL of the provider's logo without the protocol
+          ],
+          upgradeInsecureRequests: null,
+        },
+      },
+    },
+  },
+  // ...
+]
+```
+
+</TabItem>
+
+<TabItem value="ts" label="TypeScript">
+
+```ts title="./config/middlewares.ts"
+export default [
+  // ...
+  {
+    name: 'strapi::security',
+    config: {
+      contentSecurityPolicy: {
+        useDefaults: true,
+        directives: {
+          'connect-src': ["'self'", 'https:'],
+          'img-src': [
+            "'self'",
+            'data:',
+            'blob:',
+            'market-assets.strapi.io',
+            'cdn2.iconfinder.com', // Base URL of the provider's logo without the protocol
+          ],
+          'media-src': [
+            "'self'",
+            'data:',
+            'blob:',
+            'market-assets.strapi.io',
+            'cdn2.iconfinder.com', // Base URL of the provider's logo without the protocol
+          ],
+          upgradeInsecureRequests: null,
+        },
+      },
+    },
+  },
+  // ...
+]
+```
+
+</TabItem>
+</Tabs>
+</details>

--- a/docusaurus/docs/snippets/configuration-sso-server.md
+++ b/docusaurus/docs/snippets/configuration-sso-server.md
@@ -1,0 +1,88 @@
+The following server configurations are required when using SSO, for more information on available options please see the [Server Configuration](/dev-docs/configurations/server) documentation.
+
+- **`url`**: The public facing URL of your Strapi application. (e.g. `https://api.example.com`)
+- **`proxy.koa`**: Enabling trusted reverse proxy support. (`true`)
+
+<details>
+  <summary>Admin Required Configuration Example</summary>
+
+<Tabs groupId="js-ts">
+
+<TabItem value="javascript" label="JavaScript">
+
+```js title="./config/server.js"
+
+module.exports = ({ env }) => ({
+  // ...
+  url: env('PUBLIC_URL', 'https://api.example.com'),
+  proxy: {
+    koa: env.bool('TRUST_PROXY', true),
+  },
+  // ...
+});
+```
+
+</TabItem>
+
+<TabItem value="typescript" label="TypeScript">
+
+```ts title="./config/server.ts"
+
+export default ({ env }) => ({
+  // ...
+  url: env('PUBLIC_URL', 'https://api.example.com'),
+  proxy: {
+    koa: env.bool('TRUST_PROXY', true),
+  },
+  // ...
+});
+```
+
+</TabItem>
+</Tabs>
+</details>
+
+There are also some optional configurations that you can set should it be necessary:
+
+- **`proxy.global`**: If you are in a restricted network environment that requires a forward proxy (e.g Squid) for all outgoing requests. (e.g. `http://username:password@yourProxy:3128`)
+
+<details>
+  <summary>Admin Optional Configuration Example</summary>
+
+<Tabs groupId="js-ts">
+
+<TabItem value="javascript" label="JavaScript">
+
+```js title="./config/server.js"
+
+module.exports = ({ env }) => ({
+  // ...
+  url: env('PUBLIC_URL', 'https://api.example.com'),
+  proxy: {
+    koa: env.bool('TRUST_PROXY', true),
+    global: env('GLOBAL_PROXY'),
+  },
+  // ...
+});
+```
+
+</TabItem>
+
+<TabItem value="typescript" label="TypeScript">
+
+```ts title="./config/server.ts"
+
+export default ({ env }) => ({
+  // ...
+  url: env('PUBLIC_URL', 'https://api.example.com'),
+  proxy: {
+    koa: env.bool('TRUST_PROXY', true),
+    global: env('GLOBAL_PROXY'),
+  },
+  // ...
+});
+```
+
+</TabItem>
+</Tabs>
+</details>


### PR DESCRIPTION
# What this does

Completely updates all of the SSO documentation for release with Strapi 5

# Todo list

- [x] Initialize all new provider pages
- [x] Rewrite main SSO configuration page
- [x] Refactor Discord Provider
- [x] Refactor Microsoft Provider
- [x] Refactor GitHub Provider
- [x] Refactor Google Provider
- [ ] Refactor Keycloak Provider
- [x] Refactor Okta Provider
- [ ] Add new Auth0 Provider
- [ ] ~Add new Generic OIDC Provider~ TODO in the future
- [ ] ~Add new Generic SAML Provider~ TODO in the future
- [ ] Add new Gitlab Provider