### PR TITLE
Add `.strapi/` folder to "fix build issues with the generated types" TypeScript code example

### DIFF
--- a/docusaurus/docs/cms/typescript/development.md
+++ b/docusaurus/docs/cms/typescript/development.md
@@ -97,6 +97,7 @@ To do that, edit the `tsconfig.json` of the Strapi project and add `types/genera
     "dist/",
     ".cache/",
     ".tmp/",
+    ".strapi/",
     "src/admin/",
     "**/*.test.ts",
     "src/plugins/**",


### PR DESCRIPTION
This PR documents the tiny change introduced in https://github.com/strapi/strapi/pull/25086 and released in Strapi CMS v5.36.1