### PR TITLE
Fix plugin init command

### DIFF
--- a/docusaurus/docs/cms/plugins-development/create-a-plugin.md
+++ b/docusaurus/docs/cms/plugins-development/create-a-plugin.md
@@ -50,7 +50,7 @@ yarn dlx @strapi/sdk-plugin init my-strapi-plugin
 <TabItem value="npm" label="NPM">
 
 ```bash
-npx @strapi/sdk-plugin:init my-strapi-plugin
+npx @strapi/sdk-plugin init my-strapi-plugin
 ```
 
 </TabItem>


### PR DESCRIPTION

### What does it do?

This PR removes an unwanted column character in the init command of the Plugin SDK.