### PR TITLE
Fix strapi network mismatch issues in Docker instructions

### DIFF
--- a/docusaurus/docs/cms/installation/docker.md
+++ b/docusaurus/docs/cms/installation/docker.md
@@ -187,7 +187,7 @@ volumes:
 
 networks:
   strapi:
-    name: Strapi
+    name: strapi
     driver: bridge
 ```
 
@@ -253,7 +253,7 @@ volumes:
 
 networks:
   strapi:
-    name: Strapi
+    name: strapi
     driver: bridge
 ```
 
@@ -319,7 +319,7 @@ volumes:
 
 networks:
   strapi:
-    name: Strapi
+    name: strapi
     driver: bridge
 ```
 


### PR DESCRIPTION
Corrected strapi network mismatch issues. In docker compose everywhere "strapi" as network has been used but in the last segment where network is explicitly is defined it is written "Strapi" due to which while running docker compose up -d it terminates old container and restricts new container due to network mismatch and then i had to manually delete old container and run new container with new network name.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

Describe the technical changes you did.

### Why is it needed?

Describe the issue you are solving.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
