### PR TITLE
Fix `ip` middleware not appearing in Configurations > Middlewares secondary sidebar

### DIFF
--- a/docusaurus/docs/cms/configurations/middlewares.md
+++ b/docusaurus/docs/cms/configurations/middlewares.md
@@ -302,7 +302,6 @@ This security middleware is about cross-origin resource sharing (CORS) and is ba
 | `headers`           | Configure the `Access-Control-Allow-Headers` header       | `Array` or `String`  | Request headers passed in `Access-Control-Request-Headers` |
 | `keepHeaderOnError` | Add set headers to `err.header` if an error is thrown     | `Boolean`            | `false`                                                    |
 
-
 <details>
 <summary> Example: Custom configuration for the cors middleware</summary>
 
@@ -444,7 +443,7 @@ export default [
 
 </details>
 
-#### `ip`
+### `ip`
 
 The `ip` middleware is an IP filter middleware based on <ExternalLink to="https://github.com/nswbmw/koa-ip" text="koa-ip"/>. It accepts the following options:
 

--- a/docusaurus/static/llms-full.txt
+++ b/docusaurus/static/llms-full.txt
@@ -7308,7 +7308,7 @@ The `favicon` middleware serves the favicon and is based on
 
 </details>
 
-#### `ip`
+### `ip`
 
 The `ip` middleware is an IP filter middleware based on 
 


### PR DESCRIPTION
`ip` was not in the list because of a typo (h4 instead of h3, and [`toc_max_heading_level`](https://docusaurus.io/docs/markdown-features/toc#table-of-contents-heading-level) is by default set to show only h2s and h3s))