### PR TITLE
CMS docs: add Guideflows in feature pages

### DIFF
--- a/docusaurus/docs/cms/features/content-history.md
+++ b/docusaurus/docs/cms/features/content-history.md
@@ -21,13 +21,7 @@ The Content History feature, in the <Icon name="feather" /> Content Manager, giv
   <IdentityCardItem icon="desktop" title="Environment">Available in both Development & Production environment</IdentityCardItem>
 </IdentityCard>
 
-<ThemedImage
-alt="Accessing the Content History of a document"
-sources={{
-  light:'/img/assets/content-manager/accessing-content-history.png',
-  dark:'/img/assets/content-manager/accessing-content-history_DARK.png',
-}}
-/>
+<Guideflow lightId="9r2m2y1sok" darkId="er566mli6p"/>
 
 ## Usage
 

--- a/docusaurus/docs/cms/features/draft-and-publish.md
+++ b/docusaurus/docs/cms/features/draft-and-publish.md
@@ -23,13 +23,7 @@ The Draft & Publish feature allows to manage drafts for your content.
   <IdentityCardItem icon="desktop" title="Environment">Available in both Development & Production environment</IdentityCardItem>
 </IdentityCard>
 
-<ThemedImage
-  alt="Editing draft version"
-  sources={{
-    light: '/img/assets/content-manager/editing_draft_version3.png',
-    dark: '/img/assets/content-manager/editing_draft_version3_DARK.png',
-  }}
-/>
+<Guideflow lightId="3r3wj5lbnk" darkId="ok8y5xehxp"/>
 
 ## Configuration
 

--- a/docusaurus/docs/cms/features/internationalization.md
+++ b/docusaurus/docs/cms/features/internationalization.md
@@ -22,13 +22,7 @@ The Internationalization feature allows to manage content in different languages
   <IdentityCardItem icon="desktop" title="Environment">Available in both Development & Production environment</IdentityCardItem>
 </IdentityCard>
 
-<ThemedImage
-  alt="i18n settings"
-  sources={{
-    light: '/img/assets/settings/settings-i18n.png',
-    dark: '/img/assets/settings/settings-i18n_DARK.png',
-  }}
-/>
+<Guideflow lightId="zkj5431ser" darkId="vkm9nn0t3p"/>
 
 ## Configuration
 

--- a/docusaurus/docs/cms/features/media-library.md
+++ b/docusaurus/docs/cms/features/media-library.md
@@ -22,13 +22,7 @@ The <Icon name="images" /> Media Library is the Strapi feature that displays all
   <IdentityCardItem icon="desktop" title="Environment">Available in both Development & Production environment</IdentityCardItem>
 </IdentityCard>
 
-<ThemedImage
-  alt="Media Library overview, annotated"
-  sources={{
-    light: '/img/assets/media-library/media-library_overview.png',
-    dark: '/img/assets/media-library/media-library_overview_DARK.png',
-  }}
-/>
+<Guideflow lightId="mk6z26zaqp" darkId="9r2m74otok"/>
 
 ## Configuration
 

--- a/docusaurus/docs/cms/features/rbac.md
+++ b/docusaurus/docs/cms/features/rbac.md
@@ -22,13 +22,7 @@ The Role-Based Access Control (RBAC) feature allows the management of the admini
   <IdentityCardItem icon="desktop" title="Environment">Available in both Development & Production environment</IdentityCardItem>
 </IdentityCard>
 
-<ThemedImage
-  alt="Administrator roles interface"
-  sources={{
-    light: '/img/assets/users-permissions/administrator_roles.png',
-    dark: '/img/assets/users-permissions/administrator_roles_DARK.png',
-  }}
-/>
+<Guideflow lightId="gky9n4mtdp" darkId="zkjloxzaep"/>
 
 ## Configuration
 

--- a/docusaurus/docs/cms/features/releases.md
+++ b/docusaurus/docs/cms/features/releases.md
@@ -22,13 +22,7 @@ The Releases feature enables content managers to organize entries into container
   <IdentityCardItem icon="desktop" title="Environment">Available in both Development & Production environment</IdentityCardItem>
 </IdentityCard>
 
-<ThemedImage
-  alt="List of Releases"
-  sources={{
-    light: '/img/assets/releases/releases-overview2.png',
-    dark: '/img/assets/releases/releases-overview2_DARK.png',
-  }}
-/>
+<Guideflow lightId="3r3wvy5tnk" darkId="xrgw472swp"/>
 
 ## Configuration
 

--- a/docusaurus/docs/cms/features/review-workflows.md
+++ b/docusaurus/docs/cms/features/review-workflows.md
@@ -21,13 +21,7 @@ The Review Workflows feature allows you to create and manage workflows for your 
   <IdentityCardItem icon="desktop" title="Environment">Available in both Development & Production environment</IdentityCardItem>
 </IdentityCard>
 
-<ThemedImage
-  alt="Review Stage column"
-  sources={{
-    light: '/img/assets/content-manager/review-workflow-list-view.png',
-    dark: '/img/assets/content-manager/review-workflow-list-view_DARK.png',
-  }}
-/>
+<Guideflow lightId="zpez8vgs3p" darkId="lpx4d4zs4k"/>
 
 ## Configuration
 


### PR DESCRIPTION
Add Guideflow (Light + Dark) for:

- [x] Content History
- [x] Draft & Publish
- [x] i18n
- [x] Media Library
- [x] RBAC
- [x] Releases
- [x] Review Workflows