### PR TITLE
fix: broken line breaks in step-by-step file

### DIFF
--- a/docusaurus/docs/cms/migration/v4-to-v5/step-by-step.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/step-by-step.md
@@ -25,13 +25,10 @@ Your Strapi v4 application is already running on the latest v4 minor and patch v
 
 Before getting into the upgrade process itself, take the following precautions:
 
-1. **Backup your database**.
-
-  If you are using SQLite with the default configuration (the default database provided with Strapi), your database file is named `data.db` and is located in the `.tmp/` folder at the root of your Strapi application.
-  
-  If you are using another type of database, please refer to their official documentation (see <ExternalLink to="https://www.postgresql.org/docs/" text="PostgreSQL docs"/> and <ExternalLink to="https://dev.mysql.com/doc/" text="MySQL docs"/>).
-
-  If your project is hosted on Strapi Cloud, you can manually [create a backup](/cloud/projects/settings#creating-a-manual-backup).
+1. **Backup your database**:
+    * If you are using SQLite with the default configuration (the default database provided with Strapi), your database file is named `data.db` and is located in the `.tmp/` folder at the root of your Strapi application.
+    * If you are using another type of database, please refer to their official documentation (see <ExternalLink to="https://www.postgresql.org/docs/" text="PostgreSQL docs"/> and <ExternalLink to="https://dev.mysql.com/doc/" text="MySQL docs"/>).
+    * If your project is hosted on Strapi Cloud, you can manually [create a backup](/cloud/projects/settings#creating-a-manual-backup).
 2. **Backup your code**:
     * If your code is versioned with git, create a new dedicated branch to run the migration.
     * If your code is _not_ versioned with git, create a backup of your working Strapi v4 code and store it in a safe place.

--- a/docusaurus/static/llms-full.txt
+++ b/docusaurus/static/llms-full.txt
@@ -8937,13 +8937,10 @@ Your Strapi v4 application is already running on the latest v4 minor and patch v
 
 Before getting into the upgrade process itself, take the following precautions:
 
-1. **Backup your database**.
-
-  If you are using SQLite with the default configuration (the default database provided with Strapi), your database file is named `data.db` and is located in the `.tmp/` folder at the root of your Strapi application.
-  
-  If you are using another type of database, please refer to their official documentation (see  and ).
-
-  If your project is hosted on Strapi Cloud, you can manually [create a backup](/cloud/projects/settings#creating-a-manual-backup).
+1. **Backup your database**:
+    * If you are using SQLite with the default configuration (the default database provided with Strapi), your database file is named `data.db` and is located in the `.tmp/` folder at the root of your Strapi application.
+    * If you are using another type of database, please refer to their official documentation (see  and ).
+    * If your project is hosted on Strapi Cloud, you can manually [create a backup](/cloud/projects/settings#creating-a-manual-backup).
 2. **Backup your code**:
     * If your code is versioned with git, create a new dedicated branch to run the migration.
     * If your code is _not_ versioned with git, create a backup of your working Strapi v4 code and store it in a safe place.


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

Fix broken line breaks in migration/v4-to-v5/step-by-step.md file.

### Why is it needed?

**Before**
<img width="736" height="680" alt="image" src="https://github.com/user-attachments/assets/30768082-266b-4e95-a395-85cc2b04aa03" />
(There is no break before number 2.)

**After**
<img width="707" height="583" alt="image" src="https://github.com/user-attachments/assets/623aa183-b1c6-47fe-b651-b51a211ad52e" />
(Fix line breaks issue with unified format.)
