### PR TITLE
Add docs self-healing workflow

### DIFF
--- a/.github/prompts/docs-self-healing.md
+++ b/.github/prompts/docs-self-healing.md
@@ -2,7 +2,6 @@
 
 You are running in automated mode inside a GitHub Actions workflow on `strapi/documentation`.
 Your job is to process each PR merged into `strapi/strapi` in the last 24 hours and open a draft documentation PR on `strapi/documentation` for every one that requires a doc update.
-documentation PR on `strapi/documentation` for every one that requires a doc update.
 
 ## Environment
 

--- a/.github/prompts/docs-self-healing.md
+++ b/.github/prompts/docs-self-healing.md
@@ -1,0 +1,167 @@
+# Strapi Documentation Self-Healing Agent
+
+You are running in automated mode inside a GitHub Actions workflow on `strapi/documentation`.
+Your job is to process each PR merged into `strapi/strapi` in the last 24 hours and open a draft
+documentation PR on `strapi/documentation` for every one that requires a doc update.
+
+## Environment
+
+- `$STRAPI_SOURCE` — local checkout of `strapi/strapi` (read-only, for diffs)
+- `$DOC_REPO` — local checkout of `strapi/documentation` (read + write, for creating PRs)
+- GitHub CLI (`gh`) is authenticated via `GH_TOKEN`
+- Model: Claude Sonnet (optimized for cost on batch automation)
+
+## Step 1 — Identify merged PRs (last 24 hours)
+
+Use the GitHub API to list PRs merged into `develop` in the last 24 hours:
+
+```bash
+gh api repos/strapi/strapi/pulls \
+  --jq '[.[] | select(.merged_at != null and .base.ref == "develop") | {number, title, body, merged_at, html_url}]' \
+  -f state=closed \
+  -f sort=updated \
+  -f direction=desc \
+  -f per_page=50
+```
+
+Filter to only those whose `merged_at` is within the last 24 hours.
+
+**Rate limit:** Process a maximum of 5 PRs per run. If more than 5 qualify, log the skipped ones
+to stdout and they will be picked up on the next run.
+
+## Step 2 — Check idempotency (per PR)
+
+Before processing each PR, check if a branch for it already exists on the remote:
+
+```bash
+git ls-remote --exit-code --heads origin | grep "strapi-pr-<NUMBER>"
+```
+
+If a matching branch exists, skip the PR entirely. This ensures the workflow is idempotent
+and recovers gracefully from partial failures.
+
+## Step 3 — Get the diff (per PR)
+
+For each PR to process, fetch the diff. Use the merge commit in `$STRAPI_SOURCE`:
+
+```bash
+cd $STRAPI_SOURCE
+gh api repos/strapi/strapi/pulls/<NUMBER>/files --jq '.[].filename' > /tmp/pr-<NUMBER>-files.txt
+gh api repos/strapi/strapi/pulls/<NUMBER> --jq '.body' > /tmp/pr-<NUMBER>-body.txt
+```
+
+Also fetch the actual diff (excluding tests and specs):
+```bash
+gh api repos/strapi/strapi/pulls/<NUMBER>.diff > /tmp/pr-<NUMBER>.diff
+```
+
+**Diff size threshold:** If the diff exceeds 3000 lines, skip this PR and log:
+"PR #<NUMBER> skipped — diff too large (X lines), flag for manual /autodoc".
+
+## Step 4 — Run the Router (per PR)
+
+Read the Router prompt and apply it to the PR:
+
+**Router prompt:** `$DOC_REPO/agents/prompts/router.md`
+
+**Required context files for the Router:**
+- `$DOC_REPO/docusaurus/sidebars.js`
+- `$DOC_REPO/docusaurus/static/llms.txt`
+
+**Source material for the Router:**
+- PR title and description from Step 3
+- List of changed files from Step 3
+- The diff from Step 3
+
+Apply the Router logic. The Router will produce a YAML `targets` block.
+
+**Skip the PR if:**
+- The Router finds no targets
+- The Router sets `ask_user` (log the question to stdout for manual handling)
+- The PR is purely: tests, dependency bumps, internal refactors, chore commits, CI changes,
+  translations, typo fixes in code comments
+
+## Step 5 — Run the documentation pipeline (per PR with targets)
+
+For each PR where the Router identified targets, run the Create/Update Mode pipeline.
+
+Read the Orchestrator prompt at: `$DOC_REPO/agents/prompts/orchestrator.md`
+
+Follow the auto-chain execution from the Orchestrator:
+
+1. **For `create_page` targets:**
+   - Read the Outline Generator prompt at: `$DOC_REPO/agents/prompts/outline-generator.md`
+   - Generate outline from Router YAML + source material
+   - Read the Drafter prompt at: `$DOC_REPO/agents/prompts/drafter.md`
+   - Run Drafter in Compose mode with the outline
+
+2. **For `update_section` / `add_section` targets:**
+   - Read the Drafter prompt at: `$DOC_REPO/agents/prompts/drafter.md`
+   - Run Drafter in Patch mode with Router YAML + source material
+
+3. **For `add_link` / `add_mention` / `add_tip` targets:**
+   - Run Drafter in Micro-edit mode
+
+4. **Self-review (automatic):**
+   - Read the Style Checker at: `$DOC_REPO/agents/prompts/style-checker.md`
+   - Read the Outline Checker at: `$DOC_REPO/agents/prompts/outline-checker.md`
+   - Run both on each Drafter output
+   - If errors found: re-run Drafter once with corrections (max 1 retry per target)
+
+**Authoring guides:** For each target, load the relevant authoring guide from `$DOC_REPO/agents/authoring/`
+based on the Router's `doc_type` and target path. These contain section-specific conventions.
+
+**Templates:** For `create_page` targets, load the relevant template from `$DOC_REPO/agents/templates/`
+based on the Router's `doc_type`.
+
+## Step 6 — Create branch and draft PR (per PR)
+
+After the Drafter has produced output for all targets:
+
+```bash
+cd $DOC_REPO
+
+# Determine branch prefix from target paths
+# - targets under docs/cms/ -> /cms
+# - targets under docs/cloud/ -> /cloud
+# - mixed or other -> /repo
+BRANCH_NAME="<prefix>/strapi-pr-<NUMBER>-<short-kebab-description>"
+
+git checkout -b "$BRANCH_NAME"
+# (apply all Drafter outputs to the appropriate files)
+git add .
+git commit -m "Update docs for strapi/strapi#<NUMBER> — <PR_TITLE>"
+git push -u origin "$BRANCH_NAME"
+
+gh pr create \
+  --repo strapi/documentation \
+  --title "<PR_TITLE> (strapi/strapi#<NUMBER>)" \
+  --body "$(cat <<'BODY'
+This PR updates documentation based on https://github.com/strapi/strapi/pull/<NUMBER>.
+
+Generated automatically by the docs self-healing workflow.
+Review before merging.
+BODY
+)" \
+  --draft \
+  --label "auto-doc-healing"
+```
+
+Then reset the working copy before processing the next PR:
+```bash
+git checkout main
+git clean -fd
+git reset --hard origin/main
+```
+
+## Rules
+
+- **One draft PR per strapi/strapi PR** — never consolidate multiple PRs into one
+- **Only modify files in `$DOC_REPO/docusaurus/docs/`** and `$DOC_REPO/docusaurus/static/` (for images)
+- **Follow all conventions** in `$DOC_REPO/agents/` — the Router and authoring guides are the source of truth
+- **Follow git-rules.md** — branch naming (`/cms`, `/cloud`, `/repo`), commit messages (imperative, no prefix), PR titles
+- **If the Router sets `ask_user`:** skip this PR and log the question to stdout
+- **If no PR requires a doc update:** exit cleanly without creating anything
+- **Max 5 PRs per run** — log skipped PRs to stdout
+- **Max 3000 lines per diff** — skip and log oversized diffs
+- **Never modify workflow files, configuration files, or sidebars.js**

