### PR TITLE
fix: proxy breaking change in server example

### DIFF
--- a/docusaurus/docs/cms/configurations/server.md
+++ b/docusaurus/docs/cms/configurations/server.md
@@ -132,7 +132,7 @@ module.exports = ({ env }) => ({
   socket: '/tmp/nginx.socket', // only use if absolutely required
   emitErrors: false,
   url: env('PUBLIC_URL', 'https://api.example.com'),
-  proxy: env.bool('IS_PROXIED', true),
+  proxy: { koa: env.bool('IS_PROXIED', true) },
   cron: {
     enabled: env.bool('CRON_ENABLED', false),
   },
@@ -166,7 +166,7 @@ export default ({ env }) => ({
   socket: '/tmp/nginx.socket', // only use if absolutely required
   emitErrors: false,
   url: env('PUBLIC_URL', 'https://api.example.com'),
-  proxy: env.bool('IS_PROXIED', true),
+  proxy: { koa: env.bool('IS_PROXIED', true) },
   cron: {
     enabled: env.bool('CRON_ENABLED', false),
   },


### PR DESCRIPTION
### What does it do?

In Strapi 5 we had a breaking change related to the `proxy` config option in the server config, there was still an example that used the old method of `proxy: true` rather than `proxy: { koa: true }

### Why is it needed?

https://docs.strapi.io/cms/migration/v4-to-v5/breaking-changes/server-proxy

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/24452