### PR TITLE
Add "Copy Markdown" button

### DIFF
--- a/docusaurus/src/components/ContributeLink/ContributeLink.jsx
+++ b/docusaurus/src/components/ContributeLink/ContributeLink.jsx
@@ -36,7 +36,7 @@ export default function ContributeLink() {
       <a href={fullEditUrl} target="_blank" rel="noopener noreferrer">
         <Icon name="pencil-simple" /> <span>{editThisPageMessage}</span>
       </a>
-      <CopyMarkdownButton />
+      <CopyMarkdownButton Icon={Icon} />
     </div>
   );
 }

--- a/docusaurus/src/components/ContributeLink/ContributeLink.jsx
+++ b/docusaurus/src/components/ContributeLink/ContributeLink.jsx
@@ -5,6 +5,7 @@ import {useActiveDocContext} from '@docusaurus/plugin-content-docs/client';
 import {translate} from '@docusaurus/Translate';
 import styles from './contribute-link.module.scss';
 import Icon from '../Icon';
+import CopyMarkdownButton from '../CopyMarkdownButton';
 
 export default function ContributeLink() {
   const {siteConfig} = useDocusaurusContext();
@@ -35,6 +36,7 @@ export default function ContributeLink() {
       <a href={fullEditUrl} target="_blank" rel="noopener noreferrer">
         <Icon name="pencil-simple" /> <span>{editThisPageMessage}</span>
       </a>
+      <CopyMarkdownButton />
     </div>
   );
 }

--- a/docusaurus/src/components/CopyMarkdownButton.js
+++ b/docusaurus/src/components/CopyMarkdownButton.js
@@ -121,7 +121,7 @@ const CopyMarkdownButton = ({ className, docId, docPath, Icon }) => {
         copyStatus === 'error' ? 'copy-markdown-button--error' : '',
         className || ''
       ].filter(Boolean).join(' ')}
-      title="Copy the raw markdown content of this page"
+      title="Copy the raw markdown content of this page. Use it in your favorite LLM!"
     >
       <IconComponent 
         name={getStatusIcon()}

--- a/docusaurus/src/components/CopyMarkdownButton.js
+++ b/docusaurus/src/components/CopyMarkdownButton.js
@@ -1,0 +1,116 @@
+import React, { useState, useCallback } from 'react';
+import { useActiveDocContext } from '@docusaurus/plugin-content-docs/client';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import clsx from 'clsx';
+import Icon from './Icon';
+
+const CopyMarkdownButton = ({ className }) => {
+  const [copyStatus, setCopyStatus] = useState('');
+  const { activeDoc } = useActiveDocContext();
+  const { siteConfig } = useDocusaurusContext();
+
+  const handleCopyMarkdown = useCallback(async () => {
+    if (!activeDoc) {
+      setCopyStatus('error');
+      setTimeout(() => setCopyStatus(''), 3000);
+      return;
+    }
+
+    try {
+      // Build the raw markdown URL from GitHub
+      const baseUrl = 'https://raw.githubusercontent.com/strapi/documentation/main/docusaurus';
+      const markdownUrl = `${baseUrl}/docs/${activeDoc.id}.md`;
+      
+      // Fetch the raw markdown content
+      const response = await fetch(markdownUrl);
+      
+      if (!response.ok) {
+        throw new Error(`Failed to fetch markdown: ${response.status}`);
+      }
+      
+      const markdownContent = await response.text();
+      
+      // Copy to clipboard
+      await navigator.clipboard.writeText(markdownContent);
+      
+      setCopyStatus('success');
+      setTimeout(() => setCopyStatus(''), 3000);
+      
+    } catch (error) {
+      console.error('Error copying markdown:', error);
+      setCopyStatus('error');
+      setTimeout(() => setCopyStatus(''), 3000);
+    }
+  }, [activeDoc]);
+
+  // Don't render if no active document
+  if (!activeDoc) {
+    return null;
+  }
+
+  const getStatusIcon = () => {
+    switch (copyStatus) {
+      case 'success':
+        return 'check-circle';
+      case 'error':
+        return 'warning-circle';
+      default:
+        return 'copy';
+    }
+  };
+
+  const getStatusText = () => {
+    switch (copyStatus) {
+      case 'success':
+        return 'Markdown copied!';
+      case 'error':
+        return 'Copy failed';
+      default:
+        return 'Copy Markdown';
+    }
+  };
+
+  return (
+    <button
+      onClick={handleCopyMarkdown}
+      disabled={copyStatus === 'success'}
+      className={clsx(
+        'copy-markdown-button',
+        {
+          'copy-markdown-button--success': copyStatus === 'success',
+          'copy-markdown-button--error': copyStatus === 'error',
+        },
+        className
+      )}
+      title="Copy the raw markdown content of this page"
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: '6px',
+        padding: '8px 12px',
+        border: '1px solid var(--strapi-neutral-200)',
+        borderRadius: '4px',
+        backgroundColor: 'var(--strapi-neutral-0)',
+        color: 'var(--strapi-neutral-700)',
+        fontSize: '13px',
+        fontWeight: '500',
+        cursor: copyStatus === 'success' ? 'default' : 'pointer',
+        transition: 'all 0.2s ease',
+        opacity: copyStatus === 'success' ? 0.7 : 1,
+      }}
+    >
+      <Icon 
+        name={getStatusIcon()} 
+        classes="ph-fill"
+        color={
+          copyStatus === 'success' ? 'var(--strapi-success-600)' :
+          copyStatus === 'error' ? 'var(--strapi-danger-600)' :
+          'var(--strapi-neutral-500)'
+        }
+      />
+      {getStatusText()}
+    </button>
+  );
+};
+
+export default CopyMarkdownButton;

