### PR TITLE
Doc bugfix: documents().update expects documentId param outside of data

### DIFF
--- a/docusaurus/docs/cms/api/document-service/status.md
+++ b/docusaurus/docs/cms/api/document-service/status.md
@@ -199,8 +199,8 @@ To automatically publish a document while updating it, add `status: 'published'`
 
 ```js
 await strapi.documents('api::restaurant.restaurant').update({
+  documentId: 'a1b2c3d4e5f6g7h8i9j0klm',
   data: {
-    documentId: 'a1b2c3d4e5f6g7h8i9j0klm',
     name: "Biscotte Restaurant (closed)",
   },
   status: 'published',


### PR DESCRIPTION
### Description

When comparing
https://docs.strapi.io/cms/api/document-service/status#update 
and
https://docs.strapi.io/cms/api/document-service#update
you can see that the `documentId` property  is expected to be outside of the `data` property.