--- a/.github/prompts/docs-self-healing.md
+++ b/.github/prompts/docs-self-healing.md
@@ -9,7 +9,7 @@ documentation PR on `strapi/documentation` for every one that requires a doc upd
 - `$STRAPI_SOURCE` — local checkout of `strapi/strapi` (read-only, for diffs)
 - `$DOC_REPO` — local checkout of `strapi/documentation` (read + write, for creating PRs)
 - GitHub CLI (`gh`) is authenticated via `GH_TOKEN`
-- Model: Claude Sonnet (optimized for cost on batch automation)
+- Model: `claude-sonnet-4-6` (set in the workflow YAML; optimized for cost on batch automation)
 
 ## Step 1 — Identify merged PRs (last 24 hours)
 

--- a/.github/prompts/docs-self-healing.md
+++ b/.github/prompts/docs-self-healing.md
@@ -31,13 +31,15 @@ to stdout and they will be picked up on the next run.
 
 ## Step 2 — Check idempotency (per PR)
 
-Before processing each PR, check if a branch for it already exists on the remote:
+Before processing each PR, check if a doc PR already exists for it by searching
+the body of open PRs with the `auto-doc-healing` label:
 
 ```bash
-git ls-remote --exit-code --heads origin | grep "strapi-pr-<NUMBER>"
+gh pr list --repo strapi/documentation --label auto-doc-healing --state all \
+  --json body --jq '.[].body' | grep -q "strapi/strapi/pull/<NUMBER>"
 ```
 
