### PR TITLE
Fix 'v4CompatibilityMode' typo for Strapi 5 migration

### DIFF
--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/graphql-api-updated.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/graphql-api-updated.md
@@ -37,7 +37,7 @@ For an extensive description of the new Strapi 5 GraphQL API, please refer to th
 
 To gradually convert to the new GraphQL API format, follow these steps:
 
-1. Enable v4 compatibility mode with the `v4ComptabilityMode` flag in the configuration of the GraphQL plugin (see [plugins configuration](/cms/plugins/graphql#code-based-configuration)):
+1. Enable v4 compatibility mode with the `v4CompatibilityMode` flag in the configuration of the GraphQL plugin (see [plugins configuration](/cms/plugins/graphql#code-based-configuration)):
 
     ```graphql
     {

--- a/docusaurus/docs/cms/migration/v4-to-v5/step-by-step.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/step-by-step.md
@@ -110,7 +110,7 @@ Follow the steps below and leverage retro-compatibility flags and guided migrati
 
 ### Migrate GraphQL API calls
 
-1. Enable the retro-compatibility flag by setting `v4ComptabilityMode` to `true` in the `graphql.config` object of [the `/config/plugins.js|ts` file](/cms/plugins/graphql#code-based-configuration).
+1. Enable the retro-compatibility flag by setting `v4CompatibilityMode` to `true` in the `graphql.config` object of [the `/config/plugins.js|ts` file](/cms/plugins/graphql#code-based-configuration).
 2. Update your queries and mutations only, guided by the dedicated [breaking change entry for GraphQL](/cms/migration/v4-to-v5/breaking-changes/graphql-api-updated).
 3. Validate that your client is running correctly.
 4. Disable the retro-compatibily flag by setting `v4ComptabilityMode` to `false` and start using the new response format.


### PR DESCRIPTION
### What does it do?

Fix typo from `v4ComptabilityMode` to `v4CompatibilityMode`

### Why is it needed?

The flag is incorrect and does not exist. If a developer copies the value without recognising the issue, this could cause confusion.

### Related issue(s)/PR(s)

–
