### PR TITLE
Mention `/_health` endpoint in server config. & deployment docs

### DIFF
--- a/docusaurus/docs/cms/configurations/server.md
+++ b/docusaurus/docs/cms/configurations/server.md
@@ -71,6 +71,10 @@ axios.get('https://example.com', { httpsAgent: agent });
 ```
 :::
 
+:::tip
+Strapi exposes a dedicated health check route to make uptime probes straightforward. Any request to `/_health` returns an empty response with a `204` status and a `strapi: You are so French!` response header, which is suitable for load balancers or monitoring tools that only need a simple liveness indicator.
+:::
+
 ## Configurations
 
 The `./config/server.js` minimal configuration requires the `host` and `port` parameters for development. Additional parameters can be included for a full configuration.

--- a/docusaurus/docs/cms/deployment.md
+++ b/docusaurus/docs/cms/deployment.md
@@ -189,6 +189,10 @@ If you are developing a `TypeScript`-based project you must provide the `distDir
 For more information, consult the [TypeScript documentation](/cms/typescript/development#use-the-createstrapi-factory).
 :::
 
+:::tip Health check endpoint
+Strapi exposes a lightweight health check route at `/_health` for uptime monitors and load balancers. When the server is ready, it responds with an HTTP `204 No Content` status and a `strapi: You are so French!` header value, which you can use to confirm the application is reachable.
+:::
+
 ### Advanced configurations
 
 If you want to host the administration on another server than the API, [please take a look at this dedicated section](/cms/configurations/admin-panel#deploy-on-different-servers).


### PR DESCRIPTION
This documents a little easter egg 🤫 