### PR TITLE
Update findOne method to use new document structure

### DIFF
--- a/docusaurus/docs/cms/backend-customization/services.md
+++ b/docusaurus/docs/cms/backend-customization/services.md
@@ -74,7 +74,11 @@ module.exports = createCoreService('api::restaurant.restaurant', ({ strapi }) =>
 
   // Method 3: Replacing a core service
   async findOne(documentId, params = {}) {
-    return strapi.documents('api::restaurant.restaurant').findOne({documentId, ...super.getFetchParams(params)});
+    return strapi.documents('api::restaurant.restaurant').findOne({
+        documentId, 
+        // Use super to keep core fetch parameter formatting
+        ...super.getFetchParams(params),
+     });
   }
 }));
 ```


### PR DESCRIPTION
### Description

I messed arround with this for way too long now.
the documentation is just wrong it seems...

Without the `as any` I get the following type errors:
```
Argument of type '<S extends { strapi: Core.Strapi; }>({ strapi }: S) => { findOne(documentId: string, params?: object): Promise<{ id: ID; documentId: string; locale?: string; name?: string; createdAt?: DateTimeValue; publishedAt?: DateTimeValue; slug?: string; theme?: JSONValue; updatedAt?: DateTimeValue; }>; }' is not assignable to parameter of type 'WithStrapiCallback<PartialWithThis<Partial<CollectionType> & Generic>>'.
  Type '<S extends { strapi: Core.Strapi; }>({ strapi }: S) => { findOne(documentId: string, params?: object): Promise<{ id: ID; documentId: string; locale?: string; name?: string; createdAt?: DateTimeValue; publishedAt?: DateTimeValue; slug?: string; theme?: JSONValue; updatedAt?: DateTimeValue; }>; }' is not assignable to type '<S extends { strapi: Core.Strapi; }>(params: S) => PartialWithThis<Partial<CollectionType> & Generic>'.
    Type '{ findOne(documentId: string, params?: object): Promise<{ id: ID; documentId: string; locale?: string; name?: string; createdAt?: DateTimeValue; publishedAt?: DateTimeValue; slug?: string; theme?: JSONValue; updatedAt?: DateTimeValue; }>; }' is not assignable to type 'PartialWithThis<Partial<CollectionType> & Generic>'.
      Type '{ findOne(documentId: string, params?: object): Promise<{ id: ID; documentId: string; locale?: string; name?: string; createdAt?: DateTimeValue; publishedAt?: DateTimeValue; slug?: string; theme?: JSONValue; updatedAt?: DateTimeValue; }>; }' is not assignable to type 'Partial<Partial<CollectionType> & Generic>'.
        The types returned by 'findOne(...)' are incompatible between these types.
          Type 'Promise<{ id: ID; documentId: string; locale?: string; name?: string; createdAt?: DateTimeValue; publishedAt?: DateTimeValue; slug?: string; theme?: JSONValue; updatedAt?: DateTimeValue; }>' is not assignable to type 'Promise<AnyDocument>'.
            Type '{ id: ID; documentId: string; locale?: string; name?: string; createdAt?: DateTimeValue; publishedAt?: DateTimeValue; slug?: string; theme?: JSONValue; updatedAt?: DateTimeValue; }' is not assignable to type 'AnyDocument'.
              Type '{ id: ID; documentId: string; locale?: string; name?: string; createdAt?: DateTimeValue; publishedAt?: DateTimeValue; slug?: string; theme?: JSONValue; updatedAt?: DateTimeValue; }' is not assignable to type '{ documentId: string; id: number; }'.
                Types of property 'id' are incompatible.
                  Type 'ID' is not assignable to type 'number'.
                    Type 'string' is not assignable to type 'number'.ts(2345)
```

Just boiling down to a ID type mismatch..
In the typings this type is just not up to date:
```
export type AnyDocument = {
    documentId: string;
    id: number;
} & {
    [key: string]: any;
};
```
Which should be:
```
export type AnyDocument = {
    documentId: string;
    id: number | string;
} & {
    [key: string]: any;
};
```

Also `this.getFetchParams` does not exist if you do not also modify the method.. so you need to access this from the `super` object.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request or contribution idea suggested by the Docs team.
