### PR TITLE
Mark llms files as generated to hide from PR diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Generated at build time — keep in repo for discoverability but hide from PR diffs
+docusaurus/static/llms.txt linguist-generated=true
+docusaurus/static/llms-full.txt linguist-generated=true
+docusaurus/static/llms-code.txt linguist-generated=true


### PR DESCRIPTION
## Summary

Adds a `.gitattributes` file that marks `llms.txt`, `llms-full.txt`, and `llms-code.txt` as `linguist-generated=true`. This tells GitHub to collapse these files in PR diffs by default.

## Problem

Every PR that triggers a local build regenerates the llms files with slightly different output. This pollutes PR diffs with thousands of unrelated line changes, making reviews harder.

## What this does

- Adds `.gitattributes` with `linguist-generated=true` for the 3 llms files
- GitHub will collapse these files in PR diffs (they can still be expanded manually)
- The files **stay in the repo** — users and agents can still read them on GitHub
- The CI job on main continues to update them when docs content changes
- No changes to the build pipeline or Vercel deploy

## What this does NOT do

- Does NOT remove the files from git
- Does NOT change the CI workflow
- Does NOT affect the Vercel build

## Local dev note

After running `yarn build` locally, these files get modified. Use `git checkout -- docusaurus/static/llms*.txt` before switching branches to avoid checkout conflicts.