### PR TITLE
Add AI Toolbar

### DIFF
--- a/docusaurus/docs/cloud/getting-started/cloud-fundamentals.md
+++ b/docusaurus/docs/cloud/getting-started/cloud-fundamentals.md
@@ -8,7 +8,7 @@ tags:
 - concepts
 ---
 
-# Strapi Cloud fundamentals <UpdatedBadge />
+# Strapi Cloud fundamentals
 
 Before going any further into this Strapi Cloud documentation, we recommend you to acknowledge the main concepts below. They will help you to understand how Strapi Cloud works, and ensure a smooth Strapi Cloud experience.
 

--- a/docusaurus/docs/cms/admin-panel-customization/bundlers.md
+++ b/docusaurus/docs/cms/admin-panel-customization/bundlers.md
@@ -13,6 +13,8 @@ tags:
 
 import FeedbackCallout from '/docs/snippets/backend-customization-feedback-cta.md'
 
+# Admin panel bundlers
+
 Strapi's [admin panel](/cms/admin-panel-customization) is a React-based single-page application that encapsulates all the features and installed plugins of a Strapi application. 2 different bundlers can be used with your Strapi 5 application, [Vite](#vite) (the default one) and [webpack](#webpack). Both bundlers can be configured to suit your needs.
 
 :::info

--- a/docusaurus/docs/cms/api/document.md
+++ b/docusaurus/docs/cms/api/document.md
@@ -16,6 +16,8 @@ tags:
 
 <div className="document-concept-page custom-mermaid-layout">
 
+# Documents
+
 A **document** in Strapi 5 is an API-only concept. A document represents all the different variations of content for a given entry of a content-type.
 
 A single type contains a unique document, and a collection type can contain several documents.

--- a/docusaurus/docs/cms/backend-customization.md
+++ b/docusaurus/docs/cms/backend-customization.md
@@ -19,6 +19,8 @@ tags:
 
 <div className="custom-mermaid-layout">
 
+# Backend customization
+
 :::strapi Disambiguation: Strapi back end
 As a headless CMS, the Strapi software as a whole can be considered as the "back end" of your website or application.
 But the Strapi software itself includes 2 different parts:

--- a/docusaurus/docs/cms/intro.md
+++ b/docusaurus/docs/cms/intro.md
@@ -12,8 +12,6 @@ tags:
 
 # Welcome to the Strapi CMS Documentation!
 
-<DebugComponent test="ai-toolbar-component" />
-
 The Strapi CMS documentation focuses on Strapi 5 and will take you through the complete journey of your Strapi 5 project. From the technical information related to the setup, advanced usage, customization and update of your project, to the management of the admin panel and its content and users.
 
 <ThemedImage

--- a/docusaurus/docs/cms/intro.md
+++ b/docusaurus/docs/cms/intro.md
@@ -55,7 +55,7 @@ The table of content of the Strapi CMS documentation displays 7 main sections in
 - If you prefer learning more about Strapi while looking at the project code structure, you can use the interactive [project structure](/cms/project-structure) page.
 - If demos are more your thing, feel free to watch the <ExternalLink to="https://youtu.be/zd0_S_FPzKg" text="video demo"/>, or you can request a <ExternalLink to="https://strapi.io/demo" text="live demo"/>.
 - Try our AI assistant: Click or tap the **Ask AI** button and ask your questions using natural language. Watch it answer you in real time, then read recommended sources for more details.
-- To help you integrate Strapi Docs with your favorite AI models, you can use the **Copy Markdown** button or visit the [`llms.txt`](/llms.txt) and [`llms-full.txt`](/llms-full.txt) pages.
+- To help you integrate Strapi Docs with your favorite AI models, you can use the dropdown at the top of each page to **Copy Markdown** or visit the [`llms.txt`](/llms.txt) and [`llms-full.txt`](/llms-full.txt) pages.
 :::
 
 :::strapi Information for beginner developers

--- a/docusaurus/docs/cms/intro.md
+++ b/docusaurus/docs/cms/intro.md
@@ -12,7 +12,7 @@ tags:
 
 # Welcome to the Strapi CMS Documentation!
 
-<DebugComponent test="ai-toolbar" />
+<DebugComponent test="ai-toolbar-component" />
 
 The Strapi CMS documentation focuses on Strapi 5 and will take you through the complete journey of your Strapi 5 project. From the technical information related to the setup, advanced usage, customization and update of your project, to the management of the admin panel and its content and users.
 

--- a/docusaurus/docs/cms/intro.md
+++ b/docusaurus/docs/cms/intro.md
@@ -12,16 +12,7 @@ tags:
 
 # Welcome to the Strapi CMS Documentation!
 
-<!--
-<SubtleCallout title="Strapi CMS & Strapi Cloud docs" emoji="📍">
-
-There are 2 Strapi documentations, one for each Strapi product:
-
-- <Icon name="feather" /> The **CMS documentation**, that you're currently reading, which contains all the information related to a Strapi 5 project (installation, setup, deployment, content management in admin panel, etc).
-- <Icon name="cloud" /> The **[Cloud documentation](/cloud/intro)**, which is about deploying your Strapi application to Strapi Cloud and managing your Strapi Cloud projects and settings.
-
-</SubtleCallout>
--->
+<DebugComponent test="ai-toolbar" />
 
 The Strapi CMS documentation focuses on Strapi 5 and will take you through the complete journey of your Strapi 5 project. From the technical information related to the setup, advanced usage, customization and update of your project, to the management of the admin panel and its content and users.
 

