### PR TITLE
Add information &  configuration example in Email feature page

### DIFF
--- a/docusaurus/docs/cms/features/email.md
+++ b/docusaurus/docs/cms/features/email.md
@@ -31,7 +31,7 @@ The Email feature enables Strapi applications to send emails from a server or an
 
 Most configuration options for the Email feature are handled via your Strapi project's code. The Email feature is not configurable in the admin panel, however users can test email delivery if it has been setup by an administrator.
 
-:::info Provider VS Host
+:::info Provider vs. Host
 - The email provider refers to the package that Strapi calls to send an email (e.g. official providers such as Sendgrid or community packages such as `@strapi/provider-email-nodemailer`). Providers implement the logic for sending mail when Strapi invokes them.
 - The provider host (or server) refers to the connection details (e.g. an SMTP hostname, port, or REST API endpoint) that the provider exposes. Some providers hide these details behind an API key, while others require you to supply host-related options in your configuration.
 


### PR DESCRIPTION
- Add information callout to provide more clarity on email provider VS host
- Add configuration example

User request for more clarity on that topic.