### PR TITLE
Rewrite Custom fields documentation as a feature page

### DIFF
--- a/docusaurus/docs/cms/admin-panel-customization/wysiwyg-editor.md
+++ b/docusaurus/docs/cms/admin-panel-customization/wysiwyg-editor.md
@@ -14,7 +14,7 @@ tags:
 To change the default WYSIWYG editor provided with Strapi's admin panel, several options are at your disposal:
 
 - You can install a third-party plugin, such as one for CKEditor, by visiting <ExternalLink to="https://market.strapi.io/" text="Strapi's Marketplace"/>.
-- You can create your own plugin to create and register a fully custom WYSIWYG field (see [custom fields documentation](/cms/plugins-development/custom-fields)).
+- You can create your own plugin to create and register a fully custom WYSIWYG field (see [custom fields documentation](/cms/features/custom-fields)).
 - You can take advantage of Strapi's admin panel [extensions](/cms/admin-panel-customization/extension) system and leverage the [bootstrap lifecycle function](/cms/plugins-development/admin-panel-api#bootstrap) of the admin panel.
 
 If you choose to use the extensions system, create your WYSIWYG component in the `/src/admin/extensions` folder and import it in the admin panel's `/src/admin/app.[tsx|js]` entry point file, then declare the new field with the `app.addFields()` function as follows:

--- a/docusaurus/docs/cms/backend-customization/models.md
+++ b/docusaurus/docs/cms/backend-customization/models.md
@@ -508,15 +508,14 @@ The `tableName` key defines the name of the join table. It has to be specified o
 
 #### Custom fields
 
