### PR TITLE
Fix S key in Ask AI modal triggering the MeiliSearch modal

### DIFF
--- a/docusaurus/src/theme/SearchBar/index.js
+++ b/docusaurus/src/theme/SearchBar/index.js
@@ -30,7 +30,11 @@ function SearchBarContent() {
            shadowActiveElement.tagName === 'TEXTAREA' || 
            shadowActiveElement.isContentEditable)) {
         
-        e.stopImmediatePropagation();
+        const allowedKeys = ['Enter', 'Tab', 'Escape', 'ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'];
+        
+        if (!allowedKeys.includes(e.key)) {
+          e.stopImmediatePropagation();
+        }
       }
     };
 
@@ -122,6 +126,7 @@ function SearchBarContent() {
             noResultsScreen: {
               noResultsText: 'No results for',
               suggestedQueryText: 'Try searching for',
+              reportMissingResultsText: 'Believe this query should return results?',
               reportMissingResultsLinkText: 'Let us know.',
             },
           },


### PR DESCRIPTION
This PR brings a hacky fix to an unintended consequence of the new MeiliSearch modal introduction. It seems like pressing the S key triggers the opening of the MeiliSearch modal 😅 
We're stopping immediate propagation once the Kapa modal is open to avoid this weird behavior, and allow some keyboard keys (arrows, Enter, Tab) to pass.

This is intended to be a temporary fix while we report the bug to Kapa and MeiliSearch teams and found another solution (like disabling the S shortcut at the config. level)