### PR TITLE
Disable Kapa widget feedback

### DIFF
--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -107,6 +107,7 @@ const config = {
       'data-modal-x-offset': '0',              // Defaults is undefined
       'data-modal-y-offset': '3vh',            // Default is 10vh
       'data-modal-inner-max-width': '100%',
+      'data-user-satisfaction-feedback-enabled': 'false',
       async: true,
     },
     // {


### PR DESCRIPTION
This PR disables the [built-in Kapa feedback widget](https://docs.kapa.ai/integrations/website-widget/features/user-satisfaction), as Strapi Docs collect feedback on their own.