### PR TITLE
Mention codemods on breaking changes pages

### DIFF
--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/admin-panel-rbac-store-updated.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/admin-panel-rbac-store-updated.md
@@ -12,16 +12,13 @@ tags:
 
 import Intro from '/docs/snippets/breaking-change-page-intro.md'
 import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
-import YesPlugins from '/docs/snippets/breaking-change-affecting-plugins.md'
-import NoCodemods from '/docs/snippets/breaking-change-not-handled-by-codemod.md'
 
 # The admin panel RBAC system has been updated
 
 In Strapi 5, the `content-manager_rbacManager`, which is a section of Strapi's redux store for the admin panel, is removed and the regular permissions system is used instead. Additionally, the `useRBAC` hook is updated.
 
 <Intro/>
-<YesPlugins/>
-<NoCodemods />
+<BreakingChangeIdCard plugins />
 
 ## Breaking change description
 

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/attributes-and-content-types-names-reserved.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/attributes-and-content-types-names-reserved.md
@@ -12,17 +12,13 @@ tags:
 
 import Intro from '/docs/snippets/breaking-change-page-intro.md'
 import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
-import YesPlugins from '/docs/snippets/breaking-change-affecting-plugins.md'
-import NoCodemods from '/docs/snippets/breaking-change-not-handled-by-codemod.md'
 
 # Some attributes and content types names are reserved
 
 In Strapi 5, some attributes and content types names are reserved, and all fields or content types in Strapi v4 using these reserved names should be renamed before migrating to Strapi 5 to prevent data loss.
 
 <Intro />
-
-<YesPlugins />
-<NoCodemods />
+<BreakingChangeIdCard plugins />
 
 ## Breaking change description
 

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/components-and-dynamic-zones-do-not-return-id.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/components-and-dynamic-zones-do-not-return-id.md
@@ -14,15 +14,13 @@ tags:
 
 import Intro from '/docs/snippets/breaking-change-page-intro.md'
 import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
-import YesPlugins from '/docs/snippets/breaking-change-affecting-plugins.md'
 
 # Components and dynamic zones do not return an `id`
 
 In Strapi 5, components and dynamic zones do not return an `id` with REST API requests so it's not possible to partially update them.
 
 <Intro />
-
-<YesPlugins/>
+<BreakingChangeIdCard plugins/>
 
 ## Breaking change description
 

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/core-service-methods-use-document-service.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/core-service-methods-use-document-service.md
@@ -11,16 +11,13 @@ tags:
 
 import Intro from '/docs/snippets/breaking-change-page-intro.md'
 import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
-import YesPlugins from '/docs/snippets/breaking-change-affecting-plugins.md'
-import NoCodemods from '/docs/snippets/breaking-change-not-handled-by-codemod.md'
 
 # Core service methods use the Document Service API
 
 In Strapi 5, core service methods use the Document Service API instead of the Entity Service API.
 
 <Intro/>
-<YesPlugins />
-<NoCodemods />
+<BreakingChangeIdCard plugins />
 
 ## Breaking change description
 

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/database-columns.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/database-columns.md
@@ -10,16 +10,13 @@ tags:
 
 import Intro from '/docs/snippets/breaking-change-page-intro.md'
 import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
-import YesPlugins from '/docs/snippets/breaking-change-affecting-plugins.md'
-import NoCodemods from '/docs/snippets/breaking-change-not-handled-by-codemod.md'
 
 # Content types always have feature columns
 
 In Strapi 5, Content types always have document, publication and internationalization columns created in database.
 
 <Intro />
-<YesPlugins />
-<NoCodemods />
+<BreakingChangeIdCard plugins />
 
 ## Breaking change description
 

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/database-identifiers-shortened.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/database-identifiers-shortened.md
@@ -16,7 +16,11 @@ import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.
 
 In Strapi 5, database identifiers can't be longer than 55 characters. <Intro />
 
-<BreakingChangeIdCard codemod info="(This breaking change is actually handled by a data migration script that runs when your Strapi project is upgraded to Strapi 5.)"/>
+<BreakingChangeIdCard
+  plugins
+  codemod
+  info="(This breaking change is actually handled by a data migration script that runs when your Strapi project is upgraded to Strapi 5.)"
+/>
 
 ## Breaking change description
 

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/database-identifiers-shortened.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/database-identifiers-shortened.md
@@ -11,17 +11,12 @@ tags:
 
 import Intro from '/docs/snippets/breaking-change-page-intro.md'
 import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
-import NoPlugins from '/docs/snippets/breaking-change-not-affecting-plugins.md'
-import YesCodemods from '/docs/snippets/breaking-change-handled-by-codemod.md'
 
 # Database identifiers shortened in v5
 
 In Strapi 5, database identifiers can't be longer than 55 characters. <Intro />
 
-<NoPlugins />
-<YesCodemods />
-
-(_This breaking change is actually handled by a data migration script that runs when your Strapi project is upgraded to Strapi 5._)
+<BreakingChangeIdCard codemod info="(This breaking change is actually handled by a data migration script that runs when your Strapi project is upgraded to Strapi 5.)"/>
 
 ## Breaking change description
 

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/default-index-removed.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/default-index-removed.md
@@ -11,9 +11,6 @@ tags:
 
 import Intro from '/docs/snippets/breaking-change-page-intro.md'
 import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
-import NoPlugins from '/docs/snippets/breaking-change-not-affecting-plugins.md'
-import NoCodemods from '/docs/snippets/breaking-change-not-handled-by-codemod.md'
-
 
 # `defaultIndex` is removed from the `public` middleware configuration
 
@@ -21,8 +18,7 @@ In Strapi 5, the 'defaultIndex' option does not exist anymore and the root `/` U
 
  <Intro />
 
-<NoPlugins />
-<NoCodemods />
+<BreakingChangeIdCard />
 
 ## Breaking change description
 

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/default-input-validation.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/default-input-validation.md
@@ -12,8 +12,6 @@ tags:
 
 import Intro from '/docs/snippets/breaking-change-page-intro.md'
 import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
-import YesPlugins from '/docs/snippets/breaking-change-affecting-plugins.md'
-import NoCodemods from '/docs/snippets/breaking-change-not-handled-by-codemod.md'
 
 # REST API input is validated by default in controllers
 
