### PR TITLE
Allow committing llms*.txt under static for deploy workflow

### DIFF
--- a/docusaurus/.gitignore
+++ b/docusaurus/.gitignore
@@ -32,5 +32,10 @@ docs/node_modules/**
 # LLMs.txt files and related
 llms*.txt
 **/llm*.txt
+
+# Allow public LLMs files under static/ to be committed (used by deploy workflow)
+!static/llms.txt
+!static/llms-full.txt
+!static/llms-code.txt
 pr-*.diff
 *-results.json


### PR DESCRIPTION
This PR [experimental] Allow committing llms*.txt under static for deploy workflow.\n\nIt is opened as a draft to gather feedback and keep the scope reviewable.