### PR TITLE
Remove Node 18 support and misc. cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Additional official Strapi documentation websites cover different content:
 
 The following are required if you are submitting pull requests to the documentation:
 
-- NodeJS >=16.14 <=18.x.x
+- NodeJS >=20.0.0 <=22.x.x
 - NPM >= 6.x
 - Yarn >= 1.22.x
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Additional official Strapi documentation websites cover different content:
 
 The following are required if you are submitting pull requests to the documentation:
 
-- NodeJS >=20.0.0 <=22.x.x
+- NodeJS >=18.15.0 <=22.x.x
 - NPM >= 6.x
 - Yarn >= 1.22.x
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,21 +2,72 @@
 
 ## Supported Versions
 
-As of May 2020 (and until this document is updated), only the v3.0.0 *stable* release of Strapi is supported for updates. Any previous versions are currently not supported and users are advised to use them "at their own risk".
+As of September 2024 (and until this document is updated), only the v4.x.x and v5.x.x _GA_ or _STABLE_ releases of Strapi are supported for updates and bug fixes. Any previous versions are currently not supported and users are advised to use them "at their own risk".
+
+**Note**: The v4.x.x LTS version will only receive high/critical severity fixes until April 2026. Any Medium/Low severity issues will not be fixed unless specific exceptions are made.
+
+| Version | Release Tag | Support Starts | Support Ends   | Security Updates Until | Notes                          |
+| ------- | ----------- | -------------- | -------------- | ---------------------- | ------------------------------ |
+| 5.x.x   | GA / Stable | September 2024 | Further Notice | Further Notice         | LTS                            |
+| 5.x.x   | RC          | N/A            | September 2024 | N/A                    | Not Supported                  |
+| 5.x.x   | Beta        | N/A            | N/A            | N/A                    | Not Supported                  |
+| 5.x.x   | Alpha       | N/A            | N/A            | N/A                    | Not Supported                  |
+| 4.x.x   | GA / Stable | November 2021  | October 2025   | April 2026             | LTS (High/Critical fixes only) |
+| 4.x.x   | Beta        | N/A            | N/A            | N/A                    | Not Supported                  |
+| 4.x.x   | Alpha       | N/A            | N/A            | N/A                    | Not Supported                  |
+| 3.x.x   | N/A         | N/A            | N/A            | N/A                    | End Of Life                    |
 
 ## Reporting a Vulnerability
 
