### PR TITLE
Fix OpenAPI example id type to string

### DIFF
--- a/docusaurus/docs/cms/api/openapi.md
+++ b/docusaurus/docs/cms/api/openapi.md
@@ -120,7 +120,7 @@ The generated OpenAPI specification follows the <ExternalLink to="https://spec.o
       "Article": {
         "type": "object",
         "properties": {
-          "id": { "type": "integer" },
+          "id": { "type": "string" },
           "title": { "type": "string" },
           "content": { "type": "string" }
         }


### PR DESCRIPTION
This PR fixes the Article schema example in the OpenAPI page to use `id: string` instead of `id: integer`, matching Strapi v5's `documentId` behavior (strapi/strapi#26067).

Follow-ups (out of scope):
- Regenerate `static/example-openapi-spec.json` against a Strapi 5.44+ project (same `integer` → `string` fix needed)
- Confirm the core CLI generator (`@strapi/openapi`) also emits `id: string`