### PR TITLE
Add example questions to Kapa AI modal

### DIFF
--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -90,6 +90,7 @@ const config = {
         'Disclaimer: Answers are AI-generated and might be inaccurate. Please ensure you double-check the information provided by visiting source pages.',
       'data-project-color': '#4945FF',
       'data-button-bg-color': '#32324D',
+      'data-modal-example-questions': "How to create a Strapi project?,How does population work?,How to customize the admin panel?,Explain the Growth plan benefits",
       // 'data-modal-override-open-class-search': 'DocSearch-Button',
       // 'data-modal-title-search': 'Search Strapi Docs',
       // 'data-modal-open-on-command-k': 'true',


### PR DESCRIPTION
This PR adds "default prompts" or example questions to the Kapa modal:

<img width="718" height="430" alt="Screenshot 2025-08-11 at 16 11 08" src="https://github.com/user-attachments/assets/412321f3-650a-49dd-9542-831c937cb7b7" />

Questions are configurable through the `data-modal-example-questions` property in `docusaurus.config.js`.

_⚠️ Please note that, if you visit the [Vercel Preview link](https://documentation-git-repo-kapa-example-questions-strapijs.vercel.app/), you will probably get "An error occured" message when sending the question. This is because Kapa filters URLs. It will work only locally if you clone the branch on your machine, or on the official docs.strapi.io website when merged into `main`._