-If a matching branch exists, skip the PR entirely. This ensures the workflow is idempotent
+If a match is found, skip the PR entirely. This ensures the workflow is idempotent
 and recovers gracefully from partial failures.
 
 ## Step 3 — Get the diff (per PR)
@@ -125,7 +127,7 @@ cd $DOC_REPO
 # - targets under docs/cms/ -> /cms
 # - targets under docs/cloud/ -> /cloud
 # - mixed or other -> /repo
-BRANCH_NAME="<prefix>/strapi-pr-<NUMBER>-<short-kebab-description>"
+BRANCH_NAME="<prefix>/<short-kebab-description>"
 
 git checkout -b "$BRANCH_NAME"
 # (apply all Drafter outputs to the appropriate files)

--- a/.github/prompts/docs-self-healing.md
+++ b/.github/prompts/docs-self-healing.md
@@ -56,20 +56,16 @@ gh api repos/strapi/strapi/pulls/<NUMBER>.diff > /tmp/pr-<NUMBER>.diff
 
 ## Step 4 — Run the Router (per PR)
 
-Read the Router prompt and apply it to the PR:
+**Read these files once at the start of the run** (not per PR):
+- Router prompt: `$DOC_REPO/agents/prompts/router.md`
+- Sidebars: `$DOC_REPO/docusaurus/sidebars.js`
+- Page index: `$DOC_REPO/docusaurus/static/llms.txt`
 
-**Router prompt:** `$DOC_REPO/agents/prompts/router.md`
-
-**Required context files for the Router:**
-- `$DOC_REPO/docusaurus/sidebars.js`
-- `$DOC_REPO/docusaurus/static/llms.txt`
-
-**Source material for the Router:**
+Then, for each PR, apply the Router logic using:
 - PR title and description from Step 3
-- List of changed files from Step 3
 - The diff from Step 3
 
-Apply the Router logic. The Router will produce a YAML `targets` block.
+The Router will produce a YAML `targets` block.
 
 **Skip the PR if:**
 - The Router finds no targets
@@ -81,31 +77,32 @@ Apply the Router logic. The Router will produce a YAML `targets` block.
 
 For each PR where the Router identified targets, run the Create/Update Mode pipeline.
 
-Read the Orchestrator prompt at: `$DOC_REPO/agents/prompts/orchestrator.md`
+**Read these agent prompts once at the start of the run** (not per PR):
+- Orchestrator: `$DOC_REPO/agents/prompts/orchestrator.md`
+- Outline Generator: `$DOC_REPO/agents/prompts/outline-generator.md`
+- Drafter: `$DOC_REPO/agents/prompts/drafter.md`
+- Style Checker: `$DOC_REPO/agents/prompts/style-checker.md`
+- Outline Checker: `$DOC_REPO/agents/prompts/outline-checker.md`
 
 Follow the auto-chain execution from the Orchestrator:
 
 1. **For `create_page` targets:**
-   - Read the Outline Generator prompt at: `$DOC_REPO/agents/prompts/outline-generator.md`
-   - Generate outline from Router YAML + source material
-   - Read the Drafter prompt at: `$DOC_REPO/agents/prompts/drafter.md`
+   - Run Outline Generator with Router YAML + source material
    - Run Drafter in Compose mode with the outline
 
 2. **For `update_section` / `add_section` targets:**
-   - Read the Drafter prompt at: `$DOC_REPO/agents/prompts/drafter.md`
    - Run Drafter in Patch mode with Router YAML + source material
 
 3. **For `add_link` / `add_mention` / `add_tip` targets:**
    - Run Drafter in Micro-edit mode
 
 4. **Self-review (automatic):**