-Please report (suspected) security vulnerabilities to
-**[security@strapi.io](mailto:security@strapi.io)** or via the [Strapi Slack](https://slack.strapi.io).
+Please report (suspected) security vulnerabilities via GitHub's security advisory reporting system:
+Submit your vulnerability via [this link](https://github.com/strapi/strapi/security/advisories/new)
 
-When reporting a (suspected) security vulnerability via slack please reach out to any of the following Strapi employees directly:
+**Strapi does not currently and has no plans to offer any bug bounties, swag, or any other reward for reporting vulnerabilities.**
 
-- `@dmehaffy`
-- `@aureliengeorget`
-- `@alexandre`
-- `@lauriejim`
-- `@soupette`
+During our public disclosure, we can give credit to the reporter and link to any social accounts you wish to have us add, including linking to your own blog post detailing the vulnerability.
 
-You will receive a response from us within 72 hours. If the issue is confirmed,
-we will release a patch as soon as possible depending on complexity
-but historically within a few days.
+Please note the following requirements (all are required):
+
+- Summary of the suspected vulnerability
+- Detailed information as to what the suspected vulnerability does and what it has access to
+- Proof of Concept (Code samples at minimum, reproduction video optional)
+  - POC must include how the vulnerability can actually access sensitive data, simply triggering an alert popup in a browser is not a security vulnerability
+- Impact summary (who does this impact and how)
+
+Optionally you may also add your estimated CVSS 3.1 score, though we may adjust. There is no need to submit a CVE request as we will do that as part of the advisory process.
+
+You will receive a response from us within 72 hours. If the issue is confirmed, we will release a patch as soon as possible depending on complexity but historically within a few days.
+
+Please note that we follow a very strict internal and public disclosure policy, typically a patch will be issued and included in a release. We then will place a warning that a security vulnerability has been patched and delay detailed disclosure from 2 to 8 weeks depending on the severity of the issue. If you have any resources such as blog posts that you intend to publish on and would like us to include these in our disclosure please advise us ASAP.
+
+Before doing any public disclosure we do ask that you speak to us first to ensure we are not releasing too much information before a patch is available and time has been given to users to upgrade their projects.
+
+## Security Process Summary
+
+Below is a breakdown of our security process in order to set expectations:
+
+- Initial submission of vulnerability via GitHub's Advisory system
+- Begin internal tracking and communication to reporter
+- Internal validation of vulnerability
+- Internal notification and scheduling for patch development
+- Begin development of patch
+- Validation of patch (Internal and with the reporter)
+- GitHub advisory cleanup
+- Requesting of CVE via GitHub
+- Disclosure and communication draft
+- Patch released with initial warning via patch notes
+- Email communication to Strapi Enterprise customers
+- Mandatory waiting period (between 2 to 8 weeks)
+- Publishing GitHub Advisory & CVE
+- Public disclosure (via blog post)
+- Email communication to Strapi Enterprise customers
+
+## Other reporting platforms and bounties
+
+Strapi does not support other reporting platforms, all security vulnerabilities must be made via GitHub Advisory system. If you are unable to report via this method you may open a security ticket with us by emailing security@strapi.io and we will create one on your behalf but if you do not have a GitHub user account we will not be able to share the private fork, pull request, or any other information with you during the process.
+
+List of some (though not all) platforms **we do not support**:
+
+- huntr.dev
+- Direct email or communication to Strapi employees (Discord, Slack, or Email)
+- Stack Overflow

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -46,21 +46,21 @@ Before doing any public disclosure we do ask that you speak to us first to ensur
 
 Below is a breakdown of our security process in order to set expectations:
 
-- Initial submission of vulnerability via GitHub's Advisory system
-- Begin internal tracking and communication to reporter
-- Internal validation of vulnerability
-- Internal notification and scheduling for patch development
-- Begin development of patch
-- Validation of patch (Internal and with the reporter)
-- GitHub advisory cleanup
-- Requesting of CVE via GitHub
-- Disclosure and communication draft
-- Patch released with initial warning via patch notes
-- Email communication to Strapi Enterprise customers
-- Mandatory waiting period (between 2 to 8 weeks)
-- Publishing GitHub Advisory & CVE
-- Public disclosure (via blog post)
-- Email communication to Strapi Enterprise customers
+1. Initial submission of vulnerability via GitHub's Advisory system
+2. Begin internal tracking and communication to reporter
+3. Internal validation of vulnerability
+4. Internal notification and scheduling for patch development
+5. Begin development of patch
+6. Validation of patch (Internal and with the reporter)
+7. GitHub advisory cleanup
+8. Requesting of CVE via GitHub
+9. Disclosure and communication draft
+10. Patch released with initial warning via patch notes
+11. Email communication to Strapi Enterprise customers
+12. Mandatory waiting period (between 2 to 8 weeks)
+13. Publishing GitHub Advisory & CVE
+14. Public disclosure (via blog post)
+15. Email communication to Strapi Enterprise customers
 
 ## Other reporting platforms and bounties
 

--- a/docusaurus/docs/cms/installation/cli.md
+++ b/docusaurus/docs/cms/installation/cli.md
@@ -25,14 +25,14 @@ Strapi CLI (Command Line Interface) installation scripts are the fastest way to 
 A supported database is also required for any Strapi project:
 
 | Database   | Recommended | Minimum |
-| ---------- | ----------- | ------- |
-| MySQL      | 8.0         | 8.0     |
-| MariaDB    | 10.6        | 10.5    |
-| PostgreSQL | 14.0        | 12.0    |
+|------------|-------------|---------|
+| MySQL      | 8.4         | 8.0     |
+| MariaDB    | 11.4        | 10.3    |
+| PostgreSQL | 17.0        | 14.0    |
 | SQLite     | 3           | 3       |
 
 :::caution
-Strapi does not support MongoDB.
+Strapi does not support MongoDB (or any NoSQL databases), nor does it support any "Cloud Native" databases (e.g., Amazon Aurora, Google Cloud SQL, etc.)
 :::
 
 ## Creating a Strapi project
@@ -113,32 +113,32 @@ Once all questions have been answered, the script will start creating the Strapi
 
 The above installation guide only covers the basic installation option using the CLI. There are other options that can be used when creating a new Strapi project, for example:
 
-| Option | Description |
-|--------|---------------------------------------------------------|
-| `--no-run` | Do not start the application after it is created |
-| `--ts`<br/>`--typescript` | Initialize the project with TypeScript (default) |
-| `--js`<br/>`--javascript` | Initialize the project with JavaScript  |
-| `--use-npm` | Force the usage of <ExternalLink to="https://www.npmjs.com/" text="npm"/> as the project package manager |
-| `--use-yarn` | Force the usage of <ExternalLink to="https://yarnpkg.com/" text="yarn"/> as the project package manager |
-| `--use-pnpm` | Force the usage of <ExternalLink to="https://pnpm.io/" text="pnpm"/> as the project package manager |
-| `--install`  | Install all dependencies, skipping the related CLI prompt |
-| `--no-install`  | Do not install all dependencies, skipping the related CLI prompt |
-| `--git-init` | Initialize a git repository, skipping the related CLI prompt |
-| `--no-git-init` | Do not initialize a git repository, skipping the related CLI prompt |
-| `--example`  | Add example data, skipping the related CLI prompt |
-| `--no-example`  | Do not add example data, skipping the related CLI prompt |
-| `--skip-cloud` |  Skip [Strapi Cloud login and project creation steps](#skipping-the-strapi-cloud-login-step) |
-| `--skip-db` | Skip all database-related prompts and create a project with the default (SQLite) database |
-| `--template <template-name-or-url>` | Create the application based on a given template.<br/>Additional options for templates are available, see the [templates documentation](/cms/templates) for details. |
-| `--dbclient <dbclient>` | Define the database client to use by replacing `<dbclient>` in the command by one of the these values:<ul><li>`sql` for a SQLite database (default)</li><li>`postgres` for a PostgreSQL database</li><li>`mysql` for a MySQL database</li></ul> |
-| `--dbhost <dbhost>` | Define the database host to use by replacing `<dbhost>` in the command by the value of your choice |
-| `--dbport <dbport>` | Define the database port to use by replacing `<dbport>` in the command by the value of your choice |
-| `--dbname <dbname>` | Define the database name to use by replacing `<dbname>` in the command by the value of your choice |
-| `--dbusername <dbusername>` | Define the database username to use by replacing `<dbusername>` in the command by the value of your choice |
-| `--dbpassword <dbpassword>` | Define the database password to use by replacing `<dbpassword>` in the command by the value of your choice |
-| `--dbssl <dbssl>` | Define that SSL is used with the database, by passing `--dbssl=true` (No SSL by default) |
-| `--dbfile <dbfile>` | For SQLite databases, define the database file path to use by replacing `<dbclient>` in the command by the value of your choice |
-| `--quickstart` | (**Deprecated in Strapi 5**)<br/>Directly create the project in quickstart mode. |
+| Option                              | Description                                                                                                                                                                                                                                     |
+|-------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `--no-run`                          | Do not start the application after it is created                                                                                                                                                                                                |
+| `--ts`<br/>`--typescript`           | Initialize the project with TypeScript (default)                                                                                                                                                                                                |
+| `--js`<br/>`--javascript`           | Initialize the project with JavaScript                                                                                                                                                                                                          |
+| `--use-npm`                         | Force the usage of <ExternalLink to="https://www.npmjs.com/" text="npm"/> as the project package manager                                                                                                                                        |
+| `--use-yarn`                        | Force the usage of <ExternalLink to="https://yarnpkg.com/" text="yarn"/> as the project package manager                                                                                                                                         |
+| `--use-pnpm`                        | Force the usage of <ExternalLink to="https://pnpm.io/" text="pnpm"/> as the project package manager                                                                                                                                             |
+| `--install`                         | Install all dependencies, skipping the related CLI prompt                                                                                                                                                                                       |
+| `--no-install`                      | Do not install all dependencies, skipping the related CLI prompt                                                                                                                                                                                |
+| `--git-init`                        | Initialize a git repository, skipping the related CLI prompt                                                                                                                                                                                    |
+| `--no-git-init`                     | Do not initialize a git repository, skipping the related CLI prompt                                                                                                                                                                             |
+| `--example`                         | Add example data, skipping the related CLI prompt                                                                                                                                                                                               |
+| `--no-example`                      | Do not add example data, skipping the related CLI prompt                                                                                                                                                                                        |
+| `--skip-cloud`                      | Skip [Strapi Cloud login and project creation steps](#skipping-the-strapi-cloud-login-step)                                                                                                                                                     |
+| `--skip-db`                         | Skip all database-related prompts and create a project with the default (SQLite) database                                                                                                                                                       |
+| `--template <template-name-or-url>` | Create the application based on a given template.<br/>Additional options for templates are available, see the [templates documentation](/cms/templates) for details.                                                                            |
+| `--dbclient <dbclient>`             | Define the database client to use by replacing `<dbclient>` in the command by one of the these values:<ul><li>`sql` for a SQLite database (default)</li><li>`postgres` for a PostgreSQL database</li><li>`mysql` for a MySQL database</li></ul> |
+| `--dbhost <dbhost>`                 | Define the database host to use by replacing `<dbhost>` in the command by the value of your choice                                                                                                                                              |
+| `--dbport <dbport>`                 | Define the database port to use by replacing `<dbport>` in the command by the value of your choice                                                                                                                                              |
+| `--dbname <dbname>`                 | Define the database name to use by replacing `<dbname>` in the command by the value of your choice                                                                                                                                              |
+| `--dbusername <dbusername>`         | Define the database username to use by replacing `<dbusername>` in the command by the value of your choice                                                                                                                                      |
+| `--dbpassword <dbpassword>`         | Define the database password to use by replacing `<dbpassword>` in the command by the value of your choice                                                                                                                                      |
+| `--dbssl <dbssl>`                   | Define that SSL is used with the database, by passing `--dbssl=true` (No SSL by default)                                                                                                                                                        |
+| `--dbfile <dbfile>`                 | For SQLite databases, define the database file path to use by replacing `<dbclient>` in the command by the value of your choice                                                                                                                 |
+| `--quickstart`                      | (**Deprecated in Strapi 5**)<br/>Directly create the project in quickstart mode.                                                                                                                                                                |
 
 :::note Notes
 * If you do not pass a `--use-yarn|npm|pnpm` option, the installation script will use whatever package manager was used with the create command to install all dependencies (e.g., `npm create strapi` will install all the project's dependencies with npm).

--- a/docusaurus/docs/cms/installation/docker.md
+++ b/docusaurus/docs/cms/installation/docker.md
@@ -63,7 +63,7 @@ Sample `Dockerfile`:
 <TabItem value="yarn" label="yarn">
 
 ```dockerfile title="./Dockerfile"
-FROM node:18-alpine3.18
+FROM node:22-alpine
 # Installing libvips-dev for sharp Compatibility
 RUN apk update && apk add --no-cache build-base gcc autoconf automake zlib-dev libpng-dev nasm bash vips-dev git
 ARG NODE_ENV=development
@@ -89,7 +89,7 @@ CMD ["yarn", "develop"]
 <TabItem value="npm" label="npm">
 
 ```dockerfile title="./Dockerfile"
-FROM node:18-alpine3.18
+FROM node:22-alpine
 # Installing libvips-dev for sharp Compatibility
 RUN apk update && apk add --no-cache build-base gcc autoconf automake zlib-dev libpng-dev nasm bash vips-dev git
 ARG NODE_ENV=development
@@ -168,7 +168,7 @@ services:
     platform: linux/amd64 #for platform error on Apple M1 chips
     restart: unless-stopped
     env_file: .env
-    image: mysql:5.7
+    image: mysql:8.0
     command: --default-authentication-plugin=mysql_native_password
     environment:
       MYSQL_USER: ${DATABASE_USERNAME}
@@ -301,7 +301,7 @@ services:
     platform: linux/amd64 #for platform error on Apple M1 chips
     restart: unless-stopped
     env_file: .env
-    image: postgres:12.0-alpine
+    image: postgres:16.0-alpine
     environment:
       POSTGRES_USER: ${DATABASE_USERNAME}
       POSTGRES_PASSWORD: ${DATABASE_PASSWORD}
@@ -345,7 +345,7 @@ The following `Dockerfile` can be used to build a production Docker image for a 
 
 ```dockerfile title="./Dockerfile.prod"
 # Creating multi-stage build for production
-FROM node:18-alpine AS build
+FROM node:22-alpine AS build
 RUN apk update && apk add --no-cache build-base gcc autoconf automake zlib-dev libpng-dev vips-dev git > /dev/null 2>&1
 ARG NODE_ENV=production
 ENV NODE_ENV=${NODE_ENV}
@@ -360,7 +360,7 @@ COPY . .
 RUN yarn build
 
 # Creating final production image
-FROM node:18-alpine
+FROM node:22-alpine
 RUN apk add --no-cache vips-dev
 ENV NODE_ENV=production
 ENV NODE_ENV=${NODE_ENV}

--- a/docusaurus/docs/cms/usage-information.md
+++ b/docusaurus/docs/cms/usage-information.md
@@ -23,7 +23,6 @@ However, these above actions alone are often insufficient to maintain an overall
 - How long does setting up a project take? If the global install time increases, does it mean that users are encountering issues or the process is simply too complicated?
 - What type of errors our users are facing?
 - What are the most used plugins?
-- Should we focus our efforts on being compatible with Node 16? Maybe our community uses version 16 in greater percentages than the global Node.js community?
 - And more...
 
 Without these metrics, we wouldn't be able to make the right choices as we continue to move forward with the roadmap and provide what you, the community and users, are asking for.

--- a/docusaurus/docs/snippets/installation-prerequisites.md
+++ b/docusaurus/docs/snippets/installation-prerequisites.md
@@ -1,6 +1,6 @@
 Before installing Strapi, the following requirements must be installed on your computer:
 
-- <ExternalLink to="https://nodejs.org" text="Node.js"/>: Only <ExternalLink to="https://nodejs.org/en/about/previous-releases" text="Active LTS or Maintenance LTS versions"/> are supported (currently `v18`, `v20`, and `v22`). Odd-number releases of Node, known as "current" versions of Node.js, are not supported (e.g. v19, v21).
+- <ExternalLink to="https://nodejs.org" text="Node.js"/>: Only <ExternalLink to="https://nodejs.org/en/about/previous-releases" text="Active LTS or Maintenance LTS versions"/> are supported (currently `v20` and `v22`). Odd-number releases of Node, known as "current" versions of Node.js, are not supported (e.g. v21, v23).
 - Your preferred Node.js package manager:
     - <ExternalLink to="https://docs.npmjs.com/cli/v6/commands/npm-install" text="npm"/> (`v6` and above)
     - <ExternalLink to="https://yarnpkg.com/getting-started/install" text="yarn"/>


### PR DESCRIPTION
### What does it do?

- Removes/updates references of node 18 to node 20/22
- Fixes dockerfile examples with updated node version
- Fixes very outdated security policy (copied from main monorepo)
- Various other little cleanups

### Why is it needed?

Node 18 is now end of life as of 2025-04-30: https://endoflife.date/nodejs

![image](https://github.com/user-attachments/assets/d6c813f2-c295-49c9-b317-5c0173bd34d7)


### Related issue(s)/PR(s)

N/A
