### PR TITLE
Added disabled option for LiveEditor so that it does not steal focus - Closes #2409

### DIFF
--- a/docusaurus/src/components/InteractiveQueryBuilder/InteractiveQueryBuilder.jsx
+++ b/docusaurus/src/components/InteractiveQueryBuilder/InteractiveQueryBuilder.jsx
@@ -21,7 +21,6 @@ export function InteractiveQueryBuilder({
   const [queryString, setQueryString] = useState('');
   const [clipboardStatus, setClipboardStatus] = useState('');
   const [isEditorDisabled, setIsEditorDisabled] = useState(true);
-  const editorContainerRef = useRef(null);
 
   /**
    * Copy to Clipboard
@@ -125,7 +124,6 @@ export function InteractiveQueryBuilder({
           hint="Feel free to modify the code above."
         >
           <div
-            ref={editorContainerRef}
             onBlur={() => handleEditorBlur()}
             onClick={() => handleEditorFocus()}
             style={{ cursor: 'text' }}

--- a/docusaurus/src/components/InteractiveQueryBuilder/InteractiveQueryBuilder.jsx
+++ b/docusaurus/src/components/InteractiveQueryBuilder/InteractiveQueryBuilder.jsx
@@ -1,6 +1,6 @@
 import qs from 'qs';
 import clsx from 'clsx';
-import React, { useCallback, useEffect, useLayoutEffect, useState } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useState, useRef } from 'react';
 import { LiveEditor, LiveError, LivePreview, LiveProvider } from 'react-live';
 import { usePrismTheme } from '@docusaurus/theme-common';
 import { Button } from '../Button/Button';
@@ -20,6 +20,8 @@ export function InteractiveQueryBuilder({
   const [endpoint, setEndpoint] = useState(inheritEndpoint);
   const [queryString, setQueryString] = useState('');
   const [clipboardStatus, setClipboardStatus] = useState('');
+  const [isEditorDisabled, setIsEditorDisabled] = useState(true);
+  const editorContainerRef = useRef(null);
 
   /**
    * Copy to Clipboard
@@ -61,6 +63,14 @@ export function InteractiveQueryBuilder({
 
     setEndpoint(endpointChangedBeforeByUser);
   }, [localStorageKey]);
+
+  const handleEditorFocus = useCallback(() => {
+    setIsEditorDisabled(false);
+  }, []);
+
+  const handleEditorBlur = useCallback(() => {
+    setIsEditorDisabled(true);
+  }, []);
 
   return (
     <form
@@ -114,11 +124,19 @@ export function InteractiveQueryBuilder({
           label="Endpoint Query Parameters:"
           hint="Feel free to modify the code above."
         >
-          <LiveEditor
-            className={clsx(styles.iqb__editor)}
-            code={code}
-            onChange={setCode}
-          />
+          <div
+            ref={editorContainerRef}
+            onBlur={() => handleEditorBlur()}
+            onClick={() => handleEditorFocus()}
+            style={{ cursor: 'text' }}
+          >
+            <LiveEditor
+              className={clsx(styles.iqb__editor)}
+              code={code}
+              onChange={setCode}
+              disabled={isEditorDisabled}
+            />
+          </div>
         </FormField>
         <LiveError />
         <LivePreview />


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

Added disabled option for LiveEditor so that it does not steal focus from endpoint textbox after every character input

### Why is it needed?

The LiveEditor was stealing focus from endpoint input box. This seems to be an issue with the LiveEditor using useEditable hook. 

### Related issue(s)/PR(s)

#2409 
