### PR TITLE
Add tips for List View and Edit View usage of `documentId` in Content Manager

### DIFF
--- a/docusaurus/docs/cms/features/content-manager.md
+++ b/docusaurus/docs/cms/features/content-manager.md
@@ -300,7 +300,7 @@ New entries are only considered created once some of their content has been writ
 :::
 
 :::tip
-While in the Edit view, click the <Icon name="dots-three-outline"/> in the top right corner of the page to view the published, updated, and created dates for the entry. Use the <Icon name="copy"/> **Copy document ID** button to copy the value to your clipboard. This is only available for collection type entries.
+While in the Edit view, click the <Icon name="dots-three-outline"/> in the top right corner of the page to view the published, updated, and created dates for the entry. Use the <Icon name="copy"/>&nbsp;**Copy document ID** button to copy the value to your clipboard. This is only available for collection type entries.
 :::
 
 <!-- MAY BE REMOVED - NOT SURE ABOUT RELEVANCE


### PR DESCRIPTION
This PR documents [`strapi/strapi` PR #25759](https://github.com/strapi/strapi/pull/25759), mentioning you can now view `documentId` directly from the List view, and show/copy its value from the Edit view.