### PR TITLE
Expand config abbreviations in agent prompts and authoring guides

### DIFF
--- a/agents/authoring/AGENTS.cms.configurations.md
+++ b/agents/authoring/AGENTS.cms.configurations.md
@@ -16,7 +16,7 @@ Frontmatter (mandatory)
 
 Common Core (always present)
 1) H1 title — matches `title` frontmatter unless instructed differently.
-2) `<Tldr>` component — brief description of what the config file(s) control and where they live.
+2) `<Tldr>` component — brief description of what the configuration file(s) control and where they live.
 3) Intro paragraph — names the main file(s)/paths (e.g., `/config/admin`, `/config/api.js|ts`) and summarizes what the configuration controls.
 4) Optional `:::caution` callout if changes require rebuilding the admin panel or restarting the server.
 
@@ -45,7 +45,7 @@ Use these recurring patterns within H2 sections as applicable:
 - **Advanced examples**: Use `<details>` blocks for edge-case or advanced scenarios (e.g., timezones, SSL, one-off cron jobs).
 
 Heading Conventions
-- Use H2 for thematic blocks; H3 for sub-topics, nested config objects, or specific tasks within a block.
+- Use H2 for thematic blocks; H3 for sub-topics, nested configuration objects, or specific tasks within a block.
 - Prefer explicit, descriptive headings (e.g., "`connection` configuration object", "Admin panel server") over generic ones (e.g., "Options", "Settings").
 - Use sentence case for all headings.
 
@@ -56,7 +56,7 @@ Templates
 Quality Checklist (before commit)
 - TL;DR present and precise about file paths and scope.
 - Intro paragraph states where the configuration lives (paths) and what it controls.
-- H2 sections are thematic and appropriate for the page's complexity (not too many for small configs, not too few for large ones).
+- H2 sections are thematic and appropriate for the page's complexity (not too many for small configurations, not too few for large ones).
 - Parameter tables use the standard column pattern and document all options.
 - Code examples include file path titles and are runnable.
 - JS/TS variants use `<Tabs groupId="js-ts">` consistently.

--- a/agents/prompts/claude-project-instructions.md
+++ b/agents/prompts/claude-project-instructions.md
@@ -822,7 +822,7 @@ tags: [...]
 
 **Micro-edit output:** A single insertion instruction: which file, where, what to insert.
 
-**Key writing rules:** Direct neutral tone. Short sentences (< 25 words). "Use" not "utilize". No "easy/simple/difficult". Numbers as numerals. Sentence case headings. One action per numbered step. JS + TS variants for config files.
+**Key writing rules:** Direct neutral tone. Short sentences (< 25 words). "Use" not "utilize". No "easy/simple/difficult". Numbers as numerals. Sentence case headings. One action per numbered step. JS + TS variants for configuration files.
 
 ---
 

--- a/agents/prompts/drafter.md
+++ b/agents/prompts/drafter.md
@@ -327,13 +327,13 @@ These rules govern how the Drafter writes prose. They apply to **both Compose an
 ### Formatting conventions
 
 - **Sentence case** for all headings. Only capitalize the first word and proper nouns.
-- **Inline code** for: file paths, function names, parameters, commands, config keys, values, HTTP methods and endpoints. Example: `mcp.enabled`, `/config/server.js`, `POST /mcp`.
+- **Inline code** for: file paths, function names, parameters, commands, configuration keys, values, HTTP methods and endpoints. Example: `mcp.enabled`, `/config/server.js`, `POST /mcp`.
 - **Bold** for: UI element names the user interacts with. Example: Click **Save**, navigate to **Settings**.
 - **No bold for emphasis.** Use sentence structure to emphasize, not formatting.
 - **Code blocks** with language identifiers: ` ```js `, ` ```ts `, ` ```bash `, ` ```json `.
 - **Code highlights** for multi-option examples. When a code example shows a base configuration plus feature-specific options, use `// highlight-start` / `// highlight-end` to mark the lines that are specific to the feature being documented. Do not highlight surrounding boilerplate (host, port, auth, settings blocks, etc.). Apply highlights when:
-  - The example mixes baseline config with new or feature-specific keys (e.g., adding `dkim`, `pool`, or `auth.type: 'OAuth2'` to a standard SMTP block).
-  - The same base config pattern repeats across multiple scenarios in the same section — highlights help readers spot the diff at a glance.
+  - The example mixes baseline configuration with new or feature-specific keys (e.g., adding `dkim`, `pool`, or `auth.type: 'OAuth2'` to a standard SMTP block).
+  - The same base configuration pattern repeats across multiple scenarios in the same section — highlights help readers spot the diff at a glance.
 
   Do not highlight when the entire example is the point (short single-option blocks, standalone snippets with no surrounding boilerplate). In Patch mode: if the existing page already uses `// highlight-*` markers in similar code examples, apply the same pattern to any new examples you add. Treat highlights as part of the page's voice — preserve them exactly in untouched blocks, replicate the pattern in new ones.
 
