### PR TITLE
Update project creation page

### DIFF
--- a/docusaurus/docs/cloud/getting-started/deployment.md
+++ b/docusaurus/docs/cloud/getting-started/deployment.md
@@ -32,7 +32,7 @@ Before you can deploy your Strapi application on Strapi Cloud using the Cloud da
 
 1. Navigate to the <ExternalLink to="https://cloud.strapi.io" text="Strapi Cloud"/> login page.
 
-2. You have the options to **Log in with GitHub**, **Log in with Google**, **Log in with GitLab** or **Magic link**. Choose your preferred option and log in. This initial login will create your Strapi Cloud account. Once logged in, you will be redirected to the Strapi Cloud *Projects* page where you can create your first Strapi Cloud project.
+2. You have the options to log in with **GitHub**, **Google**, **GitLab** or via **Magic link**. Choose your preferred option and log in. This initial login will create your Strapi Cloud account. Once logged in, you will be redirected to the Strapi Cloud *Projects* page where you can create your first Strapi Cloud project.
 
     <ThemedImage
     alt="Strapi Cloud login page"
@@ -64,26 +64,23 @@ Before you can deploy your Strapi application on Strapi Cloud using the Cloud da
     }}
     />
 
-3. Choose a plan and a billing period for your Strapi Cloud project: either Free, Essential, Pro, or Scale. Feel free to refer to [Pricing](https://strapi.io/pricing-cloud) for more information.
+3. Choose a plan and a billing period for your Strapi Cloud project (see [Pricing](https://strapi.io/pricing-cloud) for details).
 
-4. Connect a git repository to your new Strapi Cloud project.
+4. Connect a git repository to your new Strapi Cloud project. You may first have to select a git provider. If you have already deployed a project with one git provider, you can afterward deploy another project using another provider by clicking on the **Switch git provider** button and selecting either GitHub or GitLab.
 
     :::strapi Choose your path for your new Strapi Cloud project!
     Select one of the tabs below depending on how you wish to proceed:
-    - by using a prebuilt template and creating a new repository on GitHub to discover Strapi Cloud easily and quickly *(recommended for new users and beginners — not available on another provider than GitHub)*,
-    - or by using your own, already existing GitHub or GitLab repository and Strapi project.
+    - by deploying a prebuilt Strapi template *(recommended for new users and beginners — only available on GitHub)*,
+    - or by deploying your existing Strapi project.
     :::
 
     <Tabs groupId="REPO-OPTIONS">
 
-    <TabItem value="TEMPLATE" label="New repo & prebuilt template ✨">
+    <TabItem value="TEMPLATE" label="Prebuilt Strapi template ✨">
 
-    4.a. Click on the **Use template** button. If you are deploying a project for the first time, you may first have to select GitHub as git provider and then you will see the option to use a template. 
+    4.a. After connecting your GitHub account, click on the **Use template** button.
 
-    4.b. In the *Create repository with template* modal, choose:
-    
-    - the GitHub account where the repository will be created
-    - the template to use for the new project (e.g. Blog)
+    4.b. In the *Create repository with template* modal, choose the GitHub account where the repository will be created
 
     <ThemedImage
     alt="Create repo with template modal"
@@ -98,34 +95,23 @@ Before you can deploy your Strapi application on Strapi Cloud using the Cloud da
 
     4.d. If you have already given Strapi Cloud access to all repositories of your GitHub account, go directly to the next step. If not, you will be redirected to a GitHub modal where you will have to allow Strapi Cloud access to the newly created repository (more information in the <ExternalLink to="https://docs.github.com/en/apps/overview" text="GitHub documentation"/>).
 
-    4.e. Back in the project deployment interface, select your *Account* and the *Repository* you just created.
-
-    <ThemedImage
-    alt="Selecting GitHub account and repository"
-    sources={{
-        light: '/img/assets/cloud/account-repo-selection.png',
-        dark: '/img/assets/cloud/account-repo-selection_DARK.png',
-    }}
-    />
+    4.e. Back in the project creation interface, the *Account* and *Repository* fields now match the newly created template.
 
     </TabItem>
 
-    <TabItem value="OWN-REPO" label="Own existing repo & Strapi project">
-
-
-    4.a. (optional) If you are deploying a project for the first time, you may first have to select a git provider: either GitHub or GitLab. If you already deployed a project with one git provider, you can afterward deploy another project using another provider by clicking on the **Switch git provider** button and selecting either GitHub or GitLab.
+    <TabItem value="OWN-REPO" label="Existing Strapi project">
 
     :::tip
-    Connect the GitHub or GitLab account and/or organizations that owns the repository or repositories you want to deploy. This can be different from the account that own the Strapi Cloud account.
+    Connect the GitHub or GitLab account that owns the repository you want to deploy. This can be different from the account you used to log into your Strapi Cloud account.
     :::
     :::note
 
-    You can only connect a Github organization's repositories with Strapi Cloud paid plans. With the free plan, you can only connect a personal repository.
+    You can only connect a GitHub organization repository on a paid plans. On the free plan, you can only connect a personal repository.
     :::
 
-    4.b. If you have already given Strapi Cloud access to all repositories of your GitHub or GitLab account, go directly to the next step. If not, you will be redirected to a modal where you will have to allow Strapi Cloud permission to access some or all your repositories on GitHub/GitLab (more information in the <ExternalLink to="https://docs.github.com/en/apps/overview" text="GitHub"/> and <ExternalLink to="https://docs.gitlab.com/ee/integration/oauth_provider.html#view-all-authorized-applications" text="GitLab"/> documentations).
+    4.a. If you have already given Strapi Cloud access to all repositories of your GitHub or GitLab account, go directly to the next step. If not, you will be redirected to a modal where you will have to allow Strapi Cloud permission to access some or all your repositories on GitHub/GitLab (more information in the <ExternalLink to="https://docs.github.com/en/apps/overview" text="GitHub"/> and <ExternalLink to="https://docs.gitlab.com/ee/integration/oauth_provider.html#view-all-authorized-applications" text="GitLab"/> documentation).
 
-    4.c. Back in the project deployment interface, select your *Account* and a *Repository*. 
+    4.c. Back in the project creation interface, select the *Account* and the *Repository* you want to deploy. 
 
     <ThemedImage
     alt="Selecting git account and repository"
@@ -145,13 +131,13 @@ Before you can deploy your Strapi application on Strapi Cloud using the Cloud da
 
     | Setting name | Instructions                                                                                            |
     |--------------|---------------------------------------------------------------------------------------------------------|
-    | Display name | Write the name of your Strapi app, this is fetched from the repository name but can be edited. It is automatically converted to slug format (`my-strapi-app`). |
+    | Display name | The name is automatically populated based on the repository you selected, but you can edit it if needed. |
     | Git branch   | Choose from the drop-down the branch you want to deploy. |
     | Deploy on push | Tick this box to automatically trigger a deployment when changes are pushed to your selected branch. When disabled, you will need to manually deploy the latest changes. |
     | Region       | Choose the geographic location of the servers where your Strapi application is hosted. Selected region can either be US (East), Europe (West) or Asia (Southeast). |
 
     :::note
-    The Git branch and "Deploy on push" settings can be modified afterwards through the project settings, however the hosting region can only be chosen during the creation of the project (see [Project Settings](/cloud/projects/settings)).
+    The Git branch and "Deploy on push" settings can be modified afterwards through the project settings. However, the hosting region can only be chosen during the creation of the project (see [Project Settings](/cloud/projects/settings)).
     :::
 
     5.b. (optional) Click on **Show advanced settings** to fill in the following options:
@@ -171,7 +157,7 @@ Before you can deploy your Strapi application on Strapi Cloud using the Cloud da
     | Node version | Choose a Node version from the drop-down. The default Node version will automatically be chosen to best match the version of your Strapi project. If you manually choose a version that doesn't match with your Strapi project, the build will fail but the explanation will be displayed in the build logs. |
 
     :::strapi Using Environment Variables
-    You can use environment variable to connect your project to an external database rather than the default one used by Strapi Cloud (see [database configuration](/cms/configurations/database#environment-variables-in-database-configurations) for more details). If you would like to revert and use Strapi's default database again, you have to remove your `DATABASE_` environment variables (no automatic migration implied).
+    You can use environment variable to connect your project to an external database rather than the default one used by Strapi Cloud (see [database configuration](/cms/configurations/database#environment-variables-in-database-configurations) for more details). If you would like to revert and use Strapi's default database again, remove your `DATABASE_` environment variables (no automatic migration implied).
 
     You can also set up here a custom email provider. Sendgrid is set as the default one for the Strapi applications hosted on Strapi Cloud (see [providers configuration](/cms/features/email#providers) for more details).
     :::
@@ -180,8 +166,6 @@ Before you can deploy your Strapi application on Strapi Cloud using the Cloud da
 
 :::strapi No billing step for the Free plan
 If you chose the free plan, this billing step will be skipped as you will not be asked to share your credit card details at the creation of the project.
-
-To upgrade your project to a paid plan, you will need to fill in your billing information in the **Billing** section of your Profile.
 
 <Icon name="fast-forward" /> Skip to step 5 of the section below to finalize the creation of your project.
 :::
@@ -222,7 +206,7 @@ While your project is deploying, you can already start configuring some of your 
 If an error occurs during the project creation, the progress indicator will stop and display an error message. You will see a **Retry** button next to the failed step, allowing you to restart the creation process.
 :::
 
-Once you project is successfully deployed, the creation tracker will be replaced by your deployments list and you will be able to visit your Cloud hosted project. Don't forget to create the first Admin user before sharing your Strapi project.
+Once your project is successfully deployed, the creation tracker will be replaced by your deployments list and you will be able to visit your Cloud hosted project. Don't forget to create the first Admin user before sharing your Strapi project.
 
 
 ## <Icon name="fast-forward" /> What to do next?

--- a/docusaurus/static/llms-full.txt
+++ b/docusaurus/static/llms-full.txt
@@ -421,13 +421,13 @@ Before you can deploy your Strapi application on Strapi Cloud using the Cloud da
 
     | Setting name | Instructions                                                                                            |
     |--------------|---------------------------------------------------------------------------------------------------------|
-    | Display name | Write the name of your Strapi app, this is fetched from the repository name but can be edited. It is automatically converted to slug format (`my-strapi-app`). |
+    | Display name | The name is automatically populated based on the repository you selected, but you can edit it if needed. |
     | Git branch   | Choose from the drop-down the branch you want to deploy. |
     | Deploy on push | Tick this box to automatically trigger a deployment when changes are pushed to your selected branch. When disabled, you will need to manually deploy the latest changes. |
     | Region       | Choose the geographic location of the servers where your Strapi application is hosted. Selected region can either be US (East), Europe (West) or Asia (Southeast). |
 
     :::note
-    The Git branch and "Deploy on push" settings can be modified afterwards through the project settings, however the hosting region can only be chosen during the creation of the project (see [Project Settings](/cloud/projects/settings)).
+    The Git branch and 'Deploy on push' settings can be modified afterwards through the project settings. However, the hosting region can only be chosen during the creation of the project (see [Project Settings](/cloud/projects/settings)).
     :::
 
     5.b. (optional) Click on **Show advanced settings** to fill in the following options:
@@ -439,7 +439,7 @@ Before you can deploy your Strapi application on Strapi Cloud using the Cloud da
     | Node version | Choose a Node version from the drop-down. The default Node version will automatically be chosen to best match the version of your Strapi project. If you manually choose a version that doesn't match with your Strapi project, the build will fail but the explanation will be displayed in the build logs. |
 
     :::strapi Using Environment Variables
-    You can use environment variable to connect your project to an external database rather than the default one used by Strapi Cloud (see [database configuration](/cms/configurations/database#environment-variables-in-database-configurations) for more details). If you would like to revert and use Strapi's default database again, you have to remove your `DATABASE_` environment variables (no automatic migration implied).
+    You can use environment variable to connect your project to an external database rather than the default one used by Strapi Cloud (see [database configuration](/cms/configurations/database#environment-variables-in-database-configurations) for more details). If you would like to revert and use Strapi's default database again, remove your `DATABASE_` environment variables (no automatic migration implied).
 
     You can also set up here a custom email provider. Sendgrid is set as the default one for the Strapi applications hosted on Strapi Cloud (see [providers configuration](/cms/features/email#providers) for more details).
     :::
@@ -448,8 +448,6 @@ Before you can deploy your Strapi application on Strapi Cloud using the Cloud da
 
 :::strapi No billing step for the Free plan
 If you chose the free plan, this billing step will be skipped as you will not be asked to share your credit card details at the creation of the project.
-
-To upgrade your project to a paid plan, you will need to fill in your billing information in the **Billing** section of your Profile.
 
  Skip to step 5 of the section below to finalize the creation of your project.
 :::
@@ -474,7 +472,7 @@ While your project is deploying, you can already start configuring some of your 
 If an error occurs during the project creation, the progress indicator will stop and display an error message. You will see a **Retry** button next to the failed step, allowing you to restart the creation process.
 :::
 
-Once you project is successfully deployed, the creation tracker will be replaced by your deployments list and you will be able to visit your Cloud hosted project. Don't forget to create the first Admin user before sharing your Strapi project.
+Once your project is successfully deployed, the creation tracker will be replaced by your deployments list and you will be able to visit your Cloud hosted project. Don't forget to create the first Admin user before sharing your Strapi project.
 
 ##  What to do next?
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request!

To help us merge your PR, make sure to follow the instructions detailed in the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md

Note that all documentation updates should be made against the `main` branch.
Keep your PR in Draft mode until it's ready to be reviewed and merged.


As part of the Docs Contribution Program, all external contribution PRs are labeled `contribution`.
Feel free to read more details on the Contribution Program in the dedicated guide:
https://strapi.notion.site/Documentation-Contribution-Program-1d08f359807480d480fdde68bb7a5a71

Let us know if you do not wish to take part in the Docs Contribution Program, and remove the `contribution` label.
-->

### Description

This PR updates the Cloud deployment page to better reflect the current project creation flow and improve clarity:

- Update the Display name field description to explain that it is pre-filled from the selected repository
- Simplify tab labels to fix rendering issue ("Prebuilt Strapi template" / "Existing Strapi project") 
- Move git provider selection guidance from the "Existing project" tab up to the shared step 4, since it applies to both paths
- Remove outdated screenshot for the template account/repo selection step
- Fix several style issues: remove "easily and quickly" (Rule 6), fix "Github" casing, fix comma splice with "however", fix "you project" typo
- Clean up grammar and wording throughout (simplify cross-references, fix subject-verb agreement, fix "documentations")
- Remove the billing upgrade paragraph from the Free plan callout

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request or contribution idea suggested by the Docs team.
