### PR TITLE
Update options.md Customization admin panel doc

### DIFF
--- a/docusaurus/docs/cms/admin-panel-customization/options.md
+++ b/docusaurus/docs/cms/admin-panel-customization/options.md
@@ -1,3 +1,4 @@
+
 ---
 title: Admin panel customization options
 description: Various options help you configure Strapi's administration panel behavior and look, so you can make it reflect your identity.
@@ -118,6 +119,7 @@ export default {
 <TabItem value="ts" label="TypeScript">
 
 ```jsx title="/src/admin/app.ts"
+// Note: you may see some ts errors, don't worry about it
 import AuthLogo from "./extensions/my-logo.png";
 import MenuLogo from "./extensions/logo.png";
 import favicon from "./extensions/favicon.png";
@@ -142,16 +144,25 @@ export default {
     },
     // Override or extend the theme
     theme: {
-      colors: {
-        primary100: "#f6ecfc",
-        primary200: "#e0c1f4",
-        primary500: "#ac73e6",
-        primary600: "#9736e8",
-        primary700: "#8312d1",
-        danger700: "#b72b1a",
-      },
+	    dark:{
+	      colors: {
+			  alternative100: '#f6ecfc',
+			  alternative200: '#e0c1f4',
+			  alternative500: '#ac73e6',
+			  alternative600: '#9736e8',
+			  alternative700: '#8312d1',
+			  buttonNeutral0: '#ffffff',
+			  buttonPrimary500: '#7b79ff',
+			  // you can see other colors in the lin below
+			  },
+		},
+		light:{
+			// you can see the light color here just like dark colors https://github.com/strapi/design-system/blob/main/packages/design-system/src/themes/lightTheme/light-colors.ts
+		},
+  },
     },
     // Extend the translations
+    // you can see the traslations keys here https://github.com/strapi/strapi/blob/develop/packages/core/admin/admin/src/translations
     translations: {
       fr: {
         "Auth.form.email.label": "test",
@@ -170,6 +181,11 @@ export default {
   bootstrap() {},
 };
 ```
+
+:::note Notes:  you can see the full traslation on this link below to change the welcome message,... etc.
+[translation keys](https://github.com/strapi/strapi/blob/develop/packages/core/admin/admin/src/translations)
+also for the light and dar colros you can use this: [light - dark colors](https://github.com/strapi/design-system/tree/main/packages/design-system/src/themes)
+:::
 
 </TabItem>
 </Tabs>
@@ -445,5 +461,5 @@ To extend the theme, use either:
 - the `config.theme.dark` key for the Dark mode
 
 :::strapi Strapi Design System
-The default <ExternalLink to="https://github.com/strapi/design-system/tree/main/packages/strapi-design-system/src/themes" text="Strapi theme"/> defines various theme-related keys (shadows, colors…) that can be updated through the `config.theme.light` and `config.theme.dark` keys in `./admin/src/app.js`. The <ExternalLink to="https://design-system.strapi.io/" text="Strapi Design System"/> is fully customizable and has a dedicated <ExternalLink to="https://design-system-git-main-strapijs.vercel.app" text="StoryBook"/> documentation.
+The default <ExternalLink to="https://github.com/strapi/design-system/tree/main/packages/design-system/src/themes" text="Strapi theme"/> defines various theme-related keys (shadows, colors…) that can be updated through the `config.theme.light` and `config.theme.dark` keys in `./admin/src/app.js`. The <ExternalLink to="https://design-system.strapi.io/" text="Strapi Design System"/> is fully customizable and has a dedicated <ExternalLink to="https://design-system-git-main-strapijs.vercel.app" text="StoryBook"/> documentation.
 :::


### PR DESCRIPTION
Fix the GitHub link in theme customization
Add a better explanation to edit theme colors and translation keys

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

The link for the theme is broken, also, I added a better explanation for editing translation keys and theme color

### Why is it needed?

For a better understanding of how developers can customize the admin panel UI


