### PR TITLE
Fix pagination_next values

### DIFF
--- a/docusaurus/docs/cms/api/content-api.md
+++ b/docusaurus/docs/cms/api/content-api.md
@@ -4,6 +4,7 @@ description: Learn more about Strapi 5's Content API
 displayed_sidebar: cmsSidebar
 sidebar_label: APIs Introduction
 pagination_prev: cms/setup-deployment
+pagination_next: cms/api/document
 tags:
 - concepts
 - Document Service API

--- a/docusaurus/docs/cms/api/rest/guides/intro.md
+++ b/docusaurus/docs/cms/api/rest/guides/intro.md
@@ -4,7 +4,7 @@ description: Deep dive into some specific REST API topics using guides that exte
 displayed_sidebar: cmsSidebar
 sidebar_label: Guides
 pagination_prev: cms/api/rest
-pagination_next: cms/api/rest/guides/understanding-populate
+pagination_next: cms/api/client
 tags:
 - API
 - Content API

--- a/docusaurus/docs/cms/configurations.md
+++ b/docusaurus/docs/cms/configurations.md
@@ -4,7 +4,7 @@ description: Learn how you can manage and customize the configuration of your St
 displayed_sidebar: cmsSidebar
 sidebar_label: Introduction
 pagination_prev: cms/installation
-pagination_next: cms/setup-deployment
+pagination_next: cms/configurations/admin-panel
 tags:
 - introduction
 - configuration

--- a/docusaurus/docs/cms/customization.md
+++ b/docusaurus/docs/cms/customization.md
@@ -3,7 +3,7 @@ title: Customization
 description: Learn more about Strapi 5 customization possibilities
 displayed_sidebar: cmsSidebar
 sidebar_label: Customization
-pagination_next: cms/plugins-development/developing-plugins
+pagination_next: cms/backend-customization
 tags:
 - admin panel
 - admin panel customization

--- a/docusaurus/docs/cms/plugins-development/admin-panel-api.md
+++ b/docusaurus/docs/cms/plugins-development/admin-panel-api.md
@@ -776,4 +776,3 @@ interface LayoutSettings extends Contracts.ContentTypes.Settings {
 :::note
 `EditViewLayout` and `ListViewLayout` are parts of the `useDocumentLayout` hook (see [source code](https://github.com/strapi/strapi/blob/develop/packages/core/content-manager/admin/src/hooks/useDocumentLayout.ts)).
 :::
-


### PR DESCRIPTION
This PR fixes incorrect "next" links at bottom of pages across the whole CMS docs