### PR TITLE
Fix typo in Content-type definition for credentials in TypeScript docs code example

### DIFF
--- a/docusaurus/docs/cms/typescript/documents-and-entries.md
+++ b/docusaurus/docs/cms/typescript/documents-and-entries.md
@@ -157,7 +157,7 @@ function processUsageMetrics(
 Using the types' second parameter (`TKeys`), it is possible to obtain a subset of an entity.
 
 ```typescript
-type Credentials = Data.ContentType<'api::acount.acount', 'email' | 'password'>;
+type Credentials = Data.ContentType<'api::account.account', 'email' | 'password'>;
 //   ^? { email: string; password: string }
 ```
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

Just a simple typo fix on the docs.

### Why is it needed?

Could be useful when troubleshooting copy-pasting code that wouldn't work locally but are shown as working examples.

### Related issue(s)/PR(s)

N/A
