### PR TITLE
Fix WORKDIR and COPY commands in Dockerfile

### DIFF
--- a/docusaurus/docs/cms/installation/docker.md
+++ b/docusaurus/docs/cms/installation/docker.md
@@ -363,9 +363,8 @@ FROM node:22-alpine
 RUN apk add --no-cache vips-dev
 ENV NODE_ENV=production
 ENV NODE_ENV=${NODE_ENV}
-WORKDIR /opt/
-COPY --from=build /opt/node_modules ./node_modules
 WORKDIR /opt/app
+COPY --from=build /opt/node_modules ./node_modules
 COPY --from=build /opt/app ./
 ENV PATH=/opt/node_modules/.bin:$PATH
 
@@ -400,9 +399,8 @@ FROM node:22-alpine
 RUN apk add --no-cache vips-dev
 ARG NODE_ENV=production
 ENV NODE_ENV=${NODE_ENV}
-WORKDIR /opt/
-COPY --from=build /opt/node_modules ./node_modules
 WORKDIR /opt/app
+COPY --from=build /opt/node_modules ./node_modules
 COPY --from=build /opt/app ./
 ENV PATH=/opt/node_modules/.bin:$PATH
 


### PR DESCRIPTION
Update:

Fixed the WORKDIR and COPY commands in the Dockerfile.

Previously, due to a path mismatch, the application was unable to locate the required node_modules, resulting in runtime failures.

This issue has now been resolved. The earlier error observed during runtime was related to missing dependencies caused by the incorrect path configuration.

node:internal/modules/cjs/loader:1143
  throw err;
  ^

Error: Cannot find module '/opt/app/node_modules/@strapi/strapi/bin/strapi.js'
    at Module._resolveFilename (node:internal/modules/cjs/loader:1140:15)
    at Module._load (node:internal/modules/cjs/loader:981:27)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:128:12)
    at node:internal/main/run_main_module:28:49 {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
}

<!--
Hello 👋 Thank you for submitting a pull request!

To help us merge your PR, make sure to follow the instructions detailed in the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md

Note that all documentation updates should be made against the `main` branch.
Keep your PR in Draft mode until it's ready to be reviewed and merged.


As part of the Docs Contribution Program, all external contribution PRs are labeled `contribution`.
Feel free to read more details on the Contribution Program in the dedicated guide:
https://strapi.notion.site/Documentation-Contribution-Program-1d08f359807480d480fdde68bb7a5a71

Let us know if you do not wish to take part in the Docs Contribution Program, and remove the `contribution` label.
-->

### Description

Describe the changes you did: What does it do? Why is it needed?

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request or contribution idea suggested by the Docs team.
