### PR TITLE
Add types for Backend Customization Custom Routes

### DIFF
--- a/docusaurus/docs/cms/backend-customization/routes.md
+++ b/docusaurus/docs/cms/backend-customization/routes.md
@@ -209,8 +209,9 @@ In the following example, the custom routes file name is prefixed with `01-` to 
 <TabItem value="js" label="JavaScript">
 
 ```js title="./src/api/restaurant/routes/01-custom-restaurant.js"
-
-module.exports = {
+/** @type {import('@strapi/strapi').Core.RouterConfig} */
+const config = {
+  type: 'content-api',
   routes: [
     { // Path defined with an URL parameter
       method: 'POST',
@@ -224,6 +225,8 @@ module.exports = {
     }
   ]
 }
+
+module.exports = config
 ```
 
 </TabItem>
@@ -231,8 +234,10 @@ module.exports = {
 <TabItem value="ts" label="TypeScript">
 
 ```js title="./src/api/restaurant/routes/01-custom-restaurant.ts"
+import type { Core } from '@strapi/strapi';
 
-export default {
+const config: Core.RouterConfig = {
+  type: 'content-api',
   routes: [
     { // Path defined with a URL parameter
       method: 'GET',
@@ -246,6 +251,8 @@ export default {
     }
   ]
 }
+
+export default config
 ```
 
 </TabItem>

--- a/docusaurus/static/llms-code.txt
+++ b/docusaurus/static/llms-code.txt
@@ -13372,8 +13372,9 @@ Language: JavaScript
 File path: ./src/api/restaurant/routes/01-custom-restaurant.js
 
 ```js
-
-module.exports = {
+/** @type {import('@strapi/strapi').Core.RouterConfig} */
+const config = {
+  type: 'content-api',
   routes: [
     { // Path defined with an URL parameter
       method: 'POST',
@@ -13387,6 +13388,8 @@ module.exports = {
     }
   ]
 }
+
+module.exports = config
 ```
 
 ---
@@ -13394,8 +13397,10 @@ Language: TypeScript
 File path: ./src/api/restaurant/routes/01-custom-restaurant.ts
 
 ```ts
+import type { Core } from '@strapi/strapi';
 
-export default {
+const config: Core.RouterConfig = {
+  type: 'content-api',
   routes: [
     { // Path defined with a URL parameter
       method: 'GET',
@@ -13409,6 +13414,8 @@ export default {
     }
   ]
 }
+
+export default config
 ```
 
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request!

To help us merge your PR, make sure to follow the instructions detailed in the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md

Note that all documentation updates should be made against the `main` branch.
Keep your PR in Draft mode until it's ready to be reviewed and merged.


As part of the Docs Contribution Program, all external contribution PRs are labeled `contribution`.
Feel free to read more details on the Contribution Program in the dedicated guide:
https://strapi.notion.site/Documentation-Contribution-Program-1d08f359807480d480fdde68bb7a5a71

Let us know if you do not wish to take part in the Docs Contribution Program, and remove the `contribution` label.
-->

### Description

**What does it do?**
Add the types for the Backend Customization Custom Routes Example.

**Why is it needed?**
Each time when creating custom routes, have to dig through types to understand which one of them should I use.