### PR TITLE
Fix auto-labeling: infra-only PRs always labeled as chore

### DIFF
--- a/.github/workflows/auto-label-prs-for-source-and-content.yml
+++ b/.github/workflows/auto-label-prs-for-source-and-content.yml
@@ -77,6 +77,7 @@ jobs:
             let touchesCloud = false;
             let touchesOther = false;
             let hasNewFile = false;
+            let hasDocContent = false;
             let totalChanges = 0;
 
             /**
@@ -108,9 +109,9 @@ jobs:
               console.log(`  → area: ${area}`);
 
               switch (area) {
-                case 'cms':   touchesCMS = true; break;
-                case 'cloud': touchesCloud = true; break;
-                case 'static': /* neutral — does not influence source */ break;
+                case 'cms':   touchesCMS = true; hasDocContent = true; break;
+                case 'cloud': touchesCloud = true; hasDocContent = true; break;
+                case 'static': hasDocContent = true; break;
                 default:      touchesOther = true; break;
               }
 
@@ -142,9 +143,15 @@ jobs:
 
             // -------------------------------------------------------
             // 5. Determine PR type label
+            //
+            //    Infrastructure-only PRs (.github/, agents/, scripts/,
+            //    src/, config files, etc.) are always "pr: chore",
+            //    regardless of size.
             // -------------------------------------------------------
             let prTypeLabel;
-            if (hasNewFile) {
+            if (!hasDocContent) {
+              prTypeLabel = 'pr: chore';
+            } else if (hasNewFile) {
               prTypeLabel = 'pr: new content';
             } else if (totalChanges > 10) {
               prTypeLabel = 'pr: updated content';
@@ -152,7 +159,7 @@ jobs:
               prTypeLabel = 'pr: chore';
             }
 
-            console.log(`Determined labels: ${sourceLabel}, ${prTypeLabel}`);
+            console.log(`Determined labels: ${sourceLabel}, ${prTypeLabel} (hasDocContent=${hasDocContent})`);
 
             // -------------------------------------------------------
             // 6. Apply labels (skip categories that already have one)

--- a/.github/workflows/auto-label-prs-for-source-and-content.yml
+++ b/.github/workflows/auto-label-prs-for-source-and-content.yml
@@ -98,7 +98,10 @@ jobs:
               // Snippets live under docs/ and are shared — treat as CMS by convention
               if (f.includes('/docs/snippets/') || f.startsWith('docs/snippets/')) return 'cms';
 
-              // Everything else (src/, scripts, config, .github/, agents/, etc.)
+              // Site source (components, SCSS, theme) — not infra, can be significant changes
+              if (f.includes('/src/') || f.startsWith('src/')) return 'static';
+
+              // Everything else (scripts, config, .github/, agents/, etc.)
               return 'other';
             }
 
@@ -145,8 +148,8 @@ jobs:
             // 5. Determine PR type label
             //
             //    Infrastructure-only PRs (.github/, agents/, scripts/,
-            //    src/, config files, etc.) are always "pr: chore",
-            //    regardless of size.
+            //    config files, etc.) are always "pr: chore",
+            //    regardless of size. src/ is NOT infra (SCSS, components).
             // -------------------------------------------------------
             let prTypeLabel;
             if (!hasDocContent) {


### PR DESCRIPTION
This PR fixes false positives where PRs touching only .github/, agents/, or scripts/ were labeled 'pr: updated content' instead of 'pr: chore'. Now, PRs that don't touch any doc content (docs/, static/, src/, snippets/) are always chore regardless of change size. src/ is treated as doc content since it contains SCSS, components, and theme files.