### PR TITLE
Fix identity cards design

### DIFF
--- a/docusaurus/src/components/IdentityCard/identity-card.scss
+++ b/docusaurus/src/components/IdentityCard/identity-card.scss
@@ -80,6 +80,10 @@
       }
     }
 
+    &-content p {
+      margin-bottom: 0;
+    }
+
     &-content a {
       font-size: 14px !important;
     }

--- a/docusaurus/src/components/IdentityCard/identity-card.scss
+++ b/docusaurus/src/components/IdentityCard/identity-card.scss
@@ -47,7 +47,7 @@
     }
 
     &-icon {
-      margin-right: 8px;
+      margin-right: 6px;
       color: var(--strapi-neutral-500);
 
       i::before {


### PR DESCRIPTION
This PR fixes:
- wrong spacing between icon and item title
- unwanted bottom margin after item content