### PR TITLE
Add link to blog article about webhooks and Next.js

### DIFF
--- a/docusaurus/.gitignore
+++ b/docusaurus/.gitignore
@@ -4,6 +4,7 @@
 
 # Production
 /build
+/static
 
 # Generated files
 .docusaurus

--- a/docusaurus/docs/cms/backend-customization/webhooks.md
+++ b/docusaurus/docs/cms/backend-customization/webhooks.md
@@ -507,3 +507,7 @@ The event is triggered when a [release](/cms/features/releases) is published.
 - Log webhook events for debugging and monitoring.
 - Use secure, HTTPS endpoints for receiving webhooks.
 - Set up rate limiting to avoid being overwhelmed by multiple webhook requests.
+
+:::tip
+If you want to learn more about how to use webhooks with Next.js, please have a look at the [dedicated blog article](https://strapi.io/blog/how-to-create-an-ssg-static-site-generation-application-with-strapi-webhooks-and-nextjs).
+:::


### PR DESCRIPTION
Pointing to: https://strapi.io/blog/how-to-create-an-ssg-static-site-generation-application-with-strapi-webhooks-and-nextjs