### PR TITLE
Add experimental firstPublishedAt configuration

### DIFF
--- a/docusaurus/docs/cms/configurations/features.md
+++ b/docusaurus/docs/cms/configurations/features.md
@@ -31,7 +31,7 @@ To enable a future flag:
 
 1. (_optional_) If the server is running, stop it with `Ctrl-C`.
 2. Open the `config/features.js|ts` file or create it if the file does not exist yet. The file will export a `future` object with all the future flags to enable.
-3. To enable a future flag, add its property name (see [full list](#available-future-flags)) to the `future` object and ensure the property's value is set to `true`. The following example shows how to enable the `contentReleasesScheduling` future flag:
+3. To enable a future flag, add its property name (see [full list](#available-future-flags)) to the `future` object and ensure the property's value is set to `true`. The following example shows how to enable the `experimental_firstPublishedAt` future flag:
 
   <Tabs groupId='js-ts'>
 
@@ -40,8 +40,7 @@ To enable a future flag:
   ```ts title="/config/features.ts"
   module.export = ({ env }) => ({
     future: {
-      // You could also simply write: contentReleases: true
-      contentReleasesScheduling: env.bool('STRAPI_FUTURE_CONTENT_RELEASES_SCHEDULING', false),
+      experimental_firstPublishedAt: env.bool('STRAPI_FUTURE_EXPERIMENTAL_FIRST_PUBLISHED_AT', false),
     },
   })
 
@@ -50,10 +49,10 @@ To enable a future flag:
   This example assumes that you have an `.env` environment file at the root of your application and that the file includes the following line:
 
   ```json title=".env"
-  STRAPI_FUTURE_CONTENT_RELEASES_SCHEDULING=true
+  STRAPI_FUTURE_EXPERIMENTAL_FIRST_PUBLISHED_AT=true
   ```
 
-  If your environment file does not include this value, the `contentReleasesScheduling` future flag property value  will default to `false` and the experimental feature will not be enabled.
+  If your environment file does not include this value, the `experimental_firstPublishedAt` future flag property value will default to `false` and the experimental feature will not be enabled.
 
   </TabItem>
 
@@ -62,8 +61,7 @@ To enable a future flag:
   ```ts title="/config/features.ts"
   export default {
     future: {
-      // You could also simply write: contentReleases: true
-      contentReleasesScheduling: env.bool('STRAPI_FUTURE_CONTENT_RELEASES_SCHEDULING', false),
+      experimental_firstPublishedAt: env.bool('STRAPI_FUTURE_EXPERIMENTAL_FIRST_PUBLISHED_AT', false),
     },
   };
   ```
@@ -71,10 +69,10 @@ To enable a future flag:
   This example assumes that you have an `.env` environment file at the root of your application and that the file includes the following line:
 
   ```json title=".env"
-  STRAPI_FUTURE_CONTENT_RELEASES_SCHEDULING=true
+  STRAPI_FUTURE_EXPERIMENTAL_FIRST_PUBLISHED_AT=true
   ```
 
-  If your environment file does not include this value, the `contentReleases` future flag property value will default to `false` and the experimental feature will not be enabled.
+  If your environment file does not include this value, the `experimental_firstPublishedAt` future flag property value will default to `false` and the experimental feature will not be enabled.
 
   </TabItem>
   </Tabs>
@@ -107,10 +105,6 @@ Developers can use the following APIs to interact with future flags:
 
 ## Available future flags
 
-There are currently no available future flags. This section will be updated once new experimental features are available for testing.
-
-<!-- The following future flags are currently available and can be used in the `future` object of the `config/features` configuration file:
-
-| Property name     | Related feature                              | Suggested environment variable name       |
-| ----------------- | -------------------------------------------- | ----------------------------------------- |
-| `contentReleasesScheduling` | [Releases Scheduling](/cms/features/releases#usage) | `STRAPI_FUTURE_CONTENT_RELEASES_SCHEDULING` | -->
+| Property name | Related feature | Suggested environment variable name |
+| ------------- | --------------- | ---------------------------------- |
+| `experimental_firstPublishedAt` | [Draft & Publish](/cms/features/draft-and-publish#recording-the-first-publication-date) | `STRAPI_FUTURE_EXPERIMENTAL_FIRST_PUBLISHED_AT` |

--- a/docusaurus/docs/cms/features/draft-and-publish.md
+++ b/docusaurus/docs/cms/features/draft-and-publish.md
@@ -44,6 +44,14 @@ For your content types to be managed with Draft & Publish in the Content Manager
   }}
 />
 
+### Recording the first publication date <FeatureFlagBadge feature="experimental_firstPublishedAt" /> {#recording-the-first-publication-date}
+
+When this future flag is enabled (see [features configuration](/cms/configurations/features)), Strapi automatically adds a `firstPublishedAt` attribute to all content-types that use Draft & Publish. The attribute saves the date and time when an entry is first published and never changes even if the entry is unpublished and published again.
+
+:::caution
+If the feature flag is disabled later, the `firstPublishedAt` attribute and its stored values are removed.
+:::
+
 ## Usage
 
 With Draft & Publish enabled, the [Content Manager's edit view](/cms/features/content-manager#overview) indicates the current status of your content type's entry at the top of the interface. Your content can have 3 statuses:
@@ -106,13 +114,7 @@ When a document has both a draft and a published version available, the publishe
 To schedule publication (i.e. convert a draft to a published entry at a given date and time) you can include it in a release and schedule the publication of that release. Please refer to the [Releases feature](/cms/features/releases) documentation for more information.
 :::
 
-### Recording the first publication date <FeatureFlagBadge feature="experimental_firstPublishedAt" /> {#recording-the-first-publication-date}
 
-When this future flag is enabled, Strapi automatically adds a `firstPublishedAt` attribute to all content-types that use Draft & Publish. The attribute saves the date and time when an entry is first published and never changes even if the entry is unpublished and published again.
-
-:::caution
-If the feature flag is disabled later, the `firstPublishedAt` attribute and its stored values are removed.
-:::
 
 ### Unpublishing content
 

--- a/docusaurus/docs/cms/features/draft-and-publish.md
+++ b/docusaurus/docs/cms/features/draft-and-publish.md
@@ -101,8 +101,17 @@ When a document has both a draft and a published version available, the publishe
   }}
 />
 
+
 :::tip
 To schedule publication (i.e. convert a draft to a published entry at a given date and time) you can include it in a release and schedule the publication of that release. Please refer to the [Releases feature](/cms/features/releases) documentation for more information.
+:::
+
+### Recording the first publication date <FeatureFlagBadge feature="experimental_firstPublishedAt" /> {#recording-the-first-publication-date}
+
+When this future flag is enabled, Strapi automatically adds a `firstPublishedAt` attribute to all content-types that use Draft & Publish. The attribute saves the date and time when an entry is first published and never changes even if the entry is unpublished and published again.
+
+:::caution
+If the feature flag is disabled later, the `firstPublishedAt` attribute and its stored values are removed.
 :::
 
 ### Unpublishing content

--- a/docusaurus/static/llms-full.txt
+++ b/docusaurus/static/llms-full.txt
@@ -7065,13 +7065,9 @@ Developers can use the following APIs to interact with future flags:
 
 ## Available future flags
 
-There are currently no available future flags. This section will be updated once new experimental features are available for testing.
-
-<!-- The following future flags are currently available and can be used in the `future` object of the `config/features` configuration file:
-
-| Property name     | Related feature                              | Suggested environment variable name       |
-| ----------------- | -------------------------------------------- | ----------------------------------------- |
-| `contentReleasesScheduling` | [Releases Scheduling](/cms/features/releases#usage) | `STRAPI_FUTURE_CONTENT_RELEASES_SCHEDULING` | -->
+| Property name | Related feature | Suggested environment variable name |
+| ------------- | --------------- | ---------------------------------- |
+| `experimental_firstPublishedAt` | [Draft & Publish](/cms/features/draft-and-publish#recording-the-first-publication-date) | `STRAPI_FUTURE_EXPERIMENTAL_FIRST_PUBLISHED_AT` |
 
 
 


### PR DESCRIPTION
This PR:
- documents how to enable the `experimental_firstPublishedAt` future flag
- updates Draft & Publish docs with a description of the new attribute
