### PR TITLE
Add missing factory method in TypeScript development example

### DIFF
--- a/docusaurus/docs/cms/typescript/development.md
+++ b/docusaurus/docs/cms/typescript/development.md
@@ -114,7 +114,7 @@ Strapi can be run programmatically by using the `strapi()` factory. Since the co
 ```js title="./server.js"
 
 const strapi = require('@strapi/strapi');
-const app = strapi({ distDir: './dist' });
+const app = strapi.createStrapi({ distDir: './dist' });
 app.start(); 
 ```
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

Corrects an example from the Typescript documentation to include a missing factory method call.

### Why is it needed?

The example is incorrect.

### Related issue(s)/PR(s)

NA
