### PR TITLE
Add a news ticker to homepage

### DIFF
--- a/docusaurus/src/components/NewsTicker/NewsTicker.jsx
+++ b/docusaurus/src/components/NewsTicker/NewsTicker.jsx
@@ -1,0 +1,77 @@
+import React, { useState, useEffect } from 'react';
+import clsx from 'clsx';
+import Icon from '../Icon';
+import styles from './news-ticker.module.scss';
+
+export function NewsTicker({ announcements = [], isDarkTheme = false }) {
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [isPaused, setIsPaused] = useState(false);
+
+  useEffect(() => {
+    if (announcements.length === 0 || isPaused) return;
+
+    const interval = setInterval(() => {
+      setCurrentIndex((prevIndex) => (prevIndex + 1) % announcements.length);
+    }, 5000);
+
+    return () => clearInterval(interval);
+  }, [announcements.length, isPaused]);
+
+  if (!announcements || announcements.length === 0) {
+    return null;
+  }
+
+  const currentAnnouncement = announcements[currentIndex];
+
+  const handleClick = () => {
+    if (currentAnnouncement.link) {
+      window.open(currentAnnouncement.link, '_blank', 'noopener,noreferrer');
+    }
+  };
+
+  return (
+    <div 
+      className={clsx(
+        styles.newsTicker,
+        isDarkTheme && styles.newsTickerDark,
+        currentAnnouncement.link && styles.newsTickerClickable
+      )}
+      onMouseEnter={() => setIsPaused(true)}
+      onMouseLeave={() => setIsPaused(false)}
+      onClick={handleClick}
+    >
+      <div className={styles.newsTickerLabel}>
+        <Icon name="information" />
+        Latest news:
+      </div>
+      <div className={styles.newsTickerContent}>
+        {currentAnnouncement.icon && (
+          <div className={styles.newsTickerIcon}>
+            <Icon name={currentAnnouncement.icon} />
+          </div>
+        )}
+        <span className={styles.newsTickerText}>
+          {currentAnnouncement.text}
+        </span>
+      </div>
+      {announcements.length > 1 && (
+        <div className={styles.newsTickerDots}>
+          {announcements.map((_, index) => (
+            <button
+              key={index}
+              className={clsx(
+                styles.newsTickerDot,
+                index === currentIndex && styles.newsTickerDotActive
+              )}
+              onClick={(e) => {
+                e.stopPropagation();
+                setCurrentIndex(index);
+              }}
+              aria-label={`Go to announcement ${index + 1}`}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/docusaurus/src/components/NewsTicker/NewsTicker.jsx
+++ b/docusaurus/src/components/NewsTicker/NewsTicker.jsx
@@ -6,12 +6,19 @@ import styles from './news-ticker.module.scss';
 export function NewsTicker({ announcements = [], isDarkTheme = false }) {
   const [currentIndex, setCurrentIndex] = useState(0);
   const [isPaused, setIsPaused] = useState(false);
+  const [isAnimating, setIsAnimating] = useState(false);
 
   useEffect(() => {
     if (announcements.length === 0 || isPaused) return;
 
     const interval = setInterval(() => {
-      setCurrentIndex((prevIndex) => (prevIndex + 1) % announcements.length);
+      setIsAnimating(true);
+      setTimeout(() => {
+        setCurrentIndex((prevIndex) => (prevIndex + 1) % announcements.length);
+        setTimeout(() => {
+          setIsAnimating(false);
+        }, 50);
+      }, 300);
     }, 5000);
 
     return () => clearInterval(interval);
@@ -27,6 +34,27 @@ export function NewsTicker({ announcements = [], isDarkTheme = false }) {
     if (currentAnnouncement.link) {
       window.open(currentAnnouncement.link, '_blank', 'noopener,noreferrer');
     }
+  };
+
+  const handleDotClick = (index) => {
+    if (index !== currentIndex) {
+      setIsAnimating(true);
+      setTimeout(() => {
+        setCurrentIndex(index);
+        setTimeout(() => {
+          setIsAnimating(false);
+        }, 50);
+      }, 300);
+    }
+  };
+
+  const renderText = (text) => {
+    return text.split('<br>').map((line, index, array) => (
+      <React.Fragment key={index}>
+        {line}
+        {index < array.length - 1 && <br />}
+      </React.Fragment>
+    ));
   };
 
   return (
@@ -46,12 +74,22 @@ export function NewsTicker({ announcements = [], isDarkTheme = false }) {
       </div>
       <div className={styles.newsTickerContent}>
         {currentAnnouncement.icon && (
-          <div className={styles.newsTickerIcon}>
+          <div 
+            className={clsx(
+              styles.newsTickerIcon,
+              isAnimating && styles.newsTickerIconSlide
+            )}
+          >
             <Icon name={currentAnnouncement.icon} />
           </div>
         )}
-        <span className={styles.newsTickerText}>
-          {currentAnnouncement.text}
+        <span 
+          className={clsx(
+            styles.newsTickerText,
+            isAnimating && styles.newsTickerTextSlide
+          )}
+        >
+          {renderText(currentAnnouncement.text)}
         </span>
       </div>
       {announcements.length > 1 && (
@@ -65,7 +103,7 @@ export function NewsTicker({ announcements = [], isDarkTheme = false }) {
               )}
               onClick={(e) => {
                 e.stopPropagation();
-                setCurrentIndex(index);
+                handleDotClick(index);
               }}
               aria-label={`Go to announcement ${index + 1}`}
             />

--- a/docusaurus/src/components/NewsTicker/NewsTicker.jsx
+++ b/docusaurus/src/components/NewsTicker/NewsTicker.jsx
@@ -3,7 +3,11 @@ import clsx from 'clsx';
 import Icon from '../Icon';
 import styles from './news-ticker.module.scss';
 
-export function NewsTicker({ announcements = [], isDarkTheme = false }) {
+export function NewsTicker({ 
+  announcements = [], 
+  isDarkTheme = false,
+  rotationInterval = 8000 // milliseconds
+}) {
   const [currentIndex, setCurrentIndex] = useState(0);
   const [isPaused, setIsPaused] = useState(false);
   const [isAnimating, setIsAnimating] = useState(false);
@@ -19,10 +23,10 @@ export function NewsTicker({ announcements = [], isDarkTheme = false }) {
           setIsAnimating(false);
         }, 50);
       }, 300);
-    }, 5000);
+    }, rotationInterval);
 
     return () => clearInterval(interval);
-  }, [announcements.length, isPaused]);
+  }, [announcements.length, isPaused, rotationInterval]);
 
   if (!announcements || announcements.length === 0) {
     return null;

--- a/docusaurus/src/components/NewsTicker/news-ticker.module.scss
+++ b/docusaurus/src/components/NewsTicker/news-ticker.module.scss
@@ -1,0 +1,160 @@
+@use '../../scss/_mixins.scss' as *;
+
+.newsTicker {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 12px 0;
+  margin: 16px auto 32px;
+  max-width: 100%;
+  background-color: transparent;
+  border-top: 1px solid rgba(73, 69, 255, 0.15);
+  border-bottom: 1px solid rgba(73, 69, 255, 0.15);
+  transition: all 0.2s ease;
+  position: relative;
+
+  &Clickable {
+    cursor: pointer;
+
+    &:hover {
+      border-color: rgba(73, 69, 255, 0.3);
+      
+      .newsTickerText {
+        color: #4945FF;
+      }
+    }
+  }
+
+  &Label {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    color: #4945FF;
+    font-size: 13px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    flex-shrink: 0;
+    opacity: 0.9;
+  }
+
+  &Content {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex: 1;
+    min-width: 0;
+  }
+
+  &Icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    color: #4945FF;
+    
+    svg {
+      width: 16px;
+      height: 16px;
+    }
+  }
+
+  &Text {
+    color: #666687;
+    font-size: 14px;
+    font-weight: 400;
+    line-height: 1.5;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    transition: color 0.2s ease;
+
+    strong {
+      font-weight: 600;
+    }
+  }
+
+  &Dots {
+    display: flex;
+    gap: 5px;
+    align-items: center;
+    flex-shrink: 0;
+  }
+
+  &Dot {
+    width: 5px;
+    height: 5px;
+    border-radius: 50%;
+    background-color: rgba(165, 165, 186, 0.3);
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    transition: all 0.2s ease;
+
+    &:hover {
+      background-color: #4945FF;
+      transform: scale(1.3);
+    }
+
+    &Active {
+      background-color: #4945FF;
+      width: 16px;
+      border-radius: 2.5px;
+    }
+  }
+}
+
+@include medium-up {
+  .newsTicker {
+    padding: 14px 20px;
+    margin: 20px auto 40px;
+    max-width: 900px;
+
+    &Label {
+      font-size: 13px;
+    }
+
+    &Text {
+      font-size: 15px;
+    }
+  }
+}
+
+@include dark {
+  .newsTicker {
+    border-color: rgba(165, 180, 252, 0.2);
+
+    &Clickable:hover {
+      border-color: rgba(165, 180, 252, 0.35);
+      
+      .newsTickerText {
+        color: #A5B4FC;
+      }
+    }
+  }
+
+  .newsTickerLabel {
+    color: #A5B4FC;
+  }
+
+  .newsTickerIcon {
+    color: #A5B4FC;
+  }
+
+  .newsTickerText {
+    color: #A5A5BA;
+  }
+
+  .newsTickerDot {
+    background-color: rgba(165, 165, 186, 0.25);
+
+    &:hover {
+      background-color: #A5B4FC;
+    }
+
+    &Active {
+      background-color: #A5B4FC;
+    }
+  }
+}

--- a/docusaurus/src/components/NewsTicker/news-ticker.module.scss
+++ b/docusaurus/src/components/NewsTicker/news-ticker.module.scss
@@ -3,11 +3,12 @@
 .newsTicker {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-start;
   gap: 16px;
   padding: 12px 0;
-  margin: 16px auto 32px;
-  max-width: 100%;
+  margin: 16px auto 40px;
+  max-width: 680px;
+  width: 100%;
   background-color: transparent;
   border-top: 1px solid rgba(73, 69, 255, 0.15);
   border-bottom: 1px solid rgba(73, 69, 255, 0.15);
@@ -18,7 +19,8 @@
     cursor: pointer;
 
     &:hover {
-      border-color: rgba(73, 69, 255, 0.3);
+      border-top-color: rgba(73, 69, 255, 0.3);
+      border-bottom-color: rgba(73, 69, 255, 0.3);
       
       .newsTickerText {
         color: #4945FF;
@@ -37,11 +39,13 @@
     letter-spacing: 0.5px;
     flex-shrink: 0;
     opacity: 0.9;
+    min-width: 120px;
   }
 
   &Content {
     display: flex;
     align-items: center;
+    justify-content: center;
     gap: 10px;
     flex: 1;
     min-width: 0;
@@ -53,10 +57,15 @@
     justify-content: center;
     flex-shrink: 0;
     color: #4945FF;
+    transition: all 0.3s ease;
     
     svg {
       width: 16px;
       height: 16px;
+    }
+
+    &Slide {
+      animation: slideOut 0.3s ease;
     }
   }
 
@@ -65,10 +74,12 @@
     font-size: 14px;
     font-weight: 400;
     line-height: 1.5;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+    text-align: center;
     transition: color 0.2s ease;
+
+    &Slide {
+      animation: slideOut 0.3s ease;
+    }
 
     strong {
       font-weight: 600;
@@ -80,6 +91,8 @@
     gap: 5px;
     align-items: center;
     flex-shrink: 0;
+    min-width: 60px;
+    justify-content: flex-end;
   }
 
   &Dot {
@@ -105,11 +118,21 @@
   }
 }
 
+@keyframes slideOut {
+  0% {
+    transform: translateX(0);
+  }
+  100% {
+    transform: translateX(30px);
+    opacity: 0;
+  }
+}
+
 @include medium-up {
   .newsTicker {
-    padding: 14px 20px;
-    margin: 20px auto 40px;
-    max-width: 900px;
+    padding: 14px 0;
+    margin: 20px auto 82px;
+    max-width: 680px;
 
     &Label {
       font-size: 13px;
@@ -123,10 +146,12 @@
 
 @include dark {
   .newsTicker {
-    border-color: rgba(165, 180, 252, 0.2);
+    border-top-color: rgba(165, 180, 252, 0.2);
+    border-bottom-color: rgba(165, 180, 252, 0.2);
 
     &Clickable:hover {
-      border-color: rgba(165, 180, 252, 0.35);
+      border-top-color: rgba(165, 180, 252, 0.35);
+      border-bottom-color: rgba(165, 180, 252, 0.35);
       
       .newsTickerText {
         color: #A5B4FC;

--- a/docusaurus/src/components/index.js
+++ b/docusaurus/src/components/index.js
@@ -8,4 +8,5 @@ export * from './LinkWithArrow/LinkWithArrow';
 export * from './SearchBar/SearchBar';
 export * from './SideBySide';
 export * from './IdentityCard';
+export * from './NewsTicker/NewsTicker';
 export { default as HomepageAIButton } from './HomepageAIButton/HomepageAIButton';

--- a/docusaurus/src/pages/home/Home.jsx
+++ b/docusaurus/src/pages/home/Home.jsx
@@ -17,6 +17,7 @@ import {
   HeroDescription,
   HeroTitle,
   HomepageAIButton,
+  NewsTicker,
 } from '../../components';
 import Icon from '../../components/Icon';
 import content from './_home.content';
@@ -34,10 +35,8 @@ export default function PageHome() {
 
   useEffect(() => {
     if (isBrowser) {
-      // Détecte le thème initial
       setIsDarkTheme(document.documentElement.getAttribute('data-theme') === 'dark');
       
-      // Configure un observateur pour détecter les changements de thème
       const observer = new MutationObserver((mutations) => {
         mutations.forEach((mutation) => {
           if (mutation.attributeName === 'data-theme') {
@@ -146,7 +145,16 @@ export default function PageHome() {
             </HeroDescription>
           </Container>
         </Hero>
+        
+        <Container>
+          <NewsTicker 
+            announcements={content.announcements} 
+            isDarkTheme={isDarkTheme} 
+          />
+        </Container>
+        
         <HomepageAIButton className={isDarkTheme ? styles.aiButtonDark : ''} />
+        
         <section
           id="homeCategories"
           className={styles.home__categories}

--- a/docusaurus/src/pages/home/Home.jsx
+++ b/docusaurus/src/pages/home/Home.jsx
@@ -150,6 +150,7 @@ export default function PageHome() {
           <NewsTicker 
             announcements={content.announcements} 
             isDarkTheme={isDarkTheme} 
+            rotationInterval={10000}
           />
         </Container>
         

--- a/docusaurus/src/pages/home/_home.content.js
+++ b/docusaurus/src/pages/home/_home.content.js
@@ -158,19 +158,19 @@ export default {
 
   announcements: [ // Used by the NewsTicker component
     {
-      icon: '✨',
+      icon: 'sparkle',
       text: 'New search experience available! Try it on docs-next.strapi.io',
       link: 'https://docs-next.strapi.io',
     },
     {
-      icon: '📖',
-      text: 'Tutorial: Build a blog in 30 minutes with Strapi',
-      link: '/cms/quick-start',
+      icon: 'hand-heart',
+      text: 'Feedback wanted! Take our documentation survey',
+      link: 'https://docs.google.com/forms/d/e/1FAIpQLSceA85j2C5iGcAhDUPkezy408JI4jjUQgS5SfEm8obnqTY2Hw/viewform',
     },
     {
-      icon: '☁️',
-      text: 'Deploy to Strapi Cloud with the new CLI tool',
-      link: '/cloud/getting-started/deployment-cli',
+      icon: 'newspaper-clipping',
+      text: 'New documentation updates, see what\'s new this week 👀',
+      link: '/release-notes#692',
     },
   ],
 };

--- a/docusaurus/src/pages/home/_home.content.js
+++ b/docusaurus/src/pages/home/_home.content.js
@@ -154,5 +154,23 @@ export default {
       textSecondary: '#666666',
       borderColor: '#EEEEEE',
     }
-  }
+  },
+
+  announcements: [ // Used by the NewsTicker component
+    {
+      icon: '✨',
+      text: 'New search experience available! Try it on docs-next.strapi.io',
+      link: 'https://docs-next.strapi.io',
+    },
+    {
+      icon: '📖',
+      text: 'Tutorial: Build a blog in 30 minutes with Strapi',
+      link: '/cms/quick-start',
+    },
+    {
+      icon: '☁️',
+      text: 'Deploy to Strapi Cloud with the new CLI tool',
+      link: '/cloud/getting-started/deployment-cli',
+    },
+  ],
 };

--- a/docusaurus/src/pages/home/home.module.scss
+++ b/docusaurus/src/pages/home/home.module.scss
@@ -101,11 +101,16 @@
   }
 }
 
+
 /** Responsive */
 @include medium-up {
   :root {
     --strapi-home-gap: var(--strapi-spacing-8);
     --strapi-home-huitd-margin: 20px 0 20px;
+  }
+
+  .newsTicker_src-components-NewsTicker-news-ticker-module {
+    margin-bottom: 200px !important; // spacing before footer
   }
 }
 


### PR DESCRIPTION
This PR adds a new `<NewsTicker>` component to homepage.
Its content is configurable through `_home.content.js` just like other homepage content, with the `announcements` array. Each announcement item can include:
- an icon from PhosphorIcons
- some text (with line break support and emoji support)
The `rotationInterval` is configurable and defines the time interval in milliseconds before the next announcement is displayed.