### PR TITLE
Fix incorrect query example for `$in` filter in REST API

### DIFF
--- a/docusaurus/docs/cms/api/rest/filters.md
+++ b/docusaurus/docs/cms/api/rest/filters.md
@@ -183,6 +183,12 @@ await request(`/api/restaurants?${query}`);
 {
   "data": [
     {
+      "id": 3,
+      "documentId": "ethwxjxtvuxl89jq720e38uk",
+      "name": "test3",
+      // ...
+    },
+    {
       "id": 6,
       "documentId": "ethwxjxtvuxl89jq720e38uk",
       "name": "test6",

--- a/docusaurus/docs/cms/api/rest/filters.md
+++ b/docusaurus/docs/cms/api/rest/filters.md
@@ -151,7 +151,7 @@ You can use the `$in` filter operator with an array of values to find multiple e
 <ApiCall>
 <Request title="Find multiple restaurants with ids 3, 6, 8">
 
-`GET /api/restaurants?filters[id][$in][0]=6&filters[id][$in][1]=8`
+`GET /api/restaurants?filters[id][$in][0]=3&filters[id][$in][1]=6&filters[id][$in][2]=8`
 
 </Request>
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

The query for the $in operator mentions filtering by id if it equals 3, 6 or 8. But the REST API URL only uses ids 6, and 8.

### Why is it needed?

It fixes the query so that people who read the docs aren't confused by the REST API filter parameter