### PR TITLE
Add ExternalLink custom component

### DIFF
--- a/docusaurus/docs/cms/intro.md
+++ b/docusaurus/docs/cms/intro.md
@@ -71,5 +71,5 @@ The table of content of the Strapi CMS documentation displays 7 main sections in
 :::strapi Information for beginner developers
 Some parts of the CMS documentation (e.g. APIs, Configuration, Development) are mostly intended to developers and assume some prior knowledge of the JavaScript ecosystem.
 
-If you also make your first steps with JavaScript web development while discovering Strapi, we encourage you to read more about <ExternalLink to="https://developer.mozilla.org/en-US/docs/Learn/Getting_started_with_the_web/JavaScript_basics" name="JavaScript" /> and [npm](https://docs.npmjs.com/about-npm). If applicable to your project, you can also learn about [TypeScript](https://www.typescriptlang.org/docs/handbook/typescript-in-5-minutes.html) before diving deeper into these technical parts of the CMS documentation.
+If you also make your first steps with JavaScript web development while discovering Strapi, we encourage you to read more about <ExternalLink to="https://developer.mozilla.org/en-US/docs/Learn/Getting_started_with_the_web/JavaScript_basics" text="JavaScript" /> and [npm](https://docs.npmjs.com/about-npm). If applicable to your project, you can also learn about [TypeScript](https://www.typescriptlang.org/docs/handbook/typescript-in-5-minutes.html) before diving deeper into these technical parts of the CMS documentation.
 :::

--- a/docusaurus/docs/cms/intro.md
+++ b/docusaurus/docs/cms/intro.md
@@ -71,5 +71,5 @@ The table of content of the Strapi CMS documentation displays 7 main sections in
 :::strapi Information for beginner developers
 Some parts of the CMS documentation (e.g. APIs, Configuration, Development) are mostly intended to developers and assume some prior knowledge of the JavaScript ecosystem.
 
-If you also make your first steps with JavaScript web development while discovering Strapi, we encourage you to read more about <a target="_blank" href="https://developer.mozilla.org/en-US/docs/Learn/Getting_started_with_the_web/JavaScript_basics)">JavaScript</a> and [npm](https://docs.npmjs.com/about-npm). If applicable to your project, you can also learn about [TypeScript](https://www.typescriptlang.org/docs/handbook/typescript-in-5-minutes.html) before diving deeper into these technical parts of the CMS documentation.
+If you also make your first steps with JavaScript web development while discovering Strapi, we encourage you to read more about <ExternalLink to="https://developer.mozilla.org/en-US/docs/Learn/Getting_started_with_the_web/JavaScript_basics" name="JavaScript" /> and [npm](https://docs.npmjs.com/about-npm). If applicable to your project, you can also learn about [TypeScript](https://www.typescriptlang.org/docs/handbook/typescript-in-5-minutes.html) before diving deeper into these technical parts of the CMS documentation.
 :::

--- a/docusaurus/src/components/ExternalLink.js
+++ b/docusaurus/src/components/ExternalLink.js
@@ -2,8 +2,8 @@ import React from 'react';
 import Link from '@docusaurus/Link';
 import Icon from './Icon';
 
-export const ExternalLink = ({to, name}) => (
+export const ExternalLink = ({to, text}) => (
   <Link to={to}>
-    {name}&nbsp;<Icon name="arrow-square-out" classes="ph-fill external-link" />
+    {text}&nbsp;<Icon name="arrow-square-out" classes="ph-fill external-link" />
   </Link>
 )

--- a/docusaurus/src/components/ExternalLink.js
+++ b/docusaurus/src/components/ExternalLink.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import Link from '@docusaurus/Link';
+import Icon from './Icon';
+
+export const ExternalLink = ({to, name}) => (
+  <Link to={to}>
+    {name}&nbsp;<Icon name="arrow-square-out" classes="ph-fill external-link" />
+  </Link>
+)

--- a/docusaurus/src/scss/icons.scss
+++ b/docusaurus/src/scss/icons.scss
@@ -6,3 +6,9 @@ article {
     top: 2px;
   }
 }
+
+.strapi-icons.external-link::before {
+  text-decoration: none !important;
+  position: relative;
+  top: -2px;
+}

--- a/docusaurus/src/theme/MDXComponents.js
+++ b/docusaurus/src/theme/MDXComponents.js
@@ -31,6 +31,7 @@ import SubtleCallout from '../components/SubtleCallout';
 import { PluginsConfigurationFile, HeadlessCms, DocumentDefinition, Codemods } from '../components/ReusableAnnotationComponents/ReusableAnnotationComponents';
 import Icon from '../components/Icon';
 import Guideflow from '../components/Guideflow';
+import { ExternalLink } from '../components/ExternalLink';
 
 export default {
   // Re-use the default mapping
@@ -77,6 +78,7 @@ export default {
   Guideflow,
   Annotation,
   Icon,
+  ExternalLink,
   /**
    * Reusable annotation components go below👇
    */


### PR DESCRIPTION
This PR adds a custom `ExternalLink` component built on top of the existing built-in `Link` Docusaurus component and our custom `Icon` component. 
It can be used to distinguish internal links from external links and displays an icon on the right.