### PR TITLE
Mention sorting by publish status in Content Manager List View

### DIFF
--- a/docusaurus/docs/cms/features/content-manager.md
+++ b/docusaurus/docs/cms/features/content-manager.md
@@ -65,6 +65,12 @@ When [Draft & Publish](/cms/features/draft-and-publish) is enabled for the conte
 - *Published (modified)* (published entries with draft changes not yet published),
 - or *Published (unmodified)* (published entries with no draft changes).
 
+When [Draft & Publish](/cms/features/draft-and-publish) is enabled, you can also sort entries by publication status. Click the **Status** column header to sort from draft to published, or click it again to reverse the order.
+
+:::note
+The **Status** column sort is disabled when a status filter is active, since filtered results already share the same publication status.
+:::
+
 <!-- TO INTEGRATE IN THE PAGE? USE A GUIDEFLOW?
 
 From the list view, it is possible to:

--- a/docusaurus/docs/cms/features/draft-and-publish.md
+++ b/docusaurus/docs/cms/features/draft-and-publish.md
@@ -64,7 +64,7 @@ With Draft & Publish enabled, the [Content Manager's edit view](/cms/features/co
 - <span style={{color:"#ac73e6"}}>Modified</span>: The content was previously published. You made some changes to the draft version and saved these changes, but the changes have not been published yet.
 - <span style={{color:"#7b79ff"}}>Draft</span>: The content has never been published yet.
 
-When Draft & Publish is eanbled, in the [Content Manager](/cms/features/content-manager) list view, you can filter entries by status using the **Filters** button.
+When Draft & Publish is eanbled, in the [Content Manager](/cms/features/content-manager) list view, you can filter entries by status using the **Filters** button. You can also sort entries by publication status by clicking the **Status** column header in the list view.
 
 ### Working with drafts
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request!

To help us merge your PR, make sure to follow the instructions detailed in the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md

Note that all documentation updates should be made against the `main` branch.
Keep your PR in Draft mode until it's ready to be reviewed and merged.


As part of the Docs Contribution Program, all external contribution PRs are labeled `contribution`.
Feel free to read more details on the Contribution Program in the dedicated guide:
https://strapi.notion.site/Documentation-Contribution-Program-1d08f359807480d480fdde68bb7a5a71

Let us know if you do not wish to take part in the Docs Contribution Program, and remove the `contribution` label.
-->

### Description

A community PR introduced the ability to sort entries by publication status, doc needs to reflect on this change 

### Related issue(s)/PR(s)

https://github.com/strapi/strapi/pull/25689
