### PR TITLE
Ensure the Style Checker spots em dashes

### DIFF
--- a/.cursor/rules/strapi-docs-style-checker.mdc
+++ b/.cursor/rules/strapi-docs-style-checker.mdc
@@ -197,6 +197,14 @@ Beyond the 12 rules, also check for:
 - **Severity:** warning
 - **Note:** Strapi documentation always uses absolute-style paths starting with `/`. The `./` relative prefix should not appear in documentation prose or code examples referencing project file paths.
 
+### Em dashes
+- **Detect:** Em dashes (—) anywhere in prose
+- **Severity:** error
+- **Note:** Em dashes are not used in Strapi technical documentation. They are a common signal of AI-generated text. Replace with a colon, a period, or restructure the sentence.
+  - `"Status — shows the current state"` → `"Status: shows the current state"`
+  - `"The button — visible only to admins — opens the panel"` → `"The button opens the panel. It is only visible to admins."`
+- **Exception:** Em dashes inside HTML comments (`<!-- ... -->`) and inside hyperlink text that references an external page title should NOT be flagged.
+
 ### Consistency
 - **Detect:** Inconsistent terminology within the same document (e.g., "admin panel" vs "Admin Panel" vs "administration panel"); inconsistent heading capitalization
 - **Severity:** warning

--- a/agents/prompts/style-checker.md
+++ b/agents/prompts/style-checker.md
@@ -191,6 +191,14 @@ Beyond the 12 rules, also check for:
 - **Severity:** warning
 - **Note:** Strapi documentation always uses absolute-style paths starting with `/`. The `./` relative prefix should not appear in documentation prose or code examples referencing project file paths.
 
+### Em dashes
+- **Detect:** Em dashes (—) anywhere in prose
+- **Severity:** error
+- **Note:** Em dashes are not used in Strapi technical documentation. They are a common signal of AI-generated text. Replace with a colon, a period, or restructure the sentence.
+  - `"Status — shows the current state"` → `"Status: shows the current state"`
+  - `"The button — visible only to admins — opens the panel"` → `"The button opens the panel. It is only visible to admins."`
+- **Exception:** Em dashes inside HTML comments (`<!-- ... -->`) and inside hyperlink text that references an external page title should NOT be flagged.
+
 ### Consistency
 - **Detect:** Inconsistent terminology within the same document (e.g., "admin panel" vs "Admin Panel" vs "administration panel"); inconsistent heading capitalization
 - **Severity:** warning


### PR DESCRIPTION
This PR is an improvement to style checks performed by the [Style Checker prompt](https://github.com/strapi/documentation/blob/main/agents/prompts/style-checker.md) and ensures that em dashes are spotted and flagged as to be removed. Em dashes (`—`) should never be used in technical documentation; usually, when humans spot their presence, they deduce that the content was AI-generated.