### PR TITLE
feat(upload): add documentation for new setting

### DIFF
--- a/docusaurus/docs/cms/plugins/upload.md
+++ b/docusaurus/docs/cms/plugins/upload.md
@@ -177,6 +177,31 @@ export default {
 
 </Tabs>
 
+### Limit concurrent uploads
+
+By default, Strapi does not limit concurrent uploads into the media library. On low ram environments, you might face some Out Of Memory (OOM). This setting is dedicated to limit the concurrency of uploads to 1 to reduce the stress on the ram with sharp
+
+<Tabs>
+
+<TabItem value="typescript" label="TypeScript">
+
+```js title="path: ./config/plugins.ts"
+
+export default {
+  // ...
+  upload: {
+    config: {
+      limitConcurrentUploads: true
+    }
+  }
+};
+```
+
+</TabItem>
+
+</Tabs>
+
+
 ### Upload request timeout
 
 By default, the value of `strapi.server.httpServer.requestTimeout` is set to 330 seconds. This includes uploads. To make it possible for users with slow internet connection to upload large files, it might be required to increase this timeout limit. The recommended way to do it is by setting the `http.serverOptions.requestTimeout` parameter in the `config/server.js|ts` file (see [server configuration](/cms/configurations/server).


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

This pull request add a new settings to limit the concurrency of uploads to 1 in the media library.

It also fix a small issue when the file size is checked only after that images optimizations are applied. But it means that, whatever the image size is, sharp will try to optimize it. On low ram environments, it leads to OOM.

### How to test it?

Add the new setting in the configuration for the upload plugin: limitConcurrentUpload

```
  upload: {
    config: {
      limitConcurrentUploads: true
    }
  },
```

and then try to upload multiple assets in the same time

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/pull/23253 