--- a/docusaurus/src/components/CopyMarkdownButton.js
+++ b/docusaurus/src/components/CopyMarkdownButton.js
@@ -1,7 +1,7 @@
 import React, { useState, useCallback } from 'react';
 
 // Simple Icon component fallback if not available
-const IconFallback = ({ name, color = 'currentColor' }) => {
+const IconFallback = ({ name }) => {
   const getIcon = () => {
     switch (name) {
       case 'check-circle':
@@ -14,11 +14,7 @@ const IconFallback = ({ name, color = 'currentColor' }) => {
     }
   };
   
-  return (
-    <span style={{ color, fontSize: '14px', position: 'relative', top: '-1px' }}>
-      {getIcon()}
-    </span>
-  );
+  return <span>{getIcon()}</span>;
 };
 
 const CopyMarkdownButton = ({ className, docId, docPath, Icon }) => {
@@ -126,35 +122,11 @@ const CopyMarkdownButton = ({ className, docId, docPath, Icon }) => {
         className || ''
       ].filter(Boolean).join(' ')}
       title="Copy the raw markdown content of this page"
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        gap: '0.5rem',
-        padding: '0',
-        border: 'none',
-        borderRadius: '0',
-        backgroundColor: 'transparent',
-        color: '#4945FF',
-        fontSize: '12px',
-        fontWeight: '500',
-        cursor: copyStatus === 'success' ? 'default' : 'pointer',
-        textDecoration: 'none',
-        opacity: copyStatus === 'success' ? 0.7 : 1,
-      }}
     >
       <IconComponent 
         name={getStatusIcon()}
-        color={
-          copyStatus === 'success' ? '#2F6846' :
-          copyStatus === 'error' ? '#D02B20' :
-          '#4945FF'
-        }
       />
-      <span style={{ 
-        color: copyStatus === 'success' ? '#2F6846' :
-               copyStatus === 'error' ? '#D02B20' :
-               '#4945FF'
-      }}>
+      <span>
         {getStatusText()}
       </span>
     </button>

--- a/docusaurus/src/components/CopyMarkdownButton.js
+++ b/docusaurus/src/components/CopyMarkdownButton.js
@@ -1,7 +1,31 @@
 import React, { useState, useCallback } from 'react';
 
