### PR TITLE
TL;DRs in CMS docs

### DIFF
--- a/docusaurus/docs/cms/admin-panel-customization.md
+++ b/docusaurus/docs/cms/admin-panel-customization.md
@@ -11,6 +11,9 @@ import HotReloading from '/docs/snippets/hot-reloading-admin-panel.md'
 
 # Admin panel customization
 
+> The admin panel can be tailored to match your branding, by editing `src/admin/app` and using an `extensions` folder to swap logos, favicon, locales, translations, themes, bundlers, or editors.
+<br/>
+
 The **front-end part of Strapi** <Annotation>For a clarification on the distinction between:<ul><li>the Strapi admin panel (front end of Strapi),</li><li>the Strapi server (back end of Strapi),</li><li>and the end-user-facing front end of a Strapi-powered application,</li></ul> refer to the [development introduction](/cms/customization).</Annotation> is called the admin panel. The admin panel presents a graphical user interface to help you structure and manage the content that will be accessible through the Content API. To get an overview of the admin panel, please refer to the [Getting Started > Admin panel](/cms/features/admin-panel) page.
 
 From a developer point of view, Strapi's admin panel is a React-based single-page application that encapsulates all the features and installed plugins of a Strapi application.

--- a/docusaurus/docs/cms/admin-panel-customization/bundlers.md
+++ b/docusaurus/docs/cms/admin-panel-customization/bundlers.md
@@ -13,6 +13,11 @@ tags:
 
 import FeedbackCallout from '/docs/snippets/backend-customization-feedback-cta.md'
 
+# Admin panel bundlers
+
+> Supported JavaScript bundlers influence builds and development flow.
+<br/>
+
 Strapi's [admin panel](/cms/admin-panel-customization) is a React-based single-page application that encapsulates all the features and installed plugins of a Strapi application. 2 different bundlers can be used with your Strapi 5 application, [Vite](#vite) (the default one) and [webpack](#webpack). Both bundlers can be configured to suit your needs.
 
 :::info

--- a/docusaurus/docs/cms/admin-panel-customization/homepage.md
+++ b/docusaurus/docs/cms/admin-panel-customization/homepage.md
@@ -12,6 +12,9 @@ tags:
 # Homepage customization
 <VersionBadge version="5.13.0"/>
 
+> The admin panel homepage displays default content and profile widgets and supports custom additions through the `app.widgets.register` API.
+<br/>
+
 The <Icon name="house" /> Homepage is the landing page of the Strapi admin panel. By default, it provides an overview of your content with 5 default widgets:
 
 - _Last edited entries_: Displays recently modified content entries, including their content type, status, and when they were updated.

--- a/docusaurus/docs/cms/backend-customization.md
+++ b/docusaurus/docs/cms/backend-customization.md
@@ -19,6 +19,9 @@ tags:
 
 <div className="custom-mermaid-layout">
 
+> Strapi’s back end is a Koa-based server where requests pass through global middlewares, routes, controllers, services, and models before the Document Service returns responses.
+<br/>
+
 :::strapi Disambiguation: Strapi back end
 As a headless CMS, the Strapi software as a whole can be considered as the "back end" of your website or application.
 But the Strapi software itself includes 2 different parts:

--- a/docusaurus/docs/cms/configurations/admin-panel.md
+++ b/docusaurus/docs/cms/configurations/admin-panel.md
@@ -16,6 +16,9 @@ tags:
 
 # Admin panel configuration
 
+> Options in `/config/admin` let you tweak admin panel behavior and server settings, including custom URLs, host, and port.
+<br/>
+
 The `/config/admin` file is used to define the [admin panel](/cms/features/admin-panel) configuration for the Strapi application.
 
 The present page acts as a reference for all the configuration parameters and values that you can find in the `/config/admin` file, grouped by topic. For additional information on how each feature works, please refer to links given in the introduction of each sub-section.

--- a/docusaurus/docs/cms/configurations/api.md
+++ b/docusaurus/docs/cms/configurations/api.md
@@ -10,6 +10,9 @@ tags:
 
 # API configuration
 
+> `/config/api` centralizes response privacy and REST defaults such as prefix, pagination limits, and max request size.
+<br/>
+
 General settings for API calls can be set in the `./config/api.js` file:
 
 | Property                      | Description                                                                                                                                                                                                                                          | Type         | Default |

--- a/docusaurus/docs/cms/configurations/cron.md
+++ b/docusaurus/docs/cms/configurations/cron.md
@@ -10,6 +10,9 @@ tags:
 
 # Cron jobs
 
+> Cron jobs schedule custom functions at specific times via `node-schedule`, activated through server config and optional task files.
+<br/>
+
 :::prerequisites
 The `cron.enabled` configuration option should be set to `true` in the `./config/server.js` (or `./config/server.ts` for TypeScript projects) [file](/cms/configurations/server).
 :::

--- a/docusaurus/docs/cms/configurations/database.md
+++ b/docusaurus/docs/cms/configurations/database.md
@@ -17,6 +17,9 @@ import SupportedDatabases from '/docs/snippets/supported-databases.md'
 
 # Database configuration
 
+> `/config/database` defines connections, clients, and pooling for supported databases like SQLite, MySQL, and PostgreSQL.
+<br/>
+
 The `/config/database.js|ts` file is used to define database connections that will be used to store the application content.
 
 :::strapi Supported databases

--- a/docusaurus/docs/cms/configurations/environment.md
+++ b/docusaurus/docs/cms/configurations/environment.md
@@ -12,6 +12,9 @@ import SampleEnv from '/docs/snippets/sample-env.md'
 
 # Environment configuration and variables
 
+> Strapi-specific environment variables and `.env usage` enable per-environment configs, with `env()` helpers for casting values.
+<br/>
+
 Strapi provides specific environment variable names. Defining them in an environment file (e.g., `.env`) will make these variables and their values available in your code.
 
 :::tip

