### PR TITLE
Fix typo in "Populate and Select" documentation

### DIFF
--- a/docusaurus/docs/cms/api/rest/populate-select.md
+++ b/docusaurus/docs/cms/api/rest/populate-select.md
@@ -119,7 +119,7 @@ await request(`/api/users?${query}`);
 
 The REST API by default does not populate any type of fields, so it will not populate relations, media fields, components, or dynamic zones unless you pass a `populate` parameter to populate various field types.
 
-The `populate` parameter can be used alone or [in combination with with multiple operators](#combining-population-with-other-operators) to have much more control over the population.
+The `populate` parameter can be used alone or [in combination with multiple operators](#combining-population-with-other-operators) to have much more control over the population.
 
 :::caution
 The `find` permission must be enabled for the content-types that are being populated. If a role doesn't have access to a content-type it will not be populated (see [User Guide](/cms/features/users-permissions#editing-a-role) for additional information on how to enable `find` permissions for content-types).

--- a/docusaurus/static/llms-full.txt
+++ b/docusaurus/static/llms-full.txt
@@ -4153,7 +4153,7 @@ The [REST API](/cms/api/rest) by default does not populate any relations, media 
 
 The REST API by default does not populate any type of fields, so it will not populate relations, media fields, components, or dynamic zones unless you pass a `populate` parameter to populate various field types.
 
-The `populate` parameter can be used alone or [in combination with with multiple operators](#combining-population-with-other-operators) to have much more control over the population.
+The `populate` parameter can be used alone or [in combination with multiple operators](#combining-population-with-other-operators) to have much more control over the population.
 
 :::caution
 The `find` permission must be enabled for the content-types that are being populated. If a role doesn't have access to a content-type it will not be populated (see [User Guide](/cms/features/users-permissions#editing-a-role) for additional information on how to enable `find` permissions for content-types).


### PR DESCRIPTION
### Description

This PR fixes minor typo in the "Populate and Select" documentation: duplicated word "with".
