### PR TITLE
Fix main content layout shift

### DIFF
--- a/docusaurus/src/scss/_base.scss
+++ b/docusaurus/src/scss/_base.scss
@@ -24,6 +24,10 @@ main {
   }
 }
 
+  [class*="docRoot"]:not(:has(main)) {
+    width: 0;
+  }
+
 /**
  * Experimental: Different identity based on URL
  */
@@ -59,7 +63,12 @@ main {
       padding-right: 32px !important;
     }
   }
+
+  [class*="docRoot"]:not(:has(main)) {
+    width: 300px;
+  }
 }
+
 
 /** Dark mode */
 @include dark {


### PR DESCRIPTION
This PR fixes a layout shift that was present when reloading the page or landing on a page after a MeiliSearch search.