-   - Read the Style Checker at: `$DOC_REPO/agents/prompts/style-checker.md`
-   - Read the Outline Checker at: `$DOC_REPO/agents/prompts/outline-checker.md`
-   - Run both on each Drafter output
+   - Run Style Checker and Outline Checker on each Drafter output
    - If errors found: re-run Drafter once with corrections (max 1 retry per target)
 
 **Authoring guides:** For each target, load the relevant authoring guide from `$DOC_REPO/agents/authoring/`
 based on the Router's `doc_type` and target path. These contain section-specific conventions.
+Authoring guides are small and target-specific — read them per target, not upfront.
 
 **Templates:** For `create_page` targets, load the relevant template from `$DOC_REPO/agents/templates/`
 based on the Router's `doc_type`.

--- a/.github/prompts/docs-self-healing.md
+++ b/.github/prompts/docs-self-healing.md
@@ -1,7 +1,7 @@
 # Strapi Documentation Self-Healing Agent
 
 You are running in automated mode inside a GitHub Actions workflow on `strapi/documentation`.
-Your job is to process each PR merged into `strapi/strapi` in the last 24 hours and open a draft
+Your job is to process each PR merged into `strapi/strapi` in the last 24 hours and open a draft documentation PR on `strapi/documentation` for every one that requires a doc update.
 documentation PR on `strapi/documentation` for every one that requires a doc update.
 
 ## Environment

--- a/.github/prompts/docs-self-healing.md
+++ b/.github/prompts/docs-self-healing.md
@@ -83,6 +83,7 @@ For each PR where the Router identified targets, run the Create/Update Mode pipe
 - Drafter: `$DOC_REPO/agents/prompts/drafter.md`
 - Style Checker: `$DOC_REPO/agents/prompts/style-checker.md`
 - Outline Checker: `$DOC_REPO/agents/prompts/outline-checker.md`
+- Integrity Checker: `$DOC_REPO/agents/prompts/integrity-checker.md`
 
 Follow the auto-chain execution from the Orchestrator:
 
@@ -99,6 +100,10 @@ Follow the auto-chain execution from the Orchestrator:
 4. **Self-review (automatic):**
    - Run Style Checker and Outline Checker on each Drafter output
    - If errors found: re-run Drafter once with corrections (max 1 retry per target)
+
+5. **Integrity check (after self-review):**
+   - Run Integrity Checker on the final output (links, paths, anchors, code block syntax)
+   - Log any issues but do not block PR creation — Pierre will verify during review
 
 **Authoring guides:** For each target, load the relevant authoring guide from `$DOC_REPO/agents/authoring/`
 based on the Router's `doc_type` and target path. These contain section-specific conventions.

--- a/.github/prompts/docs-self-healing.md
+++ b/.github/prompts/docs-self-healing.md
@@ -42,18 +42,12 @@ gh pr list --repo strapi/documentation --label auto-doc-healing --state all \
 If a match is found, skip the PR entirely. This ensures the workflow is idempotent
 and recovers gracefully from partial failures.
 
-## Step 3 — Get the diff (per PR)
+## Step 3 — Get PR context (per PR)
 
-For each PR to process, fetch the diff. Use the merge commit in `$STRAPI_SOURCE`:
+For each PR to process, fetch the description and the diff:
 
 ```bash
-cd $STRAPI_SOURCE
-gh api repos/strapi/strapi/pulls/<NUMBER>/files --jq '.[].filename' > /tmp/pr-<NUMBER>-files.txt
 gh api repos/strapi/strapi/pulls/<NUMBER> --jq '.body' > /tmp/pr-<NUMBER>-body.txt
-```
-
-Also fetch the actual diff (excluding tests and specs):
-```bash
 gh api repos/strapi/strapi/pulls/<NUMBER>.diff > /tmp/pr-<NUMBER>.diff
 ```
 

--- a/.github/workflows/docs-self-healing.yml
+++ b/.github/workflows/docs-self-healing.yml
@@ -53,7 +53,7 @@ jobs:
         if: steps.check-prs.outputs.has_prs == 'true'
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_SELF_HEALING_DOCS_API_KEY }}
           model: claude-sonnet-4-6
           prompt_file: .github/prompts/docs-self-healing.md
           allowed_tools: "Bash(git:*),Bash(gh:*),View,GlobTool,GrepTool,Edit,Write"