@@ -26,9 +24,7 @@ Strapi methods exist both for [sanitization and validation in controllers](/cms/
 In Strapi 5, REST API input is validated by default in controllers, instead of accepting invalid data and sanitizing it silently.
 
 <Intro />
-
-<YesPlugins />
-<NoCodemods />
+<BreakingChangeIdCard plugins />
 
 ## Breaking change description
 

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/edit-view-layout-and-list-view-layout-rewritten.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/edit-view-layout-and-list-view-layout-rewritten.md
@@ -11,17 +11,13 @@ tags:
 
 import Intro from '/docs/snippets/breaking-change-page-intro.md'
 import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
-import YesPlugins from '/docs/snippets/breaking-change-affecting-plugins.md'
-import NoCodemods from '/docs/snippets/breaking-change-not-handled-by-codemod.md'
 
 # The `EditViewLayout` and `ListViewLayout` have been rewritten
 
 In Strapi 5, some admin panel hooks have been removed from the Redux store and a new `useDocumentLayout` hook is introduced.
 
 <Intro />
-
-<YesPlugins />
-<NoCodemods />
+<BreakingChangeIdCard plugins />
 
 ## Breaking change description
 

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/entity-service-deprecated.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/entity-service-deprecated.md
@@ -12,15 +12,17 @@ tags:
 
 import Intro from '/docs/snippets/breaking-change-page-intro.md'
 import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
-import YesPlugins from '/docs/snippets/breaking-change-affecting-plugins.md'
-import PartialCodemods from '/docs/snippets/breaking-change-partially-handled-by-codemod.md'
 
 # Entity Service deprecated
 
 The Entity Service that was used in Strapi v4 is deprecated and replaced by the new [Document Service API](/cms/api/document-service) in Strapi 5. <MigrationIntro/>
 
-<YesPlugins/>
-<PartialCodemods />
+<BreakingChangeIdCard
+  plugins
+  codemodPartly
+  codemodName="entity-service-document-service"
+  codemodLink="https://github.com/strapi/strapi/blob/develop/packages/utils/upgrade/resources/codemods/5.0.0/entity-service-document-service.code.ts"
+/>
 
 ## Breaking change description
 

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/fetch.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/fetch.md
@@ -11,16 +11,13 @@ tags:
 
 import Intro from '/docs/snippets/breaking-change-page-intro.md'
 import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
-import YesPlugins from '/docs/snippets/breaking-change-affecting-plugins.md'
-import NoCodemods from '/docs/snippets/breaking-change-not-handled-by-codemod.md'
 
 # `strapi.fetch` uses the native `fetch()` API
 
 In Strapi 5, the `strapi.fetch` object is now wrapping node Fetch API instead of node-fetch.
 
 <Intro />
-<YesPlugins />
-<NoCodemods />
+<BreakingChangeIdCard plugins />
 
 ## Breaking change description
 

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/get-where-removed.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/get-where-removed.md
@@ -11,16 +11,13 @@ tags:
 
 import Intro from '/docs/snippets/breaking-change-page-intro.md'
 import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
-import YesPlugins from '/docs/snippets/breaking-change-affecting-plugins.md'
-import NoCodemods from '/docs/snippets/breaking-change-not-handled-by-codemod.md'
 
 # The `getWhere()` method for permission provider instances has been removed
 
 In Strapi 5, the `getWhere()` method for permission provider instances has been removed, and users should first get the provider values, then filter them.
 
 <Intro />
-<YesPlugins />
-<NoCodemods />
+<BreakingChangeIdCard plugins />
 
 ## Breaking change description
 

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/graphql-api-updated.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/graphql-api-updated.md
@@ -12,17 +12,13 @@ tags:
 
 import Intro from '/docs/snippets/breaking-change-page-intro.md'
 import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
-import YesPlugins from '/docs/snippets/breaking-change-affecting-plugins.md'
-import NoCodemods from '/docs/snippets/breaking-change-not-handled-by-codemod.md'
 
 # The GraphQL API has been updated
 
 In Strapi 5, the GraphQL API has been updated. It handles the new, flattened response format (see [related breaking change](/cms/migration/v4-to-v5/breaking-changes/new-response-format.md)), and can also now accept [Relay-style](https://www.apollographql.com/docs/technotes/TN0029-relay-style-connections/) queries.
 
 <Intro />
-
-<YesPlugins />
-<NoCodemods />
+<BreakingChangeIdCard plugins />
 
 ## List of changes
 

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/helper-plugin-deprecated.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/helper-plugin-deprecated.md
@@ -11,8 +11,6 @@ tags:
 
 import Intro from '/docs/snippets/breaking-change-page-intro.md'
 import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
-import YesPlugins from '/docs/snippets/breaking-change-affecting-plugins.md'
-import PartialCodemods from '/docs/snippets/breaking-change-partially-handled-by-codemod.md'
 
 # `helper-plugin` deprecated
 
@@ -20,8 +18,12 @@ In Strapi 5, the `helper-plugin` is removed. A whole migration reference is avai
 
  <Intro />
 
-<YesPlugins />
-<PartialCodemods />
+<BreakingChangeIdCard
+  plugins
+  codemodPartly
+  codemodName="deprecate-helper-plugin"
+  codemodLink="https://github.com/strapi/strapi/blob/develop/packages/utils/upgrade/resources/codemods/5.0.0/deprecate-helper-plugin.code.ts"
+/>
 
 ## Breaking change description
 

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/i18n-content-manager-locale.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/i18n-content-manager-locale.md
@@ -11,15 +11,16 @@ tags:
 
 import Intro from '/docs/snippets/breaking-change-page-intro.md'
 import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
-import YesPlugins from '/docs/snippets/breaking-change-affecting-plugins.md'
-import YesCodemods from '/docs/snippets/breaking-change-handled-by-codemod.md'
 
 Internationalization (i18n) is now part of the Strapi core and no longer a plugin, and this impacts how some parameters are sent and accessed. This also means you should not use or depend on the old `@strapi/plugin-i18n` package in your project, it is now natively included.
 
  <Intro />
 
-<YesPlugins />
-<YesCodemods />
+<BreakingChangeIdCard
+  plugins
+  codemodLink="https://github.com/strapi/strapi/blob/develop/packages/utils/upgrade/resources/codemods/5.0.0/dependency-remove-strapi-plugin-i18n.json.ts"
+  codemodName="dependency-remove-strapi-plugin-i18n"
+/>
 
 ## Breaking change description
 

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/inject-content-manager-component.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/inject-content-manager-component.md
@@ -12,17 +12,13 @@ tags:
 
 import Intro from '/docs/snippets/breaking-change-page-intro.md'
 import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
-import YesPlugins from '/docs/snippets/breaking-change-affecting-plugins.md'
-import NoCodemods from '/docs/snippets/breaking-change-not-handled-by-codemod.md'
 
 # `injectContentManagerComponent()` removed
 
 In Strapi 5, the `injectContentManagerComponent` method is removed because the Content Manager is now a plugin. The [Admin Panel API](/cms/plugins-development/admin-panel-api#injecting-components) method is replaced by `getPlugin('content-manager').injectComponent()`.
 
 <Intro />
-
-<YesPlugins />
-<NoCodemods />
+<BreakingChangeIdCard plugins />
 
 ## Breaking change description
 

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/is-supported-image-removed.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/is-supported-image-removed.md
@@ -11,17 +11,13 @@ tags:
 
 import Intro from '/docs/snippets/breaking-change-page-intro.md'
 import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
-import YesPlugins from '/docs/snippets/breaking-change-affecting-plugins.md'
-import NoCodemods from '/docs/snippets/breaking-change-not-handled-by-codemod.md'
 
 # The `isSupportedImage` method is removed
 
 The `isSupportedImage` method has been issuing a deprecation warning ever since v4, and is finally being removed in Strapi 5.
 
  <Intro />
-
-<YesPlugins />
-<NoCodemods />
+<BreakingChangeIdCard plugins />
 
 ## Breaking change description
 

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/koa-body-v6.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/koa-body-v6.md
@@ -13,8 +13,6 @@ tags:
 
 import Intro from '/docs/snippets/breaking-change-page-intro.md'
 import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
-import YesPlugins from '/docs/snippets/breaking-change-affecting-plugins.md'
-import NoCodemods from '/docs/snippets/breaking-change-not-handled-by-codemod.md'
 
 # Strapi 5 uses `koa-body` v6
 
@@ -22,8 +20,7 @@ Strapi 5 uses [`koa-body`](https://github.com/koajs/koa-body) v6, which updates 
 
  <Intro />
 
-<YesPlugins />
-<NoCodemods />
+<BreakingChangeIdCard plugins />
 
 ## Breaking change description
 

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/license-only.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/license-only.md
@@ -12,8 +12,6 @@ tags:
 
 import Intro from '/docs/snippets/breaking-change-page-intro.md'
 import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
-import YesPlugins from '/docs/snippets/breaking-change-affecting-plugins.md'
-import NoCodemods from '/docs/snippets/breaking-change-not-handled-by-codemod.md'
 
 # `lockIcon` property replaced by `licenseOnly`
 
@@ -22,9 +20,7 @@ Strapi 5 adds a new `licenseOnly` boolean property to pass in the `addMenuLink`,
 A similar result can be achieved in Strapi v4 by adding the `lockIcon` property.
 
 <Intro />
-
-<YesPlugins />
-<NoCodemods />
+<BreakingChangeIdCard plugins />
 
 ## Breaking change description
 

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/lifecycle-hooks-document-service.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/lifecycle-hooks-document-service.md
@@ -12,8 +12,6 @@ tags:
 
 import Intro from '/docs/snippets/breaking-change-page-intro.md'
 import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
-import YesPlugins from '/docs/snippets/breaking-change-affecting-plugins.md'
-import NoCodemods from '/docs/snippets/breaking-change-not-handled-by-codemod.md'
 
 # Database lifecycle hooks are triggered differently with the Document Service API methods
 
@@ -24,9 +22,7 @@ The majority of use cases should only use the Document Service. The Document Ser
 However, the Document Service API might not suit all your use cases; the database layer is therefore exposed allowing you to do anything on the database without any restriction. Users would then need to resort to the database lifecycle hooks as a system to extend the database behaviour.
 
 <Intro />
-
-<YesPlugins />
-<NoCodemods />
+<BreakingChangeIdCard plugins />
 
 ## Breaking change description
 

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/mailgun-provider-variables.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/mailgun-provider-variables.md
@@ -12,17 +12,13 @@ tags:
 
 import Intro from '/docs/snippets/breaking-change-page-intro.md'
 import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
-import YesPlugins from '/docs/snippets/breaking-change-affecting-plugins.md'
-import NoCodemods from '/docs/snippets/breaking-change-not-handled-by-codemod.md'
 
 # Some Mailgun provider legacy variables are not supported
 
 In Strapi 5, the support is dropped for some legacy variables deprecated in Strapi v4 for the Mailgun provider.
 
 <Intro />
-
-<YesPlugins />
-<NoCodemods />
+<BreakingChangeIdCard plugins />
 
 ## Breaking change description
 

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/model-config-path-uses-uid.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/model-config-path-uses-uid.md
@@ -11,16 +11,19 @@ tags:
 
 import Intro from '/docs/snippets/breaking-change-page-intro.md'
 import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
-import YesPlugins from '/docs/snippets/breaking-change-affecting-plugins.md'
-import PartialCodemods from '/docs/snippets/breaking-change-partially-handled-by-codemod.md'
 
 # Model config path uses uid instead of dot notation
 
 In Strapi 5, to retrieve config values you will need to use `config.get('plugin::upload.myconfigval')` or `config.get('api::myapi.myconfigval')`
 
 <Intro />
-<YesPlugins />
-<PartialCodemods />
+
+<BreakingChangeIdCard
+  plugins
+  codemodPartly
+  codemodName="use-uid-for-config-namespace"
+  codemodLink="https://github.com/strapi/strapi/blob/develop/packages/utils/upgrade/resources/codemods/5.0.0/use-uid-for-config-namespace.code.ts"
+/>
 
 ## Breaking change description
 

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/mysql5-unsupported.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/mysql5-unsupported.md
@@ -11,15 +11,13 @@ tags:
 
 import Intro from '/docs/snippets/breaking-change-page-intro.md'
 import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
-import NoPlugins from '/docs/snippets/breaking-change-not-affecting-plugins.md'
-import NoCodemods from '/docs/snippets/breaking-change-not-handled-by-codemod.md'
 
 # MySQL v5 is not supported in Strapi v5 anymore
 
 In Strapi 5, MySQL version 5 is not supported.
 <Intro />
-<NoPlugins />
-<NoCodemods />
+
+<BreakingChangeIdCard />
 
 ## Breaking change description
 

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/new-response-format.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/new-response-format.md
@@ -13,17 +13,13 @@ tags:
 
 import Intro from '/docs/snippets/breaking-change-page-intro.md'
 import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
-import YesPlugins from '/docs/snippets/breaking-change-affecting-plugins.md'
-import NoCodemods from '/docs/snippets/breaking-change-not-handled-by-codemod.md'
 
 # Strapi 5 has a new, flattened response format for REST API calls
 
 In Strapi 5, the REST API response format has been simplified and flattened. You can set the `Strapi-Response-Format: v4` header to use the old v4 format while you convert your code to fully take into account the new Strapi 5 response format.
 
 <Intro />
-
-<YesPlugins />
-<NoCodemods />
+<BreakingChangeIdCard plugins />
 
 ## Breaking change description
 

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/no-find-page-in-document-service.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/no-find-page-in-document-service.md
@@ -11,16 +11,13 @@ tags:
 
 import Intro from '/docs/snippets/breaking-change-page-intro.md'
 import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
-import YesPlugins from '/docs/snippets/breaking-change-affecting-plugins.md'
-import NoCodemods from '/docs/snippets/breaking-change-not-handled-by-codemod.md'
 
 # No `findPage()` in Document Service API
 
 In Strapi 5, the [Document Service API](/cms/api/document-service) replaces the Entity Service API. There is no `findPage()` method available in the Document Service API and users should use the `findMany()` method instead.
 
 <Intro />
-<YesPlugins />
-<NoCodemods />
+<BreakingChangeIdCard plugins />
 
 ## Breaking change description
 

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/no-locale-all.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/no-locale-all.md
@@ -14,16 +14,12 @@ tags:
 
 import Intro from '/docs/snippets/breaking-change-page-intro.md'
 import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
-import YesPlugins from '/docs/snippets/breaking-change-affecting-plugins.md'
-import NoCodemods from '/docs/snippets/breaking-change-not-handled-by-codemod.md'
 
 # `locale=all` can not be used to get all entries in all locales
 
 In Strapi 5, it's no longer possible to get all localized versions of a content type with the `locale=all` parameter.
 
 <Intro />
-
-<YesPlugins /><NoCodemods />
 <BreakingChangeIdCard plugins />
 
 ## Breaking change description

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/no-locale-all.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/no-locale-all.md
@@ -23,8 +23,8 @@ In Strapi 5, it's no longer possible to get all localized versions of a content 
 
 <Intro />
 
-<YesPlugins />
-<NoCodemods />
+<YesPlugins /><NoCodemods />
+<BreakingChangeIdCard plugins />
 
 ## Breaking change description
 

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/no-shared-population-strategy-components-dynamic-zones.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/no-shared-population-strategy-components-dynamic-zones.md
@@ -13,17 +13,13 @@ tags:
 
 import Intro from '/docs/snippets/breaking-change-page-intro.md'
 import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
-import YesPlugins from '/docs/snippets/breaking-change-affecting-plugins.md'
-import NoCodemods from '/docs/snippets/breaking-change-not-handled-by-codemod.md'
 
 # Components and dynamic zones should be populated using the detailed population strategy (`on` fragments)
 
 In Strapi 5, components and dynamic zones should be populated using the detailed population strategy, with `on` fragments. The shared population strategy possible in Strapi v4 is no longer supported.
 
 <Intro />
-
-<YesPlugins />
-<NoCodemods />
+<BreakingChangeIdCard plugins />
 
 ## Breaking change description
 

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/no-upload-at-entry-creation.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/no-upload-at-entry-creation.md
@@ -10,16 +10,13 @@ tags:
 
 import Intro from '/docs/snippets/breaking-change-page-intro.md'
 import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
-import NoPlugins from '/docs/snippets/breaking-change-affecting-plugins.md'
-import YesCodemods from '/docs/snippets/breaking-change-not-handled-by-codemod.md'
 
 # Upload a file at entry creation is no longer supported
 
 In Strapi 5, it is not possible to upload a file while creating an entry, so this should be done in 2 steps.
 
 <Intro />
-<NoPlugins />
-<YesCodemods />
+<BreakingChangeIdCard plugins />
 
 ## Breaking change description
 

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/only-better-sqlite3-for-sqlite.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/only-better-sqlite3-for-sqlite.md
@@ -3,7 +3,6 @@ title: Only the `better-sqlite3` package is supported for the SQLite client
 description: In Strapi 5, users can only use the `better-sqlite3` package for SQLite databases, and the `client` value for it must be set to `sqlite`.
 sidebar_label: Only better-sqlite3 for sqlite 
 displayed_sidebar: cmsSidebar
-unlisted: true
 tags:
  - breaking changes
  - database
@@ -13,16 +12,17 @@ tags:
 
 import Intro from '/docs/snippets/breaking-change-page-intro.md'
 import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
-import NoPlugins from '/docs/snippets/breaking-change-not-affecting-plugins.md'
-import YesCodemods from '/docs/snippets/breaking-change-handled-by-codemod.md'
 
 # Only the `better-sqlite3` package is supported for the SQLite client
 
 Strapi 5 can only use the `better-sqlite3` package for SQLite databases, and the `client` value for it must be set to `sqlite`.
 
 <Intro />
-<NoPlugins/>
-<YesCodemods />
+
+<BreakingChangeIdCard
+  codemodName="sqlite3-to-better-sqlite3"
+  codemodLink="https://github.com/strapi/strapi/blob/develop/packages/utils/upgrade/resources/codemods/5.0.0/sqlite3-to-better-sqlite3.json.ts"
+/>
 
 ## Breaking change description
 

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/only-mysql2-package-for-mysql.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/only-mysql2-package-for-mysql.md
@@ -21,8 +21,9 @@ import YesCodemods from '/docs/snippets/breaking-change-handled-by-codemod.md'
 Strapi 5 can only use the `mysql2` package for MySQL databases, and the `client` value for it must be set to `mysql`.
 
 <Intro />
-<NoPlugins/>
-<YesCodemods />
+<BreakingChangeIdCard
+  codemod
+/>
 
 ## Breaking change description
 

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/only-mysql2-package-for-mysql.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/only-mysql2-package-for-mysql.md
@@ -13,17 +13,13 @@ tags:
 
 import Intro from '/docs/snippets/breaking-change-page-intro.md'
 import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
-import NoPlugins from '/docs/snippets/breaking-change-not-affecting-plugins.md'
-import YesCodemods from '/docs/snippets/breaking-change-handled-by-codemod.md'
 
 # Only the `mysql2` package is supported for the MySQL client
 
 Strapi 5 can only use the `mysql2` package for MySQL databases, and the `client` value for it must be set to `mysql`.
 
 <Intro />
-<BreakingChangeIdCard
-  codemod
-/>
+<BreakingChangeIdCard codemod />
 
 ## Breaking change description
 

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/publication-state-removed.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/publication-state-removed.md
@@ -14,8 +14,6 @@ tags:
 
 import Intro from '/docs/snippets/breaking-change-page-intro.md'
 import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
-import YesPlugins from '/docs/snippets/breaking-change-affecting-plugins.md'
-import YesCodemods from '/docs/snippets/breaking-change-handled-by-codemod.md'
 
 # `publicationState` is removed and replaced by `status`
 
@@ -23,8 +21,11 @@ In Strapi 5, the [Draft & Publish feature](/cms/features/draft-and-publish) has 
 
 <Intro />
 
-<YesPlugins />
-<YesCodemods />
+<BreakingChangeIdCard
+  plugins
+  codemodName="entity-service-document-service"
+  codemodLink="https://github.com/strapi/strapi/blob/develop/packages/utils/upgrade/resources/codemods/5.0.0/entity-service-document-service.code.ts"
+/>
 
 ## Breaking change description
 

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/publishedat-always-set-when-dandp-disabled.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/publishedat-always-set-when-dandp-disabled.md
@@ -16,6 +16,7 @@ import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.
 
 In Strapi 5, content-types with Draft & Publish disabled always have the publishedAt value set to a date.
 <Intro />
+<BreakingChangeIdCard plugins />
 
 ## Breaking change description
 

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/react-router-dom-6.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/react-router-dom-6.md
@@ -12,8 +12,6 @@ tags:
 
 import Intro from '/docs/snippets/breaking-change-page-intro.md'
 import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
-import YesPlugins from '/docs/snippets/breaking-change-affecting-plugins.md'
-import YesCodemods from '/docs/snippets/breaking-change-handled-by-codemod.md'
 
 # Strapi users `react-router-dom` v6
 
@@ -21,8 +19,11 @@ Strapi 5 uses [`react-router-dom`](https://www.npmjs.com/package/react-router-do
 
  <Intro />
 
-<YesPlugins />
-<YesCodemods />
+<BreakingChangeIdCard
+  plugins
+  codemodLink="https://github.com/strapi/strapi/blob/develop/packages/utils/upgrade/resources/codemods/5.0.0/dependency-upgrade-react-router-dom.json.ts"
+  codemodName="dependency-upgrade-react-router-dom"
+/>
 
 ## Breaking change description
 

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/redux-content-manager-app-state.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/redux-content-manager-app-state.md
@@ -12,16 +12,13 @@ tags:
 
 import Intro from '/docs/snippets/breaking-change-page-intro.md'
 import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
-import YesPlugins from '/docs/snippets/breaking-change-affecting-plugins.md'
-import NoCodemods from '/docs/snippets/breaking-change-not-handled-by-codemod.md'
 
 # The ContentManagerAppState redux is modified
 
 In Strapi 5, the redux store for the Content Manager has been changed and some redux actions were removed. Notably, the `useContentManagerInitData` redux state for the Content Manager has been refactored to remove `ModelsContext`. Users might be relying on the original structure in a middleware or subscriber; doing so this will break their application.
 
 <Intro />
-<YesPlugins />
-<NoCodemods />
+<BreakingChangeIdCard plugins />
 
 ## Breaking change description
 

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/register-allowed-fields.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/register-allowed-fields.md
@@ -11,17 +11,17 @@ tags:
 
 import Intro from '/docs/snippets/breaking-change-page-intro.md'
 import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
-import NoPlugins from '/docs/snippets/breaking-change-not-affecting-plugins.md'
-import YesCodemods from '/docs/snippets/breaking-change-handled-by-codemod.md'
-
 
 # The Users & Permissions plugin's `register.allowedFields` configuration option defaults to `[]`
 
 In Strapi 5, the Users & Permissions plugin's `register.allowedFields` configuration option defaults to `[]`.
 
 <Intro />
-<NoPlugins />
-<YesCodemods />
+
+<BreakingChangeIdCard
+  codemodName="use-uid-for-config-namespace"
+  codemodLink="https://github.com/strapi/strapi/blob/develop/packages/utils/upgrade/resources/codemods/5.0.0/use-uid-for-config-namespace.code.ts"
+/>
 
 ## Breaking change description
 

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/remove-webhook-populate-relations.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/remove-webhook-populate-relations.md
@@ -11,16 +11,13 @@ tags:
 
 import Intro from '/docs/snippets/breaking-change-page-intro.md'
 import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
-import YesPlugins from '/docs/snippets/breaking-change-affecting-plugins.md'
-import NoCodemods from '/docs/snippets/breaking-change-not-handled-by-codemod.md'
 
 # The `webhooks.populateRelations` server configuration is removed
 
 In Strapi 5, webhooks have been refactored and the `webhook.populateRelations` option will become redundant. This might affect lifecycles expecting the returned relations of create, update and delete to be populated.
 
 <Intro />
-<YesPlugins />
-<NoCodemods />
+<BreakingChangeIdCard plugins />
 
 ## Breaking change description
 

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/removed-support-for-some-env-options.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/removed-support-for-some-env-options.md
@@ -12,16 +12,12 @@ tags:
 
 import Intro from '/docs/snippets/breaking-change-page-intro.md'
 import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
-import NoPlugins from '/docs/snippets/breaking-change-not-affecting-plugins.md'
-import NoCodemods from '/docs/snippets/breaking-change-not-handled-by-codemod.md'
-
 
 # Some `env`-only configuration options are handled by the server configuration
 
 In Strapi 5, some configuration options that were only handled by environment variables in Strapi v4 are now handled in the [server configuration](/cms/configurations/server) file.
 <Intro />
-<NoPlugins />
-<NoCodemods />
+<BreakingChangeIdCard />
 
 ## Breaking change description
 

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/server-default-log-level.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/server-default-log-level.md
@@ -11,16 +11,13 @@ tags:
 
 import Intro from '/docs/snippets/breaking-change-page-intro.md'
 import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
-import NoPlugins from '/docs/snippets/breaking-change-not-affecting-plugins.md'
-import NoCodemods from '/docs/snippets/breaking-change-not-handled-by-codemod.md'
 
 # Server log level is `http`
 
 You can adjust the server log level in the configuration to control how much detail you see in your server logs. If you want to see more or less verbose logs in your server logs, this feature allows you to customize it according to your needs.
 
 <Intro />
-<NoPlugins />
-<NoCodemods />
+<BreakingChangeIdCard />
 
 ## Breaking change description
 

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/server-proxy.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/server-proxy.md
@@ -11,16 +11,13 @@ tags:
 
 import Intro from '/docs/snippets/breaking-change-page-intro.md'
 import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
-import NoPlugins from '/docs/snippets/breaking-change-not-affecting-plugins.md'
-import NoCodemods from '/docs/snippets/breaking-change-not-handled-by-codemod.md'
 
 #  Server proxy configurations are grouped under the `server.proxy` object
 
 In Strapi 5, all proxy configuration options are now configured through the `server.proxy` object in `/config/server.js|ts`, whether they are for requests made within `strapi.fetch` or for the global proxy agent for the [koa](https://koajs.com/) server.
 
 <Intro />
-<NoPlugins />
-<NoCodemods />
+<BreakingChangeIdCard />
 
 ## Breaking change description
 

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/sort-by-id.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/sort-by-id.md
@@ -11,16 +11,18 @@ tags:
 
 import Intro from '/docs/snippets/breaking-change-page-intro.md'
 import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
-import YesPlugins from '/docs/snippets/breaking-change-affecting-plugins.md'
-import YesCodemods from '/docs/snippets/breaking-change-handled-by-codemod.md'
 
 # Sorting by `id` is no longer possible to sort by chronological order in Strapi 5
 
 In Strapi 5, sorting by `id` to sort by chronological order is no longer possible since [documents](/cms/api/document) use an uuid.
 
 <Intro />
-<YesPlugins />
-<YesCodemods />
+
+<BreakingChangeIdCard
+  plugins
+  codemodName="entity-service-document-service"
+  codemodLink="https://github.com/strapi/strapi/blob/develop/packages/utils/upgrade/resources/codemods/5.0.0/entity-service-document-service.code.ts"
+/>
 
 ## Breaking change description
 

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/strapi-container.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/strapi-container.md
@@ -11,15 +11,12 @@ tags:
 
 import Intro from '/docs/snippets/breaking-change-page-intro.md'
 import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
-import YesPlugins from '/docs/snippets/breaking-change-affecting-plugins.md'
-import NoCodemods from '/docs/snippets/breaking-change-not-handled-by-codemod.md'
 
 # `Strapi` is a subclass of `Container`
 
 In Strapi 5, `Strapi` is a subclass of the `Container` class to make it simpler to access services and unify the service access with one method.
 
 <Intro />
-<YesPlugins /><NoCodemods />
 <BreakingChangeIdCard plugins />
 
 ## Breaking change description

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/strapi-container.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/strapi-container.md
@@ -19,8 +19,8 @@ import NoCodemods from '/docs/snippets/breaking-change-not-handled-by-codemod.md
 In Strapi 5, `Strapi` is a subclass of the `Container` class to make it simpler to access services and unify the service access with one method.
 
 <Intro />
-<YesPlugins />
-<NoCodemods />
+<YesPlugins /><NoCodemods />
+<BreakingChangeIdCard plugins />
 
 ## Breaking change description
 

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/strapi-imports.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/strapi-imports.md
@@ -12,16 +12,19 @@ tags:
 
 import Intro from '/docs/snippets/breaking-change-page-intro.md'
 import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
-import YesPlugins from '/docs/snippets/breaking-change-affecting-plugins.md'
-import PartialCodemods from '/docs/snippets/breaking-change-partially-handled-by-codemod.md'
 
 # Strapi factories import have been updated
 
 In Strapi 5, strapi factories import have been updated.
 
 <Intro />
-<YesPlugins />
-<PartialCodemods />
+
+<BreakingChangeIdCard
+  plugins
+  codemodPartly
+  codemodName="strapi-public-interface"
+  codemodLink="https://github.com/strapi/strapi/blob/develop/packages/utils/upgrade/resources/codemods/5.0.0/strapi-public-interface.code.ts"
+/>
 
 ## Breaking change description
 

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/strapi-utils-refactored.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/strapi-utils-refactored.md
@@ -11,8 +11,6 @@ tags:
 
 import Intro from '/docs/snippets/breaking-change-page-intro.md'
 import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
-import YesPlugins from '/docs/snippets/breaking-change-affecting-plugins.md'
-import YesCodemods from '/docs/snippets/breaking-change-handled-by-codemod.md'
 
 # `strapi-utils` refactored
 
@@ -20,8 +18,11 @@ In Strapi 5, the `strapi-utils` core package has been refactored. This page list
 
 <Intro />
 
-<YesPlugins />
-<YesCodemods />
+<BreakingChangeIdCard
+  plugins
+  codemodLink="https://github.com/strapi/strapi/blob/develop/packages/utils/upgrade/resources/codemods/5.0.0/utils-public-interface.code.ts"
+  codemodName="utils-public-interface"
+/>
 
 ## List of changes
 

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/strict-requirements-config-files.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/strict-requirements-config-files.md
@@ -10,15 +10,12 @@ tags:
 
 import Intro from '/docs/snippets/breaking-change-page-intro.md'
 import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
-import NoPlugins from '/docs/snippets/breaking-change-not-affecting-plugins.md'
-import NoCodemods from '/docs/snippets/breaking-change-not-handled-by-codemod.md'
 
 # Strict requirements for configuration files
 
 Strapi 5 has strict requirements on the configuration filenames allowed to be loaded.
 <Intro />
-<NoPlugins />
-<NoCodemods />
+<BreakingChangeIdCard />
 
 ## Breaking change description
 

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/templates.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/templates.md
@@ -10,14 +10,11 @@ tags:
 
 import Intro from '/docs/snippets/breaking-change-page-intro.md'
 import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
-import NoPlugins from '/docs/snippets/breaking-change-not-affecting-plugins.md'
-import NoCodemods from '/docs/snippets/breaking-change-not-handled-by-codemod.md'
 
 # Templates are now standalone, regular Strapi applications
 
 Templates have been fully rewritten in Strapi 5 and now are standalone, regular Strapi applications, making it easier to create, distribute, and reuse them.
 <Intro />
-<NoPlugins /><NoCodemods />
 <BreakingChangeIdCard />
 
 ## Breaking change description

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/templates.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/templates.md
@@ -17,8 +17,8 @@ import NoCodemods from '/docs/snippets/breaking-change-not-handled-by-codemod.md
 
 Templates have been fully rewritten in Strapi 5 and now are standalone, regular Strapi applications, making it easier to create, distribute, and reuse them.
 <Intro />
-<NoPlugins />
-<NoCodemods />
+<NoPlugins /><NoCodemods />
+<BreakingChangeIdCard />
 
 ## Breaking change description
 

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/upgrade-to-apollov4.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/upgrade-to-apollov4.md
@@ -15,16 +15,13 @@ tags:
 import FeedbackCallout from '/docs/snippets/backend-customization-feedback-cta.md'
 import Intro from '/docs/snippets/breaking-change-page-intro.md'
 import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
-import YesPlugins from '/docs/snippets/breaking-change-affecting-plugins.md'
-import NoCodemods from '/docs/snippets/breaking-change-not-handled-by-codemod.md'
 
 # Apollo Server v3 upgraded to Apollo Server v4
 
 Strapi 5 has migrated to Apollo Server v4 and this might require some manual migration steps.
 
 <Intro />
-<YesPlugins />
-<NoCodemods />
+<BreakingChangeIdCard plugins />
 
 ## Breaking change description
 

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/use-document-id.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/use-document-id.md
@@ -12,8 +12,6 @@ tags:
 
 import Intro from '/docs/snippets/breaking-change-page-intro.md'
 import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
-import YesPlugins from '/docs/snippets/breaking-change-affecting-plugins.md'
-import PartialCodemods from '/docs/snippets/breaking-change-partially-handled-by-codemod.md'
 
 # `documentId` should be used instead of `id` in Content API calls
 
@@ -21,8 +19,12 @@ In Strapi 5, the underlying API handling content is the [Document Service API](/
 
 <Intro />
 
-<YesPlugins />
-<PartialCodemods />
+<BreakingChangeIdCard
+  plugins
+  codemodPartly
+  codemodName="entity-service-document-service"
+  codemodLink="https://github.com/strapi/strapi/blob/develop/packages/utils/upgrade/resources/codemods/5.0.0/entity-service-document-service.code.ts"
+/>
 
 ## Breaking change description
 

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/use-document-id.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/use-document-id.md
@@ -93,6 +93,8 @@ Documents are identified by their `documentId`:
 
 ## Migration
 
+<MigrationIntro />
+
 ### Notes
 
 - This breaking change impacts routes and relations.

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/vite.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/vite.md
@@ -12,16 +12,13 @@ tags:
 
 import Intro from '/docs/snippets/breaking-change-page-intro.md'
 import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
-import YesPlugins from '/docs/snippets/breaking-change-affecting-plugins.md'
-import NoCodemods from '/docs/snippets/breaking-change-not-handled-by-codemod.md'
 
 # Vite is the default bundler in Strapi 5
 
 In Strapi 5, Vite is the default bundler.
 
 <Intro />
-<YesPlugins />
-<NoCodemods />
+<BreakingChangeIdCard plugins />
 
 ## Breaking change description
 

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/webpack-aliases-removed.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/webpack-aliases-removed.md
@@ -13,16 +13,13 @@ tags:
 
 import Intro from '/docs/snippets/breaking-change-page-intro.md'
 import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
-import NoCodemods from '/docs/snippets/breaking-change-not-handled-by-codemod.md'
-import YesPlugins from '/docs/snippets/breaking-change-affecting-plugins.md'
 
 # Webpack Aliases are removed
 
 In Strapi v5, webpack aliases are removed ensuring better compatibility and reduced dependency conflicts.
 
 <Intro />
-<YesPlugins />
-<NoCodemods />
+<BreakingChangeIdCard plugins />
 
 ## Breaking change description
 

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/yarn-not-default.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/yarn-not-default.md
@@ -11,16 +11,13 @@ tags:
 
 import Intro from '/docs/snippets/breaking-change-page-intro.md'
 import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
-import NoCodemods from '/docs/snippets/breaking-change-not-handled-by-codemod.md'
-import NoPlugins from '/docs/snippets/breaking-change-not-affecting-plugins.md'
 
 # The CLI default package manager is not yarn anymore
 
 In Strapi v5, the command used to run dependencies installation is the one used to actually install them.
 
 <Intro />
-<NoPlugins />
-<NoCodemods />
+<BreakingChangeIdCard />
 
 ## Breaking change description
 

--- a/docusaurus/docs/snippets/breaking-change-affecting-plugins.md
+++ b/docusaurus/docs/snippets/breaking-change-affecting-plugins.md
@@ -1,2 +1,0 @@
-| <span style={{fontWeight: '700'}}>🔌 Is this breaking change affecting plugins?</span> | <span style={{color:'red'}}>Yes</span> |
-|--|--|

--- a/docusaurus/docs/snippets/breaking-change-handled-by-codemod.md
+++ b/docusaurus/docs/snippets/breaking-change-handled-by-codemod.md
@@ -1,2 +1,0 @@
-| <span style={{fontWeight: '700'}}>🤖 Is this breaking change automatically handled by a codemod?</span> | <span style={{color:'green'}}>Yes</span> |
-|--|--|

--- a/docusaurus/docs/snippets/breaking-change-not-affecting-plugins.md
+++ b/docusaurus/docs/snippets/breaking-change-not-affecting-plugins.md
@@ -1,2 +1,0 @@
-| <span style={{fontWeight: '700'}}>🔌 Is this breaking change affecting plugins?</span> | <span style={{fontWeight: '500', color:'green'}}>No</span> |
-|--|--|

--- a/docusaurus/docs/snippets/breaking-change-not-handled-by-codemod.md
+++ b/docusaurus/docs/snippets/breaking-change-not-handled-by-codemod.md
@@ -1,2 +1,0 @@
-| <span style={{fontWeight: '700'}}>🤖 Is this breaking change automatically handled by a codemod?</span> | <span style={{color:'red'}}>No</span> |
-|--|--|

--- a/docusaurus/docs/snippets/breaking-change-partially-handled-by-codemod.md
+++ b/docusaurus/docs/snippets/breaking-change-partially-handled-by-codemod.md
@@ -1,2 +1,0 @@
-| <span style={{fontWeight: '700'}}>🤖 Is this breaking change automatically handled by a codemod?</span> | <span style={{color:'#ff6c00'}}>Partly</span> |
-|--|--|

--- a/docusaurus/src/components/BreakingChangeIdCard.js
+++ b/docusaurus/src/components/BreakingChangeIdCard.js
@@ -1,0 +1,64 @@
+import React from 'react';
+import Icon from './Icon';
+import { ExternalLink } from './ExternalLink';
+
+export default function BreakingChangeIdCard({
+  plugins = false,
+  codemod = false, // used when we don't have a link to the codemod code
+  codemodPartly = false,
+  codemodName = false,
+  codemodLink = null,
+  info = null,
+}) {
+
+  return (
+    <div className="breaking-change-id-card">
+      <div className="breaking-change-question">
+        <Icon name="plug" />
+        <span className="breaking-change-question__label">
+          &nbsp;Is this breaking change affecting plugins?
+        </span>
+        {plugins
+          ? <span className="breaking-change-question__answer breaking-change-question__answer--negative">Yes</span>
+          : <span className="breaking-change-question__answer breaking-change-question__answer--positive">No</span>}
+      </div>
+      <div className="breaking-change-question">
+        <Icon name="robot" />
+        <span className="breaking-change-question__label">
+          &nbsp;Is this breaking change automatically handled by a codemod?
+        </span>
+        {(codemod || codemodName) && !codemodPartly ? (
+          <span className="breaking-change-question__answer breaking-change-question__answer--positive">
+            Yes
+          </span>
+        ) : codemodPartly ? (
+          <span className="breaking-change-question__answer breaking-change-question__answer--neutral">
+            Partly
+          </span>
+        ) : (
+          <span className="breaking-change-question__answer breaking-change-question__answer--negative">
+            No
+          </span>
+        )}
+      </div>
+
+      {(codemodLink && codemodLink.length > 0 && codemodName) &&
+        <span className="breaking-change-codemod-link">
+          (see&nbsp;<ExternalLink to={codemodLink} text={codemodName} />)
+        </span>}
+
+      {(codemodName && codemodName.length > 0 && !codemodLink) &&
+        <span className="breaking-change-codemod-link">
+          (see&nbsp;<code>{codemodName}</code>)
+        </span>}
+
+      {(!codemodName && codemodLink && codemodLink.length > 0) &&
+        <span className="breaking-change-codemod-link">
+          (see&nbsp;<ExternalLink to={codemodLink} text="the codemod's code" />)
+        </span>}
+
+      {info && <div className="breaking-change__info"><em>{info}</em></div>}
+    </div>
+  );
+}
+

--- a/docusaurus/src/scss/__index.scss
+++ b/docusaurus/src/scss/__index.scss
@@ -20,6 +20,7 @@
 @use 'announcement-bar.scss';
 @use 'badge.scss';
 @use 'breadcrumbs.scss';
+@use 'breaking-change-id-card.scss';
 @use 'card.scss';
 @use 'code.scss';
 @use 'code-block.scss';

--- a/docusaurus/src/scss/breaking-change-id-card.scss
+++ b/docusaurus/src/scss/breaking-change-id-card.scss
@@ -1,0 +1,59 @@
+/** Component: Breaking Change Id Card */
+@use './mixins' as *;
+
+.breaking-change-id-card {
+  border: solid 1px var(--strapi-neutral-200);
+  padding: 2em;
+
+  .breaking-change {
+    &-question {
+      font-weight: bold;
+      padding: .2em 0;
+    
+      &__label {
+        margin-right: .5em;
+      }
+
+      &__answer {
+        &--positive {
+          color: var(--strapi-success-600)
+        }
+        &--negative {
+          color: var(--strapi-danger-600)
+        }
+        &--neutral {
+          color: var(--strapi-warning-600)
+        }
+      }
+    }
+
+    &__info {
+      margin-top: 1em;
+    }
+
+    &-codemod-link {
+      font-size: .9em;
+      
+      code {
+        background-color: var(--strapi-neutral-100);
+        font-size: .9em;
+      }
+    }
+  }
+
+  .strapi-icons::before {
+    font-size: 18px;
+    margin-right: 2px;
+  }
+}
+
+@include dark {
+  .breaking-change-id-card .breaking-change-question__answer {
+    &--negative {
+      color: var(--strapi-danger-500);
+    }
+    &--positive {
+      color: var(--strapi-success-500);
+    }
+  }
+}

--- a/docusaurus/src/theme/MDXComponents.js
+++ b/docusaurus/src/theme/MDXComponents.js
@@ -32,6 +32,7 @@ import { PluginsConfigurationFile, HeadlessCms, DocumentDefinition, Codemods } f
 import Icon from '../components/Icon';
 import Guideflow from '../components/Guideflow';
 import { ExternalLink } from '../components/ExternalLink';
+import BreakingChangeIdCard from '../components/BreakingChangeIdCard';
 
 export default {
   // Re-use the default mapping
@@ -79,6 +80,7 @@ export default {
   Annotation,
   Icon,
   ExternalLink,
+  BreakingChangeIdCard,
   /**
    * Reusable annotation components go below👇
    */


### PR DESCRIPTION
This PR improves the breaking changes pages by adding link to the corresponding codemod code in the Strapi codebase where useful.

I also took the opportunity to create a `<BreakingChangeIdCard />` component that replicates the look & feel of the identity cards components we have for features and plugins. 
Consequently, now unused snippets were deleted.