-[Custom fields](/cms/plugins-development/custom-fields.md) extend Strapi’s capabilities by adding new types of fields to content-types. Custom fields are explicitly defined in the [attributes](#model-attributes) of a model with `type: customField`.
-Custom fields' attributes also accept:
+[Custom fields](/cms/features/custom-fields) extend Strapi’s capabilities by adding new types of fields to content-types. Custom fields are explicitly defined in the [attributes](#model-attributes) of a model with `type: customField`.
 
 Custom fields' attributes also show the following specificities:
 
 - a `customField` attribute whose value acts as a unique identifier to indicate which registered custom field should be used. Its value follows:
    - either the `plugin::plugin-name.field-name` format if a plugin created the custom field 
    - or the `global::field-name` format for a custom field specific to the current Strapi application
-- and additional parameters depending on what has been defined when registering the custom field (see [custom fields documentation](/cms/plugins-development/custom-fields.md)).
+- and additional parameters depending on what has been defined when registering the custom field (see [custom fields documentation](/cms/features/custom-fields)).
 
 ```json title="./src/api/[apiName]/[content-type-name]/content-types/schema.json"
 

--- a/docusaurus/docs/cms/configurations/functions.md
+++ b/docusaurus/docs/cms/configurations/functions.md
@@ -165,7 +165,7 @@ It can be used to:
 - [extend plugins](/cms/plugins-development/plugins-extension#extending-a-plugins-interface)
 - extend [content-types](/cms/backend-customization/models) programmatically
 - load some [environment variables](/cms/configurations/environment)
-- register a [custom field](/cms/plugins-development/custom-fields) that would be used only by the current Strapi application,
+- register a [custom field](/cms/features/custom-fields) that would be used only by the current Strapi application,
 - register a [custom provider for the Users & Permissions plugin](/cms/configurations/users-and-permissions-providers/new-provider-guide).
 
 `register()` is the very first thing that happens when a Strapi application is starting. This happens _before_ any setup process and you don't have any access to database, routes, policies, or any other backend server elements within the `register()` function.

--- a/docusaurus/docs/cms/features/content-type-builder.md
+++ b/docusaurus/docs/cms/features/content-type-builder.md
@@ -696,7 +696,7 @@ When using dynamic zones, different components cannot have the same field name w
 
 #### Custom fields
 
-Custom fields are a way to extend Strapi’s capabilities by adding new types of fields to content-types or components. Once installed (see [Marketplace](/cms/plugins/installing-plugins-via-marketplace) documentation), custom fields are listed in the _Custom_ tab when selecting a field for a content-type.
+[Custom fields](/cms/features/custom-fields) are a way to extend Strapi’s capabilities by adding new types of fields to content-types or components. Once installed (see [Marketplace](/cms/plugins/installing-plugins-via-marketplace) documentation), custom fields are listed in the _Custom_ tab when selecting a field for a content-type.
 
 Each custom field type can have basic and advanced settings. The <ExternalLink to="https://market.strapi.io/plugins?categories=Custom+fields" text="Marketplace"/> lists available custom fields, and hosts dedicated documentation for each custom field, including specific settings.
 

--- a/docusaurus/docs/cms/features/custom-fields.md
+++ b/docusaurus/docs/cms/features/custom-fields.md
@@ -80,6 +80,9 @@ The optional `inputSize` object, when specified, must contain all of the followi
 
 In the following example, the `color-picker` plugin was created using the CLI generator (see [plugins development](/cms/plugins-development/developing-plugins)):
 
+<Tabs groupId="js-ts">
+<TabItem value="js" label="JavaScript">
+
 ```js title="/src/plugins/color-picker/server/register.js"
 "use strict";
 
@@ -97,7 +100,17 @@ module.exports = ({ strapi }) => {
 };
 ```
 
+</TabItem>
+
+<TabItem value="ts" label="TypeScript">
+
+</TabItem>
+</Tabs>
+
 The custom field could also be declared directly within the `strapi-server.js` file if you didn't have the plugin code scaffolded by the CLI generator:
+
+<Tabs groupId="js-ts">
+<TabItem value="js" label="JavaScript">
 
 ```js title="/src/plugins/color-picker/strapi-server.js"
 module.exports = {
@@ -115,6 +128,13 @@ module.exports = {
   },
 };
 ```
+
+</TabItem>
+
+<TabItem value="ts" label="TypeScript">
+
+</TabItem>
+</Tabs>
 
 #### Registering a custom field in the admin panel
 
@@ -148,6 +168,9 @@ The `app.customFields` object exposes a `register()` method on the `StrapiApp` i
 
 In the following example, the `color-picker` plugin was created using the CLI generator (see [plugins development](/cms/plugins-development/developing-plugins.md)):
 
+<Tabs groupId="js-ts">
+<TabItem value="js" label="JavaScript">
+
 ```jsx title="/src/plugins/color-picker/admin/src/index.js"
 import ColorPickerIcon from "./components/ColorPicker/ColorPickerIcon";
 
@@ -171,9 +194,9 @@ export default {
       icon: ColorPickerIcon, // don't forget to create/import your icon component
       components: {
         Input: async () =>
-          import(
-            /* webpackChunkName: "input-component" */ "./components/Input"
-          ),
+          import('./components/Input').then((module) => ({
+            default: module.Input,
+          })),
       },
       options: {
         // declare options here
@@ -185,6 +208,13 @@ export default {
 };
 ```
 
+</TabItem>
+
+<TabItem value="ts" label="TypeScript">
+
+</TabItem>
+</Tabs>
+
 ##### Components
 
 `app.customFields.register()` must pass a `components` object with an `Input` React component to use in the Content Manager's edit view.
@@ -193,6 +223,9 @@ export default {
 
 In the following example, the `color-picker` plugin was created using the CLI generator (see [plugins development](/cms/plugins-development/developing-plugins.md)):
 
+<Tabs groupId="js-ts">
+<TabItem value="js" label="JavaScript">
+
 ```jsx title="./src/plugins/color-picker/admin/src/index.js"
 export default {
   register(app) {
@@ -200,13 +233,22 @@ export default {
       // …
       components: {
         Input: async () =>
-          import(/* webpackChunkName: "input-component" */ "./Input"),
+          import('./components/Input').then((module) => ({
+            default: module.Input,
+          })),
       },
       // …
     });
   },
 };
 ```
+
+</TabItem>
+
+<TabItem value="ts" label="TypeScript">
+</TabItem>
+
+</Tabs>
 
 <details>
 <summary>Props passed to the custom field <code>Input</code> component:</summary>
@@ -235,6 +277,9 @@ As of Strapi v4.13.0, fields in the Content Manager can be auto-focussed via the
 **Example: A custom text input**
 
 In the following example we're providing a custom text input that is controlled. All inputs should be controlled otherwise their data will not be submitted on save.
+
+<Tabs groupId="js-ts">
+<TabItem value="js" label="JavaScript">
 
 ```jsx title="/src/plugins/<plugin-name>/admin/src/components/Input.js"
 import * as React from "react";
@@ -270,6 +315,13 @@ const Input = React.forwardRef((props, ref) => {
 
 export default Input;
 ```
+
+</TabItem>
+
+<TabItem value="ts" label="TypeScript">
+</TabItem>
+
+</Tabs>
 
 :::tip
 For a more detailed view of the props provided to the customFields and how they can be used check out the <ExternalLink to="https://github.com/strapi/strapi/blob/main/packages/plugins/color-picker/admin/src/components/ColorPickerInput.tsx#L80-L95" text="ColorPickerInput file"/> in the Strapi codebase.
@@ -307,6 +359,9 @@ Each object in the `items` array can contain the following parameters:
 **Example: Declaring options for an example "color" custom field:**
 
 In the following example, the `color-picker` plugin was created using the CLI generator (see [plugins development](/cms/plugins-development/developing-plugins.md)):
+
+<Tabs groupId="js-ts">
+<TabItem value="js" label="JavaScript">
 
 ```jsx title="/src/plugins/color-picker/admin/src/index.js"
 // imports go here (ColorPickerIcon, pluginId, yup package…)
@@ -390,11 +445,18 @@ export default {
 };
 ```
 
+</TabItem>
+
+<TabItem value="ts" label="TypeScript">
+
 <!-- TODO: replace these tip and links by proper documentation of all the possible shapes and parameters for `options` -->
 
 :::tip
 The Strapi codebase gives an example of how settings objects can be described: check the <ExternalLink to="https://github.com/strapi/strapi/blob/main/packages/core/content-type-builder/admin/src/components/FormModal/attributes/baseForm.ts" text="`baseForm.ts`"/> file for the `base` settings and the <ExternalLink to="https://github.com/strapi/strapi/blob/main/packages/core/content-type-builder/admin/src/components/FormModal/attributes/advancedForm.ts" text="`advancedForm.ts`"/> file for the `advanced` settings. The base form lists the settings items inline but the advanced form gets the items from an <ExternalLink to="https://github.com/strapi/strapi/blob/main/packages/core/content-type-builder/admin/src/components/FormModal/attributes/attributeOptions.js" text="`attributeOptions.js`"/> file.
 :::
+
+</TabItem>
+</Tabs>
 
 ## Usage
 
@@ -429,7 +491,7 @@ As compared to how other types of models are defined, custom fields' attributes 
 
 **Example: A simple `color` custom field model definition:**
 
-```json title="./src/api/[apiName]/[content-type-name]/content-types/schema.json"
+```json title="/src/api/[apiName]/[content-type-name]/content-types/schema.json"
 
 {
   // …

--- a/docusaurus/docs/cms/features/custom-fields.md
+++ b/docusaurus/docs/cms/features/custom-fields.md
@@ -2,6 +2,7 @@
 title: Custom fields
 description: Learn how you can use custom fields to extend Strapi's content-types capabilities.
 displayed_sidebar: cmsSidebar
+toc_max_heading_level: 5
 canonicalUrl: https://docs.strapi.io/cms/development/custom-fields.html
 tags:
 - admin panel
@@ -18,29 +19,46 @@ import CustomFieldRequiresPlugin from '/docs/snippets/custom-field-requires-plug
 
 Custom fields extend Strapi’s capabilities by adding new types of fields to content-types and components. Once created or added to Strapi via plugins, custom fields can be used in the Content-Type Builder and Content Manager just like built-in fields.
 
-The present documentation is intended for custom field creators: it describes which APIs and functions developers must use to create a new custom field.
+<IdentityCard>
+  <IdentityCardItem icon="credit-card" title="Plan">Free feature</IdentityCardItem>
+  <IdentityCardItem icon="user" title="Role & permission">None</IdentityCardItem>
+  <IdentityCardItem icon="toggle-right" title="Activation">Available and activated by default</IdentityCardItem>
+  <IdentityCardItem icon="desktop" title="Environment">Available in both Development & Production environment</IdentityCardItem>
+</IdentityCard>
 
-It is recommended that you develop a dedicated [plugin](/cms/plugins-development/developing-plugins) for custom fields. Custom field plugins include both a server and admin panel part. The custom field must be registered in both parts before it is usable in Strapi's admin panel.
+## Configuration
 
-Once created and used, custom fields are defined like any other attribute in the model's schema. An attribute using a custom field will have its type represented as `customField` (i.e. `type: 'customField'`). Depending on the custom field being used a few additional properties may be present in the attribute's definition (see [models documentation](/cms/backend-customization/models#custom-fields)).
+Ready-made custom fields can be found on the [Marketplace](https://market.strapi.io/plugins?categories=Custom+fields). For these, no other configuration is required, and you can start using them (see [usage](#usage)).
 
-:::note NOTES
+You can also develop your own custom field.
 
-- Though the recommended way to add a custom field is through creating a plugin, app-specific custom fields can also be registered within the global `register` [function](/cms/configurations/functions) found in `src/index.js` and `src/admin/app/js` files.
-- Custom fields can only be shared using plugins.
+### Developing your own custom field
+
+Though the recommended way to add a custom field is through creating a plugin, app-specific custom fields can also be registered within the global `register` [function](/cms/configurations/functions) found in `src/index` and `src/admin/app` files.
+
+:::note Current limitations
+* Custom fields can only be shared and distributed on the Marketplace using plugins.
+* Custom fields cannot add new data types to Strapi and must use existing, built-in Strapi data types described in the [models' attributes](/cms/backend-customization/models#model-attributes) documentation. 
+* You also cannot modify an existing data type.
+* Special data types unique to Strapi, such as relation, media, component, or dynamic zone data types, cannot be used in custom fields.
 :::
-
-## Registering a custom field on the server
 
 :::prerequisites
 <CustomFieldRequiresPlugin components={props.components} />
 :::
 
+Custom field plugins include both a server and admin panel part. The custom field must be registered in both parts before it is usable in Strapi's admin panel.
+
+#### Registering a custom field on the server
+
 Strapi's server needs to be aware of all the custom fields to ensure that an attribute using a custom field is valid.
 
 The `strapi.customFields` object exposes a `register()` method on the `Strapi` instance. This method is used to register custom fields on the server during the plugin's server [register lifecycle](/cms/plugins-development/server-api#register).
 
-`strapi.customFields.register()` registers one or several custom field(s) on the server by passing an object (or an array of objects) with the following parameters:
+`strapi.customFields.register()` registers one or several custom field(s) on the server by passing an object (or an array of objects) with some parameters.
+
+<details>
+<summary>Parameters available to register the custom field on the server:</summary>
 
 | Parameter                         | Description                                                                                                                                             | Type     |
 | --------------------------------- |---------------------------------------------------------------------------------------------------------------------------------------------------------| -------- |
@@ -56,19 +74,13 @@ The optional `inputSize` object, when specified, must contain all of the followi
 | `default`     | The default size in columns that the input field will occupy in the 12-column grid in the admin panel.<br/>The value can either be `4`, `6`, `8` or `12`. | `Integer` |
 | `isResizable` | Whether the input can be resized or not                                                                                                                   | `Boolean` |
 
-:::note Current limitations
-Currently:
-* Custom fields cannot add new data types to Strapi and must use existing, built-in Strapi data types described in the [models' attributes](/cms/backend-customization/models#model-attributes) documentation. 
-* You also cannot modify an existing data type.
-* Special data types unique to Strapi, such as relation, media, component, or dynamic zone data types, cannot be used in custom fields.
-:::
+</details>
 
-<details>
-<summary>Example: Registering an example "color" custom field on the server:</summary>
+**Example: Registering an example "color" custom field on the server:**
 
 In the following example, the `color-picker` plugin was created using the CLI generator (see [plugins development](/cms/plugins-development/developing-plugins)):
 
-```js title="./src/plugins/color-picker/server/register.js"
+```js title="/src/plugins/color-picker/server/register.js"
 "use strict";
 
 module.exports = ({ strapi }) => {
@@ -87,7 +99,7 @@ module.exports = ({ strapi }) => {
 
 The custom field could also be declared directly within the `strapi-server.js` file if you didn't have the plugin code scaffolded by the CLI generator:
 
-```js title="./src/plugins/color-picker/strapi-server.js"
+```js title="/src/plugins/color-picker/strapi-server.js"
 module.exports = {
   register({ strapi }) {
     strapi.customFields.register({
@@ -104,9 +116,7 @@ module.exports = {
 };
 ```
 
-</details>
-
-## Registering a custom field in the admin panel
+#### Registering a custom field in the admin panel
 
 :::prerequisites
 <CustomFieldRequiresPlugin components={props.components} />
@@ -116,7 +126,10 @@ Custom fields must be registered in Strapi's admin panel to be available in the 
 
 The `app.customFields` object exposes a `register()` method on the `StrapiApp` instance. This method is used to register custom fields in the admin panel during the plugin's admin [register lifecycle](/cms/plugins-development/admin-panel-api#register).
 
-`app.customFields.register()` registers one or several custom field(s) in the admin panel by passing an object (or an array of objects) with the following parameters:
+`app.customFields.register()` registers one or several custom field(s) in the admin panel by passing an object (or an array of objects) with some parameters.
+
+<details>
+<summary>Parameters available to register the custom field on the server:</summary>
 
 | Parameter                        | Description                                                                                                                                  | Type                                                 |
 | -------------------------------- |----------------------------------------------------------------------------------------------------------------------------------------------| ---------------------------------------------------- |
@@ -124,17 +137,18 @@ The `app.customFields` object exposes a `register()` method on the `StrapiApp` i
 | `pluginId`<br/><br/>(_optional_) | Name of the plugin creating the custom field<br/><br/>❗️ If defined, the `plugin` value on the server registration must have the same value (see [Registering a custom field on the server](#registering-a-custom-field-on-the-server))  | `String`                                             |
 | `type`                           | Existing Strapi data type the custom field will use<br/><br/>❗️ Relations, media, components, or dynamic zones cannot be used.               | `String`                                             |
 | `icon`<br/><br/>(_optional_)     | Icon for the custom field                                                                                                                    | `React.ComponentType`                                |
-| `intlLabel`                      | Translation for the name                                                                                                                     | <ExternalLink to="https://formatjs.io/docs/react-intl/" text="`IntlObject`"/> |
-| `intlDescription`                | Translation for the description                                                                                                              | <ExternalLink to="https://formatjs.io/docs/react-intl/" text="`IntlObject`"/> |
+| `intlLabel`                      | Translation for the name                                                                                                                     | <ExternalLink to="https://formatjs.io/docs/react-intl/" text="IntlObject"/> |
+| `intlDescription`                | Translation for the description                                                                                                              | <ExternalLink to="https://formatjs.io/docs/react-intl/" text="IntlObject"/> |
 | `components`                     | Components needed to display the custom field in the Content Manager (see [components](#components))                                         |
 | `options`<br/><br/>(_optional_)  | Options to be used by the Content-type Builder (see [options](#options))                                                                     | `Object`                                             |
 
-<details>
-<summary>Example: Registering an example "color" custom field in the admin panel:</summary>
+</details>
+
+**Example: Registering an example "color" custom field in the admin panel:**
 
 In the following example, the `color-picker` plugin was created using the CLI generator (see [plugins development](/cms/plugins-development/developing-plugins.md)):
 
-```jsx title="./src/plugins/color-picker/admin/src/index.js"
+```jsx title="/src/plugins/color-picker/admin/src/index.js"
 import ColorPickerIcon from "./components/ColorPicker/ColorPickerIcon";
 
 export default {
@@ -171,14 +185,11 @@ export default {
 };
 ```
 
-</details>
-
-### Components
+##### Components
 
 `app.customFields.register()` must pass a `components` object with an `Input` React component to use in the Content Manager's edit view.
 
-<details>
-<summary>Example: Registering an Input component</summary>
+**Example: Registering an Input component:**
 
 In the following example, the `color-picker` plugin was created using the CLI generator (see [plugins development](/cms/plugins-development/developing-plugins.md)):
 
@@ -197,34 +208,35 @@ export default {
 };
 ```
 
-</details>
-
-Custom field input components receive the following props:
+<details>
+<summary>Props passed to the custom field <code>Input</code> component:</summary>
 
 | Prop             | Description                                                                                                                                                                                                                               | Type                                                                 |
 | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
 | `attribute`      | The attribute object with custom field's underlying Strapi type and options                                                                                                                                                               | `{ type: String, customField: String }`                              |
-| `description`    | The field description set in [configure the view](/cms/features/content-manager#edit-view-settings)                                                                                                  | <ExternalLink to="https://formatjs.io/docs/react-intl/" text="`IntlObject`"/>                 |
-| `placeholder`    | The field placeholder set in [configure the view](/cms/features/content-manager#edit-view-settings)                                                                                                  | <ExternalLink to="https://formatjs.io/docs/react-intl/" text="`IntlObject`"/>                 |
+| `description`    | The field description set in [configure the view](/cms/features/content-manager#edit-view-settings)                                                                                                  | <ExternalLink to="https://formatjs.io/docs/react-intl/" text="IntlObject"/>                 |
+| `placeholder`    | The field placeholder set in [configure the view](/cms/features/content-manager#edit-view-settings)                                                                                                  | <ExternalLink to="https://formatjs.io/docs/react-intl/" text="IntlObject"/>                 |
 | `hint`           | The field description set in [configure the view](/cms/features/content-manager#edit-view-settings) along with min/max [validation requirements](/cms/backend-customization/models#validations) | `String`                                                             |
 | `name`           | The field name set in the content-type builder                                                                                                                                                                                            | `String`                                                             |
-| `intlLabel`      | The field name set in the content-type builder or configure the view                                                                                                                                                                      | <ExternalLink to="https://formatjs.io/docs/react-intl/" text="`IntlObject`"/>                 |
+| `intlLabel`      | The field name set in the content-type builder or configure the view                                                                                                                                                                      | <ExternalLink to="https://formatjs.io/docs/react-intl/" text="IntlObject"/>                 |
 | `onChange`       | The handler for the input change event. The `name` argument references the field name. The `type` argument references the underlying Strapi type                                                                                          | `({ target: { name: String value: unknown type: String } }) => void` |
 | `contentTypeUID` | The content-type the field belongs to                                                                                                                                                                                                     | `String`                                                             |
 | `type`           | The custom field uid, for example `plugin::color-picker.color`                                                                                                                                                                            | `String`                                                             |
 | `value`          | The input value the underlying Strapi type expects                                                                                                                                                                                        | `unknown`                                                            |
 | `required`       | Whether or not the field is required                                                                                                                                                                                                      | `boolean`                                                            |
-| `error`          | Error received after validation                                                                                                                                                                                                           | <ExternalLink to="https://formatjs.io/docs/react-intl/" text="`IntlObject`"/>                 |
+| `error`          | Error received after validation                                                                                                                                                                                                           | <ExternalLink to="https://formatjs.io/docs/react-intl/" text="IntlObject"/>                 |
 | `disabled`       | Whether or not the input is disabled                                                                                                                                                                                                      | `boolean`                                                            |
 
 As of Strapi v4.13.0, fields in the Content Manager can be auto-focussed via the `URLSearchParam` `field`. It's recommended that your input component is wrapped in React's <ExternalLink to="https://react.dev/reference/react/forwardRef" text="`forwardRef`"/> method; you should pass the corresponding `ref` to the `input` element.
 
-<details>
-<summary>Example: A custom text input</summary>
+<br/>
+</details>
+
+**Example: A custom text input**
 
 In the following example we're providing a custom text input that is controlled. All inputs should be controlled otherwise their data will not be submitted on save.
 
-```jsx title="./src/plugins/<plugin-name>/admin/src/components/Input.js"
+```jsx title="/src/plugins/<plugin-name>/admin/src/components/Input.js"
 import * as React from "react";
 
 import { useIntl } from "react-intl";
@@ -259,15 +271,16 @@ const Input = React.forwardRef((props, ref) => {
 export default Input;
 ```
 
-</details>
-
 :::tip
-For a more detailed view of the props provided to the customFields and how they can be used check out the <ExternalLink to="https://github.com/strapi/strapi/blob/main/packages/plugins/color-picker/admin/src/components/ColorPickerInput.tsx#L80-L95" text="`ColorPickerInput` file"/> in the Strapi codebase.
+For a more detailed view of the props provided to the customFields and how they can be used check out the <ExternalLink to="https://github.com/strapi/strapi/blob/main/packages/plugins/color-picker/admin/src/components/ColorPickerInput.tsx#L80-L95" text="ColorPickerInput file"/> in the Strapi codebase.
 :::
 
-### Options
+##### Options
 
-`app.customFields.register()` can pass an additional `options` object with the following parameters:
+`app.customFields.register()` can pass an additional `options` object. with the following parameters:
+
+<details>
+<summary>Parameters passed to the custom field <code>options</code> object:</summary>
 
 | Options parameter | Description                                                                                                                               | Type                           |
 | ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------ |
@@ -277,7 +290,7 @@ For a more detailed view of the props provided to the customFields and how they 
 
 Both `base` and `advanced` settings accept an object or an array of objects, each object being a settings section. Each settings section could include:
 
-- a `sectionTitle` to declare the title of the section as an <ExternalLink to="https://formatjs.io/docs/react-intl/" text="`IntlObject`"/>
+- a `sectionTitle` to declare the title of the section as an <ExternalLink to="https://formatjs.io/docs/react-intl/" text="IntlObject"/>
 - and a list of `items` as an array of objects.
 
 Each object in the `items` array can contain the following parameters:
@@ -289,12 +302,13 @@ Each object in the `items` array can contain the following parameters:
 | `intlLabel`     | Translation for the label of the input                             | <ExternalLink to="https://formatjs.io/docs/react-intl/" text="`IntlObject`"/> |
 | `type`          | Type of the input (e.g., `select`, `checkbox`)                     | `String`                                             |
 
-<details>
-<summary>Example: Declaring options for an example "color" custom field:</summary>
+</details>
+
+**Example: Declaring options for an example "color" custom field:**
 
 In the following example, the `color-picker` plugin was created using the CLI generator (see [plugins development](/cms/plugins-development/developing-plugins.md)):
 
-```jsx title="./src/plugins/color-picker/admin/src/index.js"
+```jsx title="/src/plugins/color-picker/admin/src/index.js"
 // imports go here (ColorPickerIcon, pluginId, yup package…)
 
 export default {
@@ -376,10 +390,58 @@ export default {
 };
 ```
 
-</details>
-
 <!-- TODO: replace these tip and links by proper documentation of all the possible shapes and parameters for `options` -->
 
 :::tip
 The Strapi codebase gives an example of how settings objects can be described: check the <ExternalLink to="https://github.com/strapi/strapi/blob/main/packages/core/content-type-builder/admin/src/components/FormModal/attributes/baseForm.ts" text="`baseForm.ts`"/> file for the `base` settings and the <ExternalLink to="https://github.com/strapi/strapi/blob/main/packages/core/content-type-builder/admin/src/components/FormModal/attributes/advancedForm.ts" text="`advancedForm.ts`"/> file for the `advanced` settings. The base form lists the settings items inline but the advanced form gets the items from an <ExternalLink to="https://github.com/strapi/strapi/blob/main/packages/core/content-type-builder/admin/src/components/FormModal/attributes/attributeOptions.js" text="`attributeOptions.js`"/> file.
 :::
+
+## Usage
+
+<br/>
+
+### In the admin panel
+
+Custom fields can be added to Strapi either by installing them from the [Marketplace](/cms/plugins/installing-plugins-via-marketplace) or by creating your own.
+
+Once added to Strapi, custom fields can be added to any content type. Custom fields are listed in the _Custom_ tab when selecting a field for a content-type.
+
+<!-- TODO: add screenshot of content-type builder with custom fields tab here -->
+
+Each custom field type can have basic and advanced settings. The <ExternalLink to="https://market.strapi.io/plugins?categories=Custom+fields" text="Marketplace"/> lists available custom fields, and hosts dedicated documentation for each custom field, including specific settings.
+
+### In the code
+
+Once created and used, custom fields are defined like any other attribute in the model's schema. 
+
+Custom fields are explicitly defined in the [attributes](/cms/backend-customization/models#model-attributes) of a model with `type: customField`.
+
+As compared to how other types of models are defined, custom fields' attributes also show the following specificities:
+
+- Custom field have a `customField` attribute. Its value acts as a unique identifier to indicate which registered custom field should be used, and follows one of these 2 formats:
+
+    | Format               |  Origin |
+    |----------------------|------------------|
+    | `plugin::plugin-name.field-name` | The custom field was created through a plugin |
+    | `global::field-name` | The custom field is specific to the current Strapi application and was created directly within the `register` [function](/cms/configurations/functions) |
+
+- Custom fields can have additional parameters depending on what has been defined when registering the custom field (see [server registration](#registering-a-custom-field-on-the-server) and [admin panel registration](#registering-a-custom-field-in-the-admin-panel)).
+
+**Example: A simple `color` custom field model definition:**
+
+```json title="./src/api/[apiName]/[content-type-name]/content-types/schema.json"
+
+{
+  // …
+  "attributes": {
+    "color": { // name of the custom field defined in the Content-Type Builder
+      "type": "customField",
+      "customField": "plugin::color-picker.color",
+      "options": {
+        "format": "hex"
+      }
+    }
+  }
+  // …
+}
+```

--- a/docusaurus/docs/cms/plugins-development/admin-panel-api.md
+++ b/docusaurus/docs/cms/plugins-development/admin-panel-api.md
@@ -205,7 +205,7 @@ The Admin Panel API allows a plugin to take advantage of several small APIs to p
 | Register a hook                          | [Hooks API](#hooks-api)                 | [`registerHook()`](#hooks-api)                    | [`bootstrap()`](#bootstrap)   |
 
 :::tip Replacing the WYSIWYG
-The WYSIWYG editor can be replaced by taking advantage of [custom fields](/cms/plugins-development/custom-fields), for instance using the <ExternalLink to="https://market.strapi.io/plugins/@ckeditor-strapi-plugin-ckeditor" text="CKEditor custom field plugin"/>.
+The WYSIWYG editor can be replaced by taking advantage of [custom fields](/cms/features/custom-fields), for instance using the <ExternalLink to="https://market.strapi.io/plugins/@ckeditor-strapi-plugin-ckeditor" text="CKEditor custom field plugin"/>.
 :::
 
 :::info

--- a/docusaurus/docs/cms/plugins-development/developing-plugins.md
+++ b/docusaurus/docs/cms/plugins-development/developing-plugins.md
@@ -40,7 +40,7 @@ Strapi provides the following programmatic APIs for plugins to hook into some of
 </CustomDocCardsWrapper>
 
 :::strapi Custom fields plugins
-Plugins can also be used to add [custom fields](/cms/plugins-development/custom-fields) to Strapi.
+Plugins can also be used to add [custom fields](/cms/features/custom-fields) to Strapi.
 :::
 
 ## Guides

--- a/docusaurus/docs/cms/plugins-development/server-api.md
+++ b/docusaurus/docs/cms/plugins-development/server-api.md
@@ -56,7 +56,7 @@ The `/src/server/index.js` file at the root of the plugin folder exports the req
 
 ### register()
 
-This function is called to load the plugin, before the application is [bootstrapped](#bootstrap), in order to register [permissions](/cms/features/users-permissions), the server part of [custom fields](/cms/plugins-development/custom-fields#registering-a-custom-field-on-the-server), or database migrations.
+This function is called to load the plugin, before the application is [bootstrapped](#bootstrap), in order to register [permissions](/cms/features/users-permissions), the server part of [custom fields](/cms/features/custom-fields#registering-a-custom-field-on-the-server), or database migrations.
 
 **Type**: `Function`
 

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -63,6 +63,7 @@ const sidebars = {
           label: 'Content History',
           id: 'cms/features/content-history'
         },
+        'cms/features/custom-fields',
         {
           type: 'doc',
           label: 'Data Management',
@@ -329,7 +330,6 @@ const sidebars = {
             'cms/plugins-development/admin-panel-api',
             'cms/plugins-development/content-manager-apis',
             'cms/plugins-development/server-api',
-            'cms/plugins-development/custom-fields',
             'cms/plugins-development/plugins-extension',
             'cms/plugins-development/guides/pass-data-from-server-to-admin',
             'cms/plugins-development/guides/store-and-access-data',

--- a/docusaurus/src/scss/details.scss
+++ b/docusaurus/src/scss/details.scss
@@ -102,6 +102,10 @@ details.alert {
   a:hover {
     text-decoration: var(--ifm-link-decoration);
   }
+
+  code {
+    background-color: inherit;
+  }
 }
 
 @include dark {

--- a/docusaurus/static/js/redirector.js
+++ b/docusaurus/static/js/redirector.js
@@ -156,7 +156,7 @@ document.addEventListener('DOMContentLoaded', () => {
       'email': '/cms/features/email',
       'seo': '/cms/plugins/installing-plugins-via-marketplace',
       'gatsby': '/cms/plugins/installing-plugins-via-marketplace',
-      'custom-fields': '/cms/plugins-development/custom-fields'
+      'custom-fields': '/cms/features/custom-fields'
     },
     '/dev-docs/plugins/email': {
       '_default': '/cms/features/email',

--- a/docusaurus/vercel.json
+++ b/docusaurus/vercel.json
@@ -982,7 +982,7 @@
     },
     {
       "source": "/dev-docs/custom-fields",
-      "destination": "/cms/plugins-development/custom-fields",
+      "destination": "/cms/features/custom-fields",
       "permanent": true
     },
     {


### PR DESCRIPTION
This PR aims to make Custom Fields documentation more visible. This includes, but is not limited to:

- Moving the Custom fields documentation to /cms/features instead of /cms/plugins-development/
- Adding TypeScript examples
- Moving code blocks outside of details blocks, and instead move parameters inside details blocks
- Fixing outdated content