-const CopyMarkdownButton = ({ className, docId, docPath }) => {
+// Simple Icon component fallback if not available
+const IconFallback = ({ name, color = 'currentColor' }) => {
+  const getIcon = () => {
+    switch (name) {
+      case 'check-circle':
+        return '✓';
+      case 'warning-circle':
+        return '⚠';
+      case 'copy':
+      default:
+        return '📋';
+    }
+  };
+  
+  return (
+    <span style={{ color, fontSize: '14px', position: 'relative', top: '-1px' }}>
+      {getIcon()}
+    </span>
+  );
+};
+
+const CopyMarkdownButton = ({ className, docId, docPath, Icon }) => {
   const [copyStatus, setCopyStatus] = useState('');
+  
+  // Use provided Icon component or fallback
+  const IconComponent = Icon || IconFallback;
 
   const handleCopyMarkdown = useCallback(async () => {
     // Use props or try to get from current URL
@@ -72,11 +96,11 @@ const CopyMarkdownButton = ({ className, docId, docPath }) => {
   const getStatusIcon = () => {
     switch (copyStatus) {
       case 'success':
-        return '✓';
+        return 'check-circle';
       case 'error':
-        return '⚠';
+        return 'warning-circle';
       default:
-        return '📋';
+        return 'copy';
     }
   };
 
@@ -118,20 +142,16 @@ const CopyMarkdownButton = ({ className, docId, docPath }) => {
         opacity: copyStatus === 'success' ? 0.7 : 1,
       }}
     >
-      <span 
-        style={{
-          fontSize: '14px',
-          position: 'relative',
-          top: '-1px',
-          color: copyStatus === 'success' ? '#5CB176' :
-                 copyStatus === 'error' ? '#D02B20' :
-                 '#4945FF'
-        }}
-      >
-        {getStatusIcon()}
-      </span>
+      <IconComponent 
+        name={getStatusIcon()}
+        color={
+          copyStatus === 'success' ? '#2F6846' :
+          copyStatus === 'error' ? '#D02B20' :
+          '#4945FF'
+        }
+      />
       <span style={{ 
-        color: copyStatus === 'success' ? '#5CB176' :
+        color: copyStatus === 'success' ? '#2F6846' :
                copyStatus === 'error' ? '#D02B20' :
                '#4945FF'
       }}>

--- a/docusaurus/src/scss/__index.scss
+++ b/docusaurus/src/scss/__index.scss
@@ -26,6 +26,7 @@
 @use 'code-block.scss';
 @use 'columns.scss';
 @use 'container.scss';
+@use 'copy-markdown-button.scss';
 @use 'custom-doc-cards.scss';
 @use 'custom-search-bar.scss';
 @use 'details.scss';

--- a/docusaurus/src/scss/copy-markdown-button.scss
+++ b/docusaurus/src/scss/copy-markdown-button.scss
@@ -16,11 +16,7 @@
   transition: all 0.2s ease;
 
   &:hover {
-    text-decoration: underline;
-    
-    span {
-      text-decoration: underline;
-    }
+    text-decoration: none;
   }
 
   &:disabled {
@@ -30,14 +26,6 @@
 
   &--success {
     color: var(--strapi-success-600);
-    
-    &:hover {
-      text-decoration: none;
-      
-      span {
-        text-decoration: none;
-      }
-    }
   }
 
   &--error {
@@ -45,14 +33,15 @@
   }
 
   span {
-    color: inherit;
+    &:hover {
+      text-decoration: underline;
+    }
   }
 
-  // Icon positioning to match ContributeLink
   i {
+    margin-right: 0.5rem;
     position: relative;
     top: -1px;
-    margin-right: 0.5rem;
     text-decoration: none !important;
   }
 }

--- a/docusaurus/src/scss/copy-markdown-button.scss
+++ b/docusaurus/src/scss/copy-markdown-button.scss
@@ -1,0 +1,73 @@
+/** Component: Copy Markdown Button */
+@use './mixins' as *;
+
+.copy-markdown-button {
+  display: flex;
+  align-items: center;
+  padding: 0;
+  border: none;
+  border-radius: 0;
+  background-color: transparent;
+  color: var(--strapi-primary-600);
+  font-size: var(--strapi-font-size-xs);
+  font-weight: 500;
+  cursor: pointer;
+  text-decoration: none;
+  transition: all 0.2s ease;
+
+  &:hover {
+    text-decoration: underline;
+    
+    span {
+      text-decoration: underline;
+    }
+  }
+
+  &:disabled {
+    cursor: default;
+    opacity: 0.7;
+  }
+
+  &--success {
+    color: var(--strapi-success-600);
+    
+    &:hover {
+      text-decoration: none;
+      
+      span {
+        text-decoration: none;
+      }
+    }
+  }
+
+  &--error {
+    color: var(--strapi-danger-600);
+  }
+
+  span {
+    color: inherit;
+  }
+
+  // Icon positioning to match ContributeLink
+  i {
+    position: relative;
+    top: -1px;
+    margin-right: 0.5rem;
+    text-decoration: none !important;
+  }
+}
+
+/** Dark mode */
+@include dark {
+  .copy-markdown-button {
+    color: var(--strapi-primary-500);
+
+    &--success {
+      color: var(--strapi-success-500);
+    }
+
+    &--error {
+      color: var(--strapi-danger-500);
+    }
+  }
+}

--- a/docusaurus/src/scss/copy-markdown-button.scss
+++ b/docusaurus/src/scss/copy-markdown-button.scss
@@ -11,9 +11,10 @@
   color: var(--strapi-primary-600);
   font-size: var(--strapi-font-size-xs);
   font-weight: 500;
+  font-family: "SF Pro Text", "SF Pro Display", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
   cursor: pointer;
   text-decoration: none;
-  transition: all 0.2s ease;
+  transition: color var(--ifm-transition-fast, 0.15s) var(--ifm-transition-timing-default, ease-in-out);
 
   &:hover {
     text-decoration: none;


### PR DESCRIPTION
This PR adds a little button below the "Contribute to this page" link in the secondary navbar. When clicked, it fetches the raw Markdown file from GitHub and stores it in the user's clipboard, ready to be pasted anywhere, incl. in their favorite LLM 😎 