### PR TITLE
Docs self-healing workflow improvements: Skip Slack notification in dry run mode

### DIFF
--- a/.github/workflows/docs-self-healing.yml
+++ b/.github/workflows/docs-self-healing.yml
@@ -492,7 +492,7 @@ jobs:
           fi
 
       - name: Notify Slack
-        if: always()
+        if: always() && inputs.dry_run != true
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           SLACK_CHANNEL: ${{ secrets.SLACK_DOCUMENTATION_OPS_CHANNEL_ID }}


### PR DESCRIPTION
This PR skips the Slack notification step when the workflow is triggered in dry run mode. The nightly cron is unaffected.