### PR TITLE
Document polymorphic relations support in Document Service API populate

### DIFF
--- a/docusaurus/docs/cms/api/document-service/populate.md
+++ b/docusaurus/docs/cms/api/document-service/populate.md
@@ -30,7 +30,7 @@ If the Users & Permissions plugin is installed, the `find` permission must be en
 
 ## Relations and media fields
 
-Queries can accept a `populate` parameter to explicitly define which fields to populate, with the following syntax option examples.
+Queries can accept a `populate` parameter to explicitly define which fields to populate, with the following syntax option examples. This includes all relation types: one-to-many, many-to-one, many-to-many, and polymorphic relations (morphToOne, morphToMany).
 
 ### Populate 1 level for all relations
 


### PR DESCRIPTION
This PR updates documentation based on https://github.com/strapi/strapi/pull/26099.

Updates the populate documentation to clarify that polymorphic relations (morphToOne, morphToMany) are now fully supported in Document Service API populate queries.

Generated automatically by the docs self-healing workflow (micro-edit, Haiku).
Review before merging.