### PR TITLE
Fix incorrect import of unstable_useContentManagerContext in Helper-plugin migration reference

### DIFF
--- a/docusaurus/docs/dev-docs/migration/v4-to-v5/additional-resources/helper-plugin.md
+++ b/docusaurus/docs/dev-docs/migration/v4-to-v5/additional-resources/helper-plugin.md
@@ -595,7 +595,7 @@ A lot of the internals have been reworked and split. We are exposing a main expe
 import { useCMEditViewDataManager } from '@strapi/helper-plugin';
 
 // After
-import { unstable_useContentManagerContext as useContentManagerContext } from '@strapi/strapi/admin/hooks';
+import { unstable_useContentManagerContext as useContentManagerContext } from '@strapi/strapi/admin';
 ```
 
 Some common use cases are listed below:


### PR DESCRIPTION
### What does it do?
This PR updates an import path for the unstable_useContentManagerContext hook in the migration documentation for Strapi v4 to v5.

### Why is it needed?
I don't know if importing from `'@strapi/strapi/admin/hooks'` worked in v4, but it does not work in v5. The change helps developers use the correct import path as part of the migration process.