### PR TITLE
Add more information about the `arrayLimit` parameter from the `strapi::query` middleware

### DIFF
--- a/docusaurus/docs/cms/api/rest/parameters.md
+++ b/docusaurus/docs/cms/api/rest/parameters.md
@@ -30,6 +30,10 @@ The following API parameters are available:
 | `sort`             | String or Array  | [Sort the response](/cms/api/rest/sort-pagination.md#sorting) |
 | `pagination`       | Object        | [Page through entries](/cms/api/rest/sort-pagination.md#pagination) |
 
+:::note
+Long bracket-encoded lists in a parameter (for example `populate` or `fields`) are limited by [`arrayLimit` on `strapi::query`](/cms/configurations/middlewares#query). See [Population](/cms/api/rest/populate-select#population).
+:::
+
 Query parameters use the <ExternalLink to="https://christiangiacomi.com/posts/rest-design-principles/#lhs-brackets" text="LHS bracket syntax"/> (i.e. they are encoded using square brackets `[]`).
 
 :::tip

--- a/docusaurus/docs/cms/api/rest/populate-select.md
+++ b/docusaurus/docs/cms/api/rest/populate-select.md
@@ -129,6 +129,10 @@ You can use the `populate` parameter alone or [in combination with multiple oper
 `populate=deep` plugins are [not recommended in Strapi](https://support.strapi.io/articles/8544110758-why-populate-deep-plugins-are-not-recommended-in-strapi).
 :::
 
+:::note
+Large `populate` lists in the query string (many `populate[0]`, `populate[1]`, … entries) are bounded by the query parser `arrayLimit` (default: `100`). To allow a longer list, raise `arrayLimit` on the [`strapi::query` middleware](/cms/configurations/middlewares#query). Higher values increase parsing cost per request.
+:::
+
 The following table lists populate use cases with example syntax. Each row links to the Understanding populate guide for details:
 
 | Use case  | Example parameter syntax | Detailed explanations to read |

--- a/docusaurus/docs/cms/configurations/middlewares.md
+++ b/docusaurus/docs/cms/configurations/middlewares.md
@@ -633,6 +633,10 @@ The `query` middleware is a query parser based on <ExternalLink to="https://gith
 | `arrayLimit`         | Maximum index limit when parsing arrays (see <ExternalLink to="https://github.com/ljharb/qs#parsing-arrays" text="qs documentation"/>)                    | `Number`  | `100`         |
 | `depth`              | Maximum depth of nested objects when parsing objects (see <ExternalLink to="https://github.com/ljharb/qs#parsing-objects" text="qs documentation"/>)      | `Number`  | `20`          |
 
+:::note
+Bracket-style arrays in the query string (`populate`, `fields`, `filters`, and nested keys) are parsed with `qs` using `arrayLimit`. When a list grows past that limit, `qs` can yield object-shaped values instead of arrays. Strapi may then reject the query or return errors that do not point to this setting. Increase `arrayLimit` when you need longer lists. Larger values allow longer query strings and increase parsing work on each request.
+:::
+
 <details>
 <summary> Example: Custom configuration for the query middleware </summary>
 
@@ -668,6 +672,53 @@ export default [
     config: {
       arrayLimit: 50,
       depth: 10,
+    },
+  },
+  // ...
+]
+```
+
+</TabItem>
+
+</Tabs>
+
+</details>
+
+<details>
+<summary> Example: Raise <code>arrayLimit</code> for long REST query lists </summary>
+
+Use a value that fits your longest bracket-encoded lists (for example many `populate[n]` entries). Adjust the number based on your needs and acceptable parsing cost.
+
+<Tabs groupId="js-ts">
+
+<TabItem value="javascript" label="JavaScript">
+
+```js title="./config/middlewares.js"
+
+module.exports = [
+  // ...
+  {
+    name: 'strapi::query',
+    config: {
+      arrayLimit: 200,
+    },
+  },
+  // ...
+]
+```
+
+</TabItem>
+
+<TabItem value="typescript" label="TypeScript">
+
+```ts title="./config/middlewares.ts"
+
+export default [
+  // ...
+  {
+    name: 'strapi::query',
+    config: {
+      arrayLimit: 200,
     },
   },
   // ...


### PR DESCRIPTION
### Description

This PR documents how the `strapi::query` middleware’s `arrayLimit` (default `100`, via `qs`) affects long bracket-encoded REST parameters such as `populate[n]`, `fields`, and `filters`. Without this, users who exceed the limit often see unclear errors and assume the bug is in populate logic.

Changes:

- **`configurations/middlewares.md` (`query`):** Add a note on parser behavior when lists exceed `arrayLimit`, plus an example that sets `arrayLimit: 200` for long REST query lists.
- **`api/rest/populate-select.md`:** Add a note where readers already look for populate behavior, with a link to the middleware docs.
- **`api/rest/parameters.md`:** Short cross-link so people scanning the parameters overview find the same guidance.

### Related issue(s)/PR(s)

- Upstream context: [strapi/strapi#25633](https://github.com/strapi/strapi/pull/25633) (closed; documented workaround: configure `arrayLimit` rather than unlimited parsing). Related: [strapi/strapi#25632](https://github.com/strapi/strapi/issues/25632).