### PR TITLE
fix: export includes 3rd party providers assets

### DIFF
--- a/docusaurus/docs/cms/data-management/export.md
+++ b/docusaurus/docs/cms/data-management/export.md
@@ -34,7 +34,6 @@ The following documentation details the available options to customize your data
 
 :::caution
 * Admin users and API tokens are not exported.
-* Media from a 3rd party provider (e.g., Cloudinary or AWS S3) are not included in the export as those files do not exist in the upload folders.
 :::
 
 ## Understand the exported archive


### PR DESCRIPTION
Removed note about media from 3rd party providers not being included in the export.

<!--
Hello 👋 Thank you for submitting a pull request!

To help us merge your PR, make sure to follow the instructions detailed in the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md

Note that all documentation updates should be made against the `main` branch.
Keep your PR in Draft mode until it's ready to be reviewed and merged.


As part of the Docs Contribution Program, all external contribution PRs are labeled `contribution`.
Feel free to read more details on the Contribution Program in the dedicated guide:
https://strapi.notion.site/Documentation-Contribution-Program-1d08f359807480d480fdde68bb7a5a71

Let us know if you do not wish to take part in the Docs Contribution Program, and remove the `contribution` label.
-->

### Description

Remove "Media from a 3rd party provider (e.g., Cloudinary or AWS S3) are not included in the export as those files do not exist in the upload folders." message since the export feature actually downloads assets.

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/issues/25787
