### PR TITLE
Add cross links for admin panel configuration and customization

### DIFF
--- a/docusaurus/docs/cms/features/admin-panel.md
+++ b/docusaurus/docs/cms/features/admin-panel.md
@@ -51,6 +51,13 @@ sources={{
   }}
 />
 
+There are many more configuration and customization options available. See the following pages for more details:
+
+<CustomDocCardsWrapper>
+  <CustomDocCard icon="panorama" title="Code-based configuration" description="Configure the appearance, security, and features of the Strapi admin panel via the /config/admin file." link="/cms/configurations/admin-panel" />
+  <CustomDocCard emoji="💻" title="Customization" description="Match your branding, replace the WYSIWYG editor, configure the bundler, extend features, and more." link="/cms/admin-panel-customization" />
+</CustomDocCardsWrapper>
+
 ### Modifying profile information (name, email, username)
 
 1. Go to the *Profile* section of your profile.

--- a/docusaurus/docs/cms/testing.md
+++ b/docusaurus/docs/cms/testing.md
@@ -2,7 +2,6 @@
 title: Testing
 displayed_sidebar: cmsSidebar
 description: Learn how to test your Strapi application.
-unlisted: true
 tags:
 - auth endpoint controller
 - environment


### PR DESCRIPTION
Admin panel configuration and customization pages are often overlooked. This PR adds cards to the Getting Started > Admin Panel page so users can find them more easily.