### PR TITLE
New tabs design

### DIFF
--- a/docusaurus/docs/cms/configurations/admin-panel.md
+++ b/docusaurus/docs/cms/configurations/admin-panel.md
@@ -81,7 +81,6 @@ The default configuration created with any new project should at least include t
 <TabItem value="javascript" label="JavaScript">
 
 ```js title="./config/admin.js"
-
 module.exports = ({ env }) => ({
   apiToken: {
     salt: env('API_TOKEN_SALT', 'someRandomLongString'),

--- a/docusaurus/src/scss/tabs.scss
+++ b/docusaurus/src/scss/tabs.scss
@@ -120,6 +120,10 @@ details {
   }
 }
 
+[role="tabpanel"] p {
+  padding: 12px 12px 0 12px;
+}
+
 /** Dark mode */
 @include dark {
   :root body {

--- a/docusaurus/src/scss/tabs.scss
+++ b/docusaurus/src/scss/tabs.scss
@@ -49,6 +49,12 @@
     .tabs + .margin-top--md {
       margin-top: 0 !important; // Simplified, removed redundant line
     }
+    
+    // Remove border for nested tabs container
+    [role="tabpanel"] .tabs-container {
+      border: none;
+      border-radius: 0;
+    }
   }
   
   // Tab element styles (role="tab" attribute)

--- a/docusaurus/src/scss/tabs.scss
+++ b/docusaurus/src/scss/tabs.scss
@@ -1,106 +1,126 @@
 /** Component: Tab */
 @use './mixins' as *;
 
+// Variables
 :root body {
+  // Using variables to make future changes easier
   --custom-tabs-px: var(--strapi-spacing-5);
   --custom-tabs-py: var(--strapi-spacing-2);
-
   --ifm-tabs-padding-horizontal: var(--custom-tabs-px);
   --ifm-tabs-padding-vertical: var(--custom-tabs-py);
+  --tabs-item-height: 36px;
+  --tabs-item-border-radius: 4px;
+  --tabs-item-margin: 10px 4px;
+  --tabs-item-padding: 4px 12px;
+  --tabs-active-bg: var(--strapi-primary-100);
 }
 
+// Main tabs styles
 .tabs {
   border-bottom: solid 1px var(--strapi-neutral-100);
-
+  
+  // Tab item styles
   &__item {
     border-top: 2px solid transparent;
     border-bottom-width: 2px;
     padding-bottom: 18px !important;
     font-weight: 600;
-
+    
     &:hover {
       background-color: transparent;
       color: var(--strapi-primary-600);
     }
   }
-
+  
   &:not(.tabs__item--active) {
     color: var(--strapi-neutral-600);
   }
-
+  
+  // Container styles
   &-container {
     border-radius: 4px;
     border: solid 1px var(--strapi-neutral-150);
-
+    overflow: hidden; // Prevents children from overflowing the border-radius
+    
     .margin-top--md {
       margin-top: 24px !important;
     }
-
+    
     .tabs + .margin-top--md {
-      margin-top: 6px !important;
-      margin-top: 0 !important;
+      margin-top: 0 !important; // Simplified, removed redundant line
     }
   }
-
-  /** Tabs inside Tabs */
-  + div {
-    [role="tabpanel"] {
-      .tabs {
-        font-size: var(--strapi-font-size-ssm);
-
-        &__item {
-          &--active {
-            --ifm-tabs-color-active-border: transparent;
-
-            background-color: var(--ifm-hover-overlay);
-          }
-        }
-
-        + [class*="margin-top"] {
-          margin-top: 0 !important;
-        }
-      }
-
-      [class*="codeBlockContainer"] {
-        border: none !important;
-      }
-    }
-  }
-
+  
+  // Tab element styles (role="tab" attribute)
   [role="tab"] {
     border-bottom: none;
-    height: 36px;
-    padding: var(--spacing-xs-1, 4px) var(--spacing-xl-3, 12px);
+    height: var(--tabs-item-height);
+    padding: var(--tabs-item-padding);
     text-align: center;
-    gap: var(--spacing-m-2, 8px);
-    border-radius: 4px;
-    margin: 10px 4px !important;
-    // color: var(--strapi-neutral-600);
-
+    gap: 8px;
+    border-radius: var(--tabs-item-border-radius);
+    margin: var(--tabs-item-margin) !important;
+    
     &:nth-child(1) {
       margin-left: 10px !important;
     }
   }
+  
+  // Active tab styles
   [aria-selected="true"] {
     border-bottom: none;
-    height: 36px;
-    padding: var(--spacing-xs-1, 4px) var(--spacing-xl-3, 12px);
+    height: var(--tabs-item-height);
+    padding: var(--tabs-item-padding);
     text-align: center;
-    gap: var(--spacing-m-2, 8px);
-    border-radius: 4px;
-    background-color: var(--strapi-primary-100);
+    gap: 8px;
+    border-radius: var(--tabs-item-border-radius);
+    background-color: var(--tabs-active-bg);
+  }
+  
+  // Nested tabs
+  + div {
+    [role="tabpanel"] {
+      .tabs {
+        font-size: var(--strapi-font-size-ssm);
+        
+        &__item {
+          &--active {
+            --ifm-tabs-color-active-border: transparent;
+            background-color: var(--ifm-hover-overlay);
+          }
+        }
+        
+        + [class*="margin-top"] {
+          margin-top: 0 !important;
+        }
+      }
+      
+      // Remove borders from code blocks inside tabs
+      [class*="codeBlockContainer"] {
+        border: none !important;
+      }
+    }
   }
 }
 
 /** Tabs inside Details component */
 details {
   .tabs {
-    --ifm-tabs-color-active-border: var(--strapi-)
+    --ifm-tabs-color-active-border: var(--strapi-neutral-150); // Added value here
   }
 }
 
+/** Dark mode */
 @include dark {
+  :root body {
+    --tabs-active-bg: rgba(73, 69, 255, 0.2); // Slightly different background in dark mode
+  }
+  
   .tabs__item:not(.tabs__item--active) {
     color: var(--strapi-neutral-400);
+  }
+  
+  [aria-selected="true"] {
+    color: var(--strapi-primary-500); // Different text color in dark mode
   }
 }

--- a/docusaurus/src/scss/tabs.scss
+++ b/docusaurus/src/scss/tabs.scss
@@ -29,12 +29,16 @@
   }
 
   &-container {
+    border-radius: 4px;
+    border: solid 1px var(--strapi-neutral-150);
+
     .margin-top--md {
       margin-top: 24px !important;
     }
 
     .tabs + .margin-top--md {
       margin-top: 6px !important;
+      margin-top: 0 !important;
     }
   }
 
@@ -56,7 +60,35 @@
           margin-top: 0 !important;
         }
       }
+
+      [class*="codeBlockContainer"] {
+        border: none !important;
+      }
     }
+  }
+
+  [role="tab"] {
+    border-bottom: none;
+    height: 36px;
+    padding: var(--spacing-xs-1, 4px) var(--spacing-xl-3, 12px);
+    text-align: center;
+    gap: var(--spacing-m-2, 8px);
+    border-radius: 4px;
+    margin: 10px 4px !important;
+    // color: var(--strapi-neutral-600);
+
+    &:nth-child(1) {
+      margin-left: 10px !important;
+    }
+  }
+  [aria-selected="true"] {
+    border-bottom: none;
+    height: 36px;
+    padding: var(--spacing-xs-1, 4px) var(--spacing-xl-3, 12px);
+    text-align: center;
+    gap: var(--spacing-m-2, 8px);
+    border-radius: 4px;
+    background-color: var(--strapi-primary-100);
   }
 }
 

--- a/docusaurus/src/scss/tabs.scss
+++ b/docusaurus/src/scss/tabs.scss
@@ -102,8 +102,12 @@
       }
       
       // Remove borders from code blocks inside tabs
-      [class*="codeBlockContainer"] {
+      [class*="codeBlockContainer"]:not(:has([class*="codeBlockTitle"])) {
         border: none !important;
+      }
+
+      [class*="codeBlockContainer"]:has([class*="codeBlockTitle"]) {
+        margin: 22px 20px;
       }
     }
   }


### PR DESCRIPTION
This PR updates the style of Tabs. The main goal was to make it more obvious to know where tabs end. We also refreshed the look of the tabs "header".

Before:

<img width="703" alt="Screenshot 2025-04-10 at 16 34 40" src="https://github.com/user-attachments/assets/bfec41c5-67f3-4015-a995-b7e41842c6c3" />

After:
<img width="707" alt="Screenshot 2025-04-10 at 16 34 44" src="https://github.com/user-attachments/assets/89c1aa96-55e7-4764-bfc4-e4a7f0c997ee" />
