### PR TITLE
Add information about disabling Strapi AI

### DIFF
--- a/docusaurus/docs/cms/configurations/admin-panel.md
+++ b/docusaurus/docs/cms/configurations/admin-panel.md
@@ -296,6 +296,14 @@ The rate limiting for the admin panel's authentication endpoints can be configur
 | `rateLimit.whitelist`             | Array of IP addresses to whitelist from rate limiting                                                                                                                                              | array(string) | `[]`                                                                                                                                |
 | `rateLimit.store`                 | Rate limiting storage location (Memory, Sequelize, or Redis). For more information see the koa2-ratelimit documentation               | object        | `MemoryStore`                                                                                                                       |
 
+## Strapi AI
+
+Strapi AI, available in the [Content-Type Builder](/cms/features/content-type-builder#strapi-ai) with <GrowthBadge /> plans, can be enabled or disabled:
+
+| Parameter    | Description                              | Type     | Default         |
+| ------------ | ---------------------------------------- | -------- | --------------- |
+| `ai.enabled` | Whether Strapi AI is enabled or not      |  boolean | `true`          |
+
 ## Transfer tokens
 
 Transfer tokens for the [Data transfer](/cms/data-management/transfer) feature can be configured with the following parameters:
@@ -389,6 +397,9 @@ module.exports = ({ env }) => ({
       encryptionKey: env('ENCRYPTION_KEY'),
     },
   },
+  ai: {
+    enabled: false, // use this to disable Strapi AI
+  },
   auditLogs: { // only accessible with an Enterprise plan
     enabled: env.bool('AUDIT_LOGS_ENABLED', true),
     retentionDays: 120,
@@ -458,6 +469,9 @@ export default ({ env }) => ({
     secrets: {
       encryptionKey: env('ENCRYPTION_KEY'),
     },
+  },
+  ai: {
+    enabled: false, // use this to disable Strapi AI
   },
   auditLogs: { // only accessible with an Enterprise plan
     enabled: env.bool('AUDIT_LOGS_ENABLED', true),

--- a/docusaurus/docs/cms/features/content-type-builder.md
+++ b/docusaurus/docs/cms/features/content-type-builder.md
@@ -78,13 +78,16 @@ To use Strapi AI with the Content-Type Builder, click on the <Icon name="sparkle
 
 You can also use the <Icon name="paperclip" classes="ph" /> button at the bottom of the chat window to import code from an existing Strapi or front-end application, import a Figma project, or attach an image to extract the content structure from a design.
 
-:::tip
-The more precise your prompts, the more accurate your created schemas are likely to be.
+Strapi AI comes with 1000 credits per month on the <GrowthBadge noTooltip /> plan, and 10 free credits during the free trial.
 
-For example, the following prompt example works well when creating relations: `Could you please generate a collection of dogs then also generate an owner collection and add relationship to dogs? An owner can have multiple dogs, but a dog can only have one owner.`
+:::tip Tips
+* The more precise your prompts, the more accurate your created schemas are likely to be.
+
+  For example, the following prompt example works well when creating relations: `Could you please generate a collection of dogs then also generate an owner collection and add relationship to dogs? An owner can have multiple dogs, but a dog can only have one owner.`
+
+* Strapi AI can be disabled by setting `ai.enabled` to `false` in [the `config/admin` file](/cms/configurations/admin-panel#strapi-ai).
 :::
 
-Strapi AI comes with 1000 credits per month on the <GrowthBadge noTooltip /> plan, and 10 free credits during the free trial.
 
 #### Creating content-types manually {#new-content-type}
 


### PR DESCRIPTION
This PR mentions that you can set `ai.enabled` to `false` in `/config/admin` to disable Strapi AI.