### PR TITLE
Add hosted MCP server for docs

### DIFF
--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -108,6 +108,12 @@ const config = {
       'data-modal-y-offset': '3vh',            // Default is 10vh
       'data-modal-inner-max-width': '100%',
       'data-user-satisfaction-feedback-enabled': 'false',
+      /* 
+       * MCP config *
+      */
+      'data-mcp-enabled': 'true',
+      'data-mcp-server-url': 'https://strapi-docs.mcp.kapa.ai',
+      // 'data-mcp-button-text': 'MCP' // default: 'MCP',
       async: true,
     },
   ],


### PR DESCRIPTION
This PR enables the [native Kapa-based MCP server](https://www.kapa.ai/blog/build-an-mcp-server-with-kapa-ai) to allow users to easily add the hosted MCP server to their tool of choice (Cursor, VSCode, Claude Code…)

MCP install instructions are available from the Ask AI modal:
<img width="1188" height="447" alt="image" src="https://github.com/user-attachments/assets/8c722bd6-7d59-4388-95b4-d6fa25aa8b26" />

