### PR TITLE
fix: use admin basename for 401 redirect path (strapi/strapi#25458)

### DIFF
--- a/docusaurus/docs/cms/configurations/admin-panel.md
+++ b/docusaurus/docs/cms/configurations/admin-panel.md
@@ -87,6 +87,10 @@ module.exports = ({ env }) => ({
 
 Since by default the back-end server and the admin panel server run on the same host and port, only updating the `config/admin` file should work if you left the `host` and `port` property values untouched in the back-end [server configuration](/cms/configurations/server) file.
 
+:::note Session expiry and 401 redirects
+When you configure a custom admin panel path, session expiry and 401 authentication errors automatically redirect users to the correct login URL. For example, with `url: "/dashboard"`, the redirect target becomes `/dashboard/auth/login` instead of the default `/admin/auth/login`.
+:::
+
 ### Update the admin panel's host and port
 
 If the admin panel server and the back-end server are not hosted on the same server, you will need to update the host and port of the admin panel. For example, to host the admin panel on `my-host.com:3000`:


### PR DESCRIPTION
This PR updates documentation based on https://github.com/strapi/strapi/pull/25458.

## What changed

Adds a note in `docusaurus/docs/cms/configurations/admin-panel.md` under the "Update the admin panel's path only" section, clarifying that session expiry and 401 authentication errors correctly redirect users to the configured custom admin path (e.g. `/dashboard/auth/login`) rather than the hardcoded `/admin/auth/login` default.

This was a documented behavioral gap: users who configured a custom admin path via `admin.path` / `url` had no indication that the redirect behavior respects their configuration.

Generated automatically by the docs self-healing workflow.
Review before merging.