### PR TITLE
Add supported browsers for Strapi Admin in Quick Start Guide prerequisites

### DIFF
--- a/docusaurus/docs/snippets/installation-prerequisites.md
+++ b/docusaurus/docs/snippets/installation-prerequisites.md
@@ -6,3 +6,4 @@ Before installing Strapi, the following requirements must be installed on your c
     - <ExternalLink to="https://yarnpkg.com/getting-started/install" text="yarn"/>
     - <ExternalLink to="https://pnpm.io/" text="pnpm" />
 - <ExternalLink to="https://www.python.org/downloads/" text="Python"/> (if using a SQLite database)
+- **Web browser (Admin panel):** The Admin UI targets browsers matching the default <ExternalLink to="https://github.com/browserslist/browserslist" text="Browserslist"/> query: `last 3 major versions`, `Firefox ESR`, `last 2 Opera versions`, and `not dead`. See <ExternalLink to="https://browsersl.ist/#q=last+3+major+versions%2C+Firefox+ESR%2C+last+2+Opera+versions%2C+not+dead" text="browsersl.ist"/> for the current coverage matrix. Projects can override these defaults with a Browserslist configuration at the project root.

--- a/docusaurus/docs/snippets/installation-prerequisites.md
+++ b/docusaurus/docs/snippets/installation-prerequisites.md
@@ -1,9 +1,9 @@
 Before installing Strapi, the following requirements must be installed on your computer:
 
 - <ExternalLink to="https://nodejs.org" text="Node.js"/>: Only <ExternalLink to="https://nodejs.org/en/about/previous-releases" text="Active LTS or Maintenance LTS versions"/> are supported (currently `v20`, `v22`, and `v24`). Odd-number releases of Node, known as "current" versions of Node.js, are not supported (e.g. v23, v25).
-- Your preferred Node.js package manager:
+- Your preferred Node.js package manager is installed:
     - <ExternalLink to="https://docs.npmjs.com/cli/v6/commands/npm-install" text="npm"/> (`v6` and above)
     - <ExternalLink to="https://yarnpkg.com/getting-started/install" text="yarn"/>
     - <ExternalLink to="https://pnpm.io/" text="pnpm" />
-- <ExternalLink to="https://www.python.org/downloads/" text="Python"/> (if using a SQLite database)
-- **Web browser (Admin panel):** The Admin UI targets browsers matching the default <ExternalLink to="https://github.com/browserslist/browserslist" text="Browserslist"/> query: `last 3 major versions`, `Firefox ESR`, `last 2 Opera versions`, and `not dead`. See <ExternalLink to="https://browsersl.ist/#q=last+3+major+versions%2C+Firefox+ESR%2C+last+2+Opera+versions%2C+not+dead" text="browsersl.ist"/> for the current coverage matrix. Projects can override these defaults with a Browserslist configuration at the project root.
+- <ExternalLink to="https://www.python.org/downloads/" text="Python"/> is installed (if using a SQLite database)
+- You use a supported web browser: The Admin panel targets browsers matching the default <ExternalLink to="https://github.com/browserslist/browserslist" text="Browserslist"/> query: `last 3 major versions`, `Firefox ESR`, `last 2 Opera versions`, and `not dead`. See <ExternalLink to="https://browsersl.ist/#q=last+3+major+versions%2C+Firefox+ESR%2C+last+2+Opera+versions%2C+not+dead" text="browsersl.ist"/> for the current coverage matrix. Projects can override these defaults with a Browserslist configuration at the project root.

--- a/docusaurus/docs/snippets/installation-prerequisites.md
+++ b/docusaurus/docs/snippets/installation-prerequisites.md
@@ -1,9 +1,9 @@
 Before installing Strapi, the following requirements must be installed on your computer:
 
 - <ExternalLink to="https://nodejs.org" text="Node.js"/>: Only <ExternalLink to="https://nodejs.org/en/about/previous-releases" text="Active LTS or Maintenance LTS versions"/> are supported (currently `v20`, `v22`, and `v24`). Odd-number releases of Node, known as "current" versions of Node.js, are not supported (e.g. v23, v25).
-- Your preferred Node.js package manager is installed:
+- Your preferred Node.js package manager:
     - <ExternalLink to="https://docs.npmjs.com/cli/v6/commands/npm-install" text="npm"/> (`v6` and above)
     - <ExternalLink to="https://yarnpkg.com/getting-started/install" text="yarn"/>
     - <ExternalLink to="https://pnpm.io/" text="pnpm" />
-- <ExternalLink to="https://www.python.org/downloads/" text="Python"/> is installed (if using a SQLite database)
-- You use a supported web browser: The Admin panel targets browsers matching the default <ExternalLink to="https://github.com/browserslist/browserslist" text="Browserslist"/> query: `last 3 major versions`, `Firefox ESR`, `last 2 Opera versions`, and `not dead`. See <ExternalLink to="https://browsersl.ist/#q=last+3+major+versions%2C+Firefox+ESR%2C+last+2+Opera+versions%2C+not+dead" text="browsersl.ist"/> for the current coverage matrix. Projects can override these defaults with a Browserslist configuration at the project root.
+- <ExternalLink to="https://www.python.org/downloads/" text="Python"/> (if using a SQLite database)
+- A supported web browser: The Admin panel targets browsers matching the default <ExternalLink to="https://github.com/browserslist/browserslist" text="Browserslist"/> query: `last 3 major versions`, `Firefox ESR`, `last 2 Opera versions`, and `not dead`. See <ExternalLink to="https://browsersl.ist/#q=last+3+major+versions%2C+Firefox+ESR%2C+last+2+Opera+versions%2C+not+dead" text="browsersl.ist"/> for the current coverage matrix. Projects can override these defaults with a Browserslist configuration at the project root.


### PR DESCRIPTION
﻿## Summary

Documents the default Browserslist targets used when building the Strapi Admin panel, in the Quick Start **Prerequisites** section (via the shared installation prerequisites snippet).

Closes #2905

## Background

Strapi resolves the Admin build target with `browserslist.loadConfig({ path: cwd })` and falls back to the default queries defined in `packages/core/strapi/src/node/create-build-context.ts`:

- `last 3 major versions`
- `Firefox ESR`
- `last 2 Opera versions`
- `not dead`

## Changes

- Added a **Web browser (Admin panel)** bullet to `docusaurus/docs/snippets/installation-prerequisites.md` noting the default Browserslist query and linking to browsersl.ist for the current coverage matrix.
- Mentioned that projects can override the defaults with a Browserslist configuration at the project root.

## How to verify

1. `cd docusaurus && yarn && yarn dev` -- open the Quick Start page and confirm the Prerequisites block includes the browser note.
2. `yarn build` -- ensure the site builds with no broken links.
