### PR TITLE
Notify users about Apollo In Memory Cache ID

### DIFF
--- a/docusaurus/docs/cms/plugins/graphql.md
+++ b/docusaurus/docs/cms/plugins/graphql.md
@@ -1066,6 +1066,25 @@ To increase GraphQL security even further, 3rd-party tools can be used. See the 
 
 The GraphQL plugin adds a GraphQL endpoint accessible and provides access to a GraphQL playground, accessing at the `/graphql` route of the Strapi admin panel, to interactively build your queries and mutations and read documentation tailored to your content types. For detailed instructions on how to use the GraphQL Playground, please refer to the official <ExternalLink to="https://www.apollographql.com/docs/apollo-server/v2/testing/graphql-playground" text="Apollo Server documentation"/>.
 
+
+:::note
+Strapi uses `documentId` as the unique identifier for entities instead of `id`. When using Apollo Client with Strapi's GraphQL API, you need to [configure](https://www.apollographql.com/docs/react/caching/cache-configuration#customizing-identifier-generation-globally) the `InMemoryCache` to use `documentId` for cache normalization:
+
+```javascript
+import { ApolloClient, InMemoryCache, HttpLink } from '@apollo/client';
+
+const client = new ApolloClient({
+  link: new HttpLink({ uri: "http://localhost:1337/graphql" }),
+  cache: new InMemoryCache({
+    dataIdFromObject: (o) => `${o.__typename}:${o["documentId"]}`,
+  }),
+});
+```
+
+This ensures that Apollo Client correctly caches and updates your GraphQL data based on Strapi's identifier structure.
+:::
+
+
 ### Usage with the Users & Permissions feature {#usage-with-the-users--permissions-plugin}
 
 The [Users & Permissions feature](/cms/features/users-permissions) allows protecting the API with a full authentication process.

--- a/docusaurus/static/llms-code.txt
+++ b/docusaurus/static/llms-code.txt
@@ -28753,6 +28753,25 @@ export default {
 ```
 
 
+## Usage
+Description: :::note Strapi uses documentId as the unique identifier for entities instead of id.
+(Source: https://docs.strapi.io/cms/plugins/graphql#usage)
+
+Language: JavaScript
+File path: N/A
+
+```js
+import { ApolloClient, InMemoryCache, HttpLink } from '@apollo/client';
+
+const client = new ApolloClient({
+  link: new HttpLink({ uri: "http://localhost:1337/graphql" }),
+  cache: new InMemoryCache({
+    dataIdFromObject: (o) => `${o.__typename}:${o["documentId"]}`,
+  }),
+});
+```
+
+
 ## Registration
 Description: Code example from "Registration"
 (Source: https://docs.strapi.io/cms/plugins/graphql#registration)


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request!

To help us merge your PR, make sure to follow the instructions detailed in the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md

Note that all documentation updates should be made against the `main` branch.
Keep your PR in Draft mode until it's ready to be reviewed and merged.


As part of the Docs Contribution Program, all external contribution PRs are labeled `contribution`.
Feel free to read more details on the Contribution Program in the dedicated guide:
https://strapi.notion.site/Documentation-Contribution-Program-1d08f359807480d480fdde68bb7a5a71

Let us know if you do not wish to take part in the Docs Contribution Program, and remove the `contribution` label.
-->

### Description

Add a note that when using Apollo Client, `InMemoryCache` needs to be configured to consider `documentId` instead of `id` for the data to be normalized in cache

An example repo https://github.com/unrevised6419/example-strapi-apollo-graphql/blob/e93a44ec8e5900e1578e844edc9f793907f7d7eb/web/src/main.tsx#L7-L13

This is clearly visible in the Apollo Devtools

| Before | After |
|--------|--------|
| <img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/31441023-3204-4919-834e-20f137d335d7" /> | <img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/deadb0e5-2362-4429-9429-2aafb08ef57a" /> | 

### Related issue(s)/PR(s)

Closes #2379
