### PR TITLE
Expand and improve Client docs

### DIFF
--- a/docusaurus/docs/cms/api/client.md
+++ b/docusaurus/docs/cms/api/client.md
@@ -408,7 +408,7 @@ The `strapi.client.files.upload()` method returns an array of file objects, each
 }
 ```
 
-:::note Additional Response Fields
+:::note Additional response fields
 The upload response includes additional fields beyond those shown above. See the complete FileResponse interface in the [client source code](https://github.com/strapi/client/blob/main/src/files/types.ts) for all available fields.
 :::
 

--- a/docusaurus/docs/cms/api/client.md
+++ b/docusaurus/docs/cms/api/client.md
@@ -87,7 +87,7 @@ The `baseURL` must include the protocol (`http` or `https`). An invalid URL will
 
 ### Authentication
 
-The Strapi Client supports different authentication strategies to access protected resources in your Strapi back end.
+The Strapi Client currently only supports API tokens as an authentication method, to access protected resources in your Strapi back end.
 
 If your Strapi instance uses API tokens, configure the Strapi Client as follows:
 
@@ -99,6 +99,7 @@ const client = strapi({
 ```
 
 This allows your requests to include the necessary authentication credentials automatically.
+If the token is invalid or missing, the client will throw an error during initialization `StrapiValidationError` [[source]](https://github.com/strapi/client/blob/f4a5d0dad9de23513f572700bc48ba9f1bafb3a9/src/index.ts).
 
 ## API Reference
 

--- a/docusaurus/docs/cms/api/client.md
+++ b/docusaurus/docs/cms/api/client.md
@@ -51,11 +51,27 @@ To use the Strapi Client in your project, install it as a dependency using your 
 
 To start interacting with your Strapi back end, initialize the Strapi Client and set the base API URL:
 
+#### Javascript
+
+Require the `strapi` function and create a client instance:
+
 ```js
 import { strapi } from '@strapi/client';
 
 const client = strapi({ baseURL: 'http://localhost:1337/api' });
 ```
+
+#### TypeScript / ESM
+
+Import the `strapi` function and create a client instance with your Strapi API base URL:
+
+```typescript
+import { strapi } from '@strapi/client';
+
+const client = strapi({ baseURL: 'http://localhost:1337/api' });
+```
+
+#### Browser (UMD)
 
 If you're using the Strapi Client in a browser environment, you can include it using a `<script>` tag:
 
@@ -66,6 +82,8 @@ If you're using the Strapi Client in a browser environment, you can include it u
   const client = strapi.strapi({ baseURL: 'http://localhost:1337/api' });
 </script>
 ```
+
+The `baseURL` must include the protocol (`http` or `https`). An invalid URL will throw an error `StrapiInitializationError` [[source]](https://github.com/strapi/client/blob/f4a5d0dad9de23513f572700bc48ba9f1bafb3a9/README.md).
 
 ### Authentication
 
@@ -164,6 +182,9 @@ const updatedHomepage = await homepage.update(
 // Delete the homepage content
 await homepage.delete();
 ```
+
+
+
 
 ### Working with files <NewBadge />
 

--- a/docusaurus/docs/cms/api/client.md
+++ b/docusaurus/docs/cms/api/client.md
@@ -51,30 +51,31 @@ To use the Strapi Client in your project, install it as a dependency using your 
 
 To start interacting with your Strapi back end, initialize the Strapi Client and set the base API URL:
 
-#### Javascript
-
-Require the `strapi` function and create a client instance:
+With Javascript, require the `strapi` function and create a client instance:
+<Tabs groupId="js-ts"> 
+<TabItem value="js" label="JavaScript">
 
 ```js
 import { strapi } from '@strapi/client';
 
 const client = strapi({ baseURL: 'http://localhost:1337/api' });
 ```
+</TabItem>
 
-#### TypeScript / ESM
 
-Import the `strapi` function and create a client instance with your Strapi API base URL:
+With Typescript, import the `strapi` function and create a client instance with your Strapi API base URL:
+<TabItem value="ts" label="TypeScript">
 
 ```typescript
 import { strapi } from '@strapi/client';
 
 const client = strapi({ baseURL: 'http://localhost:1337/api' });
 ```
+</TabItem>
 
-#### Browser (UMD)
 
-If you're using the Strapi Client in a browser environment, you can include it using a `<script>` tag:
-
+If you're using the Strapi Client in a browser environment, you can include it using a `<script>` tag. 
+<TabItem value="browser" label="Browser (UMD)">
 ```js title="./src/api/[apiName]/routes/[routerName].ts (e.g './src/api/restaurant/routes/restaurant.ts')"
 <script src="https://cdn.jsdelivr.net/npm/@strapi/client"></script>
 
@@ -82,8 +83,9 @@ If you're using the Strapi Client in a browser environment, you can include it u
   const client = strapi.strapi({ baseURL: 'http://localhost:1337/api' });
 </script>
 ```
-
+</TabItem>
 The `baseURL` must include the protocol (`http` or `https`). An invalid URL will throw an error `StrapiInitializationError`.
+
 
 ### Authentication
 
@@ -97,6 +99,7 @@ const client = strapi({
   auth: 'your-api-token-here',
 });
 ```
+
 
 This allows your requests to include the necessary authentication credentials automatically.
 If the token is invalid or missing, the client will throw an error during initialization `StrapiValidationError`.
@@ -134,6 +137,8 @@ Collection types in Strapi are entities with multiple entries (e.g., a blog with
 | `delete(documentID, queryParams?)`  | Update an existing document. |
 
 **Usage examples:**
+<Tabs groupId="js-ts"> 
+<TabItem value="js" label="JavaScript">
 ```js
 const articles = client.collection('articles');
 
@@ -155,6 +160,8 @@ const updatedArticle = await articles.update('article-document-id', { title: 'Up
 // Delete an article
 await articles.delete('article-id');
 ```
+</TabItem>
+</Tabs>
 
 ### Working with single types
 

--- a/docusaurus/docs/cms/api/client.md
+++ b/docusaurus/docs/cms/api/client.md
@@ -51,31 +51,35 @@ To use the Strapi Client in your project, install it as a dependency using your 
 
 To start interacting with your Strapi back end, initialize the Strapi Client and set the base API URL:
 
-With Javascript, require the `strapi` function and create a client instance:
 <Tabs groupId="js-ts"> 
 <TabItem value="js" label="JavaScript">
+
+With Javascript, require the `strapi` function and create a client instance:
 
 ```js
 import { strapi } from '@strapi/client';
 
 const client = strapi({ baseURL: 'http://localhost:1337/api' });
 ```
+
 </TabItem>
 
+<TabItem value="ts" label="TypeScript">
 
 With Typescript, import the `strapi` function and create a client instance with your Strapi API base URL:
-<TabItem value="ts" label="TypeScript">
 
 ```typescript
 import { strapi } from '@strapi/client';
 
 const client = strapi({ baseURL: 'http://localhost:1337/api' });
 ```
+
 </TabItem>
 
+<TabItem value="browser" label="Browser (UMD)">
 
 If you're using the Strapi Client in a browser environment, you can include it using a `<script>` tag. 
-<TabItem value="browser" label="Browser (UMD)">
+
 ```js title="./src/api/[apiName]/routes/[routerName].ts (e.g './src/api/restaurant/routes/restaurant.ts')"
 <script src="https://cdn.jsdelivr.net/npm/@strapi/client"></script>
 
@@ -83,9 +87,12 @@ If you're using the Strapi Client in a browser environment, you can include it u
   const client = strapi.strapi({ baseURL: 'http://localhost:1337/api' });
 </script>
 ```
-</TabItem>
-The `baseURL` must include the protocol (`http` or `https`). An invalid URL will throw an error `StrapiInitializationError`.
 
+</TabItem>
+
+</Tabs>
+
+The `baseURL` must include the protocol (`http` or `https`). An invalid URL will throw an error `StrapiInitializationError`.
 
 ### Authentication
 

--- a/docusaurus/docs/cms/api/client.md
+++ b/docusaurus/docs/cms/api/client.md
@@ -262,7 +262,7 @@ console.log(file.mime); // The file MIME type
 
 #### `update`
 
-The `strapi.client.files.findOne()` method updates metadata for an existing filei, accepting 2 parameters, the `fileId`, and an object containing options such as the name, alternative text, and caption for the media.
+The `strapi.client.files.update()` method updates metadata for an existing file, accepting 2 parameters, the `fileId`, and an object containing options such as the name, alternative text, and caption for the media.
 
 The methods can be used as follows:
 

--- a/docusaurus/docs/cms/api/client.md
+++ b/docusaurus/docs/cms/api/client.md
@@ -51,35 +51,31 @@ To use the Strapi Client in your project, install it as a dependency using your 
 
 To start interacting with your Strapi back end, initialize the Strapi Client and set the base API URL:
 
+With Javascript, require the `strapi` function and create a client instance:
 <Tabs groupId="js-ts"> 
 <TabItem value="js" label="JavaScript">
-
-With Javascript, require the `strapi` function and create a client instance:
 
 ```js
 import { strapi } from '@strapi/client';
 
 const client = strapi({ baseURL: 'http://localhost:1337/api' });
 ```
-
 </TabItem>
 
-<TabItem value="ts" label="TypeScript">
 
 With Typescript, import the `strapi` function and create a client instance with your Strapi API base URL:
+<TabItem value="ts" label="TypeScript">
 
 ```typescript
 import { strapi } from '@strapi/client';
 
 const client = strapi({ baseURL: 'http://localhost:1337/api' });
 ```
-
 </TabItem>
 
-<TabItem value="browser" label="Browser (UMD)">
 
 If you're using the Strapi Client in a browser environment, you can include it using a `<script>` tag. 
-
+<TabItem value="browser" label="Browser (UMD)">
 ```js title="./src/api/[apiName]/routes/[routerName].ts (e.g './src/api/restaurant/routes/restaurant.ts')"
 <script src="https://cdn.jsdelivr.net/npm/@strapi/client"></script>
 
@@ -87,12 +83,9 @@ If you're using the Strapi Client in a browser environment, you can include it u
   const client = strapi.strapi({ baseURL: 'http://localhost:1337/api' });
 </script>
 ```
-
 </TabItem>
-
-</Tabs>
-
 The `baseURL` must include the protocol (`http` or `https`). An invalid URL will throw an error `StrapiInitializationError`.
+
 
 ### Authentication
 

--- a/docusaurus/docs/cms/api/client.md
+++ b/docusaurus/docs/cms/api/client.md
@@ -95,7 +95,7 @@ The `baseURL` must include the protocol (`http` or `https`). An invalid URL will
 
 ### Authentication
 
-The Strapi Client currently only supports API tokens as an authentication method, to access protected resources in your Strapi back end.
+The Strapi Client supports different authentication strategies to access protected resources in your Strapi back end.
 
 If your Strapi instance uses API tokens, configure the Strapi Client as follows:
 

--- a/docusaurus/docs/cms/api/client.md
+++ b/docusaurus/docs/cms/api/client.md
@@ -409,7 +409,7 @@ The `strapi.client.files.upload()` method returns an array of file objects, each
 ```
 
 :::note Additional response fields
-The upload response includes additional fields beyond those shown above. See the complete FileResponse interface in the [client source code](https://github.com/strapi/client/blob/main/src/files/types.ts) for all available fields.
+The upload response includes additional fields beyond those shown above. See the complete FileResponse interface in the <ExternalLink to="https://github.com/strapi/client/blob/main/src/files/types.ts" text="client source code"/> for all available fields.
 :::
 
 #### `delete`

--- a/docusaurus/docs/cms/api/client.md
+++ b/docusaurus/docs/cms/api/client.md
@@ -83,7 +83,7 @@ If you're using the Strapi Client in a browser environment, you can include it u
 </script>
 ```
 
-The `baseURL` must include the protocol (`http` or `https`). An invalid URL will throw an error `StrapiInitializationError` [[source]](https://github.com/strapi/client/blob/f4a5d0dad9de23513f572700bc48ba9f1bafb3a9/README.md).
+The `baseURL` must include the protocol (`http` or `https`). An invalid URL will throw an error `StrapiInitializationError`.
 
 ### Authentication
 
@@ -99,7 +99,7 @@ const client = strapi({
 ```
 
 This allows your requests to include the necessary authentication credentials automatically.
-If the token is invalid or missing, the client will throw an error during initialization `StrapiValidationError` [[source]](https://github.com/strapi/client/blob/f4a5d0dad9de23513f572700bc48ba9f1bafb3a9/src/index.ts).
+If the token is invalid or missing, the client will throw an error during initialization `StrapiValidationError`.
 
 ## API Reference
 

--- a/docusaurus/docs/cms/api/client.md
+++ b/docusaurus/docs/cms/api/client.md
@@ -56,7 +56,7 @@ To start interacting with your Strapi back end, initialize the Strapi Client and
 <Tabs groupId="js-ts"> 
 <TabItem value="js" label="JavaScript">
 
-With Javascript, require the `strapi` function and create a client instance:
+With Javascript, import the `strapi` function and create a client instance:
 
 ```js
 import { strapi } from '@strapi/client';
@@ -97,7 +97,7 @@ The `baseURL` must include the protocol (`http` or `https`). An invalid URL will
 
 The Strapi Client supports different authentication strategies to access protected resources in your Strapi back end.
 
-If your Strapi instance uses API tokens, configure the Strapi Client as follows:
+If your Strapi instance uses [API tokens](/cms/features/api-tokens), configure the Strapi Client as follows:
 
 ```js
 const client = strapi({
@@ -407,6 +407,10 @@ The `strapi.client.files.upload()` method returns an array of file objects, each
   "updatedAt": "2025-07-23T12:34:56.789Z"
 }
 ```
+
+:::note Additional Response Fields
+The upload response includes additional fields beyond those shown above. See the complete FileResponse interface in the [client source code](https://github.com/strapi/client/blob/main/src/files/types.ts) for all available fields.
+:::
 
 #### `delete`
 

--- a/docusaurus/docs/cms/api/client.md
+++ b/docusaurus/docs/cms/api/client.md
@@ -1,6 +1,7 @@
 ---
 title: Strapi Client
 description: The Strapi Client library simplifies interactions with your Strapi back end, providing a way to fetch, create, update, and delete content.  
+toc_max_heading_level: 4
 displayed_sidebar: cmsSidebar
 tags:
 - API
@@ -51,20 +52,22 @@ To use the Strapi Client in your project, install it as a dependency using your 
 
 To start interacting with your Strapi back end, initialize the Strapi Client and set the base API URL:
 
-With Javascript, require the `strapi` function and create a client instance:
 <Tabs groupId="js-ts"> 
 <TabItem value="js" label="JavaScript">
+
+With Javascript, require the `strapi` function and create a client instance:
 
 ```js
 import { strapi } from '@strapi/client';
 
 const client = strapi({ baseURL: 'http://localhost:1337/api' });
 ```
+
 </TabItem>
 
+<TabItem value="ts" label="TypeScript">
 
 With Typescript, import the `strapi` function and create a client instance with your Strapi API base URL:
-<TabItem value="ts" label="TypeScript">
 
 ```typescript
 import { strapi } from '@strapi/client';
@@ -73,9 +76,9 @@ const client = strapi({ baseURL: 'http://localhost:1337/api' });
 ```
 </TabItem>
 
-
-If you're using the Strapi Client in a browser environment, you can include it using a `<script>` tag. 
 <TabItem value="browser" label="Browser (UMD)">
+If you're using the Strapi Client in a browser environment, you can include it using a `<script>` tag. 
+
 ```js title="./src/api/[apiName]/routes/[routerName].ts (e.g './src/api/restaurant/routes/restaurant.ts')"
 <script src="https://cdn.jsdelivr.net/npm/@strapi/client"></script>
 
@@ -83,7 +86,10 @@ If you're using the Strapi Client in a browser environment, you can include it u
   const client = strapi.strapi({ baseURL: 'http://localhost:1337/api' });
 </script>
 ```
+
 </TabItem>
+</Tabs>
+
 The `baseURL` must include the protocol (`http` or `https`). An invalid URL will throw an error `StrapiInitializationError`.
 
 
@@ -139,6 +145,7 @@ Collection types in Strapi are entities with multiple entries (e.g., a blog with
 **Usage examples:**
 <Tabs groupId="js-ts"> 
 <TabItem value="js" label="JavaScript">
+
 ```js
 const articles = client.collection('articles');
 
@@ -160,6 +167,7 @@ const updatedArticle = await articles.update('article-document-id', { title: 'Up
 // Delete an article
 await articles.delete('article-id');
 ```
+
 </TabItem>
 </Tabs>
 
@@ -192,16 +200,96 @@ const updatedHomepage = await homepage.update(
 await homepage.delete();
 ```
 
-## FilesManager use in the Client
+### Working with files
 
-### Media File Upload <NewBadge />
+The Strapi Client provides access to the [Media Library](/cms/features/media-library) via the `files` property. This allows you to retrieve and manage file metadata without directly interacting with the REST API.
 
-The Strapi Client provides media file upload functionality through the `FilesManager`, accessible as `client.files`.
+The following methods are available for working with files. Click on the method name in the  table to jump to the corresponding section with more details and examples:
 
-The `client.files.upload()` method allows you to upload media files (such as images, videos, or documents) to your Strapi backend. It supports uploading files as `Blob` (in browsers or Node.js) or as `Buffer` (in Node.js). The method also supports attaching metadata to the uploaded file, such as `alternativeText` and `caption`.
+| Method | Description |
+|--------|-------------|
+| [`find(params?)`](#find) | Retrieves a list of file metadata based on optional query parameters |
+| [`findOne(fileId)`](#findOne) | Retrieves the metadata for a single file by its ID |
+| [`update(fileId, fileInfo)`](#update) | Updates metadata for an existing file |
+| [`upload(type, options)`](#upload) | Uploads a file, specifying:<ul><li>`type` which can be `file`, `fileContentBuffer`, or `fileBlob`</li><li>and an additional `options` object</li></ul> |
+| [`delete(fileId)`](#delete) | Deletes a file by its ID |
+
+#### `find`
+
+The `strapi.client.files.find()` method retrieves a list of file metadata based on optional query parameters.
+
+The method can be used as follows:
+
+```js
+// Initialize the client
+const client = strapi({
+  baseURL: 'http://localhost:1337/api',
+  auth: 'your-api-token',
+});
+
+// Find all file metadata
+const allFiles = await client.files.find();
+console.log(allFiles);
+
+// Find file metadata with filtering and sorting
+const imageFiles = await client.files.find({
+  filters: {
+    mime: { $contains: 'image' }, // Only get image files
+    name: { $contains: 'avatar' }, // Only get files with 'avatar' in the name
+  },
+  sort: ['name:asc'], // Sort by name in ascending order
+});
+```
+
+#### `findOne`
+
+The `strapi.client.files.findOne()` method retrieves the metadata for a single file by its id.
+
+The method can be used as follows:
+
+```js
+// Initialize the client
+const client = strapi({
+  baseURL: 'http://localhost:1337/api',
+  auth: 'your-api-token',
+});
+
+// Find file metadata by ID
+const file = await client.files.findOne(1);
+console.log(file.name);
+console.log(file.url); 
+console.log(file.mime); // The file MIME type
+```
+
+#### `update`
+
+The `strapi.client.files.findOne()` method updates metadata for an existing filei, accepting 2 parameters, the `fileId`, and an object containing options such as the name, alternative text, and caption for the media.
+
+The methods can be used as follows:
+
+```js
+// Initialize the client
+const client = strapi({
+  baseURL: 'http://localhost:1337/api',
+  auth: 'your-api-token',
+});
+
+// Update file metadata
+const updatedFile = await client.files.update(1, {
+  name: 'New file name',
+  alternativeText: 'Descriptive alt text for accessibility',
+  caption: 'A caption for the file',
+});
+```
 
 
-### Method Signature
+#### `upload` <NewBadge />
+
+The Strapi Client provides media file upload functionality through the `FilesManager`, accessible through the  `strapi.client.files.upload()` method. The method allows you to upload media files (such as images, videos, or documents) to your Strapi backend.
+
+The method supports uploading files as `Blob` (in browsers or Node.js) or as `Buffer` (in Node.js only). The method also supports attaching metadata to the uploaded file, such as `alternativeText` and `caption`.
+
+##### Method Signature
 
 ```js
 async upload(file: Blob, options?: BlobUploadOptions): Promise<MediaUploadResponse>
@@ -213,9 +301,10 @@ async upload(file: Buffer, options: BufferUploadOptions): Promise<MediaUploadRes
 
 The response is an array of file objects, each containing details such as `id`, `name`, `url`, `size`, and `mime` [source](https://github.com/strapi/client/blob/60a0117e361346073bed1959d354c7facfb963b3/src/files/types.ts).
 
-**Usage examples:**
+<Tabs>
+<TabItem value="browser" label="Upload a file with the browser">
 
-#### Uploading a File in the Browser
+You can upload a file use through the browser as follows:
 
 ```js
 const client = strapi({ baseURL: 'http://localhost:1337/api' });
@@ -236,7 +325,14 @@ try {
 }
 ```
 
-#### Uploading a Blob in Node.js
+</TabItem>
+
+<TabItem value="node" label="Upload a file with Node.js">
+
+With Node.js, you can either upload a blob or a buffer, as in the following examples:
+
+<Tabs>
+<TabItem value="node-blob" label="Uploading a Blob">
 
 ```js
 import { readFile } from 'fs/promises';
@@ -262,7 +358,9 @@ try {
 }
 ```
 
-#### Uploading a Buffer in Node.js
+</TabItem>
+
+<TabItem value="node-buffer" label="Uploading a Buffer">
 
 ```js
 import { readFile } from 'fs/promises';
@@ -288,10 +386,15 @@ try {
 }
 ```
 
+</TabItem>
+</Tabs>
 
-### Response Structure
+</TabItem>
+</Tabs>
 
-The upload method returns an array of file objects, each with fields such as:
+##### Response Structure
+
+The `strapi.client.files.upload()` method returns an array of file objects, each with fields such as:
 
 ```json
 {
@@ -307,53 +410,17 @@ The upload method returns an array of file objects, each with fields such as:
 }
 ```
 
+#### `delete`
 
-### Managing files
+The `strapi.client.files.delete()` method deletes a file by its ID.
 
-The Strapi Client provides access to the [Media Library](/cms/features/media-library) via the `files` property. This allows you to retrieve and manage file metadata without directly interacting with the REST API.
-
-The following methods are available for working with files:
-
-| Method | Description |
-|--------|-------------|
-| `find(params?)` | Retrieves a list of file metadata based on optional query parameters |
-| `findOne(fileId)` | Retrieves the metadata for a single file by its ID |
-| `update(fileId, fileInfo)` | Updates metadata for an existing file |
-| `delete(fileId)` | Deletes a file by its ID |
-
-**Usage examples:**
+The method can be used as follows:
 
 ```js
 // Initialize the client
 const client = strapi({
   baseURL: 'http://localhost:1337/api',
   auth: 'your-api-token',
-});
-
-// Find all file metadata
-const allFiles = await client.files.find();
-console.log(allFiles);
-
-// Find file metadata with filtering and sorting
-const imageFiles = await client.files.find({
-  filters: {
-    mime: { $contains: 'image' }, // Only get image files
-    name: { $contains: 'avatar' }, // Only get files with 'avatar' in the name
-  },
-  sort: ['name:asc'], // Sort by name in ascending order
-});
-
-// Find file metadata by ID
-const file = await client.files.findOne(1);
-console.log(file.name); // The file name
-console.log(file.url); // The file URL
-console.log(file.mime); // The file MIME type
-
-// Update file metadata
-const updatedFile = await client.files.update(1, {
-  name: 'New file name',
-  alternativeText: 'Descriptive alt text for accessibility',
-  caption: 'A caption for the file',
 });
 
 // Delete a file by ID
@@ -363,11 +430,17 @@ console.log('Deleted file ID:', deletedFile.id);
 console.log('Deleted file name:', deletedFile.name);
 ```
 
+<br/>
+
 ## Handling Common Errors
 
-- **Permission Errors:** If the authenticated user does not have permission to upload or manage files, a `FileForbiddenError` is thrown.
-- **HTTP Errors:** If the server is unreachable, authentication fails, or there are network issues, an `HTTPError` is thrown.
-- **Missing Parameters:** When uploading a `Buffer`, both `filename` and `mimetype` must be provided in the options object. If either is missing, an error is thrown.
+The following errors might occur when sending queries through the Strapi Client:
+
+| Error | Description |
+|-------|-------------|
+| Permission Errors | If the authenticated user does not have permission to upload or manage files, a `FileForbiddenError` is thrown. |
+| HTTP Errors|If the server is unreachable, authentication fails, or there are network issues, an `HTTPError` is thrown. |
+| Missing Parameters|When uploading a `Buffer`, both `filename` and `mimetype` must be provided in the options object. If either is missing, an error is thrown. |
 
 
 :::strapi Additional information

--- a/docusaurus/docs/cms/api/client.md
+++ b/docusaurus/docs/cms/api/client.md
@@ -15,6 +15,7 @@ tags:
 The Strapi Client library simplifies interactions with your Strapi back end, providing a way to fetch, create, update, and delete content. This guide walks you through setting up the Strapi Client, configuring authentication, and using its key features effectively.
 
 ## Getting Started
+
 :::prerequisites
 - A Strapi project has been created and is running. If you haven't set one up yet, follow the [Quick Start Guide](/cms/quick-start) to create one.
 - You know the URL of the Content API of your Strapi instance (e.g., `http://localhost:1337/api`).
@@ -92,7 +93,6 @@ If you're using the Strapi Client in a browser environment, you can include it u
 
 The `baseURL` must include the protocol (`http` or `https`). An invalid URL will throw an error `StrapiInitializationError`.
 
-
 ### Authentication
 
 The Strapi Client currently only supports API tokens as an authentication method, to access protected resources in your Strapi back end.
@@ -105,7 +105,6 @@ const client = strapi({
   auth: 'your-api-token-here',
 });
 ```
-
 
 This allows your requests to include the necessary authentication credentials automatically.
 If the token is invalid or missing, the client will throw an error during initialization `StrapiValidationError`.
@@ -178,7 +177,7 @@ Single types in Strapi represent unique content entries that exist only once (e.
 | ----------| -------------------------------------------------------------------------------------------- |
 | `find(queryParams?)`  | Fetch the document.        |
 | `update(documentID, data, queryParams?)`  | Update the document. |
-| `delete(queryParams?) `  | Remove the document. |
+| `delete(queryParams?)`  | Remove the document. |
 
 **Usage examples:**
 ```js
@@ -209,7 +208,7 @@ The following methods are available for working with files. Click on the method 
 | Method | Description |
 |--------|-------------|
 | [`find(params?)`](#find) | Retrieves a list of file metadata based on optional query parameters |
-| [`findOne(fileId)`](#findOne) | Retrieves the metadata for a single file by its ID |
+| [`findOne(fileId)`](#findone) | Retrieves the metadata for a single file by its ID |
 | [`update(fileId, fileInfo)`](#update) | Updates metadata for an existing file |
 | [`upload(type, options)`](#upload) | Uploads a file, specifying:<ul><li>`type` which can be `file`, `fileContentBuffer`, or `fileBlob`</li><li>and an additional `options` object</li></ul> |
 | [`delete(fileId)`](#delete) | Deletes a file by its ID |
@@ -241,7 +240,7 @@ const imageFiles = await client.files.find({
 });
 ```
 
-#### `findOne`
+#### `findOne` {#findone}
 
 The `strapi.client.files.findOne()` method retrieves the metadata for a single file by its id.
 
@@ -282,8 +281,7 @@ const updatedFile = await client.files.update(1, {
 });
 ```
 
-
-#### `upload` <NewBadge />
+#### `upload` <NewBadge /> {#upload}
 
 The Strapi Client provides media file upload functionality through the `FilesManager`, accessible through the  `strapi.client.files.upload()` method. The method allows you to upload media files (such as images, videos, or documents) to your Strapi backend.
 

--- a/docusaurus/docs/cms/api/client.md
+++ b/docusaurus/docs/cms/api/client.md
@@ -210,7 +210,7 @@ The following methods are available for working with files. Click on the method 
 | [`find(params?)`](#find) | Retrieves a list of file metadata based on optional query parameters |
 | [`findOne(fileId)`](#findone) | Retrieves the metadata for a single file by its ID |
 | [`update(fileId, fileInfo)`](#update) | Updates metadata for an existing file |
-| [`upload(type, options)`](#upload) | Uploads a file, specifying:<ul><li>`type` which can be `file`, `fileContentBuffer`, or `fileBlob`</li><li>and an additional `options` object</li></ul> |
+| [`upload(file, options)`](#upload) | Uploads a file (Blob or Buffer) with an optional `options` object for metadata |
 | [`delete(fileId)`](#delete) | Deletes a file by its ID |
 
 #### `find`


### PR DESCRIPTION
### What does it do?

- adds documentation for client.files.upload as implemented in https://github.com/strapi/client/pull/92
- extends and improves documentation for initialization and authentication slightly

** note this documentation was created with the help of Dosu :) 

### Why is it needed?

Documentation for media upload is currently missing from Strapi docs.

### Related issue(s)/PR(s)

https://github.com/strapi/client/pull/92
