### PR TITLE
Ensure the Outline UX Analyzer tool is included in auto-chain mode

### DIFF
--- a/.cursor/rules/strapi-docs-orchestrator.mdc
+++ b/.cursor/rules/strapi-docs-orchestrator.mdc
@@ -30,23 +30,23 @@ You are a documentation review assistant for Strapi. You help review documentati
        └──────┬──────┘             └──────┬──────┘
               │                           │
               ▼                           ▼
-       ┌─────────────┐             ┌─────────────┐
-       │  Outliner   │             │  Outliner   │
-       │  (Checker)  │             │ (Generator) │
-       └──────┬──────┘             └──────┬──────┘
-              │                           │
-              ▼                           ▼
-       ┌─────────────┐             ┌─────────────┐
-       │   Style     │             │   Drafter   │
-       │   Checker   │             └──────┬──────┘
-       └──────┬──────┘                    │
+       ┌──────────────┐            ┌─────────────┐
+       │   Outliner   │            │  Outliner   │
+       │  (Quick or   │            │ (Generator) │
+       │ Full Review) │            └──────┬──────┘
+       └──────┬───────┘                   │
               │                           ▼
               ▼                    ┌─────────────┐
-       ┌─────────────┐             │   Style     │
-       │  Integrity  │             │   Checker   │
-       │   Checker   │             └──────┬──────┘
-       └─────────────┘                    │
-                                          ▼
+       ┌─────────────┐            │   Drafter   │
+       │   Style     │            └──────┬──────┘
+       │   Checker   │                   │
+       └──────┬──────┘                   ▼
+              │                    ┌─────────────┐
+              ▼                    │   Style     │
+       ┌─────────────┐            │   Checker   │
+       │  Integrity  │            └──────┬──────┘
+       │   Checker   │                   │
+       └─────────────┘                   ▼
                                    ┌─────────────┐
                                    │  Integrity  │
                                    │   Checker   │
@@ -63,8 +63,19 @@ You are a documentation review assistant for Strapi. You help review documentati
 
 **Sequence:**
 ```
-Router → Outliner (Checker) → Style Checker → Integrity Checker
+Router → Outliner (Quick Check or Full Review) → Style Checker → Integrity Checker
 ```
+
+- **Quick Check** = Outline Checker only (structure/template compliance)
+- **Full Review** = Outline Checker + UX Analyzer (structure + reader experience)
+
+**Full Review escalation:** The Outliner automatically runs a Full Review when any of these conditions are met:
+- A file in the PR is **new** (not modifying an existing page)
+- The PR diff shows **>50% of a file changed**
+- A document exceeds **300 lines**
+- The user explicitly requests "full review" or "UX analysis"
+
+Otherwise, the Outliner runs a Quick Check.
 
 **Use cases:**
 - Reviewing a PR before merge
@@ -99,7 +110,8 @@ Router → Outliner (Generator) if needed → Drafter → Style Checker → Inte
 | "UX check", "UX analysis", "reader experience" | **UX Analyzer** | `outline-ux-analyzer.md` |
 | "full outline review" | **Outline Checker** + **UX Analyzer** | `outline-checker.md` + `outline-ux-analyzer.md` |
 | "check links", "verify paths" | **Integrity Checker** | *(coming soon)* |
-| "review this PR", "full review" | **Router** → **Outliner** → **Style Checker** | `router.md` → `outliner.md` → `style-checker.md` |
+| "review this PR" | **Router** → **Outliner** (auto-selects Quick or Full) → **Style Checker** | `router.md` → `outliner.md` → `style-checker.md` |
+| "full review" | **Router** → **Outliner** (Full Review: Checker + UX) → **Style Checker** | `router.md` → `outliner.md` → `style-checker.md` |
 | "create docs for...", "document this feature" | **Auto-chain** (see below) | `router.md` → `outline-generator.md` → `drafter.md` |
 | "how do I update docs with this?", "update docs with this", "how should I update the documentation?" | **Auto-chain** (see below) | `router.md` → `outline-generator.md` → `drafter.md` |
 | User provides source material (PR, diff, spec) + asks to document/update it | **Auto-chain** (see below) | `router.md` → `outline-generator.md` → `drafter.md` |
@@ -107,6 +119,8 @@ Router → Outliner (Generator) if needed → Drafter → Style Checker → Inte
 | User pastes Markdown without instructions | Ask: review or create? | — |
 
 **Disambiguation:** If the user says "where does this go?" or "what docs need updating?" without asking for the actual writing, run the Router only. If they say "update the docs with this" or "how do I update docs?" or provide source material and ask to create/update documentation, run the full auto-chain.
+
+**Review Mode escalation:** When "review this PR" is triggered, the Outliner auto-selects Quick Check or Full Review based on the conditions listed in the [Review Mode workflow](#review-mode-existing-content) above. When "full review" is explicitly requested, the Outliner always runs a Full Review regardless of document characteristics.
 
 ---
 
@@ -227,6 +241,8 @@ Always tell the user which prompt is executing and in which mode:
 > "Running **Style Checker** on `account-billing.md`..."
 
 > "Running **Create / Update Mode** (auto-chain): Router → Outline Generator → Drafter"
+
+> "Running **Outliner** (Full Review: Checker + UX Analyzer) on `admin-configuration-customization.md` — new file, 1103 lines..."
 
 ---
 
@@ -789,12 +805,16 @@ tags: [...]
 | Check | Errors | Warnings | Suggestions |
 |-------|--------|----------|-------------|
 | Structure (Outliner) | X | Y | Z |
+| UX Analysis (if Full Review) | — | — | X |
 | Style (12 Rules) | X | Y | Z |
 | Integrity (Links) | X | Y | Z |
 | **Total** | **X** | **Y** | **Z** |
 
 ## Structure Issues
 [from Outline Checker]
+
+## UX Analysis
+[from UX Analyzer — only present when Full Review was triggered]
 
 ## Style Issues
 [from Style Checker]
@@ -805,9 +825,12 @@ tags: [...]
 ## Recommended Fixes (by priority)
 1. **[error]** Most critical
 2. **[warning]** Next priority
-3. **[suggestion]** Nice to have
+3. **[ux-high]** High-impact UX fix
+4. **[suggestion]** Nice to have
+5. **[ux-medium]** Medium-impact UX fix
+6. **[ux-low]** Nice-to-have UX improvement
 ```
 
 **Create / Update Mode output:** A series of artifacts produced by the auto-chain (Routing Report, Outline Report if applicable, Draft/Patch/Micro-edit for each target). No consolidated report — each artifact stands alone.
 
-**Behavioral rules:** Determine mode first. State mode explicitly. Execute prompts in sequence. In auto-chain mode, do not pause between steps unless `ask_user` is set. Deduplicate issues across prompts. Prioritize errors → warnings → suggestions.
+**Behavioral rules:** Determine mode first. State mode explicitly. Execute prompts in sequence. In Review Mode, the Outliner auto-selects Quick Check or Full Review based on the escalation conditions defined in the [Review Mode workflow](#review-mode-existing-content). In auto-chain mode, do not pause between steps unless `ask_user` is set. Deduplicate issues across prompts. Prioritize errors → warnings → ux-high → suggestions → ux-medium → ux-low.


### PR DESCRIPTION
This PR builds upon #2980 and #2981 and ensures the Outline UX Analyzer is triggered when necessary. Previous tests were showing that it wasn't, so hopefully it's now fixed.