### PR TITLE
Increase modal width to 720px

### DIFF
--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -99,6 +99,7 @@ const config = {
       'data-submit-query-button-bg-color': '#4945FF',
       'data-modal-body-padding-top': '20px',
       'data-modal-y-offset': "25vh",
+      'data-modal-size': '720px',
       async: true,
     },
     {


### PR DESCRIPTION
We can't customize the Kapa "Ask AI" modal any further in its current state, but at least we can increase its width using the `data-modal-size` parameter in the Docusaurus configuration file.