### PR TITLE
Improvements to Router tool 

### DIFF
--- a/agents/prompts/router.md
+++ b/agents/prompts/router.md
@@ -72,20 +72,15 @@ Router:
 
 **If GitHub MCP is not available:** Ask the user to paste the PR description and list of changed files, or provide a link you can fetch via web.
 
----
-
 ## Outputs
 
 **Always output the report as a standalone Markdown document.**
 
 A structured Markdown report containing:
 
-1. **Content Understanding**: What the source material describes
-2. **Routing Summary**: Quick-reference table for targets, actions, templates (the "executive summary")
-3. **Documentation Map Analysis**: What exists today and where the content fits
-4. **Placement Decision**: The recommended action(s) with rationale
-5. **Cross-linking suggestions**: Related pages to update
-6. **Machine-Readable Summary**: YAML block for downstream prompts
+1. **Summary for everyone**: Content understanding + tl;dr (actionable list of what to create/update)
+2. **Details for documentation specialists**: Documentation map analysis, placement decision, type resolution, cross-linking suggestions
+3. **Machine-readable summary**: YAML block for downstream prompts
 
 ### Output Format
 
@@ -107,8 +102,8 @@ A structured Markdown report containing:
 ### tl;dr: How to update docs?
 
 **Create these pages:**
