### PR TITLE
Allow agents to do a single round of self-check after PR creation

### DIFF
--- a/.cursor/rules/strapi-docs-orchestrator.mdc
+++ b/.cursor/rules/strapi-docs-orchestrator.mdc
@@ -189,8 +189,9 @@ Step 5: AUTO-CORRECT (conditional, max 1 retry per target)
   │   │   └─ RE-RUN Drafter (same mode) with corrections
   │   └─ OUTPUT corrected artifacts (replace originals)
   │
-  └─ IF no errors (only warnings/suggestions):
-      └─ Append review summary as <!-- drafter:review-notes --> comment
+  └─ IF no errors or warnings (suggestions only):
+     └─ Append review summary to each artifact as a
+        <!-- drafter:review-notes --> comment block
 
 Step 6: OUTPUT final deliverables + Self-Review Report artifact
 ```
@@ -202,10 +203,10 @@ Step 6: OUTPUT final deliverables + Self-Review Report artifact
 3. **Output each deliverable as a separate Markdown artifact** with a descriptive title (e.g., "Routing Report — MCP Server feature", "Draft — cms/features/mcp-server.md").
 4. **State the chain upfront.** At the start, tell the user what will run:
    > "Running **Create / Update Mode**: Router → Outline Generator → Drafter → Self-Review → Auto-Correct (if needed)"
-5. **Self-review runs automatically after the Drafter.** The Outline Checker, UX Analyzer (for `create_page` targets), and Style Checker run on every Drafter output. If errors are found, the Drafter re-runs once with the review reports as context. Warnings and suggestions are appended as review notes but do not trigger a retry. Maximum 1 retry per target — never more.
+5. **Self-review runs automatically after the Drafter.** The Outline Checker, UX Analyzer (for `create_page` targets), and Style Checker run on every Drafter output. If errors or warnings are found, the Drafter re-runs once with the review reports as context. Suggestions are appended as review notes but do not trigger a retry. Maximum 1 retry per target — never more.
 6. **Handle multiple targets sequentially.** Process primary targets first, then required, then optional.
 7. **Respect `conditional` targets.** Do not process them until the condition is resolved.
-8. **Self-review severity threshold.** Only `[error]`-level findings trigger a Drafter retry. `[warning]` and `[suggestion]` findings are reported but do not cause re-runs. This prevents infinite loops while catching clear rule violations.
+8. **Self-review severity threshold.** `[error]` and `[warning]` findings trigger a Drafter retry. Only `[suggestion]` findings are reported without causing re-runs. This prevents infinite loops while catching clear rule violations (e.g., "easy/simple" slipping through, missing backticks on file paths, procedures not in numbered lists).
 
 ### When Outline Generator is needed vs. straight to Drafter
 

--- a/agents/prompts/claude-project-instructions.md
+++ b/agents/prompts/claude-project-instructions.md
@@ -183,8 +183,9 @@ Step 5: AUTO-CORRECT (conditional, max 1 retry per target)
   │   │   └─ RE-RUN Drafter (same mode) with corrections
   │   └─ OUTPUT corrected artifacts (replace originals)
   │
-  └─ IF no errors (only warnings/suggestions):
-      └─ Append review summary as <!-- drafter:review-notes --> comment
+  └─ IF no errors or warnings (suggestions only):
+     └─ Append review summary to each artifact as a
+        <!-- drafter:review-notes --> comment block
 
 Step 6: OUTPUT final deliverables + Self-Review Report artifact
 ```
@@ -196,10 +197,10 @@ Step 6: OUTPUT final deliverables + Self-Review Report artifact
 3. **Output each deliverable as a separate Markdown artifact** with a descriptive title (e.g., "Routing Report — MCP Server feature", "Draft — cms/features/mcp-server.md").
 4. **State the chain upfront.** At the start, tell the user what will run:
    > "Running **Create / Update Mode**: Router → Outline Generator → Drafter → Self-Review → Auto-Correct (if needed)"
-5. **Self-review runs automatically after the Drafter.** The Outline Checker, UX Analyzer (for `create_page` targets), and Style Checker run on every Drafter output. If errors are found, the Drafter re-runs once with the review reports as context. Warnings and suggestions are appended as review notes but do not trigger a retry. Maximum 1 retry per target — never more.
+5. **Self-review runs automatically after the Drafter.** The Outline Checker, UX Analyzer (for `create_page` targets), and Style Checker run on every Drafter output. If errors or warnings are found, the Drafter re-runs once with the review reports as context. Suggestions are appended as review notes but do not trigger a retry. Maximum 1 retry per target — never more.
 6. **Handle multiple targets sequentially.** Process primary targets first, then required, then optional.
 7. **Respect `conditional` targets.** Do not process them until the condition is resolved.
