### PR TITLE
Expand caution callout for media asset relations

### DIFF
--- a/docusaurus/docs/cms/api/rest/relations.md
+++ b/docusaurus/docs/cms/api/rest/relations.md
@@ -63,7 +63,7 @@ You can also use the longhand syntax to [reorder relations](#relations-reorderin
 `connect` can be used in combination with [`disconnect`](#disconnect).
 
 :::caution
-`connect` can not be used for media attributes
+`connect` is not officially supported for media attributes. Advanced users can technically connect media entries by targeting upload file IDs, but this workaround isn't recommended or supported by Strapi and can easily break (e.g. when Draft & Publish uses mismatched IDs). Proceed with caution.
 :::
 
 <Tabs groupId="shorthand-longhand">


### PR DESCRIPTION
Document workaround found by users while warning of the risks involved.