### PR TITLE
Add example to Theme extension documentation

### DIFF
--- a/docusaurus/docs/cms/admin-panel-customization/theme-extension.md
+++ b/docusaurus/docs/cms/admin-panel-customization/theme-extension.md
@@ -23,7 +23,7 @@ To extend the theme, use either:
 The default <ExternalLink to="https://github.com/strapi/design-system/tree/main/packages/design-system/src/themes" text="Strapi theme"/> defines various theme-related keys (shadows, colors…) that can be updated through the `config.theme.light` and `config.theme.dark` keys in `./admin/src/app.js`. The <ExternalLink to="https://design-system.strapi.io/" text="Strapi Design System"/> is fully customizable and has a dedicated <ExternalLink to="https://design-system-git-main-strapijs.vercel.app" text="StoryBook"/> documentation.
 :::
 
-The following example shows how to override the primary color by customizing the light and dark theme keys in the [admin panel configuration]/cms/configurations/admin-panel):
+The following example shows how to override the primary color by customizing the light and dark theme keys in the [admin panel configuration](/cms/configurations/admin-panel):
 
 
 <Tabs groupId="js-ts">


### PR DESCRIPTION
This PR adds a minimal TypeScript example parallel to the JavaScript example in the Theme extension documentation.