### PR TITLE
Setting up local plugin in Strapi without the Plugin SDK

### DIFF
--- a/docusaurus/docs/dev-docs/plugins/development/create-a-plugin.md
+++ b/docusaurus/docs/dev-docs/plugins/development/create-a-plugin.md
@@ -183,7 +183,7 @@ Because the server looks at the `server/src/index.ts|js` file to import your plu
 
 ## Setting a local plugin in a monorepo environment without the Plugin SDK
 
-In a monorepo, you can configure your local plugin without using the Plugin SDK by adding two entry point files at the root of your plugin:
+In a monorepo, you can configure your local plugin without using the Plugin SDK by adding 2 entry point files at the root of your plugin:
 
 Server Entry Point: `strapi-server.js` or `strapi-server.ts`
 Admin Entry Point: `strapi-admin.js` or `strapi-admin.ts`

--- a/docusaurus/docs/dev-docs/plugins/development/create-a-plugin.md
+++ b/docusaurus/docs/dev-docs/plugins/development/create-a-plugin.md
@@ -190,7 +190,7 @@ In a monorepo, you can configure your local plugin without using the Plugin SDK 
 
 ### Server entry point
 
-This file initializes your plugin’s server-side functionalities. The expected structure for `strapi-server.js` (or its TypeScript variant) is:
+The server entry point file initializes your plugin’s server-side functionalities. The expected structure for `strapi-server.js` (or its TypeScript variant) is:
 
 ```js
 module.exports = () => {

--- a/docusaurus/docs/dev-docs/plugins/development/create-a-plugin.md
+++ b/docusaurus/docs/dev-docs/plugins/development/create-a-plugin.md
@@ -221,4 +221,5 @@ export default {
 This object includes methods to register your plugin with the admin app, perform bootstrapping actions, and handle translations.
 
 ::: tip
-For a complete example of how to structure your local plugin in a monorepo environment, check out our example setup in our monorepo:
+For a complete example of how to structure your local plugin in a monorepo environment, check out our example setup in our monorepo: [Example Local Plugin Setup](https://github.com/strapi/strapi/tree/develop/examples/getstarted/src/plugins/local-plugin)
+:::

--- a/docusaurus/docs/dev-docs/plugins/development/create-a-plugin.md
+++ b/docusaurus/docs/dev-docs/plugins/development/create-a-plugin.md
@@ -222,4 +222,3 @@ This object includes methods to register your plugin with the admin app, perform
 
 ::: tip
 For a complete example of how to structure your local plugin in a monorepo environment, check out our example setup in our monorepo:
-[Example Local Plugin Setup](https://github.com/strapi/strapi/tree/develop/examples/getstarted/src/plugins/local-plugin)

--- a/docusaurus/docs/dev-docs/plugins/development/create-a-plugin.md
+++ b/docusaurus/docs/dev-docs/plugins/development/create-a-plugin.md
@@ -156,6 +156,8 @@ Because the server looks at the `server/src/index.ts|js` file to import your plu
 
 ### Configuration with a local plugin
 
+Since the Plugin SDK is primarily designed for developing plugins, not locally, the configuration needs to be adjusted manually for local plugins.
+
 When developing your plugin locally (using `@strapi/sdk-plugin`), your plugins configuration file looks like in the following example:
 
 ```js title="/config/plugins.js|ts"

