### PR TITLE
Docs self-healing workflow improvements: Add ultra-light Haiku triage before Router

### DIFF
--- a/.github/prompts/docs-self-healing-triage.md
+++ b/.github/prompts/docs-self-healing-triage.md
@@ -1,0 +1,45 @@
+# Self-Healing Triage (Haiku — ultra-light)
+
+You are a fast triage agent. For each PR, decide if it MIGHT need documentation.
+You do NOT decide WHERE or WHAT to document — that's the Router's job.
+
+You only read the PR title and body (no diff, no sidebars, no agent prompts).
+
+## Environment
+
+- `$FILTERED_PRS` — JSON array of pre-filtered PRs
+- Pre-fetched bodies in `/tmp/pr-<NUMBER>-body.txt`
+
+## Instructions
+
+1. Parse `$FILTERED_PRS` to get the list of PRs.
+
+2. For each PR, read `/tmp/pr-<NUMBER>-body.txt` (the PR description).
+
+3. Based ONLY on the title and body, decide:
+   - `"yes"` — this PR changes user-facing behavior, APIs, configuration, features, or CLI commands. Documentation might need updating.
+   - `"no"` — this PR is clearly internal: refactors, race condition fixes, internal optimizations, test infrastructure, build tooling, admin UI polish with no behavior change, dependency version alignment, code style changes. No documentation impact.
+
+4. Write the result to `/tmp/triage-results.json`:
+
+```json
+{
+  "prs": [
+    {"number": 12345, "title": "feat: add webhook retry config", "triage": "yes"},
+    {"number": 12346, "title": "fix(admin): eliminate browser race conditions", "triage": "no", "reason": "Internal admin UI fix, no behavior change"}
+  ]
+}
+```
+
+## When in doubt, say "yes"
+
+False negatives are worse than false positives. If you're not sure, say `"yes"` — the Router will do the detailed analysis. The goal is to cheaply eliminate obvious "no" cases.
+
+## Rules
+
+- **Do NOT read diffs** — you don't need them
+- **Do NOT read sidebars.js, llms.txt, or any agent prompts**
+- **Do NOT modify any files except `/tmp/triage-results.json`**
+- **Do NOT create branches, commits, or PRs**
+- **NEVER run any write operation on strapi/strapi**
+- **Be fast** — this step should use minimal tokens

--- a/.github/workflows/docs-self-healing.yml
+++ b/.github/workflows/docs-self-healing.yml
@@ -153,9 +153,74 @@ jobs:
             fi
           done
 
-      # ── Step A: Haiku Router (cheap, fast) ──
-      - name: Load Router prompt
+      # ── Step 0: Haiku Triage (ultra-light, ~$0.01) ──
+      - name: Load Triage prompt
         if: steps.check-prs.outputs.has_prs == 'true'
+        id: load-triage-prompt
+        run: |
+          echo "prompt<<PROMPT_EOF" >> $GITHUB_OUTPUT
+          cat .github/prompts/docs-self-healing-triage.md >> $GITHUB_OUTPUT
+          echo "PROMPT_EOF" >> $GITHUB_OUTPUT
+
+      - name: Run Triage (Haiku)
+        if: steps.check-prs.outputs.has_prs == 'true'
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_SELF_HEALING_DOCS_API_KEY }}
+          github_token: ${{ secrets.PAT_TOKEN_PIWI }}
+          prompt: ${{ steps.load-triage-prompt.outputs.prompt }}
+          claude_args: '--model claude-haiku-4-5-20251001 --max-turns 10 --allowedTools "Bash,Read"'
+          show_full_output: true
+        env:
+          FILTERED_PRS: ${{ steps.check-prs.outputs.pr_list }}
+
+      - name: Check Triage results
+        if: steps.check-prs.outputs.has_prs == 'true'
+        id: check-triage
+        run: |
+          TRIAGE_FILE="/tmp/triage-results.json"
+          if [ ! -f "$TRIAGE_FILE" ]; then
+            echo "Triage did not produce results — passing all PRs to Router"
+            cp /tmp/new-prs.json /tmp/triaged-prs.json
+            echo "has_candidates=true" >> $GITHUB_OUTPUT
+          else
+            # Keep only PRs where triage said "yes"
+            YES_NUMBERS=$(jq '[.prs[] | select(.triage == "yes") | .number]' "$TRIAGE_FILE")
+            jq --argjson yes "$YES_NUMBERS" '[.[] | select(.number as $n | $yes | index($n))]' \
+              /tmp/new-prs.json > /tmp/triaged-prs.json
+
+            YES_COUNT=$(jq 'length' /tmp/triaged-prs.json)
+            NO_COUNT=$(jq '[.prs[] | select(.triage == "no")] | length' "$TRIAGE_FILE")
+
+            echo "Triage: $YES_COUNT candidates, $NO_COUNT eliminated"
+
+            # Log triage results in summary
+            if [ "$NO_COUNT" -gt 0 ]; then
+              echo "### Triage (Haiku — title+body only)" >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "**Eliminated ($NO_COUNT):**" >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+              jq -r '.prs[] | select(.triage == "no") | "- ~~#\(.number) — \(.title)~~ — \(.reason)"' "$TRIAGE_FILE" >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+            fi
+
+            if [ "$YES_COUNT" -eq 0 ]; then
+              echo "has_candidates=false" >> $GITHUB_OUTPUT
+            else
+              echo "has_candidates=true" >> $GITHUB_OUTPUT
+            fi
+          fi
+
+          # Update PR list for Router
+          {
+            echo "triaged_pr_list<<TRIAGE_EOF"
+            cat /tmp/triaged-prs.json
+            echo "TRIAGE_EOF"
+          } >> $GITHUB_OUTPUT
+
+      # ── Step A: Haiku Router (only for triage "yes" PRs) ──
+      - name: Load Router prompt
+        if: steps.check-triage.outputs.has_candidates == 'true'
         id: load-router-prompt
         run: |
           echo "prompt<<PROMPT_EOF" >> $GITHUB_OUTPUT
