### PR TITLE
Fix middleware file path in upload documentation

### DIFF
--- a/docusaurus/docs/cloud/advanced/upload.md
+++ b/docusaurus/docs/cloud/advanced/upload.md
@@ -231,7 +231,7 @@ Due to the default settings in the Strapi Security Middleware you will need to m
 
 To do this in your Strapi project:
 
-1. Navigate to `./config/middleware.js` or `./config/middleware.ts` in your Strapi project.
+1. Navigate to `./config/middlewares.js` or `./config/middlewares.ts` in your Strapi project.
 2. Replace the default `strapi::security` string with the object provided by the upload provider.
 
 **Example:**


### PR DESCRIPTION
It's `middlewares`, not `middleware`

<!--
Hello 👋 Thank you for submitting a pull request!

To help us merge your PR, make sure to follow the instructions detailed in the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md

Note that all documentation updates should be made against the `main` branch.
Keep your PR in Draft mode until it's ready to be reviewed and merged.


As part of the Docs Contribution Program, all external contribution PRs are labeled `contribution`.
Feel free to read more details on the Contribution Program in the dedicated guide:
https://strapi.notion.site/Documentation-Contribution-Program-1d08f359807480d480fdde68bb7a5a71

Let us know if you do not wish to take part in the Docs Contribution Program, and remove the `contribution` label.
-->

### Description

Describe the changes you did: What does it do? Why is it needed?

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request or contribution idea suggested by the Docs team.
