### PR TITLE
Remove obsolete version attribute from Docker guide

### DIFF
--- a/docusaurus/docs/cms/installation/docker.md
+++ b/docusaurus/docs/cms/installation/docker.md
@@ -130,7 +130,6 @@ Sample `docker-compose.yml`:
 <TabItem value="mysql" label="MySQL">
 
 ```yml title="./docker-compose.yml"
-version: "3"
 services:
   strapi:
     container_name: strapi


### PR DESCRIPTION
### What does it do?

Update docker-compose.yml


### Why is it needed?

The attribute `version` is obsolete.
