### PR TITLE
Add repeatable components/Document Service API breaking change

### DIFF
--- a/docusaurus/docs/cms/api/document-service.md
+++ b/docusaurus/docs/cms/api/document-service.md
@@ -380,7 +380,10 @@ To update a document and publish the new version right away, you can:
 
 - update its draft version with `update()`, then [publish it](#publish) with `publish()`,
 - or directly add `status: 'published'` along with the other parameters passed to `update()` (see [`status` documentation](/cms/api/document-service/status#update)).
+:::
 
+:::caution
+It's not recommended to update repeatable components with the Document Service API (see the related [breaking change entry](/cms/migration/v4-to-v5/breaking-changes/do-not-update-repeatable-components-with-document-service-api.md) for more details).
 :::
 
 ### Example

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes.md
@@ -100,4 +100,4 @@ You can click on the description of any breaking change in the following tables 
 | [Some attributes and content-types names are reserved by Strapi](/cms/migration/v4-to-v5/breaking-changes/attributes-and-content-types-names-reserved) | Yes | No |
 | [Upload a file at entry creation is no longer possible](/cms/migration/v4-to-v5/breaking-changes/no-upload-at-entry-creation) | Yes | No |
 | [Components and dynamic zones should be populated using the detailed population strategy](/cms/migration/v4-to-v5/breaking-changes/no-shared-population-strategy-components-dynamic-zones) | Yes | No |
-| [Repeatable components can't be updated with the Document Service API](/cms/migration/v4-to-v5/breaking-changes/do-not-update-repeatable-components-with-document-service-api) | Yes | No |
+| [Updating repeatable components with the Document Service API is not recommended](/cms/migration/v4-to-v5/breaking-changes/do-not-update-repeatable-components-with-document-service-api) | Yes | No |

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes.md
@@ -100,3 +100,4 @@ You can click on the description of any breaking change in the following tables 
 | [Some attributes and content-types names are reserved by Strapi](/cms/migration/v4-to-v5/breaking-changes/attributes-and-content-types-names-reserved) | Yes | No |
 | [Upload a file at entry creation is no longer possible](/cms/migration/v4-to-v5/breaking-changes/no-upload-at-entry-creation) | Yes | No |
 | [Components and dynamic zones should be populated using the detailed population strategy](/cms/migration/v4-to-v5/breaking-changes/no-shared-population-strategy-components-dynamic-zones) | Yes | No |
+| [Repeatable components can't be updated with the Document Service API](/cms/migration/v4-to-v5/breaking-changes/do-not-update-repeatable-components-with-document-service-api) | Yes | No |

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/do-not-update-repeatable-components-with-document-service-api.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/do-not-update-repeatable-components-with-document-service-api.md
@@ -1,6 +1,6 @@
 ---
 title: defaultIndex removed
-description: In Strapi 5, the 'defaultIndex' option is removed from the 'public' middleware.
+description: In Strapi 5, it's not recommended to update repeatable components with the Document Service API
 sidebar_label: defaultIndex removed
 displayed_sidebar: cmsSidebar
 tags:
@@ -12,7 +12,7 @@ tags:
 import Intro from '/docs/snippets/breaking-change-page-intro.md'
 import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
 
-#  Repeatable components can't be updated with the API in Strapi 5
+#  Updating repeatable components with the Document Service API is not recommended
 
 In Strapi 5, it's not recommended to update repeatable components with the API, due to some limitations of the new Document Service API.
 
@@ -78,4 +78,4 @@ PUT /articles/{documentId} // <== Update draft article
 }
 ```
 
-However, this would fail because the component id of the draft article is different from the published one.
+However, this would fail because the component id of the draft article is different from the published one. Therefore, it's not recommended to try to update repeatable components with the Document Service API.

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/do-not-update-repeatable-components-with-document-service-api.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/do-not-update-repeatable-components-with-document-service-api.md
@@ -1,0 +1,81 @@
+---
+title: defaultIndex removed
+description: In Strapi 5, the 'defaultIndex' option is removed from the 'public' middleware.
+sidebar_label: defaultIndex removed
+displayed_sidebar: cmsSidebar
+tags:
+ - breaking changes
+ - middlewares
+ - upgrade to Strapi 5
+---
+
+import Intro from '/docs/snippets/breaking-change-page-intro.md'
+import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
+
+#  Repeatable components can't be updated with the API in Strapi 5
+
+In Strapi 5, it's not recommended to update repeatable components with the API, due to some limitations of the new Document Service API.
+
+ <Intro />
+
+<BreakingChangeIdCard
+  plugins
+/>
+
+## Breaking change description
+
+<SideBySideContainer>
+
+<SideBySideColumn>
+
+**In Strapi v4**
+
+You could update a repeatable component with its `id`.
+
+</SideBySideColumn>
+
+<SideBySideColumn>
+
+**In Strapi 5**
+
+Strapi 5 uses `documentId` due to the introduction of the [Document Service API](/cms/api/document-service), and you can't update a repeatable component by its `documentId` due to the way the [Draft & Publish](/cms/features/draft-and-publish) feature works with the new API.
+
+</SideBySideColumn>
+
+</SideBySideContainer>
+
+## Migration
+
+<br/>
+
+### Notes
+
+In Strapi 5, draft components and published components have different ids, and you could fetch data like follows:
+
+```js
+// Request
+GET /articles // -> returns published article
+
+// Response
+{
+   documentId …
+   component: [
+     { id: 2, name: 'component-1'  },
+     { id: 4, name: 'component-2'  },
+   ]
+}
+```
+
+You can then try to do the following:
+
+```js
+PUT /articles/{documentId} // <== Update draft article
+{
+   documentId …
+   component: [
+     { id: 2, name: 'component-1-updated'  }, // <== Update component 1
+   ]
+}
+```
+
+However, this would fail because the component id of the draft article is different from the published one.

--- a/docusaurus/static/llms-full.txt
+++ b/docusaurus/static/llms-full.txt
@@ -2117,6 +2117,10 @@ Syntax: `update(parameters: Params) => Promise
 
 </ApiCall>
 
+:::note
+It's not recommended to update repeatable components with the Document Service API (see the related [breaking change entry](/cms/migration/v4-to-v5/breaking-changes/do-not-update-repeatable-components-with-document-service-api.md) for more details).
+:::
+
 <!-- ! not working -->
 <!-- #### Update many document locales
 
@@ -8880,6 +8884,7 @@ You can click on the description of any breaking change in the following tables 
 | [Some attributes and content-types names are reserved by Strapi](/cms/migration/v4-to-v5/breaking-changes/attributes-and-content-types-names-reserved) | Yes | No |
 | [Upload a file at entry creation is no longer possible](/cms/migration/v4-to-v5/breaking-changes/no-upload-at-entry-creation) | Yes | No |
 | [Components and dynamic zones should be populated using the detailed population strategy](/cms/migration/v4-to-v5/breaking-changes/no-shared-population-strategy-components-dynamic-zones) | Yes | No |
+| [Repeatable components can't be updated with the Document Service API](/cms/migration/v4-to-v5/breaking-changes/do-not-update-repeatable-components-with-document-service-api) | Yes | No |
 
 
 


### PR DESCRIPTION
This PR documents why it's not recommended to update repeatable components through the Document Service API.