### PR TITLE
Cross-link best practices for high-performance Strapi blog post

### DIFF
--- a/docusaurus/docs/cms/api/rest.md
+++ b/docusaurus/docs/cms/api/rest.md
@@ -26,6 +26,10 @@ All content types are private by default and need to be either made public or qu
 By default, the REST API responses only include top-level fields and does not populate any relations, media fields, components, or dynamic zones. Use the [`populate` parameter](/cms/api/rest/populate-select) to populate specific fields. Ensure that the find permission is given to the field(s) for the relation(s) you populate.
 :::
 
+:::tip Performance best practices
+For production applications, be intentional about data fetching: use explicit population, limit population depth, and centralize population logic in route middlewares. See <ExternalLink to="https://strapi.io/blog/building-high-performance-strapi-applications-common-pitfalls-and-best-practices" text="Building High-Performance Strapi Applications" /> on the Strapi blog for a comprehensive guide.
+:::
+
 :::strapi Strapi Client
 The [Strapi Client](/cms/api/client) library simplifies interactions with your Strapi back end, providing a way to fetch, create, update, and delete content.
 :::

--- a/docusaurus/docs/cms/api/rest/guides/understanding-populate.md
+++ b/docusaurus/docs/cms/api/rest/guides/understanding-populate.md
@@ -1419,3 +1419,7 @@ In the following example response, highlighted lines show that:
 </Response>
 
 </ApiCall>
+
+:::tip Avoid over-populating in production
+Using `populate=*` or deep population plugins can create unpredictable, costly database queries. In production, always populate explicitly and limit depth to 2-3 levels. Consider using route-level middlewares to centralize population logic. See <ExternalLink to="https://strapi.io/blog/building-high-performance-strapi-applications-common-pitfalls-and-best-practices" text="Building High-Performance Strapi Applications" /> on the Strapi blog.
+:::

--- a/docusaurus/docs/cms/api/rest/populate-select.md
+++ b/docusaurus/docs/cms/api/rest/populate-select.md
@@ -295,3 +295,7 @@ await request(`/api/articles?${query}`);
 
 </Response>
 </ApiCall>
+
+:::tip Performance tip
+In production, always use explicit population instead of wildcards like `populate=*`. Limit population depth to 2-3 levels and consider centralizing population logic in route middlewares. See <ExternalLink to="https://strapi.io/blog/building-high-performance-strapi-applications-common-pitfalls-and-best-practices" text="Building High-Performance Strapi Applications" /> on the Strapi blog.
+:::

--- a/docusaurus/docs/cms/backend-customization/middlewares.md
+++ b/docusaurus/docs/cms/backend-customization/middlewares.md
@@ -223,3 +223,7 @@ Proper implementation largely depends on your project's needs and custom code, b
 :::info
 You can find more information about route middlewares in the [routes documentation](/cms/backend-customization/routes).
 :::
+
+:::tip Middlewares for performance
+Route-level middlewares are a good place to centralize population logic and prevent accidental over-fetching. See <ExternalLink to="https://strapi.io/blog/building-high-performance-strapi-applications-common-pitfalls-and-best-practices" text="Building High-Performance Strapi Applications" /> on the Strapi blog for patterns and examples.
+:::

--- a/docusaurus/docs/cms/backend-customization/routes.md
+++ b/docusaurus/docs/cms/backend-customization/routes.md
@@ -548,6 +548,10 @@ export default  {
 
 </Tabs>
 
+:::tip Centralizing population logic
+Route-level middlewares are the recommended place to enforce consistent population rules across your API. This prevents accidental over-fetching and ensures predictable response sizes. See <ExternalLink to="https://strapi.io/blog/building-high-performance-strapi-applications-common-pitfalls-and-best-practices" text="Building High-Performance Strapi Applications" /> on the Strapi blog.
+:::
+
 ### Public routes
 
 By default, routes are protected by Strapi's authentication system, which is based on [API tokens](/cms/features/api-tokens) or on the use of the [Users & Permissions plugin](/cms/features/users-permissions).

--- a/docusaurus/docs/cms/features/custom-fields.md
+++ b/docusaurus/docs/cms/features/custom-fields.md
@@ -711,3 +711,7 @@ As compared to how other types of models are defined, custom fields' attributes 
 // …
 }
 ```
+
+:::tip Custom fields for performance
+Custom fields that store structured JSON can be a performant alternative to deeply nested relational structures. When data does not need to be queried independently, storing it as a single JSON field avoids costly joins. See <ExternalLink to="https://strapi.io/blog/building-high-performance-strapi-applications-common-pitfalls-and-best-practices" text="Building High-Performance Strapi Applications" /> on the Strapi blog.
+:::


### PR DESCRIPTION
This PR adds performance tips linking to the [Building High-Performance Strapi Applications](https://strapi.io/blog/building-high-performance-strapi-applications-common-pitfalls-and-best-practices) blog post in 6 documentation pages.

## Pages updated

- `cms/api/rest.md` — general performance tip after the populate note
- `cms/api/rest/populate-select.md` — explicit population tip
- `cms/api/rest/guides/understanding-populate.md` — avoid over-population tip
- `cms/backend-customization/middlewares.md` — middlewares for performance tip
- `cms/backend-customization/routes.md` — centralizing population logic tip
- `cms/features/custom-fields.md` — custom fields vs nested relations tip

All additions are `:::tip` callouts with a link to the blog post. No existing content was modified.