### PR TITLE
Document populate support in Document Service API `delete()` operations

### DIFF
--- a/docusaurus/docs/cms/api/document-service/populate.md
+++ b/docusaurus/docs/cms/api/document-service/populate.md
@@ -383,3 +383,44 @@ strapi.documents("api::article.article").publish({
 
 </Response>
 </ApiCall>
+
+## Populating with `delete()`
+
+To populate while deleting documents:
+
+<ApiCall noSideBySide>
+<Request title="Example request">
+
+```js
+strapi.documents("api::article.article").delete({
+  documentId: "cjld2cjxh0000qzrmn831i7rn",
+  populate: ["headerImage"],
+});
+```
+
+</Request>
+
+<Response title="Example response">
+
+```json
+{
+  "documentId": "cjld2cjxh0000qzrmn831i7rn",
+  "entries": [
+    {
+      "id": "cjld2cjxh0000qzrmn831i7rn",
+      "title": "Test Article",
+      "slug": "test-article",
+      "body": "Test 1",
+      "headerImage": {
+        "id": 2,
+        "name": "17520.jpg"
+        // ...
+      }
+      // ...
+    }
+  ]
+}
+```
+
+</Response>
+</ApiCall>


### PR DESCRIPTION
This PR documents the new feature from https://github.com/strapi/strapi/pull/25097 that allows `fields` and `populate` parameters in document delete operations.

Added a new "Populating with \`delete()\`" section to the populate.md documentation explaining how to use the populate parameter when deleting documents.

Generated automatically by the docs self-healing workflow (micro-edit, Haiku).
Review before merging.