### PR TITLE
Update admin-panel-api.md

### DIFF
--- a/docusaurus/docs/dev-docs/plugins/admin-panel-api.md
+++ b/docusaurus/docs/dev-docs/plugins/admin-panel-api.md
@@ -774,6 +774,6 @@ interface LayoutSettings extends Contracts.ContentTypes.Settings {
 ```
 
 :::note
-`EditViewLayout` and `ListViewLayout` are parts of the `useDocumentLayout` hook (see [source code](https://github.com/strapi/strapi/blob/develop/packages/core/admin/admin/src/content-manager/hooks/useDocumentLayout.ts)).
+`EditViewLayout` and `ListViewLayout` are parts of the `useDocumentLayout` hook (see [source code](https://github.com/strapi/strapi/blob/develop/packages/core/content-manager/admin/src/hooks/useDocumentLayout.ts)).
 :::
 


### PR DESCRIPTION
Fix link in the documentation, the previous one was leading to a dead end

### What does it do?

Replaces link in a documentation to a valid one.

### Why is it needed?

The link in the documentation is pointing to a wrong file.