### PR TITLE
More clarity and precisions on multi relations support

### DIFF
--- a/docusaurus/docs/cms/api/rest/relations.md
+++ b/docusaurus/docs/cms/api/rest/relations.md
@@ -26,7 +26,7 @@ Relations can be connected, disconnected or set through the Content API by passi
 | [`set`](#set)           | Set entities to a specific set. Using `set` will overwrite all existing connections to other entities.<br /><br />Cannot be used in combination with `connect` or `disconnect`.  | Full |
 
 :::note
-Multi relations can be managed from the REST API, the [GraphQL API](/cms/api/graphql#fetch-relations) and the [Document Service API](/cms/api/document-service). The  `connect`, `disconnect`, and `set` operations are available across all APIs.
+Multi relations can be managed from the REST API and the [GraphQL API](/cms/api/graphql#fetch-relations): the  `connect`, `disconnect`, and `set` operations are available across both APIs. However, the [Document Service API](/cms/api/document-service) does not handle relations.
 :::
 
 :::note

--- a/docusaurus/docs/cms/backend-customization/models.md
+++ b/docusaurus/docs/cms/backend-customization/models.md
@@ -250,7 +250,7 @@ The `uid` type is used to automatically prefill the field value in the admin pan
 
 Relations link content-types together. Strapi supports both single-entry relations (one-way and one-to-one) and multi relations where at least one side can point to several entries (one-to-many, many-to-one, many-to-many, and many-way). Multi relations are persisted as arrays in the database layer and are returned as arrays in the Content API responses.
 
-Relations are explicitly defined in the [attributes](#model-attributes)  of a model with `type: 'relation'`  and accept the following additional parameters:
+Relations are explicitly defined in the [attributes](#model-attributes) of a model with `type: 'relation'` and accept the following additional parameters:
 
 | Parameter                         | Description                                                                                                                                     |
 | --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docusaurus/docs/cms/features/content-type-builder.md
+++ b/docusaurus/docs/cms/features/content-type-builder.md
@@ -449,7 +449,7 @@ There are 6 different types of relations:
 - <img width="25" src="/img/assets/icons/v5/ctb_relation_manyway.svg" /> Many way: Content-type A *has many* Content-type B
 
 :::info Multi relations and single relations
-Relations where at least one side can reference several entries are called multi relations. In the Content-type Builder, this includes one-to-many, many-to-one, many-to-many, and many-way relations. These relations appear as multi-select fields in the Content Manager and return arrays from the REST, GraphQL, and Document Service APIs ; while single relations (one-way and one-to-one relations) return a single linked entry (see [Managing relations with API requests](/cms/api/rest/relations) for more information).
+Relations where at least one side can reference several entries are called multi relations. In the Content-type Builder, this includes one-to-many, many-to-one, many-to-many, and many-way relations. These relations appear as multi-select fields in the Content Manager and return arrays from the REST, GraphQL, and Document Service APIs; while single relations (one-way and one-to-one relations) return a single linked entry (see [Managing relations with API requests](/cms/api/rest/relations) for more information).
 :::
 
 <Tabs>


### PR DESCRIPTION
Small updates in REST API relations, Content-type Builder and Models docs to mention "multi relations" (for the search) and explain more clearly what it means.