### PR TITLE
Fix CMS Quick Start for NPM compatibility

### DIFF
--- a/docusaurus/docs/cms/quick-start.md
+++ b/docusaurus/docs/cms/quick-start.md
@@ -82,10 +82,10 @@ As you will see in the terminal, your project is now building locally.
 
 ### Step 2: Register the first local administrator user
 
-Once the installation is complete, you need to start the server. In the terminal, type `cd my-strapi-project && yarn develop` and your browser automatically opens a new tab.
+Once the installation is complete, you need to start the server. In the terminal, type `cd my-strapi-project && npm run develop` and your browser automatically opens a new tab.
 
 :::tip
-As long as you stay in the `my-strapi-project` folder, you will just need to run `yarn develop` any time you want to start the Strapi server again.
+As long as you stay in the `my-strapi-project` folder, you will just need to run `npm run develop` any time you want to start the Strapi server again.
 :::
 
 By completing the form, you create your own account. Once done, you become the first administrator user of this Strapi application. Welcome aboard, commander!


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

Invite user to coherently use `npm` over `yarn`. The rationale being that the CLI is prompting for npm use by default.

### Why is it needed?

This would help newcomers to the JS stack to not stumble upon errors because of Yarn. Neither creating both the `package-lock.json` from `npm` and `yarn.lock` from `yarn`.

### Related issue(s)/PR(s)

I did not found any related issues.
