### PR TITLE
Explain `unique` parameter behavior with Draft & Publish

### DIFF
--- a/docusaurus/docs/cms/backend-customization/models.md
+++ b/docusaurus/docs/cms/backend-customization/models.md
@@ -196,7 +196,7 @@ When [Draft & Publish](/cms/features/draft-and-publish) is enabled, Strapi inten
 To avoid unexpected publication failures:
 
 - disable Draft & Publish on content-types that must stay globally unique,
-- or add custom validation (e.g. lifecycle hooks or middleware) that checks for draft duplicates before saving, or
+- or add custom validation (e.g. lifecycle hooks or middleware) that checks for draft duplicates before saving,
 - or rely on automatically generated unique identifiers such as a `uid` field and document editorial conventions.
 :::
 


### PR DESCRIPTION
This PR:
- clarifies that database-level `unique` checks run on publish when Draft & Publish is enabled
- adds guidance on mitigating duplicate drafts when relying on uniqueness