--- a/docusaurus/docs/cms/configurations/features.md
+++ b/docusaurus/docs/cms/configurations/features.md
@@ -12,6 +12,9 @@ tags:
 
 # Features configuration
 
+> Future flags in `/config/features` toggle experimental Strapi features, allowing early testing at your own risk.
+<br/>
+
 The `config/features.js|ts` file is used to enable feature flags. Currently this file only includes a `future` object used to enable experimental features through **future flags**.
 
 Some incoming Strapi features are not yet ready to be shipped to all users, but Strapi still offers community users the opportunity to provide early feedback on these new features or changes. With these experimental features, developers have the flexibility to choose and integrate new features and changes into their Strapi applications as they become available in the current major version as well as assist us in shaping these new features.

--- a/docusaurus/docs/cms/configurations/functions.md
+++ b/docusaurus/docs/cms/configurations/functions.md
@@ -16,6 +16,9 @@ tags:
 
 # Functions
 
+> `src/index` hosts global register, bootstrap, and destroy functions to run logic during application lifecycle.
+<br/>
+
 <div className="dont_hide_secondary_bar">
 
 The `./src/index.js` file (or `./src/index.ts` file in a [TypeScript-based](/cms/typescript) project) includes global [register](#register), [bootstrap](#bootstrap) and [destroy](#destroy) functions that can be used to add dynamic and logic-based configurations.

--- a/docusaurus/docs/cms/configurations/middlewares.md
+++ b/docusaurus/docs/cms/configurations/middlewares.md
@@ -19,6 +19,9 @@ import MiddlewareTypes from '/docs/snippets/middleware-types.md'
 
 # Middlewares configuration
 
+> `/config/middlewares` orders global middleware, enables custom names or resolves, and exposes built-in configuration options.
+<br/>
+
 <MiddlewareTypes />
 
 The `./config/middlewares.js` file is used to define all the global middlewares that should be applied by the Strapi server.

--- a/docusaurus/docs/cms/configurations/plugins.md
+++ b/docusaurus/docs/cms/configurations/plugins.md
@@ -16,6 +16,9 @@ tags:
 
 # Plugins configuration
 
+> `/config/plugins` enables or disables plugins and overrides their settings, with examples for local plugin development.
+<br/>
+
 Plugin configurations are stored in `/config/plugins.js|ts` (see [project structure](/cms/project-structure)). Each plugin can be configured with the following available parameters:
 
 | Parameter                  | Description                                                                                                                                                            | Type    |

--- a/docusaurus/docs/cms/configurations/server.md
+++ b/docusaurus/docs/cms/configurations/server.md
@@ -14,6 +14,9 @@ tags:
 
 # Server configuration
 
+> `/config/server` manages host, port, URL, proxy, cron, and more; changes require rebuilding the admin panel.
+<br/>
+
 The `/config/server.js` file is used to define the server configuration for a Strapi application.
 
 :::caution

--- a/docusaurus/docs/cms/configurations/typescript.md
+++ b/docusaurus/docs/cms/configurations/typescript.md
@@ -11,6 +11,9 @@ tags:
 
 # TypeScript configuration
 
+> TypeScript configuration explains the project’s tsconfig files, output directories, and an optional config/typescript.js|ts that auto-generates types on server restart. This documentation explains which folders store compiled code and how to toggle this experimental feature.
+<br/>
+
 [TypeScript](/cms/typescript)-enabled Strapi projects have a specific project structure and handle TypeScript project configuration through [`tsconfig.json` files](#project-structure-and-typescript-specific-configuration-files).
 
 Strapi also has dedicated TypeScript features that are configured [in the `config/typescript.js|ts` file](#strapi-specific-configuration-for-typescript).

--- a/docusaurus/docs/cms/error-handling.md
+++ b/docusaurus/docs/cms/error-handling.md
@@ -16,6 +16,9 @@ tags:
 
 # Error handling
 
+> Strapi’s APIs return errors in a consistent structure and let backend code throw custom exceptions for controllers, services, policies, or lifecycles. This documentation lists error classes, context helpers, and examples for crafting meaningful responses.
+<br/>
+
 Strapi is natively handling errors with a standard format.
 
 There are 2 use cases for error handling:

--- a/docusaurus/docs/cms/features/admin-panel.md
+++ b/docusaurus/docs/cms/features/admin-panel.md
@@ -11,6 +11,9 @@ tags:
 
 # Administration panel
 
+> The admin panel acts as Strapi’s back office for managing content types, entries, and both administrator and end‑user accounts. This documentation gives an overview of the admin panel before focusing on profile settings that manage interface language and mode, login and personal information, and logo for branding.
+<br/>
+
 The admin panel is the back office of your Strapi application. From the admin panel, you will be able to manage content-types and write their actual content, but also manage users, both administrators and end users of your Strapi application.
 
 <ThemedImage

--- a/docusaurus/docs/cms/features/api-tokens.md
+++ b/docusaurus/docs/cms/features/api-tokens.md
@@ -13,6 +13,9 @@ tags:
 
 # API Tokens
 
+> API tokens provide scoped authentication for REST and GraphQL requests without exposing user credentials. This documentation explains token types, creation, expiration, and secure usage within the admin panel.
+<br/>
+
 API tokens allow users to authenticate REST and GraphQL API queries (see [APIs introduction](/cms/api/content-api)).
 
 <IdentityCard>

--- a/docusaurus/docs/cms/features/audit-logs.md
+++ b/docusaurus/docs/cms/features/audit-logs.md
@@ -17,6 +17,9 @@ tags:
 
 <VersionBadge version="4.6.0" />
 
+> Audit Logs captures every administrative action in a searchable, filterable history to aid troubleshooting and compliance. In this documentation, examples show viewing payloads and filtering by user or date.
+<br/>
+
 The Audit Logs feature provides a searchable and filterable display of all activities performed by users of the Strapi application.
 
 <IdentityCard>

--- a/docusaurus/docs/cms/features/content-history.md
+++ b/docusaurus/docs/cms/features/content-history.md
@@ -12,6 +12,9 @@ tags:
 # Content History
 <GrowthBadge /> <EnterpriseBadge/> <VersionBadge version="5.0.0" />
 
+> Content History stores previous document versions so editors can compare and restore earlier states from the Content Manager. This documentation explains how to browse and restore workflows for quick rollback of mistakes.
+<br/>
+
 The Content History feature, in the <Icon name="feather" /> Content Manager, gives you the ability to browse and restore previous versions of documents created with the [Content Manager](/cms/features/content-manager).
 
 <IdentityCard>

--- a/docusaurus/docs/cms/features/content-manager.md
+++ b/docusaurus/docs/cms/features/content-manager.md
@@ -16,6 +16,9 @@ import ScreenshotNumberReference from '/src/components/ScreenshotNumberReference
 
 # Content Manager
 
+> ...
+<br/>
+
 From the <Icon name="feather" /> Content Manager, accessible via the main navigation of the admin panel, users can write and manage their content.
 
 <IdentityCard>

--- a/docusaurus/docs/cms/features/custom-fields.md
+++ b/docusaurus/docs/cms/features/custom-fields.md
@@ -17,6 +17,9 @@ import CustomFieldRequiresPlugin from '/docs/snippets/custom-field-requires-plug
 
 # Custom Fields
 
+> Custom Fields extend Strapi with new field types that behave like native fields in the Content‑type Builder and Content Manager. Instructions in this documentation cover building or installing fields via plugins and registering them programmatically.
+<br/>
+
 Custom fields extend Strapi’s capabilities by adding new types of fields to content-types and components. Once created or added to Strapi via plugins, custom fields can be used in the Content-Type Builder and Content Manager just like built-in fields.
 
 <IdentityCard>

--- a/docusaurus/docs/cms/features/data-management.md
+++ b/docusaurus/docs/cms/features/data-management.md
@@ -14,6 +14,9 @@ tags:
 
 # Data Management
 
+> Data Management handles CLI-based import, export, and transfer of content between Strapi instances with partial configuration in the admin panel. Step-by-step commands and prerequisite settings explained in this documentation ensure safe migrations.
+<br/>
+
 The Data Management feature can be used to import, export, or transfer data. Data Management is  CLI-based only, but is partly configured in the admin panel.
 
 <IdentityCard>

--- a/docusaurus/docs/cms/features/draft-and-publish.md
+++ b/docusaurus/docs/cms/features/draft-and-publish.md
@@ -14,6 +14,9 @@ tags:
 
 # Draft & Publish
 
+> Draft & Publish separates drafts from live entries, allowing editors to stage content before release. This documentation shows how to enable it per content type and manage publish or unpublish actions.
+<br/>
+
 The Draft & Publish feature allows to manage drafts for your content.
 
 <IdentityCard>

--- a/docusaurus/docs/cms/features/email.md
+++ b/docusaurus/docs/cms/features/email.md
@@ -14,6 +14,9 @@ tags:
 
 # Email
 
+> The Email feature sends transactional messages through local SMTP or external providers like SendGrid. Setup guidance in this documentation covers provider configuration and extending delivery via controllers or hooks.
+<br/>
+
 The Email feature enables Strapi applications to send emails from a server or an external provider.
 
 <IdentityCard>

--- a/docusaurus/docs/cms/features/internationalization.md
+++ b/docusaurus/docs/cms/features/internationalization.md
@@ -13,6 +13,9 @@ tags:
 
 # Internationalization (i18n)
 
+> Internationalization manages content in multiple locales directly from the admin panel. This documentation explains how to add locales, translate entries, and control locale-specific permissions.
+<br/>
+
 The Internationalization feature allows to manage content in different languages, called "locales".
 
 <IdentityCard>

--- a/docusaurus/docs/cms/features/media-library.md
+++ b/docusaurus/docs/cms/features/media-library.md
@@ -14,6 +14,9 @@ import MediaLibraryProvidersList from '/docs/snippets/media-library-providers-li
 
 # Media Library
 
+> Media Library centralizes all uploaded assets with search, filters, and folder organization. This documentation includes provider options, upload workflows, and explanations on inserting media into content.
+<br/>
+
 The <Icon name="images" /> Media Library is the Strapi feature that displays all assets uploaded in the Strapi application and allows users to manage them.
 
 <IdentityCard>

--- a/docusaurus/docs/cms/features/preview.md
+++ b/docusaurus/docs/cms/features/preview.md
@@ -11,6 +11,9 @@ tags:
 
 # Preview
 
+> Preview connects the Content Manager to your front end so editors can see changes before publishing. Configuration steps set preview URLs and explain Live Preview availability for higher plans.
+<br/>
+
 With the Preview feature, you can preview your front end application directly from Strapi's admin panel. This is helpful to see how updates to your content in the Edit View of the Content Manager will affect the final result.
 
 <IdentityCard>

--- a/docusaurus/docs/cms/features/rbac.md
+++ b/docusaurus/docs/cms/features/rbac.md
@@ -13,6 +13,9 @@ import ScreenshotNumberReference from '/src/components/ScreenshotNumberReference
 
 # Role-Based Access Control (RBAC)
 
+> Role-Based Access Control (RBAC) manages administrator roles and granular permissions in the admin panel. This documentation covers creating roles, assigning rights, and securing administrative workflows.
+<br/>
+
 The Role-Based Access Control (RBAC) feature allows the management of the administrators, who are the users of the admin panel. More specifically, RBAC manages the administrators' accounts and roles.
 
 <IdentityCard>

--- a/docusaurus/docs/cms/features/releases.md
+++ b/docusaurus/docs/cms/features/releases.md
@@ -13,6 +13,9 @@ tags:
 # Releases
 <GrowthBadge/>
 
+> Releases group entries into publishable batches to trigger simultaneous publish or unpublish actions across content types and locales. Instructions in this documentation detail creating releases, adding entries, and understanding plan limitations.
+<br/>
+
 The Releases feature enables content managers to organize entries into containers that can perform publish and unpublish actions simultaneously. A release can contain entries from different content types and can mix locales.
 
 <IdentityCard>

--- a/docusaurus/docs/cms/features/review-workflows.md
+++ b/docusaurus/docs/cms/features/review-workflows.md
@@ -12,6 +12,9 @@ tags:
 # Review Workflows
 <EnterpriseBadge />
 
+> Review Workflows define custom multi-stage pipelines for content review, facilitating collaboration from draft to publication. This documentation walks through creating workflows and assigning stages.
+<br/>
+
 The Review Workflows feature allows you to create and manage workflows for your various content-types. Each workflow can consist of any review stages for your content, enabling your team to collaborate in the content creation flow from draft to publication.
 
 <IdentityCard>

--- a/docusaurus/docs/cms/features/sso.md
+++ b/docusaurus/docs/cms/features/sso.md
@@ -12,6 +12,9 @@ tags:
 # Single Sign-On (SSO)
 <EnterpriseBadge /> <SsoBadge />
 
+> Single Sign-On (SSO) lets administrators authenticate via identity providers such as Azure AD instead of local passwords. Configuration steps in this documentation cover enabling SSO and mapping roles.
+<br/>
+
 The Single Sign-On (SSO) feature can be made available on a Strapi application to allow administrators to authenticate through an identity provider (e.g. Microsoft Azure Active Directory).
 
 <IdentityCard>

--- a/docusaurus/docs/cms/features/users-permissions.md
+++ b/docusaurus/docs/cms/features/users-permissions.md
@@ -11,6 +11,9 @@ tags:
 
 # Users & Permissions
 
+> Users & Permissions manages end-user accounts, JWT-based authentication, and role-based access to APIs. This documentation explains how to create roles, configure permissions, and issue API tokens for secure access control.
+<br/>
+
 The Users & Permissions feature allows the management of the end-users <Annotation>💡 **What are end users?** <br/> End-users are the users who consume the content that is created and managed with a Strapi application and displayed on front-end applications (e.g. websites, mobile applications, connected devices etc.). Unlike the administrators, they do not have access to the admin panel.</Annotation> of a Strapi project. It provides a full authentication process based on JSON Web Tokens (JWT) to protect your API, and an access-control list (ACL) strategy that enables you to manage permissions between groups of users.
 
 <IdentityCard>

--- a/docusaurus/docs/cms/plugins-development/admin-panel-api.md
+++ b/docusaurus/docs/cms/plugins-development/admin-panel-api.md
@@ -22,6 +22,9 @@ tags:
 
 # Admin Panel API for plugins
 
+> The Admin Panel API exposes `register`, `bootstrap`, and `registerTrads` hooks to inject React components and translations into Strapi’s UI. Menu, settings, injection zone, reducer, and hook APIs let plugins add navigation, configuration panels, or custom actions.
+<br/>
+
 A Strapi plugin can interact with both the [back end](/cms/plugins-development/server-api) and the front end of a Strapi application. The Admin Panel API is about the front end part, i.e. it allows a plugin to customize Strapi's [admin panel](/cms/intro).
 
 The admin panel is a <ExternalLink to="https://reactjs.org/" text="React"/> application that can embed other React applications. These other React applications are the admin parts of each Strapi plugin.

--- a/docusaurus/docs/cms/plugins-development/content-manager-apis.md
+++ b/docusaurus/docs/cms/plugins-development/content-manager-apis.md
@@ -11,6 +11,9 @@ tags:
 
 # Content Manager APIs
 
+> Content Manager APIs add panels and actions to list or edit views through `addEditViewSidePanel`, `addDocumentAction`, `addDocumentHeaderAction`, or `addBulkAction`. Each API accepts component functions with typed contexts, enabling precise control over document-aware UI injections.
+<br/>
+
 Content-Manager APIs are part of the [Admin Panel API](/cms/plugins-development/admin-panel-api). They are a way to add content or options from plugins to the [Content-Manager](/cms/features/content-manager), so you can extend the Content-Manager by adding functionality from your own plugin, just like you can do it with [Injection Zones](/cms/plugins-development/admin-panel-api#injection-zones-api).
 
 Strapi 5 provides 4 Content-Manager APIs, all accessible through `app.getPlugin('content-manager').apis`:

--- a/docusaurus/docs/cms/plugins-development/create-a-plugin.md
+++ b/docusaurus/docs/cms/plugins-development/create-a-plugin.md
@@ -11,6 +11,9 @@ tags:
 
 # Plugin creation
 
+> The Plugin SDK generates plugins without a Strapi project and links them to an existing app with `watch:link` and yalc. In this documentation: build and verify commands to bundle the plugin for npm or marketplace publishing, and information for monorepos and local setups.
+<br/>
+
 There are many ways to create a Strapi 5 plugin, but the fastest and recommended way is to use the Plugin SDK.
 
 The Plugin SDK is a set of commands orientated around developing plugins to use them as local plugins or to publish them on NPM and/or submit them to the Marketplace.

--- a/docusaurus/docs/cms/plugins-development/plugins-extension.md
+++ b/docusaurus/docs/cms/plugins-development/plugins-extension.md
@@ -14,6 +14,8 @@ tags:
 
 # Plugins extension
 
+> Existing plugins can be overriden by placing code in `/src/extensions` or using global `register/bootstrap` hooks. Instructions in this documentation cover reshaping plugin content-type schemas or server logic — altough upstream updates may break extensions.
+
 Strapi comes with plugins that can be installed from the [Marketplace](/cms/plugins/installing-plugins-via-marketplace#installing-marketplace-plugins-and-providers) or as npm packages. You can also create your own plugins (see [plugins development](/cms/plugins-development/developing-plugins)) or extend the existing ones.
 
 :::warning

--- a/docusaurus/docs/cms/plugins/documentation.md
+++ b/docusaurus/docs/cms/plugins/documentation.md
@@ -16,6 +16,9 @@ tags:
 
 # Documentation plugin
 
+> The Documentation plugin auto-generates OpenAPI/Swagger docs for your API by scanning content types and routes. This documentation walks you through installation, customizing settings, and restricting access to the docs.
+<br/>
+
 The Documentation plugin automates your API documentation creation. It basically generates a swagger file. It follows the <ExternalLink to="https://swagger.io/specification/" text="Open API specification version"/>.
 
 <IdentityCard isPlugin>

--- a/docusaurus/docs/cms/plugins/graphql.md
+++ b/docusaurus/docs/cms/plugins/graphql.md
@@ -19,6 +19,9 @@ tags:
 
 # GraphQL plugin
 
+> The GraphQL plugin adds a GraphQL endpoint and Apollo-based sandbox for crafting queries and mutations. Options in config/plugins let you tune depth, item limits, and other Apollo Server settings which are explained in this documentation.
+<br/>
+
 By default Strapi create [REST endpoints](/cms/api/rest#endpoints) for each of your content-types. The GraphQL plugin adds a GraphQL endpoint to fetch and mutate your content. With the GraphQL plugin installed, you can use the Apollo Server-based GraphQL Sandbox to interactively build your queries and mutations and read documentation tailored to your content types.
 
 <IdentityCard isPlugin>

--- a/docusaurus/docs/cms/plugins/installing-plugins-via-marketplace.md
+++ b/docusaurus/docs/cms/plugins/installing-plugins-via-marketplace.md
@@ -11,6 +11,9 @@ tags:
 
 # Using the Marketplace
 
+> The in-app Marketplace lists plugins and providers with badges, search, and “More” links to detailed Strapi Market pages. This documentation outlines browsing cards and following provider-specific instructions to install new integrations.
+<br/>
+
 Strapi comes with built-in plugins such as [Documentation](/cms/plugins/documentation), [GraphQL](/cms/plugins/graphql), and [Sentry](/cms/plugins/sentry). The Marketplace is where users can find additional plugins to customize Strapi applications, and additional providers to extend plugins. The Marketplace is located in the admin panel, indicated by <Icon name="shopping-cart" /> _Marketplace_. In the Marketplace, users can browse or search for plugins and providers, link to detailed descriptions for each, and submit new plugins and providers.
 
 :::note strapi In-app Marketplace vs. Market website

--- a/docusaurus/docs/cms/plugins/sentry.md
+++ b/docusaurus/docs/cms/plugins/sentry.md
@@ -10,6 +10,9 @@ tags:
 
 # Sentry plugin
 
+> The Sentry plugin connects Strapi to Sentry to report errors and attach debugging metadata. This documentation details installation, environment-based configuration, and ways to disable or skip sending events outside production.
+<br/>
+
 This plugin enables you to track errors in your Strapi application using Sentry.
 
 <IdentityCard isPlugin>

--- a/docusaurus/docs/cms/templates.md
+++ b/docusaurus/docs/cms/templates.md
@@ -10,6 +10,9 @@ tags:
 
 # Templates
 
+> Templates are full Strapi apps that bootstrap new projects via CLI flags such as `--template`, `--template-path`, and `--template-branch`. Instructions in this documentation cover referencing templates from GitHub and turning any Strapi project into a reusable template.
+<br/>
+
 Templates in Strapi 5 are standalone, pre-made Strapi applications designed for specific use cases.
 
 Strapi 5 templates are folders that include all files and folders that you would find in a typical Strapi application (see [project structure](/cms/project-structure)).

--- a/docusaurus/docs/cms/testing.md
+++ b/docusaurus/docs/cms/testing.md
@@ -9,6 +9,9 @@ tags:
 
 # Unit testing
 
+> Testing uses Jest and Supertest with a temporary SQLite database to run unit and API checks. Walkthroughs generate a Strapi instance, verify endpoints like `/hello`, and authenticate users to ensure controllers behave as expected.
+<br/>
+
 :::strapi
 The Strapi blog has a tutorial on how to implement <ExternalLink to="https://strapi.io/blog/automated-testing-for-strapi-api-with-jest-and-supertest" text="API testing with Jest and Supertest"/> and <ExternalLink to="https://strapi.io/blog/how-to-add-unit-tests-to-your-strapi-plugin" text="how to add unit tests to your Strapi plugin"/>.
 :::

--- a/docusaurus/docs/cms/typescript/development.md
+++ b/docusaurus/docs/cms/typescript/development.md
@@ -9,7 +9,10 @@ tags:
 - plugins development
 ---
 
-# TypeScript development with Strapi 
+# TypeScript development with Strapi
+
+> TypeScript development showcases Strapi typings for autocompletion, schema type generation with `ts:generate-types`, and programmatic server starts via `strapi()` or `strapi.compile()`. This documentation addresses plugin builds and managing generated type definitions.
+<br/>
 
 While developing a [TypeScript](/cms/typescript)-based application with Strapi, you can:
 

--- a/docusaurus/static/llms-full.txt
+++ b/docusaurus/static/llms-full.txt
@@ -1327,6 +1327,9 @@ Source: https://docs.strapi.io/cms/admin-panel-customization
 
 # Admin panel customization
 
+> The admin panel can be tailored to match your branding, by editing `src/admin/app` and using an `extensions` folder to swap logos, favicon, locales, translations, themes, bundlers, or editors.
+<br/>
+
 The **front-end part of Strapi**  is called the admin panel. The admin panel presents a graphical user interface to help you structure and manage the content that will be accessible through the Content API. To get an overview of the admin panel, please refer to the [Getting Started > Admin panel](/cms/features/admin-panel) page.
 
 From a developer point of view, Strapi's admin panel is a React-based single-page application that encapsulates all the features and installed plugins of a Strapi application.
@@ -1371,6 +1374,11 @@ The following is an example of a basic customization of the admin panel:
 
 # Admin panel bundlers
 Source: https://docs.strapi.io/cms/admin-panel-customization/bundlers
+
+# Admin panel bundlers
+
+> Supported JavaScript bundlers influence builds and development flow.
+<br/>
 
 Strapi's [admin panel](/cms/admin-panel-customization) is a React-based single-page application that encapsulates all the features and installed plugins of a Strapi application. 2 different bundlers can be used with your Strapi 5 application, [Vite](#vite) (the default one) and [webpack](#webpack). Both bundlers can be configured to suit your needs.
 
@@ -4602,6 +4610,9 @@ Source: https://docs.strapi.io/cms/backend-customization
 
 <div className="custom-mermaid-layout">
 
+> Strapi’s back end is a Koa-based server where requests pass through global middlewares, routes, controllers, services, and models before the Document Service returns responses.
+<br/>
+
 :::strapi Disambiguation: Strapi back end
 As a headless CMS, the Strapi software as a whole can be considered as the "back end" of your website or application.
 But the Strapi software itself includes 2 different parts:
@@ -6595,6 +6606,9 @@ Source: https://docs.strapi.io/cms/configurations/api
 
 # API configuration
 
+> `/config/api` centralizes response privacy and REST defaults such as prefix, pagination limits, and max request size.
+<br/>
+
 General settings for API calls can be set in the `./config/api.js` file:
 
 | Property                      | Description                                                                                                                                                                                                                                          | Type         | Default |
@@ -6620,6 +6634,9 @@ If the `rest.maxLimit` value is less than the `rest.defaultLimit` value, `maxLim
 Source: https://docs.strapi.io/cms/configurations/cron
 
 # Cron jobs
+
+> Cron jobs schedule custom functions at specific times via `node-schedule`, activated through server config and optional task files.
+<br/>
 
 :::prerequisites
 The `cron.enabled` configuration option should be set to `true` in the `./config/server.js` (or `./config/server.ts` for TypeScript projects) [file](/cms/configurations/server).
@@ -6719,6 +6736,9 @@ strapi.cron.jobs
 Source: https://docs.strapi.io/cms/configurations/database
 
 # Database configuration
+
+> `/config/database` defines connections, clients, and pooling for supported databases like SQLite, MySQL, and PostgreSQL.
+<br/>
 
 The `/config/database.js|ts` file is used to define database connections that will be used to store the application content.
 
@@ -6865,6 +6885,9 @@ Source: https://docs.strapi.io/cms/configurations/environment
 
 # Environment configuration and variables
 
+> Strapi-specific environment variables and `.env usage` enable per-environment configs, with `env()` helpers for casting values.
+<br/>
+
 Strapi provides specific environment variable names. Defining them in an environment file (e.g., `.env`) will make these variables and their values available in your code.
 
 :::tip
@@ -6904,6 +6927,9 @@ Source: https://docs.strapi.io/cms/configurations/features
 
 # Features configuration
 
+> Future flags in `/config/features` toggle experimental Strapi features, allowing early testing at your own risk.
+<br/>
+
 The `config/features.js|ts` file is used to enable feature flags. Currently this file only includes a `future` object used to enable experimental features through **future flags**.
 
 Some incoming Strapi features are not yet ready to be shipped to all users, but Strapi still offers community users the opportunity to provide early feedback on these new features or changes. With these experimental features, developers have the flexibility to choose and integrate new features and changes into their Strapi applications as they become available in the current major version as well as assist us in shaping these new features.
@@ -6936,6 +6962,9 @@ Developers can use the following APIs to interact with future flags:
 Source: https://docs.strapi.io/cms/configurations/functions
 
 # Functions
+
+> `src/index` hosts global register, bootstrap, and destroy functions to run logic during application lifecycle.
+<br/>
 
 <div className="dont_hide_secondary_bar">
 
@@ -7001,6 +7030,9 @@ You might find additional information in  about registering lifecycle functions.
 Source: https://docs.strapi.io/cms/configurations/middlewares
 
 # Middlewares configuration
+
+> `/config/middlewares` orders global middleware, enables custom names or resolves, and exposes built-in configuration options.
+<br/>
 
 </Tabs>
 
@@ -7159,6 +7191,9 @@ Source: https://docs.strapi.io/cms/configurations/plugins
 
 # Plugins configuration
 
+> `/config/plugins` enables or disables plugins and overrides their settings, with examples for local plugin development.
+<br/>
+
 Plugin configurations are stored in `/config/plugins.js|ts` (see [project structure](/cms/project-structure)). Each plugin can be configured with the following available parameters:
 
 | Parameter                  | Description                                                                                                                                                            | Type    |
@@ -7185,6 +7220,9 @@ If no specific configuration is required, a plugin can also be declared with the
 Source: https://docs.strapi.io/cms/configurations/server
 
 # Server configuration
+
+> `/config/server` manages host, port, URL, proxy, cron, and more; changes require rebuilding the admin panel.
+<br/>
 
 The `/config/server.js` file is used to define the server configuration for a Strapi application.
 
@@ -7220,6 +7258,9 @@ The `./config/server.js` file can include the following parameters:
 Source: https://docs.strapi.io/cms/configurations/typescript
 
 # TypeScript configuration
+
+> TypeScript configuration explains the project’s tsconfig files, output directories, and an optional config/typescript.js|ts that auto-generates types on server restart. This documentation explains which folders store compiled code and how to toggle this experimental feature.
+<br/>
 
 [TypeScript](/cms/typescript)-enabled Strapi projects have a specific project structure and handle TypeScript project configuration through [`tsconfig.json` files](#project-structure-and-typescript-specific-configuration-files).
 
@@ -7481,6 +7522,9 @@ Source: https://docs.strapi.io/cms/error-handling
 
 # Error handling
 
+> Strapi’s APIs return errors in a consistent structure and let backend code throw custom exceptions for controllers, services, policies, or lifecycles. This documentation lists error classes, context helpers, and examples for crafting meaningful responses.
+<br/>
+
 Strapi is natively handling errors with a standard format.
 
 There are 2 use cases for error handling:
@@ -7582,6 +7626,9 @@ Source: https://docs.strapi.io/cms/features/admin-panel
 
 # Administration panel
 
+> The admin panel acts as Strapi’s back office for managing content types, entries, and both administrator and end‑user accounts. This documentation gives an overview of the admin panel before focusing on profile settings that manage interface language and mode, login and personal information, and logo for branding.
+<br/>
+
 The admin panel is the back office of your Strapi application. From the admin panel, you will be able to manage content-types and write their actual content, but also manage users, both administrators and end users of your Strapi application.
 
 ### Modifying profile information (name, email, username)
@@ -7674,6 +7721,9 @@ If you prefer or are required to log in via an SSO provider, please refer to the
 Source: https://docs.strapi.io/cms/features/api-tokens
 
 # API Tokens
+
+> API tokens provide scoped authentication for REST and GraphQL requests without exposing user credentials. This documentation explains token types, creation, expiration, and secure usage within the admin panel.
+<br/>
 
 API tokens allow users to authenticate REST and GraphQL API queries (see [APIs introduction](/cms/api/content-api)).
 
@@ -7783,6 +7833,9 @@ If the [Internationalization (i18n)](/cms/features/internationalization) feature
 Source: https://docs.strapi.io/cms/features/content-manager
 
 # Content Manager
+
+> ...
+<br/>
 
 From the 
   
@@ -8005,6 +8058,9 @@ Source: https://docs.strapi.io/cms/features/custom-fields
 
 # Custom Fields
 
+> Custom Fields extend Strapi with new field types that behave like native fields in the Content‑type Builder and Content Manager. Instructions in this documentation cover building or installing fields via plugins and registering them programmatically.
+<br/>
+
 Custom fields extend Strapi’s capabilities by adding new types of fields to content-types and components. Once created or added to Strapi via plugins, custom fields can be used in the Content-Type Builder and Content Manager just like built-in fields.
 
 </IdentityCard>
@@ -8128,6 +8184,9 @@ Source: https://docs.strapi.io/cms/features/data-management
 
 # Data Management
 
+> Data Management handles CLI-based import, export, and transfer of content between Strapi instances with partial configuration in the admin panel. Step-by-step commands and prerequisite settings explained in this documentation ensure safe migrations.
+<br/>
+
 The Data Management feature can be used to import, export, or transfer data. Data Management is  CLI-based only, but is partly configured in the admin panel.
 
 </IdentityCard>
@@ -8157,6 +8216,9 @@ Source: https://docs.strapi.io/cms/features/draft-and-publish
 
 # Draft & Publish
 
+> Draft & Publish separates drafts from live entries, allowing editors to stage content before release. This documentation shows how to enable it per content type and manage publish or unpublish actions.
+<br/>
+
 The Draft & Publish feature allows to manage drafts for your content.
 
 </IdentityCard>
@@ -8169,6 +8231,9 @@ On the back-end server of Strapi, the Document Service API can also be used to i
 Source: https://docs.strapi.io/cms/features/email
 
 # Email
+
+> The Email feature sends transactional messages through local SMTP or external providers like SendGrid. Setup guidance in this documentation covers provider configuration and extending delivery via controllers or hooks.
+<br/>
 
 The Email feature enables Strapi applications to send emails from a server or an external provider.
 
@@ -8229,6 +8294,9 @@ Source: https://docs.strapi.io/cms/features/internationalization
 
 # Internationalization (i18n)
 
+> Internationalization manages content in multiple locales directly from the admin panel. This documentation explains how to add locales, translate entries, and control locale-specific permissions.
+<br/>
+
 The Internationalization feature allows to manage content in different languages, called "locales".
 
 </IdentityCard>
@@ -8241,6 +8309,9 @@ On the back-end server of Strapi, the Document Service API can also be used to i
 Source: https://docs.strapi.io/cms/features/media-library
 
 # Media Library
+
+> Media Library centralizes all uploaded assets with search, filters, and folder organization. This documentation includes provider options, upload workflows, and explanations on inserting media into content.
+<br/>
 
 The 
 
@@ -8331,6 +8402,9 @@ The dotfiles are not exposed. It means that every file name that starts with `.`
 Source: https://docs.strapi.io/cms/features/preview
 
 # Preview
+
+> Preview connects the Content Manager to your front end so editors can see changes before publishing. Configuration steps set preview URLs and explain Live Preview availability for higher plans.
+<br/>
 
 With the Preview feature, you can preview your front end application directly from Strapi's admin panel. This is helpful to see how updates to your content in the Edit View of the Content Manager will affect the final result.
 
@@ -8434,6 +8508,9 @@ Switch between Desktop and Mobile preview mode using the dropdown at the top to 
 Source: https://docs.strapi.io/cms/features/rbac
 
 # Role-Based Access Control (RBAC)
+
+> Role-Based Access Control (RBAC) manages administrator roles and granular permissions in the admin panel. This documentation covers creating roles, assigning rights, and securing administrative workflows.
+<br/>
 
 The Role-Based Access Control (RBAC) feature allows the management of the administrators, who are the users of the admin panel. More specifically, RBAC manages the administrators' accounts and roles.
 
@@ -8784,6 +8861,9 @@ To access the admin panel using a specific provider instead of logging in with a
 Source: https://docs.strapi.io/cms/features/users-permissions
 
 # Users & Permissions
+
+> Users & Permissions manages end-user accounts, JWT-based authentication, and role-based access to APIs. This documentation explains how to create roles, configure permissions, and issue API tokens for secure access control.
+<br/>
 
 The Users & Permissions feature allows the management of the end-users  of a Strapi project. It provides a full authentication process based on JSON Web Tokens (JWT) to protect your API, and an access-control list (ACL) strategy that enables you to manage permissions between groups of users.
 
@@ -10988,6 +11068,9 @@ Source: https://docs.strapi.io/cms/plugins/documentation
 
 # Documentation plugin
 
+> The Documentation plugin auto-generates OpenAPI/Swagger docs for your API by scanning content types and routes. This documentation walks you through installation, customizing settings, and restricting access to the docs.
+<br/>
+
 The Documentation plugin automates your API documentation creation. It basically generates a swagger file. It follows the 
 
 </IdentityCard>
@@ -11252,6 +11335,9 @@ Strapi is secured by default, which means that most of your endpoints require th
 Source: https://docs.strapi.io/cms/plugins/graphql
 
 # GraphQL plugin
+
+> The GraphQL plugin adds a GraphQL endpoint and Apollo-based sandbox for crafting queries and mutations. Options in config/plugins let you tune depth, item limits, and other Apollo Server settings which are explained in this documentation.
+<br/>
 
 By default Strapi create [REST endpoints](/cms/api/rest#endpoints) for each of your content-types. The GraphQL plugin adds a GraphQL endpoint to fetch and mutate your content. With the GraphQL plugin installed, you can use the Apollo Server-based GraphQL Sandbox to interactively build your queries and mutations and read documentation tailored to your content types.
 
@@ -11622,6 +11708,9 @@ Source: https://docs.strapi.io/cms/plugins/installing-plugins-via-marketplace
 
 # Using the Marketplace
 
+> The in-app Marketplace lists plugins and providers with badges, search, and “More” links to detailed Strapi Market pages. This documentation outlines browsing cards and following provider-specific instructions to install new integrations.
+<br/>
+
 Strapi comes with built-in plugins such as [Documentation](/cms/plugins/documentation), [GraphQL](/cms/plugins/graphql), and [Sentry](/cms/plugins/sentry). The Marketplace is where users can find additional plugins to customize Strapi applications, and additional providers to extend plugins. The Marketplace is located in the admin panel, indicated by  _Marketplace_. In the Marketplace, users can browse or search for plugins and providers, link to detailed descriptions for each, and submit new plugins and providers.
 
 :::note strapi In-app Marketplace vs. Market website
@@ -11667,6 +11756,9 @@ Can't find a plugin that suits your use case? Feel free to [create your own](/cm
 Source: https://docs.strapi.io/cms/plugins/sentry
 
 # Sentry plugin
+
+> The Sentry plugin connects Strapi to Sentry to report errors and attach debugging metadata. This documentation details installation, environment-based configuration, and ways to disable or skip sending events outside production.
+<br/>
 
 This plugin enables you to track errors in your Strapi application using Sentry.
 
@@ -11987,6 +12079,9 @@ Source: https://docs.strapi.io/cms/templates
 
 # Templates
 
+> Templates are full Strapi apps that bootstrap new projects via CLI flags such as `--template`, `--template-path`, and `--template-branch`. Instructions in this documentation cover referencing templates from GitHub and turning any Strapi project into a reusable template.
+<br/>
+
 Templates in Strapi 5 are standalone, pre-made Strapi applications designed for specific use cases.
 
 Strapi 5 templates are folders that include all files and folders that you would find in a typical Strapi application (see [project structure](/cms/project-structure)).
@@ -12023,6 +12118,9 @@ An example of what a template could look like is the .
 Source: https://docs.strapi.io/cms/testing
 
 # Unit testing
+
+> Testing uses Jest and Supertest with a temporary SQLite database to run unit and API checks. Walkthroughs generate a Strapi instance, verify endpoints like `/hello`, and authenticate users to ensure controllers behave as expected.
+<br/>
 
 :::strapi
 The Strapi blog has a tutorial on how to implement 
@@ -12353,7 +12451,10 @@ Source: https://docs.strapi.io/cms/typescript
 # TypeScript development
 Source: https://docs.strapi.io/cms/typescript/development
 
-# TypeScript development with Strapi 
+# TypeScript development with Strapi
+
+> TypeScript development showcases Strapi typings for autocompletion, schema type generation with `ts:generate-types`, and programmatic server starts via `strapi()` or `strapi.compile()`. This documentation addresses plugin builds and managing generated type definitions.
+<br/>
 
 While developing a [TypeScript](/cms/typescript)-based application with Strapi, you can:
 

--- a/docusaurus/static/llms.txt
+++ b/docusaurus/static/llms.txt
@@ -115,7 +115,7 @@
 - [Server API for plugins](https://docs.strapi.io/cms/plugins-development/server-api): Strapi's Server API for plugins allows a Strapi plugin to customize the back end part (i.e. the server) of your application.
 - [Documentation plugin](https://docs.strapi.io/cms/plugins/documentation): By using Swagger UI, the API documentation plugin takes out most of your pain to generate your documentation.
 - [GraphQL plugin](https://docs.strapi.io/cms/plugins/graphql): Use a GraphQL endpoint in your Strapi project to fetch and mutate your content.
-- [Installing Plugins via the Marketplace](https://docs.strapi.io/cms/plugins/installing-plugins-via-marketplace): Strapi comes with built-in plugins such as [Documentation](/cms/plugins/documentation), [GraphQL](/cms/plugins/graphql), and [Sentry](/cms/plugins/sen...
+- [Installing Plugins via the Marketplace](https://docs.strapi.io/cms/plugins/installing-plugins-via-marketplace): > The in-app Marketplace lists plugins and providers with badges, search, and “More” links to detailed Strapi Market pages. This documentation outline...
 - [Sentry plugin](https://docs.strapi.io/cms/plugins/sentry): Track errors in your Strapi application.
 - [Project structure](https://docs.strapi.io/cms/project-structure): Discover the project structure of any default Strapi application.
 - [Quick Start Guide - Strapi Developer Docs](https://docs.strapi.io/cms/quick-start): Get ready to get Strapi, your favorite open-source headless cms up and running in less than 3 minutes.


### PR DESCRIPTION
Add TL;DRs at the beginning of most files of the CMS docs.