### PR TITLE
Mention that the Document Service API `findOne` returns `null` if no document found

### DIFF
--- a/docusaurus/docs/cms/api/document-service.md
+++ b/docusaurus/docs/cms/api/document-service.md
@@ -92,6 +92,8 @@ await strapi.documents('api::restaurant.restaurant').findOne({
 
 </ApiCall>
 
+The `findOne()` method returns the matching document if found, otherwise returns `null`.
+
 ## `findFirst()`
 
 Find the first document matching the parameters.


### PR DESCRIPTION
This PR fixes one of the identified documentation problems highlighted by users.