@@ -622,7 +622,7 @@ For Patch mode, metadata is embedded in the output header (File, Section, Edits 
 19. **Annotate sources for the Integrity Checker.** For every code example and significant technical claim you produce, annotate the source to enable downstream verification. This applies to Compose and Patch modes.
 
     **For code examples:**
-    1. Search the codebase for the primary identifiers (method names, config options, parameter names).
+    1. Search the codebase for the primary identifiers (method names, configuration options, parameter names).
     2. If found, add a `<!-- source: path/to/file.ts#L42-L58 -->` comment before the code block.
     3. If not found, add a `<!-- unverified: description of what couldn't be confirmed -->` comment.
     4. If you synthesize an example from multiple real usages, cite all sources: `<!-- source: path/one.ts#L12-L30, path/two.ts#L8-L22 -->`.
@@ -665,7 +665,7 @@ Before delivering the output, verify:
 - [ ] Every `content_hint` has been addressed
 - [ ] All specified `components` are used
 - [ ] Code examples have language identifiers
-- [ ] JS/TS config examples use `<Tabs groupId="js-ts">`
+- [ ] JS/TS configuration examples use `<Tabs groupId="js-ts">`
 - [ ] Multi-option code examples use `// highlight-start` / `// highlight-end` to mark feature-specific lines (see Writing Rules > Formatting conventions)
 - [ ] Numbered lists for all procedures
 - [ ] One action per step in procedures

--- a/agents/prompts/integrity-code-verifier.md
+++ b/agents/prompts/integrity-code-verifier.md
@@ -43,7 +43,7 @@ Verify that code examples in the documentation reflect real APIs, methods, and p
 | Import paths | Verify the module/package exists at the stated path | **error** |
 | Return value shapes | Compare with actual return types in source | **warning** |
 | API call patterns (e.g., `strapi.service(...)`) | Find real usage examples in the codebase | **warning** |
-| Configuration option names and types | Find the config schema or validation logic | **error** |
+| Configuration option names and types | Find the configuration schema or validation logic | **error** |
 | Lifecycle hook usage context | Verify which services/APIs are available at that lifecycle stage | **error** |
 | JS/TS parity | If both JS and TS tabs exist, verify they are equivalent | **warning** |
 
@@ -53,7 +53,7 @@ For each code example in the content:
 
 1. **Extract identifiers**: List all method names, parameter names, imported modules, and API patterns.
 2. **Search the codebase**: For each identifier, search (grep or GitHub search) to confirm it exists.
-3. **Fetch and compare**: For critical identifiers (method signatures, config schemas), fetch the actual source file and compare.
+3. **Fetch and compare**: For critical identifiers (method signatures, configuration schemas), fetch the actual source file and compare.
 4. **Check usage context**: Verify the example uses the API in a valid context (e.g., correct lifecycle hook, correct service scope).
 5. **Cross-check internal consistency**: If the example has both JS and TS variants, verify they are semantically equivalent.
 
@@ -86,7 +86,7 @@ Verify that prose statements about Strapi's behavior match the actual implementa
 | Lifecycle ordering ("X runs before Y") | Trace the boot sequence in the codebase | **error** |
 | Behavioral claims ("X automatically does Y") | Find the implementation and confirm the behavior | **error** |
 | Availability claims ("X is available in Y context") | Check if the API/service is registered at that point | **error** |
-| Default values ("X defaults to Y") | Find the config schema or factory function | **warning** |
+| Default values ("X defaults to Y") | Find the configuration schema or factory function | **warning** |
 | Conditional claims ("If X, then Y") | Find the branching logic in source | **warning** |
 | Scope claims ("X applies to all Y") | Verify the scope isn't narrower than stated | **warning** |
 | Version-specific claims ("Since v5, X does Y") | Check the changelog or git history | **suggestion** |
@@ -267,7 +267,7 @@ Produce the output in the format specified below. Group findings by severity (fa
 | Import path doesn't exist | error | falsified |
 | API pattern doesn't match real usage | warning | falsified |
 | Return shape doesn't match | warning | falsified |
-| Config option not found in schema | error | unverified |
+| Configuration option not found in schema | error | unverified |
 | JS/TS examples not equivalent | warning | falsified |
 | v3/v4 pattern in v5 docs | error | falsified |
 | Lifecycle ordering incorrect | error | falsified |

--- a/agents/prompts/outline-generator.md
+++ b/agents/prompts/outline-generator.md
@@ -99,7 +99,7 @@ If both `template` and `guide` are null (rare), fall back to the type-specific h
 Extract the key information that will need to be documented. What you look for depends on the document type:
 
 **For all types:**
-- What is being documented? (feature, plugin, config area, API, procedure, breaking change)
+- What is being documented? (feature, plugin, configuration area, API, procedure, breaking change)
 - What is the audience? (end users, developers, admins)
 - What related pages exist that should be cross-linked?
 
@@ -151,7 +151,7 @@ Generate the structured YAML outline following the output format defined below.
 **Skeleton:** H1 → `<Tldr>` → Intro → `<IdentityCard>` → `## Configuration` → `## Usage`
 
 **Outline Generator decisions (not in template):**
-- **Configuration H3s:** If both admin UI and code config exist → 2 H3s. If only one → single H3. If a subsection has multiple distinct areas → add H4s.
+- **Configuration H3s:** If both admin UI and code configuration exist → 2 H3s. If only one → single H3. If a subsection has multiple distinct areas → add H4s.
 - **Usage H3s:** One H3 per distinct user task. Group related tasks; aim for 3–7 H3s. If API usage exists → add H3s or `<CustomDocCardsWrapper>` linking to API pages.
 
 ---

--- a/agents/prompts/router.md
+++ b/agents/prompts/router.md
@@ -319,10 +319,10 @@ Set `ask_user` (as a top-level YAML field or as the placement decision) when:
 
 1. **Path-based** (highest confidence): If the target path clearly maps to a type, use it.
 2. **Sidebar-based**: The position in `sidebars.js` can disambiguate (e.g., a page under the "Configurations" category is a configuration page).
-3. **Content-based**: Analyze the source material's nature — is it describing a feature, a procedure, an API, a config file?
+3. **Content-based**: Analyze the source material's nature — is it describing a feature, a procedure, an API, a configuration file?
 4. **Heuristic**: When nothing else matches, use content signals:
    - Step-by-step instructions → Guide
-   - Config file structures, env variables → Configuration
+   - Configuration file structures, env variables → Configuration
    - Endpoints, methods, parameters → API
    - UI feature description → Feature
    - "How to…" in title → Guide
@@ -334,7 +334,7 @@ Set `ask_user` (as a top-level YAML field or as the placement decision) when:
 ### Step 1 — Understand the source (briefly)
 
 Read the source material just enough to answer these placement questions:
-- **What is it?** (feature, fix, config change, new API, etc.)
+- **What is it?** (feature, fix, configuration change, new API, etc.)
 - **Key topics** (specific terms, feature names — these are your search keywords for Step 2)
 - **How big is it?** (minor tweak → update; significant addition → new section; entirely new capability → new page)
 
@@ -406,7 +406,7 @@ For **each target** in the routing:
 
 **Important:** Each target may have a different document type. For example, a routing with both `cms/features/mcp-server.md` and `cms/configurations/server.md` requires:
 - Feature template + Features authoring guide for the feature page
-- Configuration template + Configurations authoring guide for the config page
+- Configuration template + Configurations authoring guide for the configuration page
 
 The "Existing pages found" table must show the correct template and authoring guide **per row**, not just for the primary target.
 
@@ -577,8 +577,8 @@ ask_user: "The diff modifies convert-query-params.ts, suggesting hasPublishedVer
 **Source:** Jira ticket: "Add rate limiting documentation"
 
 **Expected routing:**
-- Search `llms.txt` → no dedicated rate limiting page; `cms/configurations/` has related config pages
-- Could be: a configuration page, a section in an existing server config page, or a guide
+- Search `llms.txt` → no dedicated rate limiting page; `cms/configurations/` has related configuration pages
+- Could be: a configuration page, a section in an existing server configuration page, or a guide
 - Targets: uncertain
 
 ```yaml
@@ -640,5 +640,5 @@ targets:
 
 1. Fetch PR metadata → Title: "Add MCP Server documentation"
 2. Fetch changed files → `docs/cms/features/mcp-server.md` (added), `docs/cms/configurations/server.md` (modified)
-3. Analyze: new file in `cms/features/` → Feature page; modified config → required update
+3. Analyze: new file in `cms/features/` → Feature page; modified configuration → required update
 4. Proceed with standard routing analysis


### PR DESCRIPTION
## Summary

Replaces bare "config" and "configs" with "configuration" and "configurations" in prose text across agent prompts and authoring guides, per the style guide and 12 Rules of Technical Writing (no abbreviations in prose).

## Changes

6 files, 22 replacements:

- **agents/prompts/router.md** (6): config file → configuration file, config change → configuration change, config page → configuration page, config pages → configuration pages
- **agents/prompts/drafter.md** (4): config keys → configuration keys, baseline config → baseline configuration, config options → configuration options, config examples → configuration examples
- **agents/prompts/integrity-code-verifier.md** (4): config schema → configuration schema (×3), Config option → Configuration option
- **agents/prompts/outline-generator.md** (2): config area → configuration area, code config → code configuration
- **agents/prompts/claude-project-instructions.md** (1): config files → configuration files
- **agents/authoring/AGENTS.cms.configurations.md** (3): config file(s) → configuration file(s), config objects → configuration objects, small configs → small configurations

## Not changed

- `config` inside inline code backticks or code blocks (allowed per style guide)
- HTML comments used as code annotation examples (e.g., `<!-- unverified: could not locate the config schema -->`)