### PR TITLE
Add sanitization warning to Document Service API page

### DIFF
--- a/docusaurus/docs/cms/api/document-service.md
+++ b/docusaurus/docs/cms/api/document-service.md
@@ -46,7 +46,7 @@ Relations can also be connected, disconnected, and set through the Document Serv
 :::
 
 :::caution Document Service returns unsanitized data
-The Document Service is a **data-access layer**: it interacts with the database and is not aware of user permissions or field visibility. Results may include private fields, passwords, and restricted relations.
+The Document Service is a data-access layer: it interacts with the database and is not aware of user permissions or field visibility. Results may include private fields, passwords, and restricted relations.
 
 The built-in REST and GraphQL APIs automatically sanitize responses before sending them to the client. But if you build custom controllers or plugin routes that call Document Service methods directly, you must sanitize the output yourself before returning it. Use `strapi.contentAPI.sanitize.output()` in your controller (see [Sanitization and validation when building custom controllers](/cms/backend-customization/controllers#sanitize-validate-custom-controllers) for details and code examples).
 :::

--- a/docusaurus/docs/cms/api/document-service.md
+++ b/docusaurus/docs/cms/api/document-service.md
@@ -45,6 +45,12 @@ Additional information on how to migrate from the Entity Service API to the Docu
 Relations can also be connected, disconnected, and set through the Document Service API, just like with the REST API (see the [REST API relations documentation](/cms/api/rest/relations) for examples).
 :::
 
+:::caution Document Service returns unsanitized data
+The Document Service is a **data-access layer**: it interacts with the database and is not aware of user permissions or field visibility. Results may include private fields, passwords, and restricted relations.
+
+The built-in REST and GraphQL APIs automatically sanitize responses before sending them to the client. But if you build custom controllers or plugin routes that call Document Service methods directly, you must sanitize the output yourself before returning it. Use `strapi.contentAPI.sanitize.output()` in your controller (see [Sanitization and validation when building custom controllers](/cms/backend-customization/controllers#sanitize-validate-custom-controllers) for details and code examples).
+:::
+
 ## Configuration
 
 The `documents.strictParams` option enables strict validation of parameters passed to Document Service methods such as `findMany` and `findOne`. Configure it in the [API configuration](/cms/configurations/api) file (`./config/api.js` or `./config/api.ts`). See the [API configuration](/cms/configurations/api) table for details on `documents.strictParams`.


### PR DESCRIPTION
This PR adds a caution callout to the Document Service API page explaining that the Document Service returns unsanitized data and that custom controllers must call `strapi.contentAPI.sanitize.output()` before returning results to clients.

Prompted by strapi/strapi#26182 where a user reported that private fields were exposed through a custom controller using the Document Service directly.

The information already exists on the Controllers page, but was missing from the Document Service page itself — developers reading only that page had no indication that sanitization was their responsibility.