### PR TITLE
Fix TypeScript code fences in backend customization documentation

### DIFF
--- a/docusaurus/docs/cms/backend-customization/controllers.md
+++ b/docusaurus/docs/cms/backend-customization/controllers.md
@@ -95,7 +95,7 @@ module.exports = createCoreController('api::restaurant.restaurant', ({ strapi })
 
 <TabItem value="ts" label="TypeScript">
 
-```js title="./src/api/restaurant/controllers/restaurant.ts"
+```ts title="./src/api/restaurant/controllers/restaurant.ts"
 
 import { factories } from '@strapi/strapi';
 

--- a/docusaurus/docs/cms/backend-customization/middlewares.md
+++ b/docusaurus/docs/cms/backend-customization/middlewares.md
@@ -108,7 +108,7 @@ module.exports = () => {
 
 <TabItem value="ts" label="TypeScript">
 
-```js title="/config/middlewares.ts"
+```ts title="/config/middlewares.ts"
 
 export default () => {
   return async (ctx, next) => {

--- a/docusaurus/docs/cms/backend-customization/routes.md
+++ b/docusaurus/docs/cms/backend-customization/routes.md
@@ -97,7 +97,7 @@ module.exports = createCoreRouter('api::restaurant.restaurant', {
 
 <TabItem value="ts" label="TypeScript">
 
-```js title="./src/api/[apiName]/routes/[routerName].ts (e.g './src/api/restaurant/routes/restaurant.ts')"
+```ts title="./src/api/[apiName]/routes/[routerName].ts (e.g './src/api/restaurant/routes/restaurant.ts')"
 
 import { factories } from '@strapi/strapi'; 
 
@@ -149,7 +149,7 @@ module.exports = createCoreRouter('api::restaurant.restaurant', {
 
 <TabItem value="ts" label="TypeScript">
 
-```js title="./src/api/restaurant/routes/restaurant.ts"
+```ts title="./src/api/restaurant/routes/restaurant.ts"
 
 import { factories } from '@strapi/strapi'; 
 

--- a/docusaurus/docs/cms/backend-customization/services.md
+++ b/docusaurus/docs/cms/backend-customization/services.md
@@ -83,7 +83,7 @@ module.exports = createCoreService('api::restaurant.restaurant', ({ strapi }) =>
 
 <TabItem value="ts" label="TypeScript">
 
-```js title="./src/api/restaurant/services/restaurant.ts"
+```ts title="./src/api/restaurant/services/restaurant.ts"
 
 import { factories } from '@strapi/strapi'; 
 
@@ -171,7 +171,7 @@ module.exports = createCoreService('api::restaurant.restaurant', ({ strapi }) =>
 
 <TabItem value="ts" label="TypeScript">
 
-```js title="./src/api/restaurant/services/restaurant.ts"
+```ts title="./src/api/restaurant/services/restaurant.ts"
 
 
 import { factories } from '@strapi/strapi'; 


### PR DESCRIPTION
This PR normalizes JS/TS code fence language labels across backend customization pages.