### PR TITLE
Fix 'v4CompatibilityMode' typo for Strapi 5 migration in step by step guide

### DIFF
--- a/docusaurus/docs/cms/migration/v4-to-v5/step-by-step.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/step-by-step.md
@@ -113,4 +113,4 @@ Follow the steps below and leverage retro-compatibility flags and guided migrati
 1. Enable the retro-compatibility flag by setting `v4CompatibilityMode` to `true` in the `graphql.config` object of [the `/config/plugins.js|ts` file](/cms/plugins/graphql#code-based-configuration).
 2. Update your queries and mutations only, guided by the dedicated [breaking change entry for GraphQL](/cms/migration/v4-to-v5/breaking-changes/graphql-api-updated).
 3. Validate that your client is running correctly.
-4. Disable the retro-compatibily flag by setting `v4ComptabilityMode` to `false` and start using the new response format.
+4. Disable the retro-compatibily flag by setting `v4CompatibilityMode` to `false` and start using the new response format.


### PR DESCRIPTION
### What does it do?

Fix typo from v4ComptabilityMode to v4CompatibilityMode

### Why is it needed?

The flag is incorrect and does not exist. If a developer copies the value without recognising the issue, this could cause confusion.

### Related issue(s)/PR(s)

–
