### PR TITLE
Fix unneeded margin on first-in-the-list custom docs card component

### DIFF
--- a/docusaurus/src/scss/custom-doc-cards.scss
+++ b/docusaurus/src/scss/custom-doc-cards.scss
@@ -13,6 +13,11 @@
     flex: 0 0 calc(50% - 10px);
   }
 
+  article.custom-doc-card:first-of-type {
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+  }
+
   .cardContainer {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
This PR fixes a regression CSS bug resulting in unneeded margins on the first card of a `<CustomDocsCardWrapper>` element.

Before the fix:
<img width="776" height="441" alt="Screenshot 2025-11-27 at 12 06 55" src="https://github.com/user-attachments/assets/f4f26662-3667-471f-bc8d-3b08dd5fafec" />


After the fix:
<img width="823" height="446" alt="Screenshot 2025-11-27 at 12 06 38" src="https://github.com/user-attachments/assets/f3eaecdb-6e2e-4fe2-8c45-32e642fe0b45" />