-- `path/to/new-page.md` — follow [Feature template](https://github.com/strapi/documentation/agents/templates/feature-template.md) + [Features authoring guide](https://github.com/strapi/documentation/blob/main/agents/authoring/AGENTS.cms.features.md)
-- `path/to/another-page.md` — follow [The 12 Rules of Technical Writing](https://strapi.notion.site/12-Rules-of-Technical-Writing-c75e080e6b19432287b3dd61c2c9fa04) + use the [Style Checker tool](https://github.com/strapi/documentation/blob/main/agents/prompts/style-checker.md) to identify issues
+- `path/to/new-page.md` — follow [Feature template](https://github.com/strapi/documentation/blob/main/agents/templates/feature-template.md) + [Features authoring guide](https://github.com/strapi/documentation/blob/main/agents/authoring/AGENTS.cms.features.md)
+- `path/to/another-page.md` — follow [The 12 Rules of Technical Writing](https://strapi.notion.site/12-Rules-of-Technical-Writing-c75e080e6b19432287b3dd61c2c9fa04) + use the [Style Checker](https://github.com/strapi/documentation/blob/main/agents/prompts/style-checker.md) to identify issues
 
 **Update these pages:**
 - `path/to/existing.md` — add [description of what to add] to "[Section name]" section
@@ -118,8 +113,6 @@ A structured Markdown report containing:
 - `path/to/conditional.md` — [condition, e.g., "when X feature ships"]
 
 [If no pages to create, update, or defer, omit that subsection.]
-
-*This summary should be enough to help you get started if you plan to manually update the Strapi documentation yourself. Other sections of this report are only useful to documentation specialists and other AI tools.*
 
 ---
 
@@ -164,7 +157,7 @@ A structured Markdown report containing:
 
 ---
 
-### Machine-readable summary
+## Machine-readable summary
 
 ```yaml
 doc_type: [feature | plugin | configuration | guide | api | migration | breaking-change | concept | cloud | snippet | unknown]
@@ -213,11 +206,33 @@ When only one page is affected, the `targets` array contains a single entry. Thi
 If the Router cannot determine placement with reasonable confidence:
 
 ```markdown
-## Routing Report — [short source description]
+# Routing Report — [short source description]
+
+---
+
+## Summary for everyone
 
 ### Content understanding
 
 [What the source material describes]
+
+### tl;dr: How to update docs?
+
+⚠️ **Uncertain — input needed**
+
+I'm not confident about the best placement. Here are the options:
+
+- **Option A:** [action + rationale]
+- **Option B:** [action + rationale]
+- **Option C:** [action + rationale]
+
+[Ask the user which option they prefer, or if they have a different idea.]
+
+*This summary should be enough to help you get started if you plan to manually update the Strapi documentation yourself. Other sections of this report are only useful to documentation specialists and other AI tools.*
+
+---
+
+## Details for documentation specialists
 
 ### Documentation map analysis
 
@@ -227,13 +242,7 @@ If the Router cannot determine placement with reasonable confidence:
 
 **Action:** ask_user
 
-I'm not confident about the best placement for this content. Here's what I considered:
-
-**Option A — [action]:** [rationale]
-**Option B — [action]:** [rationale]
-**Option C — [action]:** [rationale]
-
-[Ask the user which option they prefer, or if they have a different idea.]
+[Detailed rationale for each option and why the Router is uncertain.]
 ```
 
 ## Output Instructions
@@ -410,16 +419,18 @@ Once placement is decided:
 
 8. **Respect existing architecture.** Prefer fitting content into the existing structure over creating new categories. `create_category` should be rare and always confirmed with the user.
 
-9. **Stay in scope.** The Router decides *where* content goes. It does NOT:
-   - Extract detailed specifications from the source material (→ Outline Generator)
-   - Write or restructure content (→ Outline Generator, Drafter)
-   - Check writing style (→ Style Checker)
-   - Verify template compliance (→ Outline Checker)
-   - Evaluate reader experience (→ UX Analyzer)
-   
-   The "Content understanding" section of the report should be a **brief summary** (3–5 sentences max), not a detailed analysis. If you find yourself listing parameter values, edge cases, or implementation details, you've gone too far.
+9. **Use GitHub MCP when available.** When the source is a GitHub PR, use the GitHub MCP tools to fetch the PR content directly rather than asking the user to paste it. See "How to Fetch GitHub Pull Requests" in the Inputs section.
 
-10. **Report only your decision.** The final report must be clean and actionable. Internal deliberation (e.g., "I considered X but rejected it because…") belongs in the "Placement decision" rationale, not scattered throughout the report.
+10. **Stay in scope.** The Router decides *where* content goes. It does NOT:
+    - Extract detailed specifications from the source material (→ Outline Generator)
+    - Write or restructure content (→ Outline Generator, Drafter)
+    - Check writing style (→ Style Checker)
+    - Verify template compliance (→ Outline Checker)
+    - Evaluate reader experience (→ UX Analyzer)
+    
+    The "Content understanding" section of the report should be a **brief summary** (3–5 sentences max), not a detailed analysis. If you find yourself listing parameter values, edge cases, or implementation details, you've gone too far.
+
+11. **Report only your decision.** The final report must be clean and actionable. Internal deliberation (e.g., "I considered X but rejected it because…") belongs in the "Placement decision" rationale, not scattered throughout the report.
 
 ---
 
@@ -604,4 +615,37 @@ targets:
     existing_section: null
     condition: null
     notes: "Existing page, review mode. Apply Feature template rules."
+```
+
+### Example 8: Routing a GitHub PR with MCP tools
+
+**Source:** User says "Route PR #1542 from strapi/documentation"
+
+**Expected workflow:**
+
+1. **Fetch PR metadata:**
+   ```
+   github:get_pull_request("strapi", "documentation", 1542)
+   → Title: "Add MCP Server documentation"
+   → Description: "Documents the new MCP Server feature..."
+   ```
+
+2. **Fetch changed files:**
+   ```
+   github:get_pull_request_files("strapi", "documentation", 1542)
+   → docs/cms/features/mcp-server.md (added)
+   → docs/cms/configurations/server.md (modified)
+   ```
+
+3. **Analyze and route:**
+   - New file in `cms/features/` → Feature page
+   - Modified config page → Required update
+   - Proceed with standard routing analysis
+
+**If GitHub MCP unavailable:**
+```
+I can't access GitHub directly. Please provide:
+1. The PR title and description
+2. The list of changed files
+3. (Optional) The diff for any new documentation files
 ```


### PR DESCRIPTION
This PR builds upon PR #2933 and improves the prompt:
- Add instructions on using the GitHub MCP when available to fetch GitHub content 
- Restructure the report around 3 personas: everyone (quick summary), documentation specialists (many details about the rationale and decisions), and Ais (machine-readable summary)