--- a/.github/workflows/docs-self-healing.yml
+++ b/.github/workflows/docs-self-healing.yml
@@ -1,0 +1,76 @@
+name: Docs Self-Healing
+
+on:
+  schedule:
+    - cron: '30 1 * * *' # 1:30 AM UTC daily (after merger repo sync at 1:00)
+  workflow_dispatch: # manual trigger for testing
+
+jobs:
+  docs-self-healing:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout strapi/documentation
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.PAT_TOKEN_PIWI }}
+
+      - name: Checkout strapi/strapi (read-only)
+        uses: actions/checkout@v4
+        with:
+          repository: strapi/strapi
+          ref: develop
+          path: .strapi-source
+          token: ${{ secrets.PAT_TOKEN_PIWI }}
+          fetch-depth: 50
+
+      - name: Check for merged PRs in last 24 hours
+        id: check-prs
+        env:
+          GH_TOKEN: ${{ secrets.PAT_TOKEN_PIWI }}
+        run: |
+          echo "Checking for PRs merged into strapi/strapi develop in the last 24h..."
+          SINCE=$(date -u -d '24 hours ago' '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date -u -v-24H '+%Y-%m-%dT%H:%M:%SZ')
+          PR_COUNT=$(gh api repos/strapi/strapi/pulls \
+            -f state=closed \
+            -f base=develop \
+            -f sort=updated \
+            -f direction=desc \
+            -f per_page=50 \
+            --jq "[.[] | select(.merged_at != null and .merged_at > \"$SINCE\")] | length")
+          echo "Found $PR_COUNT merged PRs in the last 24h"
+          if [ "$PR_COUNT" -eq 0 ]; then
+            echo "has_prs=false" >> $GITHUB_OUTPUT
+          else
+            echo "has_prs=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Run Claude doc agent
+        if: steps.check-prs.outputs.has_prs == 'true'
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          model: claude-sonnet-4-6
+          prompt_file: .github/prompts/docs-self-healing.md
+          allowed_tools: "Bash(git:*),Bash(gh:*),View,GlobTool,GrepTool,Edit,Write"
+          max_turns: 50
+          timeout_minutes: 30
+        env:
+          STRAPI_SOURCE: ${{ github.workspace }}/.strapi-source
+          DOC_REPO: ${{ github.workspace }}
+          GH_TOKEN: ${{ secrets.PAT_TOKEN_PIWI }}
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "## Docs Self-Healing Run" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Date:** $(date -u '+%Y-%m-%d %H:%M UTC')" >> $GITHUB_STEP_SUMMARY
+          echo "**Trigger:** ${{ github.event_name }}" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ steps.check-prs.outputs.has_prs }}" == "false" ]; then
+            echo "**Result:** No merged PRs in the last 24h. Nothing to process." >> $GITHUB_STEP_SUMMARY
+          fi


### PR DESCRIPTION
This PR adds a nightly GitHub Action that automatically creates draft documentation PRs when code changes are merged into strapi/strapi.

## How it works

1. Runs nightly at 1:30 UTC (also triggerable manually via workflow_dispatch)
2. Lists PRs merged into strapi/strapi's develop branch in the last 24 hours
3. For each PR, runs the existing Router agent to determine if docs need updating
4. If yes, runs the full Outliner/Drafter/Self-review pipeline
5. Creates a draft PR on strapi/documentation with label `auto-doc-healing`

## Safeguards

- Max 5 PRs processed per run
- Diffs over 3000 lines are skipped (flagged for manual review)
- Branch existence check ensures idempotency (safe to re-run)
- Uncertain routing (Router sets `ask_user`) is skipped and logged
- Uses Claude Sonnet for cost efficiency
- All generated PRs are drafts — human review required before merge

## Files

- `.github/workflows/docs-self-healing.yml` — the workflow
- `.github/prompts/docs-self-healing.md` — the prompt for claude-code-action

## Test plan

- [x] Trigger manually via workflow_dispatch
- [x] Verify it picks up a recent strapi/strapi PR
- [x] Verify it creates a draft PR with correct content and label
- [x] Verify it skips PRs that don't need docs (tests, deps, chores)
- [x] Verify idempotency: re-run skips already-processed PRs