### PR TITLE
Add TypeScript example and deliverability tip to Email documentation

### DIFF
--- a/docusaurus/docs/cms/features/email.md
+++ b/docusaurus/docs/cms/features/email.md
@@ -209,6 +209,9 @@ You can set a specific configuration in the `/config/env/{env}/plugins.js|ts` co
 
 Some providers expose SMTP-style connection details instead of (or in addition to) an API key. Add those values in `providerOptions` so Strapi can reach the provider host. For instance, the community Nodemailer provider expects the host, port, and authentication credentials:
 
+<Tabs groupId="js-ts">
+<TabItem value="js" label="JavaScript">
+
 ```js title="/config/plugins.js"
 module.exports = ({ env }) => ({
   email: {
@@ -230,6 +233,7 @@ module.exports = ({ env }) => ({
     },
   },
 });
+```
 
 </TabItem>
 
@@ -253,6 +257,7 @@ export default ({ env }) => ({
 ```
 
 </TabItem>
+</Tabs>
 
 If your provider gives you a single URL instead of host and port values, pass that URL (for example `https://api.eu.mailgun.net`) in `providerOptions` using the key the package expects.
 

--- a/docusaurus/static/llms-code.txt
+++ b/docusaurus/static/llms-code.txt
@@ -20889,6 +20889,27 @@ module.exports = ({ env }) => ({
 });
 ```
 
+---
+Language: TypeScript
+File path: /config/plugins.ts
+
+```ts
+export default ({ env }) => ({
+  email: {
+    config: {
+      provider: 'sendmail', // replace with your provider
+      providerOptions: {
+        // ... provider-specific options
+      },
+      settings: {
+        defaultFrom: 'no-reply@example.com',
+        defaultReplyTo: 'support@example.com',
+      },
+    },
+  },
+});
+```
+
 
 ## Creating providers
 Description: The interface that must be exported depends on the plugin you are developing the provider for.

--- a/docusaurus/static/llms-full.txt
+++ b/docusaurus/static/llms-full.txt
@@ -8311,6 +8311,10 @@ The Email feature only handles outbound delivery. Receiving or parsing incoming 
 
 </Tabs>
 
+:::tip Deliverability
+For best deliverability, configure SPF/DKIM with your email provider and ensure the `defaultFrom` domain aligns with the domain you verified with the provider.
+:::
+
 ##### Configuring providers
 
 Newly installed providers are enabled and configured in [the `/config/plugins` file](/cms/configurations/plugins). If this file does not exist you must create it.
@@ -8335,28 +8339,7 @@ You can set a specific configuration in the `/config/env/{env}/plugins.js|ts` co
 
 Some providers expose SMTP-style connection details instead of (or in addition to) an API key. Add those values in `providerOptions` so Strapi can reach the provider host. For instance, the community Nodemailer provider expects the host, port, and authentication credentials:
 
-```js title="/config/plugins.js"
-module.exports = ({ env }) => ({
-  email: {
-    config: {
-      provider: 'nodemailer',
-      providerOptions: {
-        host: env('SMTP_HOST'),
-        port: env.int('SMTP_PORT', 587),
-        secure: false, // Use `true` for port 465
-        auth: {
-          user: env('SMTP_USERNAME'),
-          pass: env('SMTP_PASSWORD'),
-        },
-      },
-      settings: {
-        defaultFrom: 'no-reply@example.com',
-        defaultReplyTo: 'support@example.com',
-      },
-    },
-  },
-});
-```
+</Tabs>
 
 If your provider gives you a single URL instead of host and port values, pass that URL (for example `https://api.eu.mailgun.net`) in `providerOptions` using the key the package expects.
 


### PR DESCRIPTION
This PR adds a TypeScript example and a deliverability tip to the Email documentation.

- Add TypeScript provider example (config/plugins.ts) alongside JavaScript via Tabs
- Add deliverability tip: SPF/DKIM and aligning the defaultFrom domain