### PR TITLE
Add sample .env doc

### DIFF
--- a/docusaurus/docs/cms/configurations/environment.md
+++ b/docusaurus/docs/cms/configurations/environment.md
@@ -8,6 +8,8 @@ tags:
 - environment
 ---
 
+import SampleEnv from '/docs/snippets/sample-env.md'
+
 # Environment configuration and variables
 
 Strapi provides specific environment variable names. Defining them in an environment file (e.g., `.env`) will make these variables and their values available in your code.
@@ -36,6 +38,13 @@ Strapi provides the following environment variables:
 :::tip
 Prefixing an environment variable name with `STRAPI_ADMIN_` exposes the variable to the admin front end (e.g., `STRAPI_ADMIN_MY_PLUGIN_VARIABLE` is accessible through `process.env.STRAPI_ADMIN_MY_PLUGIN_VARIABLE`).
 :::
+
+
+### Sample `.env` file
+
+The Strapi CLI generates a `.env` file when creating a new project. It contains automatically-generated security keys and database settings:
+
+<SampleEnv />
 
 ## Environment configurations
 

--- a/docusaurus/docs/cms/deployment.md
+++ b/docusaurus/docs/cms/deployment.md
@@ -71,7 +71,7 @@ module.exports = ({ env }) => ({
 });
 ```
 
-Then you can create a `.env` file or directly set environment variables in your chosen deployment platform:
+Then you can create a `.env` file or directly set environment variables in your chosen deployment platform. See the [environment configuration documentation](/cms/configurations/environment#sample-env-file) for a sample `.env` file:
 
 ```
 HOST=10.0.0.1

--- a/docusaurus/docs/snippets/sample-env.md
+++ b/docusaurus/docs/snippets/sample-env.md
@@ -1,0 +1,14 @@
+Sample `.env` file generated for a new Strapi project:
+
+```bash title=".env"
+# Database
+DATABASE_CLIENT=sqlite
+DATABASE_FILENAME=.tmp/data.db
+
+# Security keys
+APP_KEYS=strapiAppKey1,strapiAppKey2
+API_TOKEN_SALT=randomSalt
+ADMIN_JWT_SECRET=randomAdminSecret
+TRANSFER_TOKEN_SALT=randomTransferSecret
+JWT_SECRET=randomJwtSecret
+```


### PR DESCRIPTION
## Summary
- document the default `.env` file generated by the Strapi CLI
- link to the sample from deployment guide

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_b_688cd19995c483319eac83cee45ae78b