### PR TITLE
Add openapi.json route documentation (#2143) (#2159)

### DIFF
--- a/docusaurus/docs/cms/plugins/documentation.md
+++ b/docusaurus/docs/cms/plugins/documentation.md
@@ -42,7 +42,9 @@ The Documentation plugin is not actively maintained and may not work with Strapi
 
 If installed, the Documentation plugin will inspect content types and routes found on all APIs in your project and any plugin specified in the configuration. The plugin will then programmatically generate documentation to match the <ExternalLink to="https://swagger.io/specification/" text="OpenAPI specification"/>. The Documentation plugin generates the <ExternalLink to="https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#paths-object" text="paths objects"/> and <ExternalLink to="https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#schema-object" text="schema objects"/> and converts all Strapi types to <ExternalLink to="https://swagger.io/docs/specification/data-models/data-types/" text="OpenAPI data types"/>.
 
-The generated documentation JSON file can be found in your application at the following path: `src/extensions/documentation/documentation/<version>/full_documentation.json`
+The generated documentation can be accessed either through your application's source code or through the running application itself:
+- **Source code**: The documentation is located at <br/>`src/extensions/documentation/documentation/<version>/full_documentation.json`
+- **Running application**: Use the URL <br/>`<server-url>:<server-port>/documentation/<version>/openapi.json`
 
 ## Installation
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the `main` branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md
-->

### What does it do?

Porting dev docs _"Adds documentation for new route `/documentation/<version>/openapi.json` provided by the documentation plugin."_ into v5.

See https://github.com/strapi/documentation/pull/2159 for more information.

### Related issue(s)/PR(s)

- https://github.com/strapi/strapi/pull/24550
- https://github.com/strapi/strapi/pull/20871
- https://github.com/strapi/documentation/issues/2143
- https://github.com/strapi/documentation/issues/590
- https://github.com/strapi/documentation/issues/366
- https://github.com/strapi/strapi/issues/10734