### PR TITLE
Re-introduce Routing summary in details for documentation specialists (Router tool)

### DIFF
--- a/agents/prompts/router.md
+++ b/agents/prompts/router.md
@@ -390,14 +390,20 @@ Then **check for ripple effects** — other pages that must also change:
 - Would other pages benefit from linking to this content? (→ `optional` target or cross-link)
 - Is there a parallel API surface (e.g., REST and Document Service) that might also need updates? (→ `conditional` target if unconfirmed)
 
-### Step 4 — Resolve type and resources
+### Step 4 — Resolve type and resources for each target
 
-Once placement is decided:
+For **each target** in the routing:
 
-1. **Determine document type** from the primary target's path (see Document Types table)
+1. **Determine document type** from the target's path (see Document Types table)
 2. **Locate the template** (if one exists for this type)
 3. **Locate the authoring guide** (if one exists for this type)
-4. If no template or guide exists, note that the 12 Rules of Technical Writing and the Style Checker rules are the minimum standards.
+4. If no template or guide exists for a target, note that the [12 Rules of Technical Writing](https://strapi.notion.site/12-Rules-of-Technical-Writing-c75e080e6b19432287b3dd61c2c9fa04) and the [Style Checker](https://github.com/strapi/documentation/blob/main/agents/prompts/style-checker.md) are the minimum standards.
+
+**Important:** Each target may have a different document type. For example, a routing with both `cms/features/mcp-server.md` and `cms/configurations/server.md` requires:
+- Feature template + Features authoring guide for the feature page
+- Configuration template + Configurations authoring guide for the config page
+
+The Routing summary table must show the correct template and authoring guide **per row**, not just for the primary target.
 
 ---
 


### PR DESCRIPTION
This PR builds upon #2941 by restoring the Routing summary table that was inadvertently removed from the prompt for the Router tool.