### PR TITLE
docs(cms): add angular renderer documentation for blocks editor

### DIFF
--- a/docusaurus/docs/cms/features/content-type-builder.md
+++ b/docusaurus/docs/cms/features/content-type-builder.md
@@ -292,6 +292,10 @@ The Rich Text (Blocks) field displays an editor with live rendering and various 
 If using the Blocks editor, we recommend that you also use the <ExternalLink to="https://github.com/strapi/blocks-react-renderer" text="Strapi Blocks React Renderer"/> to easily render the content in a React frontend.
 :::
 
+:::strapi Angular renderer
+If using the Blocks editor, we recommend that you also use the <ExternalLink to="https://github.com/TupiC/blocks-renderer-angular" text="Strapi Blocks Angular Renderer"/> to easily render the content in an Angular frontend.
+:::
+
 #### <img width="28" src="/img/assets/icons/v5/ctb_number.svg" /> Number {#number}
 
 The Number field displays a field for any kind of number: integer, decimal and float.


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request!

To help us merge your PR, make sure to follow the instructions detailed in the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md

Note that all documentation updates should be made against the `main` branch.
Keep your PR in Draft mode until it's ready to be reviewed and merged.


As part of the Docs Contribution Program, all external contribution PRs are labeled `contribution`.
Feel free to read more details on the Contribution Program in the dedicated guide:
https://strapi.notion.site/Documentation-Contribution-Program-1d08f359807480d480fdde68bb7a5a71

Let us know if you do not wish to take part in the Docs Contribution Program, and remove the `contribution` label.
-->

### Description

- adds a tip block recommending the Strapi Blocks Angular Renderer (`blocks-renderer-angular`) for Angular frontends
- there simply does not exist a renderer for Angular so no one would know about it. 