--- a/docusaurus/docs/dev-docs/plugins/development/create-a-plugin.md
+++ b/docusaurus/docs/dev-docs/plugins/development/create-a-plugin.md
@@ -220,6 +220,6 @@ export default {
 
 This object includes methods to register your plugin with the admin app, perform bootstrapping actions, and handle translations.
 
-Example Setup
+::: tip
 For a complete example of how to structure your local plugin in a monorepo environment, check out our example setup in our monorepo:
 [Example Local Plugin Setup](https://github.com/strapi/strapi/tree/develop/examples/getstarted/src/plugins/local-plugin)

--- a/docusaurus/docs/dev-docs/plugins/development/create-a-plugin.md
+++ b/docusaurus/docs/dev-docs/plugins/development/create-a-plugin.md
@@ -188,7 +188,7 @@ In a monorepo, you can configure your local plugin without using the Plugin SDK 
 - server entry point: `strapi-server.js` or `strapi-server.ts`
 - admin entry point: `strapi-admin.js` or `strapi-admin.ts`
 
-### Server Entry Point
+### Server entry point
 
 This file initializes your plugin’s server-side functionalities. The expected structure for `strapi-server.js` (or its TypeScript variant) is:
 

--- a/docusaurus/docs/dev-docs/plugins/development/create-a-plugin.md
+++ b/docusaurus/docs/dev-docs/plugins/development/create-a-plugin.md
@@ -186,7 +186,7 @@ Because the server looks at the `server/src/index.ts|js` file to import your plu
 In a monorepo, you can configure your local plugin without using the Plugin SDK by adding 2 entry point files at the root of your plugin:
 
 - server entry point: `strapi-server.js` or `strapi-server.ts`
-Admin Entry Point: `strapi-admin.js` or `strapi-admin.ts`
+- admin entry point: `strapi-admin.js` or `strapi-admin.ts`
 
 ### Server Entry Point
 

--- a/docusaurus/docs/dev-docs/plugins/development/create-a-plugin.md
+++ b/docusaurus/docs/dev-docs/plugins/development/create-a-plugin.md
@@ -206,7 +206,7 @@ module.exports = () => {
 
 Here, you export a function that returns your plugin's core components such as controllers, routes, and configuration.
 
-### Admin Entry Point
+### Admin entry point
 
 This file sets up your plugin within the Strapi admin panel. The expected structure for `strapi-admin.js` (or its TypeScript variant) is:
 

--- a/docusaurus/docs/dev-docs/plugins/development/create-a-plugin.md
+++ b/docusaurus/docs/dev-docs/plugins/development/create-a-plugin.md
@@ -208,7 +208,7 @@ Here, you export a function that returns your plugin's core components such as c
 
 ### Admin entry point
 
-This file sets up your plugin within the Strapi admin panel. The expected structure for `strapi-admin.js` (or its TypeScript variant) is:
+The admin entry point file sets up your plugin within the Strapi admin panel. The expected structure for `strapi-admin.js` (or its TypeScript variant) is:
 
 ```js
 export default {

--- a/docusaurus/docs/dev-docs/plugins/development/create-a-plugin.md
+++ b/docusaurus/docs/dev-docs/plugins/development/create-a-plugin.md
@@ -151,16 +151,21 @@ export default (config, webpack) => {
 ```
 
 :::caution
-When developing your plugin locally (using @strapi/sdk-plugin), your configuration in config/plugins.js might look like this:
+Because the server looks at the `server/src/index.ts|js` file to import your plugin code, you must use the `watch` command otherwise the code will not be transpiled and the server will not be able to find your plugin.
+:::
 
-```js
+### Configuration with a local plugin
+
+When developing your plugin locally (using `@strapi/sdk-plugin`), your plugins configuration file looks like in the following example:
+
+```js title="/config/plugins.js|ts"
 myplugin: {
-    enabled: true,
-    resolve: `./src/plugins/local-plugin`,
-  },
+  enabled: true,
+  resolve: `./src/plugins/local-plugin`,
+},
 ```
 
-However, this setup can sometimes lead to errors such as:
+However, this setup can sometimes lead to errors such as the following:
 
 ```js
 Error: 'X must be used within StrapiApp';
@@ -172,21 +177,14 @@ This error often occurs when your plugin attempts to import core Strapi function
 import { unstable_useContentManagerContext as useContentManagerContext } from '@strapi/strapi/admin';
 ```
 
-Solution:
 To resolve the issue, remove `@strapi/strapi` as a dev dependency from your plugin. This ensures that your plugin uses the same instance of Strapi’s core modules as the main application, preventing conflicts and the associated errors.
-
-:::
-
-:::caution
-Because the server looks at the `server/src/index.ts|js` file to import your plugin code, you must use the `watch` command otherwise the code will not be transpiled and the server will not be able to find your plugin.
-:::
 
 ## Setting a local plugin in a monorepo environment without the Plugin SDK
 
 In a monorepo, you can configure your local plugin without using the Plugin SDK by adding 2 entry point files at the root of your plugin:
 
-- server entry point: `strapi-server.js` or `strapi-server.ts`
-- admin entry point: `strapi-admin.js` or `strapi-admin.ts`
+- server entry point: `strapi-server.js|ts`
+- admin entry point: `strapi-admin.js|ts`
 
 ### Server entry point
 
@@ -220,6 +218,6 @@ export default {
 
 This object includes methods to register your plugin with the admin app, perform bootstrapping actions, and handle translations.
 
-::: tip
-For a complete example of how to structure your local plugin in a monorepo environment, check out our example setup in our monorepo: [Example Local Plugin Setup](https://github.com/strapi/strapi/tree/develop/examples/getstarted/src/plugins/local-plugin)
+:::tip
+For a complete example of how to structure your local plugin in a monorepo environment, please check out our [example setup in the strapi/strapi monorepo](https://github.com/strapi/strapi/tree/develop/examples/getstarted/src/plugins/local-plugin).
 :::

--- a/docusaurus/docs/dev-docs/plugins/development/create-a-plugin.md
+++ b/docusaurus/docs/dev-docs/plugins/development/create-a-plugin.md
@@ -204,7 +204,7 @@ module.exports = () => {
 };
 ```
 
-Here, you export a function that returns your plugin's core components such as controllers, routes, and configuration.
+Here, you export a function that returns your plugin's core components such as controllers, routes, and configuration. For more details, please refer to the [Server API reference](/dev-docs/plugins/server-api).
 
 ### Admin entry point
 
@@ -218,7 +218,7 @@ export default {
 };
 ```
 
-This object includes methods to register your plugin with the admin app, perform bootstrapping actions, and handle translations.
+This object includes methods to register your plugin with the admin application, perform bootstrapping actions, and handle translations. For more details, please refer to the [Admin Panel API reference](/dev-docs/plugins/admin-panel-api).
 
 :::tip
 For a complete example of how to structure your local plugin in a monorepo environment, please check out our [example setup in the strapi/strapi monorepo](https://github.com/strapi/strapi/tree/develop/examples/getstarted/src/plugins/local-plugin).

--- a/docusaurus/docs/dev-docs/plugins/development/create-a-plugin.md
+++ b/docusaurus/docs/dev-docs/plugins/development/create-a-plugin.md
@@ -151,5 +151,75 @@ export default (config, webpack) => {
 ```
 
 :::caution
+When developing your plugin locally (using @strapi/sdk-plugin), your configuration in config/plugins.js might look like this:
+
+```js
+myplugin: {
+    enabled: true,
+    resolve: `./src/plugins/local-plugin`,
+  },
+```
+
+However, this setup can sometimes lead to errors such as:
+
+```js
+Error: 'X must be used within StrapiApp';
+```
+
+This error often occurs when your plugin attempts to import core Strapi functionality, for example using:
+
+```js
+import { unstable_useContentManagerContext as useContentManagerContext } from '@strapi/strapi/admin';
+```
+
+Solution:
+To resolve the issue, remove `@strapi/strapi` as a dev dependency from your plugin. This ensures that your plugin uses the same instance of Strapi’s core modules as the main application, preventing conflicts and the associated errors.
+
+:::
+
+:::caution
 Because the server looks at the `server/src/index.ts|js` file to import your plugin code, you must use the `watch` command otherwise the code will not be transpiled and the server will not be able to find your plugin.
 :::
+
+## Setting a local plugin in a monorepo environment without the Plugin SDK
+
+In a monorepo, you can configure your local plugin without using the Plugin SDK by adding two entry point files at the root of your plugin:
+
+Server Entry Point: `strapi-server.js` or `strapi-server.ts`
+Admin Entry Point: `strapi-admin.js` or `strapi-admin.ts`
+
+### Server Entry Point
+
+This file initializes your plugin’s server-side functionalities. The expected structure for `strapi-server.js` (or its TypeScript variant) is:
+
+```js
+module.exports = () => {
+  return {
+    register,
+    config,
+    controllers,
+    contentTypes,
+    routes,
+  };
+};
+```
+
+Here, you export a function that returns your plugin's core components such as controllers, routes, and configuration.
+
+### Admin Entry Point
+
+This file sets up your plugin within the Strapi admin panel. The expected structure for `strapi-admin.js` (or its TypeScript variant) is:
+
+```js
+export default {
+  register(app) {},
+  bootstrap() {},
+  registerTrads({ locales }) {},
+};
+```
+
+This object includes methods to register your plugin with the admin app, perform bootstrapping actions, and handle translations.
+
+Example Setup
+For a complete example of how to structure your local plugin in a monorepo environment, check out our example setup in our monorepo:
+[Example Local Plugin Setup](https://github.com/strapi/strapi/tree/develop/examples/getstarted/src/plugins/local-plugin)

--- a/docusaurus/docs/dev-docs/plugins/development/create-a-plugin.md
+++ b/docusaurus/docs/dev-docs/plugins/development/create-a-plugin.md
@@ -185,7 +185,7 @@ Because the server looks at the `server/src/index.ts|js` file to import your plu
 
 In a monorepo, you can configure your local plugin without using the Plugin SDK by adding 2 entry point files at the root of your plugin:
 
-Server Entry Point: `strapi-server.js` or `strapi-server.ts`
+- server entry point: `strapi-server.js` or `strapi-server.ts`
 Admin Entry Point: `strapi-admin.js` or `strapi-admin.ts`
 
 ### Server Entry Point


### PR DESCRIPTION
### What does it do?

- Adding as section to local plugin creation about how to set it up without plugin sdk
- adding a warning for local plugins that are created with plugin sdk and how to manage it's dependencies

### Why is it needed?

- people are having issues with plugins setup locally, this is a solution for them to go with before we fix the issue on our side
- documents how you can create a plugin without the sdk for even more complicated issues

### Related issues:
Resolves strapi/strapi#22547
Resolves strapi/strapi#22162
Resolves strapi/strapi#22536
Resolves strapi/strapi#21823