### PR TITLE
chore: Display required version for audit logs, data export and import, and relations reordering

### DIFF
--- a/docusaurus/docs/cms/api/rest/relations.md
+++ b/docusaurus/docs/cms/api/rest/relations.md
@@ -165,6 +165,8 @@ const response = await fetch(
 
 ### Relations reordering
 
+<VersionBadge version="4.6.0" />
+
 Positional arguments can be passed to the longhand syntax of `connect` to define the order of relations.
 
 The longhand syntax accepts an array of objects, each object containing the `documentId` of the entry to be connected and an optional `position` object to define where to connect the relation.

--- a/docusaurus/docs/cms/data-management/export.md
+++ b/docusaurus/docs/cms/data-management/export.md
@@ -17,6 +17,8 @@ tags:
 
 # Data export
 
+<VersionBadge version="4.6.0" />
+
 The `strapi export` command is part of the [Data Management feature](/cms/features/data-management) and used to export data from a local Strapi instance. By default, the `strapi export` command exports data as an encrypted and compressed `tar.gz.enc` file which includes:
 
 - the project configuration,

--- a/docusaurus/docs/cms/data-management/import.md
+++ b/docusaurus/docs/cms/data-management/import.md
@@ -15,6 +15,8 @@ tags:
 
 # Data import
 
+<VersionBadge version="4.6.0" />
+
 The `strapi import` command is part of the [Data Management feature](/cms/features/data-management) and used to import data from a file. By default, the `strapi import` command imports data from an encrypted and compressed `tar.gz.enc` file which includes:
 
 - the project configuration,

--- a/docusaurus/docs/cms/features/audit-logs.md
+++ b/docusaurus/docs/cms/features/audit-logs.md
@@ -15,6 +15,8 @@ tags:
 # Audit Logs
 <EnterpriseBadge />
 
+<VersionBadge version="4.6.0" />
+
 The Audit Logs feature provides a searchable and filterable display of all activities performed by users of the Strapi application.
 
 <IdentityCard>


### PR DESCRIPTION
### What does it do?

Add required version for the features audit logs, data export and import, and relations reordering

### Why is it needed?

TLDR: let people to easily find minimum version and check if it is a fit.

The team I work with is needing audit logs. We dropped the idea because we are running on 4.2 and we thought audit logs was for version 5, we would need to fix the breaking changes. Further reading (through release history) I discovered that the minimum version is 4.6 so, next week, I'm suggesting my team to update from 4.2 to 4.6. So, maybe this happens to other teams as well.

### Related issue(s)/PR(s)

Relates to

https://github.com/strapi/strapi/pull/15536
https://github.com/strapi/strapi/pull/15119
https://github.com/strapi/strapi/pull/15036

### Screenshot (not needed in the PR template, but maybe it is usefull)

This is what is looks like

<img width="675" alt="image" src="https://github.com/user-attachments/assets/5e593288-afd3-4a06-af2a-4f6728742111" />
