### PR TITLE
Fix old Strapi code base links wrongly referencing master branch

### DIFF
--- a/docusaurus/docs/cms/configurations/media-library-providers.md
+++ b/docusaurus/docs/cms/configurations/media-library-providers.md
@@ -237,7 +237,7 @@ In the send function you will have access to:
 * `settings` that contains configurations written in `plugins.js|ts`
 * `options` that contains options you send when you call the send function from the email plugin service
 
-You can review the <ExternalLink to="https://github.com/strapi/strapi/tree/master/packages/providers" text="Strapi-maintained providers"/> for example implementations.
+You can review the <ExternalLink to="https://github.com/strapi/strapi/tree/main/packages/providers" text="Strapi-maintained providers"/> for example implementations.
 
 After creating your new provider you can <ExternalLink to="https://docs.npmjs.com/creating-and-publishing-unscoped-public-packages" text="publish it to npm"/> to share with the community or [use it locally](#local-providers) for your project only.
 

--- a/docusaurus/docs/cms/faq.md
+++ b/docusaurus/docs/cms/faq.md
@@ -78,7 +78,7 @@ Strapi uses a system called [extension](/cms/plugins-development/plugins-extensi
 
 ## Can I add my own 3rd party auth provider?
 
-Yes, you can either follow the following [documentation](/cms/configurations/users-and-permissions-providers/new-provider-guide) or you can take a look at the <ExternalLink to="https://github.com/strapi/strapi/tree/master/packages/plugins/users-permissions" text="users-permissions"/> code and submit a pull request to include the provider for everyone. Eventually Strapi does plan to move from the current grant/purest provider to a split natured system similar to the upload providers.
+Yes, you can either follow the following [documentation](/cms/configurations/users-and-permissions-providers/new-provider-guide) or you can take a look at the <ExternalLink to="https://github.com/strapi/strapi/tree/main/packages/plugins/users-permissions" text="users-permissions"/> code and submit a pull request to include the provider for everyone. Eventually Strapi does plan to move from the current grant/purest provider to a split natured system similar to the upload providers.
 
 There is currently no ETA on this migration however.
 

--- a/docusaurus/docs/cms/features/email.md
+++ b/docusaurus/docs/cms/features/email.md
@@ -236,7 +236,7 @@ In the send function you will have access to:
 * `settings` that contains configurations written in `plugins.js|ts`
 * `options` that contains options you send when you call the send function from the email plugin service
 
-You can review the <ExternalLink to="https://github.com/strapi/strapi/tree/master/packages/providers" text="Strapi-maintained providers"/> for example implementations.
+You can review the <ExternalLink to="https://github.com/strapi/strapi/tree/main/packages/providers" text="Strapi-maintained providers"/> for example implementations.
 
 After creating your new provider you can <ExternalLink to="https://docs.npmjs.com/creating-and-publishing-unscoped-public-packages" text="publish it to npm"/> to share with the community or [use it locally](#local-providers) for your project only.
 


### PR DESCRIPTION
The branch is now called `main`