### PR TITLE
Add note about Vite `.mts` ESM syntax support

### DIFF
--- a/docusaurus/docs/cms/admin-panel-customization/bundlers.md
+++ b/docusaurus/docs/cms/admin-panel-customization/bundlers.md
@@ -72,7 +72,7 @@ export default (config) => {
 </Tabs>
 
 :::tip
-Strapi also supports the `.mts` file extension for Vite config files (`vite.config.mts`), for projects that use explicit ESM module resolution in their `package.json`.
+Strapi also supports the `.mts` file extension for Vite config files (`vite.config.mts`), for projects that use explicit ESM module resolution in their `package.json`. This is useful as Vite's CJS Node API is [deprecated since Vite 6](https://v6.vite.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated) and will be removed in a future version.
 :::
 
 ## Webpack

--- a/docusaurus/docs/cms/admin-panel-customization/bundlers.md
+++ b/docusaurus/docs/cms/admin-panel-customization/bundlers.md
@@ -72,7 +72,7 @@ export default (config) => {
 </Tabs>
 
 :::tip
-Strapi also supports the `.mts` file extension for Vite config files (`vite.config.mts`), for projects that use explicit ESM module resolution in their `package.json`. This is useful as Vite's CJS Node API is [deprecated since Vite 6](https://v6.vite.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated) and will be removed in a future version.
+Strapi also supports the `.mts` file extension for Vite config files (`vite.config.mts`), for projects that use explicit ESM module resolution in their `package.json`. This is useful as Vite's CJS Node API is <ExternalLink text="deprecated since Vite 6" to="https://v6.vite.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated" /> and will be removed in a future version.
 :::
 
 ## Webpack

--- a/docusaurus/docs/cms/admin-panel-customization/bundlers.md
+++ b/docusaurus/docs/cms/admin-panel-customization/bundlers.md
@@ -69,29 +69,10 @@ export default (config) => {
 ```
 
 </TabItem>
-
-<TabItem value="mts" label="TypeScript (ESM)">
-
-```ts title="/src/admin/vite.config.mts"
-import { mergeConfig } from "vite";
-
-export default (config) => {
-  // Important: always return the modified config
-  return mergeConfig(config, {
-    resolve: {
-      alias: {
-        "@": "/src",
-      },
-    },
-  });
-};
-```
-
-</TabItem>
 </Tabs>
 
-:::info
-ESM syntax is now supported for Vite configuration files. You can use `.mts` file extension to write your config in TypeScript with ESM syntax, which is the recommended approach as CJS is being phased out by Vite.
+:::tip
+Strapi also supports the `.mts` file extension for Vite config files (`vite.config.mts`), for projects that use explicit ESM module resolution in their `package.json`.
 :::
 
 ## Webpack

--- a/docusaurus/docs/cms/admin-panel-customization/bundlers.md
+++ b/docusaurus/docs/cms/admin-panel-customization/bundlers.md
@@ -69,7 +69,30 @@ export default (config) => {
 ```
 
 </TabItem>
+
+<TabItem value="mts" label="TypeScript (ESM)">
+
+```ts title="/src/admin/vite.config.mts"
+import { mergeConfig } from "vite";
+
+export default (config) => {
+  // Important: always return the modified config
+  return mergeConfig(config, {
+    resolve: {
+      alias: {
+        "@": "/src",
+      },
+    },
+  });
+};
+```
+
+</TabItem>
 </Tabs>
+
+:::info
+ESM syntax is now supported for Vite configuration files. You can use `.mts` file extension to write your config in TypeScript with ESM syntax, which is the recommended approach as CJS is being phased out by Vite.
+:::
 
 ## Webpack
 


### PR DESCRIPTION
This PR updates documentation based on https://github.com/strapi/strapi/pull/25238.

Adds a new TabItem example showing .mts ESM syntax for Vite configuration, along with a note explaining that ESM syntax is now supported and recommended.

Generated automatically by the docs self-healing workflow (micro-edit, Haiku).
Review before merging.