--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -260,14 +260,6 @@ const config = {
             title: 'Additional resources',
             items: [
               {
-                label: 'LLMs.txt',
-                href: 'https://docs.strapi.io/llms.txt',
-              },
-              {
-                label: 'LLMs-full.txt',
-                href: 'https://docs.strapi.io/llms-full.txt',
-              },
-              {
                 label: 'v4 Docs',
                 href: 'https://docs-v4.strapi.io',
               },

--- a/docusaurus/src/components/AiToolbar/AiToolbar.jsx
+++ b/docusaurus/src/components/AiToolbar/AiToolbar.jsx
@@ -106,6 +106,9 @@ const AiToolbar = () => {
           onClick={toggleDropdown}
           className={`ai-toolbar__dropdown-trigger ${isDropdownOpen ? 'ai-toolbar__dropdown-trigger--open' : ''}`}
           title="More AI options"
+          style={{
+            borderColor: currentState === 'success' ? 'var(--strapi-neutral-200)' : undefined
+          }}
         >
           <Icon 
             name="caret-down" 

--- a/docusaurus/src/components/AiToolbar/AiToolbar.jsx
+++ b/docusaurus/src/components/AiToolbar/AiToolbar.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const AiToolbar = () => {
+  return <div>AiToolbar - Coming soon</div>;
+};
+
+export default AiToolbar;

--- a/docusaurus/src/components/AiToolbar/AiToolbar.jsx
+++ b/docusaurus/src/components/AiToolbar/AiToolbar.jsx
@@ -55,14 +55,17 @@ const AiToolbar = () => {
         <Icon 
           name={displayConfig.icon} 
           classes={displayConfig.iconClasses}
+          color={currentState === 'success' ? 'var(--strapi-success-700)' : 'inherit'}
         />
+
         <span className="ai-toolbar__button-text">
           {displayConfig.label}
         </span>
-        {/* Dropdown arrow - will be implemented in step 5 */}
+
         <Icon 
           name="caret-down" 
-          classes="ph-bold ai-toolbar__dropdown-arrow" 
+          classes="ph-bold ai-toolbar__dropdown-arrow"
+          color={currentState === 'success' ? 'var(--strapi-success-700)' : 'inherit'}
         />
       </button>
     </div>

--- a/docusaurus/src/components/AiToolbar/AiToolbar.jsx
+++ b/docusaurus/src/components/AiToolbar/AiToolbar.jsx
@@ -1,7 +1,72 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { getPrimaryAction } from './utils/aiToolsHelpers';
+import { executeAction, getActionDisplay } from './actions/actionRegistry';
+import Icon from '../Icon';
 
 const AiToolbar = () => {
-  return <div>AiToolbar - Coming soon</div>;
+  const [actionStates, setActionStates] = useState({
+    'copy-markdown': 'idle'
+  });
+
+  const primaryAction = getPrimaryAction();
+
+  // Function to update action state
+  const updateActionState = (actionId, state) => {
+    setActionStates(prev => ({
+      ...prev,
+      [actionId]: state
+    }));
+  };
+
+  // Handle primary action click
+  const handlePrimaryAction = async () => {
+    if (!primaryAction) {
+      console.error('No primary action configured');
+      return;
+    }
+
+    const context = {
+      updateActionState,
+      // Add any additional context needed
+      docId: null, // Will be auto-detected by the action
+      docPath: null, // Will be auto-detected by the action
+    };
+
+    await executeAction(primaryAction, context);
+  };
+
+  // Don't render if no primary action
+  if (!primaryAction) {
+    return null;
+  }
+
+  const currentState = actionStates[primaryAction.id] || 'idle';
+  const displayConfig = getActionDisplay(primaryAction.id, currentState);
+  const isDisabled = currentState === 'loading' || currentState === 'success';
+
+  return (
+    <div className="ai-toolbar">
+      <button
+        onClick={handlePrimaryAction}
+        disabled={isDisabled}
+        className={`ai-toolbar__button ${displayConfig.className}`}
+        title={primaryAction.description}
+      >
+        <Icon 
+          name={displayConfig.icon} 
+          classes={displayConfig.iconClasses}
+        />
+        <span className="ai-toolbar__button-text">
+          {displayConfig.label}
+        </span>
+        {/* Dropdown arrow - will be implemented in step 5 */}
+        <Icon 
+          name="caret-down" 
+          classes="ph-bold ai-toolbar__dropdown-arrow" 
+        />
+      </button>
+    </div>
+  );
 };
 
 export default AiToolbar;

--- a/docusaurus/src/components/AiToolbar/AiToolbar.jsx
+++ b/docusaurus/src/components/AiToolbar/AiToolbar.jsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { getPrimaryAction } from './utils/aiToolsHelpers';
+import React, { useState, useRef, useEffect } from 'react';
+import { getPrimaryAction, getDropdownActions } from './utils/aiToolsHelpers';
 import { executeAction, getActionDisplay } from './actions/actionRegistry';
 import Icon from '../Icon';
 
@@ -7,8 +7,25 @@ const AiToolbar = () => {
   const [actionStates, setActionStates] = useState({
     'copy-markdown': 'idle'
   });
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const dropdownRef = useRef(null);
 
   const primaryAction = getPrimaryAction();
+  const dropdownActions = getDropdownActions();
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    const handleClickOutside = (event) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target)) {
+        setIsDropdownOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, []);
 
   // Function to update action state
   const updateActionState = (actionId, state) => {
@@ -16,6 +33,11 @@ const AiToolbar = () => {
       ...prev,
       [actionId]: state
     }));
+  };
+
+  // Function to close dropdown
+  const closeDropdown = () => {
+    setIsDropdownOpen(false);
   };
 
   // Handle primary action click
@@ -27,12 +49,28 @@ const AiToolbar = () => {
 
     const context = {
       updateActionState,
-      // Add any additional context needed
+      closeDropdown,
       docId: null, // Will be auto-detected by the action
       docPath: null, // Will be auto-detected by the action
     };
 
     await executeAction(primaryAction, context);
+  };
+
+  // Handle dropdown action click
+  const handleDropdownAction = async (action) => {
+    const context = {
+      updateActionState,
+      closeDropdown,
+      url: action.url, // For navigate actions
+    };
+
+    await executeAction(action, context);
+  };
+
+  // Toggle dropdown
+  const toggleDropdown = () => {
+    setIsDropdownOpen(!isDropdownOpen);
   };
 
   // Don't render if no primary action
@@ -46,28 +84,66 @@ const AiToolbar = () => {
 
   return (
     <div className="ai-toolbar">
-      <button
-        onClick={handlePrimaryAction}
-        disabled={isDisabled}
-        className={`ai-toolbar__button ${displayConfig.className}`}
-        title={primaryAction.description}
-      >
-        <Icon 
-          name={displayConfig.icon} 
-          classes={displayConfig.iconClasses}
-          color={currentState === 'success' ? 'var(--strapi-success-700)' : 'inherit'}
-        />
+      <div className="ai-toolbar__container" ref={dropdownRef}>
+        <button
+          onClick={handlePrimaryAction}
+          disabled={isDisabled}
+          className={`ai-toolbar__button ${displayConfig.className}`}
+          title={primaryAction.description}
+        >
+          <Icon 
+            name={displayConfig.icon} 
+            classes={displayConfig.iconClasses}
+            color={currentState === 'success' ? 'var(--strapi-success-700)' : 'inherit'}
+          />
+          <span className="ai-toolbar__button-text">
+            {displayConfig.label}
+          </span>
+        </button>
+        
+        {/* Dropdown button */}
+        <button
+          onClick={toggleDropdown}
+          className={`ai-toolbar__dropdown-trigger ${isDropdownOpen ? 'ai-toolbar__dropdown-trigger--open' : ''}`}
+          title="More AI options"
+        >
+          <Icon 
+            name="caret-down" 
+            classes="ph-bold"
+            color="inherit"
+          />
+        </button>
 
-        <span className="ai-toolbar__button-text">
-          {displayConfig.label}
-        </span>
-
-        <Icon 
-          name="caret-down" 
-          classes="ph-bold ai-toolbar__dropdown-arrow"
-          color={currentState === 'success' ? 'var(--strapi-success-700)' : 'inherit'}
-        />
-      </button>
+        {/* Dropdown menu */}
+        {isDropdownOpen && (
+          <div className="ai-toolbar__dropdown">
+            {dropdownActions.map((action) => (
+              <button
+                key={action.id}
+                onClick={() => handleDropdownAction(action)}
+                className="ai-toolbar__dropdown-item"
+                title={action.description}
+              >
+                <Icon 
+                  name={action.icon} 
+                  classes="ph-bold"
+                  color="inherit"
+                />
+                <div className="ai-toolbar__dropdown-item-content">
+                  <span className="ai-toolbar__dropdown-item-label">
+                    {action.label}
+                  </span>
+                  {action.description && (
+                    <span className="ai-toolbar__dropdown-item-description">
+                      {action.description}
+                    </span>
+                  )}
+                </div>
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
     </div>
   );
 };

--- a/docusaurus/src/components/AiToolbar/actions/actionRegistry.js
+++ b/docusaurus/src/components/AiToolbar/actions/actionRegistry.js
@@ -1,0 +1,74 @@
+import { copyMarkdownAction } from './copyMarkdown';
+import { navigateAction } from './navigate';
+
+// Central registry of all available actions
+export const actionHandlers = {
+  'copy-markdown': copyMarkdownAction,
+  'navigate': navigateAction,
+};
+
+// Main function to execute an action
+export const executeAction = async (actionConfig, additionalContext = {}) => {
+  const handler = actionHandlers[actionConfig.actionType];
+  
+  if (!handler) {
+    console.warn(`Unknown action type: ${actionConfig.actionType}`);
+    return;
+  }
+  
+  const context = {
+    ...actionConfig, // url, etc.
+    ...additionalContext, // docId, docPath, updateActionState, closeDropdown, etc.
+  };
+  
+  try {
+    await handler(context);
+  } catch (error) {
+    console.error(`Error executing action ${actionConfig.actionType}:`, error);
+  }
+};
+
+// Utility to get display information based on action state
+export const getActionDisplay = (actionId, currentState = 'idle') => {
+  switch (actionId) {
+    case 'copy-markdown':
+      switch (currentState) {
+        case 'loading':
+          return {
+            icon: 'circle-notch',
+            iconClasses: 'ph-bold spinning',
+            label: 'Copying...',
+            className: 'ai-toolbar-button--loading'
+          };
+        case 'success':
+          return {
+            icon: 'check-circle',
+            iconClasses: 'ph-fill',
+            label: 'Copied!',
+            className: 'ai-toolbar-button--success'
+          };
+        case 'error':
+          return {
+            icon: 'warning-circle',
+            iconClasses: 'ph-fill',
+            label: 'Copy failed',
+            className: 'ai-toolbar-button--error'
+          };
+        default: // 'idle'
+          return {
+            icon: 'copy',
+            iconClasses: 'ph-bold',
+            label: 'Copy Markdown',
+            className: 'ai-toolbar-button--idle'
+          };
+      }
+    default:
+      // For other actions, just return their base configuration
+      return {
+        icon: 'question',
+        iconClasses: 'ph-bold',
+        label: 'Unknown',
+        className: 'ai-toolbar-button--idle'
+      };
+  }
+};

--- a/docusaurus/src/components/AiToolbar/actions/copyMarkdown.js
+++ b/docusaurus/src/components/AiToolbar/actions/copyMarkdown.js
@@ -1,0 +1,62 @@
+export const copyMarkdownAction = async (context) => {
+  const { docId, docPath, updateActionState } = context;
+  
+  try {
+    updateActionState('copy-markdown', 'loading');
+    
+    // Helper functions to get current document info from URL (reused from CopyMarkdownButton)
+    const getCurrentDocId = () => {
+      if (typeof window === 'undefined') return null;
+      const path = window.location.pathname;
+      // Remove leading/trailing slashes and split
+      const segments = path.replace(/^\/|\/$/g, '').split('/');
+      // For paths like /cms/api/rest or /cloud/getting-started/intro
+      if (segments.length >= 2) {
+        return segments.join('/');
+      }
+      return null;
+    };
+
+    const getCurrentDocPath = () => {
+      if (typeof window === 'undefined') return null;
+      const path = window.location.pathname;
+      // Convert URL path to docs file path
+      const cleanPath = path.replace(/^\/|\/$/g, '');
+      return cleanPath ? `docs/${cleanPath}.md` : null;
+    };
+
+    // Use props or try to get from current URL
+    const currentDocId = docId || getCurrentDocId();
+    const currentDocPath = docPath || getCurrentDocPath();
+    
+    if (!currentDocId && !currentDocPath) {
+      throw new Error('Unable to determine document path');
+    }
+
+    // Build the raw markdown URL from GitHub
+    const baseUrl = 'https://raw.githubusercontent.com/strapi/documentation/main/docusaurus';
+    const markdownUrl = currentDocPath 
+      ? `${baseUrl}/${currentDocPath}` 
+      : `${baseUrl}/docs/${currentDocId}.md`;
+    
+    // Fetch the raw markdown content
+    const response = await fetch(markdownUrl);
+    
+    if (!response.ok) {
+      throw new Error(`Failed to fetch markdown: ${response.status}`);
+    }
+    
+    const markdownContent = await response.text();
+    
+    // Copy to clipboard
+    await navigator.clipboard.writeText(markdownContent);
+    
+    updateActionState('copy-markdown', 'success');
+    setTimeout(() => updateActionState('copy-markdown', 'idle'), 3000);
+    
+  } catch (error) {
+    console.error('Error copying markdown:', error);
+    updateActionState('copy-markdown', 'error');
+    setTimeout(() => updateActionState('copy-markdown', 'idle'), 3000);
+  }
+};

--- a/docusaurus/src/components/AiToolbar/actions/navigate.js
+++ b/docusaurus/src/components/AiToolbar/actions/navigate.js
@@ -1,0 +1,16 @@
+export const navigateAction = (context) => {
+  const { url, closeDropdown } = context;
+  
+  if (!url) {
+    console.error('Navigate action requires a URL');
+    return;
+  }
+  
+  // Open URL in new tab
+  window.open(url, '_blank');
+  
+  // Close dropdown immediately for navigation actions
+  if (closeDropdown) {
+    closeDropdown();
+  }
+};

--- a/docusaurus/src/components/AiToolbar/config/aiToolsConfig.js
+++ b/docusaurus/src/components/AiToolbar/config/aiToolsConfig.js
@@ -1,0 +1,29 @@
+export const aiToolsConfig = {
+  primaryActionId: 'copy-markdown',
+  
+  actions: [
+    {
+      id: 'copy-markdown',
+      label: 'Copy Markdown',
+      description: 'Copy the raw markdown content of this page',
+      icon: 'copy',
+      actionType: 'copy-markdown'
+    },
+    {
+      id: 'view-llms',
+      label: 'View LLMs.txt',
+      description: 'Lightweight version for AI models',
+      icon: 'file-text',
+      actionType: 'navigate',
+      url: '/llms.txt'
+    },
+    {
+      id: 'view-llms-full',
+      label: 'View LLMs-full.txt', 
+      description: 'Complete documentation for AI models',
+      icon: 'file-text',
+      actionType: 'navigate',
+      url: '/llms-full.txt'
+    }
+  ]
+};

--- a/docusaurus/src/components/AiToolbar/index.js
+++ b/docusaurus/src/components/AiToolbar/index.js
@@ -1,0 +1,4 @@
+export { default as AiToolbar } from './AiToolbar';
+export * from './config/aiToolsConfig';
+export * from './utils/aiToolsHelpers';
+export * from './actions/actionRegistry';

--- a/docusaurus/src/components/AiToolbar/utils/aiToolsHelpers.js
+++ b/docusaurus/src/components/AiToolbar/utils/aiToolsHelpers.js
@@ -1,0 +1,27 @@
+import { aiToolsConfig } from '../config/aiToolsConfig';
+
+export const getPrimaryAction = () => {
+  return aiToolsConfig.actions.find(action => action.id === aiToolsConfig.primaryActionId);
+};
+
+export const getDropdownActions = () => {
+  return aiToolsConfig.actions.filter(action => action.id !== aiToolsConfig.primaryActionId);
+};
+
+export const getActionById = (id) => {
+  return aiToolsConfig.actions.find(action => action.id === id);
+};
+
+export const getAllActions = () => {
+  return aiToolsConfig.actions;
+};
+
+// Utility to check if an action exists
+export const hasAction = (id) => {
+  return aiToolsConfig.actions.some(action => action.id === id);
+};
+
+// Utility to get the complete configuration
+export const getConfig = () => {
+  return aiToolsConfig;
+};

--- a/docusaurus/src/components/ContributeLink/ContributeLink.jsx
+++ b/docusaurus/src/components/ContributeLink/ContributeLink.jsx
@@ -5,7 +5,6 @@ import {useActiveDocContext} from '@docusaurus/plugin-content-docs/client';
 import {translate} from '@docusaurus/Translate';
 import styles from './contribute-link.module.scss';
 import Icon from '../Icon';
-import CopyMarkdownButton from '../CopyMarkdownButton';
 
 export default function ContributeLink() {
   const {siteConfig} = useDocusaurusContext();
@@ -36,7 +35,6 @@ export default function ContributeLink() {
       <a href={fullEditUrl} target="_blank" rel="noopener noreferrer">
         <Icon name="pencil-simple" /> <span>{editThisPageMessage}</span>
       </a>
-      <CopyMarkdownButton Icon={Icon} />
     </div>
   );
 }

--- a/docusaurus/src/components/DebugComponent.jsx
+++ b/docusaurus/src/components/DebugComponent.jsx
@@ -1,0 +1,33 @@
+// Temporary component for testing during development
+// Just import and use: <DebugComponent test="ai-toolbar" />
+
+import React, { useEffect } from 'react';
+
+const DebugComponent = ({ test }) => {
+  useEffect(() => {
+    if (test === 'ai-toolbar') {
+      console.log('🧪 Testing AIToolbar Configuration');
+      
+      try {
+        // Dynamic import to avoid breaking if files don't exist yet
+        import('./AiToolbar').then(({ getPrimaryAction, getDropdownActions, getConfig }) => {
+          console.log('Primary action:', getPrimaryAction());
+          console.log('Dropdown actions:', getDropdownActions());
+          console.log('Full config:', getConfig());
+          console.log('✅ AIToolbar config test completed');
+        });
+      } catch (error) {
+        console.error('❌ AIToolbar test failed:', error);
+      }
+    }
+    
+    // Add other tests here as needed
+    // if (test === 'other-feature') { ... }
+    
+  }, [test]);
+
+  // Return null to not affect the UI
+  return null;
+};
+
+export default DebugComponent;

--- a/docusaurus/src/components/DebugComponent.jsx
+++ b/docusaurus/src/components/DebugComponent.jsx
@@ -2,6 +2,7 @@
 // Just import and use: <DebugComponent test="ai-toolbar" />
 
 import React, { useEffect } from 'react';
+import { AiToolbar } from './AiToolbar'; // Adjust path as needed
 
 const DebugComponent = ({ test }) => {
   useEffect(() => {
@@ -21,11 +22,31 @@ const DebugComponent = ({ test }) => {
       }
     }
     
+    if (test === 'ai-actions') {
+      console.log('🧪 Testing modular actions');
+      
+      try {
+        import('./AiToolbar/actions/actionRegistry').then(({ executeAction, getActionDisplay, actionHandlers }) => {
+          console.log('Available action handlers:', Object.keys(actionHandlers));
+          console.log('Copy markdown display (idle):', getActionDisplay('copy-markdown', 'idle'));
+          console.log('Copy markdown display (loading):', getActionDisplay('copy-markdown', 'loading'));
+          console.log('✅ Modular actions test completed');
+        });
+      } catch (error) {
+        console.error('❌ Actions test failed:', error);
+      }
+    }
+
     // Add other tests here as needed
     // if (test === 'other-feature') { ... }
     
   }, [test]);
 
+  // Afficher le composant directement selon le test
+  if (test === 'ai-toolbar-component') {
+    return <AiToolbar />;
+  }
+  
   // Return null to not affect the UI
   return null;
 };

--- a/docusaurus/src/hooks/useBadgeReorder.js
+++ b/docusaurus/src/hooks/useBadgeReorder.js
@@ -44,7 +44,7 @@ export function useBadgeReorder() {
         if (badgesAfterHeader.length > 0) {
           const badgeContainer = document.createElement('div');
           badgeContainer.className = 'h1-badges-container';
-          badgeContainer.style.margin = '1rem 0';
+          badgeContainer.style.margin = '-1rem 0 2rem 0';
           badgeContainer.style.display = 'flex';
           badgeContainer.style.gap = '0.5rem';
           badgeContainer.style.flexWrap = 'wrap';

--- a/docusaurus/src/hooks/useBadgeReorder.js
+++ b/docusaurus/src/hooks/useBadgeReorder.js
@@ -1,3 +1,19 @@
+/**
+ * Hook to reorder badges that appear after h1 elements with AiToolbar.
+ * 
+ * Problem: In Docusaurus MDX rendering, badges (GrowthBadge, EnterpriseBadge, etc.) 
+ * are positioned absolutely in the gutter and appear after the AiToolbar in the DOM,
+ * creating a visual hierarchy issue where badges come after the toolbar instead of
+ * between the h1 title and the toolbar.
+ * 
+ * Solution: This hook detects badges that follow a header containing an h1 + AiToolbar,
+ * hides the original badges to prevent visual flash, clones them with proper relative
+ * positioning, and inserts them between the h1 and AiToolbar for correct visual order.
+ * 
+ * The reordered badges maintain their original styling and functionality while being
+ * positioned in the expected location in the visual hierarchy.
+ */
+
 import { useEffect } from 'react';
 
 export function useBadgeReorder() {

--- a/docusaurus/src/hooks/useBadgeReorder.js
+++ b/docusaurus/src/hooks/useBadgeReorder.js
@@ -1,0 +1,97 @@
+import { useEffect } from 'react';
+
+export function useBadgeReorder() {
+  useEffect(() => {
+    // Hide badges immediately to prevent flash
+    const hideBadgesImmediately = () => {
+      const header = document.querySelector('header');
+      if (header) {
+        let current = header.nextElementSibling;
+        while (current && current.classList?.contains('badge')) {
+          current.style.visibility = 'hidden';
+          current = current.nextElementSibling;
+        }
+      }
+    };
+    
+    hideBadgesImmediately();
+    
+    const reorderBadges = () => {
+      const h1Elements = document.querySelectorAll('h1');
+      
+      h1Elements.forEach(h1 => {
+        const toolbar = h1.nextElementSibling?.classList?.contains('ai-toolbar') 
+          ? h1.nextElementSibling 
+          : null;
+        
+        if (!toolbar) return;
+        
+        if (document.querySelector('.h1-badges-container')) {
+          return;
+        }
+        
+        const header = h1.closest('header');
+        if (!header) return;
+        
+        const badgesAfterHeader = [];
+        let current = header.nextElementSibling;
+        
+        while (current && current.classList?.contains('badge')) {
+          badgesAfterHeader.push(current);
+          current = current.nextElementSibling;
+        }
+        
+        if (badgesAfterHeader.length > 0) {
+          const badgeContainer = document.createElement('div');
+          badgeContainer.className = 'h1-badges-container';
+          badgeContainer.style.margin = '1rem 0';
+          badgeContainer.style.display = 'flex';
+          badgeContainer.style.gap = '0.5rem';
+          badgeContainer.style.flexWrap = 'wrap';
+          badgeContainer.style.opacity = '0';
+          badgeContainer.style.transition = 'opacity 0.2s ease';
+          
+          badgesAfterHeader.forEach(badge => {
+            const clone = badge.cloneNode(true);
+            
+            clone.style.position = 'relative';
+            clone.style.left = 'auto';
+            clone.style.top = 'auto';
+            clone.style.right = 'auto';
+            clone.style.display = 'inline-flex';
+            clone.style.alignItems = 'center';
+            clone.style.minWidth = 'auto';
+            clone.style.maxWidth = 'none';
+            clone.style.visibility = 'visible';
+            
+            const badgeText = clone.querySelector('.badge__text');
+            if (badgeText) {
+              badgeText.style.display = 'inline';
+            }
+            
+            const icon = clone.querySelector('.strapi-icons');
+            if (icon) {
+              icon.style.left = 'auto';
+              icon.style.top = 'auto';
+              icon.style.position = 'relative';
+              icon.style.marginRight = '0.25rem';
+            }
+            
+            badgeContainer.appendChild(clone);
+            badge.style.display = 'none';
+          });
+          
+          h1.parentNode.insertBefore(badgeContainer, toolbar);
+          
+          requestAnimationFrame(() => {
+            badgeContainer.style.opacity = '1';
+          });
+        }
+      });
+    };
+    
+    const timer = setTimeout(reorderBadges, 50);
+    
+    return () => clearTimeout(timer);
+  }, []);
+}

--- a/docusaurus/src/scss/__index.scss
+++ b/docusaurus/src/scss/__index.scss
@@ -16,6 +16,7 @@
 
 /** Components */
 @use 'admonition.scss';
+@use 'ai-toolbar.scss';
 @use 'api-call.scss';
 @use 'announcement-bar.scss';
 @use 'badge.scss';

--- a/docusaurus/src/scss/ai-toolbar.scss
+++ b/docusaurus/src/scss/ai-toolbar.scss
@@ -1,3 +1,5 @@
+// src/scss/ai-toolbar.scss
+
 @use './mixins' as *;
 
 .ai-toolbar {
@@ -5,7 +7,6 @@
   justify-content: flex-end;
   padding: 1rem 0;
   margin-bottom: 1rem;
-  border-bottom: 1px solid var(--strapi-neutral-200);
 
   &__button {
     display: flex;
@@ -15,7 +16,7 @@
     border: 1px solid var(--strapi-neutral-300);
     border-radius: 0.25rem;
     background-color: var(--strapi-neutral-0);
-    color: var(--strapi-primary-600);
+    color: var(--strapi-neutral-600);
     font-size: var(--strapi-font-size-sm);
     font-weight: 500;
     font-family: "SF Pro Text", "SF Pro Display", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
@@ -23,9 +24,16 @@
     text-decoration: none;
     transition: all 0.2s ease;
 
+    // Icon alignment fix
+    .strapi-icons {
+      position: relative;
+      top: 1px;
+    }
+
     &:hover {
       background-color: var(--strapi-neutral-100);
-      border-color: var(--strapi-primary-500);
+      border-color: var(--strapi-neutral-400);
+      color: var(--strapi-neutral-800);
     }
 
     &:disabled {
@@ -43,7 +51,12 @@
 
     &--success {
       color: var(--strapi-success-700);
-      border-color: var(--strapi-success-600);
+      
+      // Keep border neutral but make text and icon green
+      .strapi-icons {
+        color: var(--strapi-success-700);
+        top: -1px;
+      }
     }
 
     &--error {
@@ -52,7 +65,7 @@
     }
 
     &--idle {
-      color: var(--strapi-primary-600);
+      color: var(--strapi-neutral-600);
     }
   }
 
@@ -80,16 +93,16 @@
 // Dark mode styles
 @include dark {
   .ai-toolbar {
-    border-bottom-color: var(--strapi-neutral-700);
 
     &__button {
       background-color: var(--strapi-neutral-900);
       border-color: var(--strapi-neutral-600);
-      color: var(--strapi-primary-500);
+      color: var(--strapi-neutral-400);
 
       &:hover {
         background-color: var(--strapi-neutral-800);
-        border-color: var(--strapi-primary-400);
+        border-color: var(--strapi-neutral-500);
+        color: var(--strapi-neutral-200);
       }
 
       &--loading {
@@ -98,7 +111,10 @@
 
       &--success {
         color: var(--strapi-success-500);
-        border-color: var(--strapi-success-400);
+        
+        .strapi-icons {
+          color: var(--strapi-success-500);
+        }
       }
 
       &--error {
@@ -107,7 +123,7 @@
       }
 
       &--idle {
-        color: var(--strapi-primary-500);
+        color: var(--strapi-neutral-400);
       }
     }
   }

--- a/docusaurus/src/scss/ai-toolbar.scss
+++ b/docusaurus/src/scss/ai-toolbar.scss
@@ -1,12 +1,14 @@
-// src/scss/ai-toolbar.scss
-
 @use './mixins' as *;
-
 .ai-toolbar {
   display: flex;
   justify-content: flex-end;
   padding: 1rem 0;
   margin-bottom: 1rem;
+
+  &__container {
+    position: relative;
+    display: flex;
+  }
 
   &__button {
     display: flex;
@@ -14,7 +16,8 @@
     gap: 0.5rem;
     padding: 0.5rem 1rem;
     border: 1px solid var(--strapi-neutral-300);
-    border-radius: 0.25rem;
+    border-right: none;
+    border-radius: 0.25rem 0 0 0.25rem;
     background-color: var(--strapi-neutral-0);
     color: var(--strapi-neutral-600);
     font-size: var(--strapi-font-size-sm);
@@ -23,32 +26,27 @@
     cursor: pointer;
     text-decoration: none;
     transition: all 0.2s ease;
-
     // Icon alignment fix
     .strapi-icons {
       position: relative;
       top: 1px;
     }
-
     &:hover {
       background-color: var(--strapi-neutral-100);
       border-color: var(--strapi-neutral-400);
       color: var(--strapi-neutral-800);
     }
-
     &:disabled {
       cursor: default;
       opacity: 0.7;
       pointer-events: none;
     }
-
     // State-specific styles
     &--loading {
       opacity: 0.7;
       pointer-events: none;
       color: var(--strapi-neutral-600);
     }
-
     &--success {
       color: var(--strapi-success-700);
       
@@ -58,43 +56,158 @@
         top: -1px;
       }
     }
-
     &--error {
       color: var(--strapi-danger-600);
       border-color: var(--strapi-danger-500);
     }
-
     &--idle {
       color: var(--strapi-neutral-600);
     }
   }
 
+  &__dropdown-trigger {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 2rem;
+    padding: 0.5rem 0;
+    border: 1px solid var(--strapi-neutral-300);
+    border-left: none;
+    border-radius: 0 0.25rem 0.25rem 0;
+    background-color: var(--strapi-neutral-0);
+    color: var(--strapi-neutral-600);
+    cursor: pointer;
+    transition: all 0.2s ease;
+
+    &:hover {
+      background-color: var(--strapi-neutral-100);
+      border-color: var(--strapi-neutral-400);
+      color: var(--strapi-neutral-800);
+    }
+
+    &--open {
+      background-color: var(--strapi-neutral-100);
+      border-color: var(--strapi-neutral-400);
+      
+      .strapi-icons {
+        transform: rotate(180deg);
+      }
+    }
+
+    .strapi-icons {
+      transition: transform 0.2s ease;
+    }
+  }
+
+  &__dropdown {
+    position: absolute;
+    top: 100%;
+    right: 0;
+    z-index: 1000;
+    min-width: 250px;
+    margin-top: 0.25rem;
+    background-color: var(--strapi-neutral-0);
+    border: 1px solid var(--strapi-neutral-300);
+    border-radius: 0.25rem;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    overflow: hidden;
+  }
+
+  &__dropdown-item {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    width: 100%;
+    padding: 0.75rem 1rem;
+    border: none;
+    background-color: transparent;
+    color: var(--strapi-neutral-800);
+    font-size: var(--strapi-font-size-sm);
+    font-family: inherit;
+    text-align: left;
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+
+    &:hover {
+      background-color: var(--strapi-neutral-100);
+    }
+
+    &:not(:last-child) {
+      border-bottom: 1px solid var(--strapi-neutral-200);
+    }
+
+    .strapi-icons {
+      flex-shrink: 0;
+      color: var(--strapi-neutral-600);
+    }
+  }
+
+  &__dropdown-item-content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  &__dropdown-item-label {
+    font-weight: 500;
+    line-height: 1.2;
+  }
+
+  &__dropdown-item-description {
+    font-size: var(--strapi-font-size-xs);
+    color: var(--strapi-neutral-600);
+    line-height: 1.3;
+  }
+
   &__button-text {
     // Text styling if needed
   }
-
   &__dropdown-arrow {
     margin-left: 0.25rem;
     opacity: 0.6;
     transition: opacity 0.2s ease;
   }
 }
-
 // Spinner animation for loading state
 .spinning {
   animation: spin 1s linear infinite;
 }
-
 @keyframes spin {
   from { transform: rotate(0deg); }
   to { transform: rotate(360deg); }
 }
-
 // Dark mode styles
 @include dark {
   .ai-toolbar {
-
     &__button {
+      background-color: var(--strapi-neutral-900);
+      border-color: var(--strapi-neutral-600);
+      color: var(--strapi-neutral-400);
+      &:hover {
+        background-color: var(--strapi-neutral-800);
+        border-color: var(--strapi-neutral-500);
+        color: var(--strapi-neutral-200);
+      }
+      &--loading {
+        color: var(--strapi-neutral-400);
+      }
+      &--success {
+        color: var(--strapi-success-500);
+        
+        .strapi-icons {
+          color: var(--strapi-success-500);
+        }
+      }
+      &--error {
+        color: var(--strapi-danger-500);
+        border-color: var(--strapi-danger-400);
+      }
+      &--idle {
+        color: var(--strapi-neutral-400);
+      }
+    }
+
+    &__dropdown-trigger {
       background-color: var(--strapi-neutral-900);
       border-color: var(--strapi-neutral-600);
       color: var(--strapi-neutral-400);
@@ -105,26 +218,36 @@
         color: var(--strapi-neutral-200);
       }
 
-      &--loading {
+      &--open {
+        background-color: var(--strapi-neutral-800);
+        border-color: var(--strapi-neutral-500);
+      }
+    }
+
+    &__dropdown {
+      background-color: var(--strapi-neutral-900);
+      border-color: var(--strapi-neutral-600);
+      box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
+    }
+
+    &__dropdown-item {
+      color: var(--strapi-neutral-200);
+
+      &:hover {
+        background-color: var(--strapi-neutral-800);
+      }
+
+      &:not(:last-child) {
+        border-bottom-color: var(--strapi-neutral-700);
+      }
+
+      .strapi-icons {
         color: var(--strapi-neutral-400);
       }
+    }
 
-      &--success {
-        color: var(--strapi-success-500);
-        
-        .strapi-icons {
-          color: var(--strapi-success-500);
-        }
-      }
-
-      &--error {
-        color: var(--strapi-danger-500);
-        border-color: var(--strapi-danger-400);
-      }
-
-      &--idle {
-        color: var(--strapi-neutral-400);
-      }
+    &__dropdown-item-description {
+      color: var(--strapi-neutral-400);
     }
   }
 }

--- a/docusaurus/src/scss/ai-toolbar.scss
+++ b/docusaurus/src/scss/ai-toolbar.scss
@@ -8,6 +8,8 @@
   &__container {
     position: relative;
     display: flex;
+    border: 1px solid var(--strapi-neutral-300);
+    border-radius: 0.25rem;
   }
 
   &__button {
@@ -15,8 +17,8 @@
     align-items: center;
     gap: 0.5rem;
     padding: 0.5rem 1rem;
-    border: 1px solid var(--strapi-neutral-300);
-    border-right: none;
+    border: none;
+    border-right: 1px solid var(--strapi-neutral-300);
     border-radius: 0.25rem 0 0 0.25rem;
     background-color: var(--strapi-neutral-0);
     color: var(--strapi-neutral-600);
@@ -33,7 +35,6 @@
     }
     &:hover {
       background-color: var(--strapi-neutral-100);
-      border-color: var(--strapi-neutral-400);
       color: var(--strapi-neutral-800);
     }
     &:disabled {
@@ -50,7 +51,6 @@
     &--success {
       color: var(--strapi-success-700);
       
-      // Keep border neutral but make text and icon green
       .strapi-icons {
         color: var(--strapi-success-700);
         top: -1px;
@@ -58,7 +58,6 @@
     }
     &--error {
       color: var(--strapi-danger-600);
-      border-color: var(--strapi-danger-500);
     }
     &--idle {
       color: var(--strapi-neutral-600);
@@ -71,8 +70,7 @@
     justify-content: center;
     width: 2rem;
     padding: 0.5rem 0;
-    border: 1px solid var(--strapi-neutral-300);
-    border-left: none;
+    border: none;
     border-radius: 0 0.25rem 0.25rem 0;
     background-color: var(--strapi-neutral-0);
     color: var(--strapi-neutral-600);
@@ -81,13 +79,11 @@
 
     &:hover {
       background-color: var(--strapi-neutral-100);
-      border-color: var(--strapi-neutral-400);
       color: var(--strapi-neutral-800);
     }
 
     &--open {
       background-color: var(--strapi-neutral-100);
-      border-color: var(--strapi-neutral-400);
       
       .strapi-icons {
         transform: rotate(180deg);
@@ -168,29 +164,38 @@
     transition: opacity 0.2s ease;
   }
 }
+
 // Spinner animation for loading state
 .spinning {
   animation: spin 1s linear infinite;
 }
+
 @keyframes spin {
   from { transform: rotate(0deg); }
   to { transform: rotate(360deg); }
 }
+
 // Dark mode styles
 @include dark {
   .ai-toolbar {
+    &__container {
+      border-color: var(--strapi-neutral-200);
+    }
+
     &__button {
-      background-color: var(--strapi-neutral-900);
-      border-color: var(--strapi-neutral-600);
-      color: var(--strapi-neutral-400);
+      background-color: var(--strapi-neutral-0);
+      border-right-color: var(--strapi-neutral-200);
+      color: var(--strapi-neutral-800);
+      
       &:hover {
-        background-color: var(--strapi-neutral-800);
-        border-color: var(--strapi-neutral-500);
-        color: var(--strapi-neutral-200);
+        background-color: var(--strapi-neutral-100);
+        color: var(--strapi-neutral-900);
       }
+      
       &--loading {
-        color: var(--strapi-neutral-400);
+        color: var(--strapi-neutral-600);
       }
+      
       &--success {
         color: var(--strapi-success-500);
         
@@ -198,56 +203,54 @@
           color: var(--strapi-success-500);
         }
       }
+      
       &--error {
         color: var(--strapi-danger-500);
-        border-color: var(--strapi-danger-400);
       }
+      
       &--idle {
-        color: var(--strapi-neutral-400);
+        color: var(--strapi-neutral-800);
       }
     }
 
     &__dropdown-trigger {
-      background-color: var(--strapi-neutral-900);
-      border-color: var(--strapi-neutral-600);
-      color: var(--strapi-neutral-400);
+      background-color: var(--strapi-neutral-0);
+      color: var(--strapi-neutral-800);
 
       &:hover {
-        background-color: var(--strapi-neutral-800);
-        border-color: var(--strapi-neutral-500);
-        color: var(--strapi-neutral-200);
+        background-color: var(--strapi-neutral-100);
+        color: var(--strapi-neutral-900);
       }
 
       &--open {
-        background-color: var(--strapi-neutral-800);
-        border-color: var(--strapi-neutral-500);
+        background-color: var(--strapi-neutral-100);
       }
     }
 
     &__dropdown {
-      background-color: var(--strapi-neutral-900);
-      border-color: var(--strapi-neutral-600);
-      box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
+      background-color: var(--strapi-neutral-0);
+      border-color: var(--strapi-neutral-200);
+      box-shadow: 0 4px 6px rgba(0, 0, 0, 0.5);
     }
 
     &__dropdown-item {
-      color: var(--strapi-neutral-200);
+      color: var(--strapi-neutral-900);
 
       &:hover {
-        background-color: var(--strapi-neutral-800);
+        background-color: var(--strapi-neutral-100);
       }
 
       &:not(:last-child) {
-        border-bottom-color: var(--strapi-neutral-700);
+        border-bottom-color: var(--strapi-neutral-200);
       }
 
       .strapi-icons {
-        color: var(--strapi-neutral-400);
+        color: var(--strapi-neutral-600);
       }
     }
 
     &__dropdown-item-description {
-      color: var(--strapi-neutral-400);
+      color: var(--strapi-neutral-500);
     }
   }
 }

--- a/docusaurus/src/scss/ai-toolbar.scss
+++ b/docusaurus/src/scss/ai-toolbar.scss
@@ -1,8 +1,8 @@
 @use './mixins' as *;
 .ai-toolbar {
   display: flex;
-  justify-content: flex-end;
-  padding: 1rem 0;
+  justify-content: flex-start;
+  padding: 0 0 1rem 0;
   margin-bottom: 1rem;
 
   &__container {
@@ -98,7 +98,7 @@
   &__dropdown {
     position: absolute;
     top: 100%;
-    right: 0;
+    left: 0;
     z-index: 1000;
     min-width: 250px;
     margin-top: 0.25rem;

--- a/docusaurus/src/scss/ai-toolbar.scss
+++ b/docusaurus/src/scss/ai-toolbar.scss
@@ -1,0 +1,114 @@
+@use './mixins' as *;
+
+.ai-toolbar {
+  display: flex;
+  justify-content: flex-end;
+  padding: 1rem 0;
+  margin-bottom: 1rem;
+  border-bottom: 1px solid var(--strapi-neutral-200);
+
+  &__button {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 1rem;
+    border: 1px solid var(--strapi-neutral-300);
+    border-radius: 0.25rem;
+    background-color: var(--strapi-neutral-0);
+    color: var(--strapi-primary-600);
+    font-size: var(--strapi-font-size-sm);
+    font-weight: 500;
+    font-family: "SF Pro Text", "SF Pro Display", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    cursor: pointer;
+    text-decoration: none;
+    transition: all 0.2s ease;
+
+    &:hover {
+      background-color: var(--strapi-neutral-100);
+      border-color: var(--strapi-primary-500);
+    }
+
+    &:disabled {
+      cursor: default;
+      opacity: 0.7;
+      pointer-events: none;
+    }
+
+    // State-specific styles
+    &--loading {
+      opacity: 0.7;
+      pointer-events: none;
+      color: var(--strapi-neutral-600);
+    }
+
+    &--success {
+      color: var(--strapi-success-700);
+      border-color: var(--strapi-success-600);
+    }
+
+    &--error {
+      color: var(--strapi-danger-600);
+      border-color: var(--strapi-danger-500);
+    }
+
+    &--idle {
+      color: var(--strapi-primary-600);
+    }
+  }
+
+  &__button-text {
+    // Text styling if needed
+  }
+
+  &__dropdown-arrow {
+    margin-left: 0.25rem;
+    opacity: 0.6;
+    transition: opacity 0.2s ease;
+  }
+}
+
+// Spinner animation for loading state
+.spinning {
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+// Dark mode styles
+@include dark {
+  .ai-toolbar {
+    border-bottom-color: var(--strapi-neutral-700);
+
+    &__button {
+      background-color: var(--strapi-neutral-900);
+      border-color: var(--strapi-neutral-600);
+      color: var(--strapi-primary-500);
+
+      &:hover {
+        background-color: var(--strapi-neutral-800);
+        border-color: var(--strapi-primary-400);
+      }
+
+      &--loading {
+        color: var(--strapi-neutral-400);
+      }
+
+      &--success {
+        color: var(--strapi-success-500);
+        border-color: var(--strapi-success-400);
+      }
+
+      &--error {
+        color: var(--strapi-danger-500);
+        border-color: var(--strapi-danger-400);
+      }
+
+      &--idle {
+        color: var(--strapi-primary-500);
+      }
+    }
+  }
+}

--- a/docusaurus/src/scss/badge.scss
+++ b/docusaurus/src/scss/badge.scss
@@ -245,6 +245,17 @@
   }
 }
 
+
+.h1-badges-placeholder {
+  // Styles déjà définis dans le JS
+}
+
+.h1-badges-container {
+  .badge {
+    // Les transitions sont déjà définies dans le JS
+  }
+}
+
 /**
  * New/updated badges in main content gutter
  */

--- a/docusaurus/src/scss/badge.scss
+++ b/docusaurus/src/scss/badge.scss
@@ -245,17 +245,21 @@
   }
 }
 
+h1 + .h1-badges-container {
+  margin: 0;
+}
 
 .h1-badges-placeholder {
-  // Styles déjà définis dans le JS
+  // styles already defined in the JS hook: src/hooks/useBadgeReorder
 }
 
 .h1-badges-container {
   .badge {
-    // Les transitions sont déjà définies dans le JS
+    // transitions already defined in the JS hook: src/hooks/useBadgeReorder
   }
 }
 
+h1 
 /**
  * New/updated badges in main content gutter
  */

--- a/docusaurus/src/theme/MDXComponents.js
+++ b/docusaurus/src/theme/MDXComponents.js
@@ -37,6 +37,8 @@ import { ExternalLink } from '../components/ExternalLink';
 import BreakingChangeIdCard from '../components/BreakingChangeIdCard';
 import MermaidWithFallback from '../components/MermaidWithFallback.js';
 import IdentityCard, { IdentityCardItem } from '../components/IdentityCard';
+// Debug component for testing, for instance the AIToolbar configuration
+import DebugComponent from '../components/DebugComponent';
 
 export default {
   // Re-use the default mapping
@@ -90,6 +92,7 @@ export default {
   BreakingChangeIdCard,
   IdentityCard,
   IdentityCardItem,
+  DebugComponent,
   /**
    * Reusable annotation components go below👇
    */

--- a/docusaurus/src/theme/MDXComponents/Heading.js
+++ b/docusaurus/src/theme/MDXComponents/Heading.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import Heading from '@theme/Heading';
+import { AiToolbar } from '../../components/AiToolbar';
+
+export default function MDXHeading(props) {
+  const isH1 = props.as === 'h1';
+  
+  return (
+    <>
+      <Heading {...props} />
+      {isH1 && <AiToolbar />}
+    </>
+  );
+}

--- a/docusaurus/src/theme/MDXComponents/Heading.js
+++ b/docusaurus/src/theme/MDXComponents/Heading.js
@@ -1,9 +1,12 @@
-import React from 'react';
 import Heading from '@theme/Heading';
 import { AiToolbar } from '../../components/AiToolbar';
+import { useBadgeReorder } from '../../hooks/useBadgeReorder';
 
 export default function MDXHeading(props) {
   const isH1 = props.as === 'h1';
+  
+  // Le hook fait tout le travail automatiquement
+  useBadgeReorder();
   
   return (
     <>


### PR DESCRIPTION
This PR creates an extensible "AI toolbar" system.
The toolbar is displayed below h1 items, and includes a few actions:
- copy Markdown code
- view LLMs.txt
- view LLMs-full.txt

The architecture is flexible enough to accept more buttons.
The code includes:
- an `actions` folder, with dedicated and reusable actions (for now, we have one to copy the Markdown, and another one to navigate to another page)
- a `config` folder which for now only includes one config. file, where you can define the buttons details (icon, title, description, etc.)

The `Heading` component from Docusaurus has been [swizzled](https://docusaurus.io/docs/swizzling) to include the AiToolbar rendering, which means the toolbar is rendered whenever an h1 is rendered.

A `useBadgeReorder` hook has also been created to ensure badges added below an h1 (`<EnterpriseBadge />` and so on) are rendered in this order: 1. h1, 2. badges (within a container), and 3. `AiToolbar` component. Without this hook, the toolbar is rendered in between h1 and badges, which was not really reflecting the originally intended design for the h1s and associated badges.

As a bonus, the PR finally introduces a `DebugComponent` that can be used to test various scenarios while developing custom components.



https://github.com/user-attachments/assets/9489f369-036c-4ecf-a1ee-847105577353

