### PR TITLE
Add listing tip to Middlewares documentation

### DIFF
--- a/docusaurus/docs/cms/backend-customization/middlewares.md
+++ b/docusaurus/docs/cms/backend-customization/middlewares.md
@@ -108,7 +108,7 @@ module.exports = () => {
 
 <TabItem value="ts" label="TypeScript">
 
-```ts title="/config/middlewares.ts"
+```js title="/config/middlewares.ts"
 
 export default () => {
   return async (ctx, next) => {


### PR DESCRIPTION
This PR adds a hint to list registered middlewares (`yarn strapi middlewares:list`).