### PR TITLE
Fix main content alignment "flash"

### DIFF
--- a/docusaurus/src/scss/_base.scss
+++ b/docusaurus/src/scss/_base.scss
@@ -16,12 +16,9 @@
 main {
   article:first-child:not(.col):not(.custom-doc-card),
   article:first-child:not(.col) + nav {
-    --custom-main-px: var(--strapi-spacing-0);
-    --custom-main-width: 608px;
-
-    max-width: calc(var(--custom-main-width) + calc(var(--strapi-spacing-4) * 2));
-    padding-left: var(--custom-main-px) !important;
-    padding-right: var(--custom-main-px) !important;
+    max-width: 608px;
+    padding-left: 0 !important;
+    padding-right: 0 !important;
     margin-left: auto;
     margin-right: auto;
   }
@@ -57,7 +54,9 @@ main {
   main {
     article:first-child:not(.col),
     article:first-child:not(.col) + nav {
-      --custom-main-px: var(--strapi-spacing-4);
+      max-width: 672px;
+      padding-left: 32px !important;
+      padding-right: 32px !important;
     }
   }
 }


### PR DESCRIPTION
Currently, the width available for main article content is calculated after page has finished loading. This causes some "alignment flash", where the page content is initially pushed to the right then finally properly positioned once all values are calculated.

This PR replaces the current behavior with a fixed values approach.

Disclaimer: On some edge cases, the alignment might not be as good as before.