### PR TITLE
Update Doc Service API middleware example

### DIFF
--- a/docusaurus/docs/dev-docs/api/document-service/middlewares.md
+++ b/docusaurus/docs/dev-docs/api/document-service/middlewares.md
@@ -360,8 +360,10 @@ strapi.documents.use(async (context, next) => {
 
   const result = await next();
 
-  // do something with the result before returning it
-  return result
+  // Modify the result as necessary before returning it
+  result.retrievedAt = Date.now();
+
+  return result;
 });
 ```
 


### PR DESCRIPTION
Added a line to the example code to better clarify how to mutate results in middleware before returning them (or passing them to other middleware down the chain).

Per the instructions, this PR is ready to be merged.

### What does it do?
This PR improves the Document Service API middleware example to better convey how to mutate query results prior to returning them to the client or other downstream middleware.

### Why is it needed?
I had trouble implementing result mutations during an upgrade to Strapi 5.  I thought this change could help future explorers figure it out a little bit faster.

### Related issue(s)/PR(s)
N/A