-8. **Self-review severity threshold.** Only `[error]`-level findings trigger a Drafter retry. `[warning]` and `[suggestion]` findings are reported but do not cause re-runs. This prevents infinite loops while catching clear rule violations.
+8. **Self-review severity threshold.** `[error]` and `[warning]` findings trigger a Drafter retry. Only `[suggestion]` findings are reported without causing re-runs. This prevents infinite loops while catching clear rule violations (e.g., "easy/simple" slipping through, missing backticks on file paths, procedures not in numbered lists).
 
 ### When Outline Generator is needed vs. straight to Drafter
 

--- a/agents/prompts/orchestrator.md
+++ b/agents/prompts/orchestrator.md
@@ -177,7 +177,7 @@ Router → Outliner (Generator) if needed → Drafter → Self-Review (Outline C
    │   │   └─ RE-RUN Drafter (same mode) with corrections
    │   └─ OUTPUT corrected artifacts (replace originals)
    │
-   └─ IF no errors (only warnings/suggestions):
+   └─ IF no errors or warnings (suggestions only):
        └─ Append review summary to each artifact as a
           <!-- drafter:review-notes --> comment block
 
@@ -190,7 +190,7 @@ Router → Outliner (Generator) if needed → Drafter → Self-Review (Outline C
 2. **Do NOT pause between Router and Drafter** unless `ask_user` is set or a critical error occurs.
 3. **Output each step's result as a separate artifact** with descriptive titles (e.g., "Routing Report — MCP Server feature", "Outline — cms/features/mcp-server.md", "Draft — cms/features/mcp-server.md").
 4. **Only the Outline Generator needs the full Router report.** The Drafter receives the outline (for Compose) or the target info + source material (for Patch/Micro-edit).
-5. **Self-review runs automatically after the Drafter.** The Outline Checker, UX Analyzer (for `create_page` targets), and Style Checker run on every Drafter output. If errors are found, the Drafter re-runs once with the review reports as context. Warnings and suggestions are appended as review notes but do not trigger a retry. Maximum 1 retry per target — never more.
+5. **Self-review runs automatically after the Drafter.** The Outline Checker, UX Analyzer (for `create_page` targets), and Style Checker run on every Drafter output. If errors or warnings are found, the Drafter re-runs once with the review reports as context. Suggestions are appended as review notes but do not trigger a retry. Maximum 1 retry per target — never more.
 6. **Handle multiple targets sequentially.** Process primary targets first (with OG → Drafter), then required (Drafter Patch), then optional (Drafter Micro-edit). Each produces its own artifact.
 7. **Respect `conditional` targets.** Do not process them until the condition is resolved. If the Router sets `ask_user`, present the question and wait.
 8. **Self-review severity threshold.** Only `[error]`-level findings trigger a Drafter retry. `[warning]` and `[suggestion]` findings are reported but do not cause re-runs. This prevents infinite loops while catching clear rule violations (e.g., "easy/simple" slipping through, missing backticks on file paths, procedures not in numbered lists).

--- a/agents/prompts/shared/drafter-interface.md
+++ b/agents/prompts/shared/drafter-interface.md
@@ -349,6 +349,6 @@ These questions were resolved during design (2025-02-11) and are documented here
 
 **Decision:** The Orchestrator runs a self-review loop after the Drafter completes. The Outline Checker, UX Analyzer (for `create_page` targets), and Style Checker run automatically on every Drafter output. If any report contains `[error]`-level findings, the Drafter re-runs once with the review reports injected as context. Maximum 1 retry per target, never more.
 
-**Severity threshold:** Only errors trigger a retry. Warnings and suggestions are appended as `<!-- drafter:review-notes -->` comments but do not cause re-runs. This prevents infinite loops while catching clear violations (e.g., "easy" slipping through, missing backticks on file paths, procedures not in numbered lists).
+**Severity threshold:** Errors and warnings trigger a retry. Only suggestions are appended as `<!-- drafter:review-notes -->` comments without causing re-runs.
 
 **Rationale:** Automated re-runs are valuable but risky if unbounded. A single retry with a severity threshold (errors only) balances automation with predictability. The expanded self-review (Outline Checker + UX Analyzer + Style Checker, not just Style Checker) ensures structural and experiential issues are also caught before delivery.


### PR DESCRIPTION
This PR improves the Orchestrator AI workflow (and similar files) to include one run of self, full review (Outline Checker, Outline UX Analyzer, and Style Checker) after content creation.

Therefore, when using the Orchestrator to create content, the end of the pipeline should now look like follows: Drafter → Full review → Drafter.