@@ -163,7 +228,7 @@ jobs:
           echo "PROMPT_EOF" >> $GITHUB_OUTPUT
 
       - name: Run Router (Haiku)
-        if: steps.check-prs.outputs.has_prs == 'true'
+        if: steps.check-triage.outputs.has_candidates == 'true'
         id: router
         uses: anthropics/claude-code-action@v1
         with:
@@ -175,10 +240,10 @@ jobs:
         env:
           DOC_REPO: ${{ github.workspace }}
           GH_TOKEN: ${{ secrets.PAT_TOKEN_PIWI }}
-          FILTERED_PRS: ${{ steps.check-prs.outputs.pr_list }}
+          FILTERED_PRS: ${{ steps.check-triage.outputs.triaged_pr_list }}
 
       - name: Check Router results
-        if: steps.check-prs.outputs.has_prs == 'true'
+        if: steps.check-triage.outputs.has_candidates == 'true'
         id: check-router
         run: |
           RESULTS_FILE="/tmp/router-results.json"
@@ -275,13 +340,19 @@ jobs:
           echo "**Trigger:** ${{ github.event_name }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
-          # Case 1: No PRs passed pre-filter
+          # Case 1: No PRs passed bash pre-filter
           if [ "${{ steps.check-prs.outputs.has_prs }}" == "false" ]; then
-            echo "**Result:** No candidate PRs after pre-filtering. Sonnet was not invoked." >> $GITHUB_STEP_SUMMARY
+            echo "**Result:** No candidate PRs after pre-filtering. No AI invoked." >> $GITHUB_STEP_SUMMARY
             exit 0
           fi
 
-          # Case 2: Router ran but found no targets — Sonnet was NOT invoked
+          # Case 2: Triage eliminated all PRs
+          if [ "${{ steps.check-triage.outputs.has_candidates }}" != "true" ]; then
+            echo "**Result:** Triage (Haiku) eliminated all PRs. Router and Sonnet were not invoked." >> $GITHUB_STEP_SUMMARY
+            exit 0
+          fi
+
+          # Case 3: Router ran but found no targets — Sonnet was NOT invoked
           if [ "${{ steps.check-router.outputs.has_targets }}" != "true" ]; then
             echo "**Result:** Router (Haiku) found no documentation targets. Sonnet was not invoked." >> $GITHUB_STEP_SUMMARY
             exit 0


### PR DESCRIPTION
## Summary

- New **Triage step** (Haiku, ~$0.01): reads only PR title + body, decides "might need docs?" yes/no
- Eliminates obvious "no" cases (internal refactors, race condition fixes, etc.) before the Router loads its heavy context (router.md + sidebars.js + llms.txt + diffs)
- When Triage says "no" to all PRs: Router is never invoked → **$0.01 instead of $0.10**

## Pipeline (4 stages)

```
bash filter → Triage (Haiku ~$0.01) → Router (Haiku ~$0.05-0.10) → Drafter (Sonnet ~$0.50-0.70)
     $0          title+body only          + diff + sidebars           only if targets found
```

Each stage is a gate: if it eliminates everything, subsequent stages don't run.

## Estimated cost comparison per nightly run

| Scenario | Before this PR | After |
|---|---|---|
| All PRs are chores (bash filter) | $0.00 | $0.00 |
| PRs pass bash but are internal fixes | ~$0.10 (Router with Haiku) | ~$0.01 (Triage) |
| PRs need Router analysis | ~$0.10 | ~$0.11 ($0.01 triage + $0.10 router with Haiku) |
| PRs need full drafting | ~$0.60 | ~$0.61 |

## Test plan

- [x] `workflow_dispatch` with internal-only PRs → Triage says "no", Router NOT invoked
- [x] `workflow_dispatch` with a feature PR → Triage says "yes", Router runs
- [x] Verify `/tmp/triage-results.json` format
- [x] Check summary shows triage eliminations

🤖 Generated with [Claude Code](https://claude.com/claude-code)