### PR TITLE
Admin Panel API typo in example

### DIFF
--- a/docusaurus/docs/cms/plugins-development/admin-panel-api.md
+++ b/docusaurus/docs/cms/plugins-development/admin-panel-api.md
@@ -481,7 +481,7 @@ Both the `injectComponent()` and `getPlugin('content-manager').injectComponent()
 
 export default {
   bootstrap(app) {
-    app.getPlugin('content-manager').injectComponent()('editView', 'informations', {
+    app.getPlugin('content-manager').injectComponent('editView', 'informations', {
       name: 'my-plugin-my-compo',
       Component: () => 'my-compo',
     });

--- a/docusaurus/docs/cms/plugins-development/content-manager-apis.md
+++ b/docusaurus/docs/cms/plugins-development/content-manager-apis.md
@@ -31,7 +31,7 @@ All Content Manager APIs works in the same way: to use them, call them on your p
 - Passing an array with what you want to add. For example, the following code would add the ReleasesPanel at the end of the current EditViewSidePanels:
   
   ```jsx
-  app.getPlugin('content-manager').apis.addEditViewSidePanel([ReleasesPanel])`
+  app.getPlugin('content-manager').apis.addEditViewSidePanel([ReleasesPanel])
   ```
 
 - Passing a function that receives the current elements and return the new ones. This is useful if, for example, you want to add something in a specific position in the list, like in the following code:


### PR DESCRIPTION
### What does it do?

Per documentation `injectComponent()` is being called with no arguments, and then immediately called again as if it returned a function. That way it doesn't work and I always had console errors, the code itself is valid and so my IDE didn't catch it.
