### PR TITLE
Add security configuration documentation for Media Library

### DIFF
--- a/docusaurus/docs/cms/features/media-library.md
+++ b/docusaurus/docs/cms/features/media-library.md
@@ -147,7 +147,7 @@ module.exports = ({ env })=>({
         xsmall: 64
       },
       security: {
-        allowedTypes: ['image/*', 'application/pdf'],
+        allowedTypes: ['image/*', 'application/*'],
         deniedTypes: ['application/x-sh', 'application/x-dosexec']
       },
     },
@@ -177,7 +177,7 @@ export default () => ({
         xsmall: 64
       },
       security: {
-        allowedTypes: ['image/*', 'application/pdf'],
+        allowedTypes: ['image/*', 'application/*'],
         deniedTypes: ['application/x-sh', 'application/x-dosexec']
       },
     },
@@ -331,15 +331,15 @@ export default {
 #### Security
 
 The Upload plugin validates files based on their actual MIME type rather than the declared file extension.
-Only files matching the defined security rules are uploaded; others are filtered out.
+Only files matching the defined security rules are uploaded.
 
 The `security` configuration provides 2 options: `allowedTypes` or `deniedTypes`, which let you control which file types can or cannot be uploaded.
 
 :::note
-It's best to define either `allowedTypes` or `deniedTypes`, not both, to avoid conflicts in file validation logic.
+You can use `allowedTypes` and `deniedTypes` separately or together to fine-tune which files are accepted. Files must match an allowed type and must not match any denied type. If you use a wildcard like `*` in `allowedTypes`, you can narrow down the validation by specifying exceptions in `deniedTypes`.
 :::
 
-You can provide them by creating or editing [the `/config/plugins` file](/cms/configurations/plugins). The following example sets the `allowedTypes` filter:
+You can provide them by creating or editing [the `/config/plugins` file](/cms/configurations/plugins). The following is an example of how to combine `allowedTypes` and `deniedTypes`:
 
 <Tabs groupId="js-ts">
 
@@ -351,7 +351,8 @@ module.exports = {
   upload: {
     config: {
       security: {
-        allowedTypes: ['image/*', 'application/pdf']
+        allowedTypes: ['image/*', 'application/*'],
+        deniedTypes: ['application/x-sh', 'application/x-dosexec']
       },
     }
   }
@@ -368,7 +369,8 @@ export default {
   upload: {
     config: {
       security: {
-        allowedTypes: ['image/*', 'application/pdf']
+        allowedTypes: ['image/*', 'application/*'],
+        deniedTypes: ['application/x-sh', 'application/x-dosexec']
       },
     }
   }


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request!

To help us merge your PR, make sure to follow the instructions detailed in the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md

Note that all documentation updates should be made against the `main` branch.
Keep your PR in Draft mode until it's ready to be reviewed and merged.


As part of the Docs Contribution Program, all external contribution PRs are labeled `contribution`.
Feel free to read more details on the Contribution Program in the dedicated guide:
https://strapi.notion.site/Documentation-Contribution-Program-1d08f359807480d480fdde68bb7a5a71

Let us know if you do not wish to take part in the Docs Contribution Program, and remove the `contribution` label.
-->

### Description

Adds documentation for the new security configuration in the Upload plugin, describing `allowedTypes` and `deniedTypes` options for MIME-type validation.

### Related issue(s)/PR(s)

https://github.com/orgs/strapi/projects/48/views/2?sliceBy%5Bvalue%5D=araksyagevorgyan&pane=issue&itemId=132687011&issue=strapi%7Ccontent-squad%7C108
