### PR TITLE
Widen self-healing deduplication to scan all doc PRs

### DIFF
--- a/.github/workflows/docs-self-healing.yml
+++ b/.github/workflows/docs-self-healing.yml
@@ -126,9 +126,9 @@ jobs:
           echo "After title filtering: $FILTERED candidates ($EXCLUDED excluded by title, $BOTS by bot author)"
 
           # Check idempotency: remove PRs that already have a doc PR
-          # Extract PR numbers already referenced in auto-doc-healing PR bodies
-          gh pr list --repo strapi/documentation --label auto-doc-healing --state all \
-            --json body --jq '[.[].body | scan("strapi/strapi/pull/([0-9]+)") | .[0] | tonumber] | unique' \
+          # Scan ALL doc PRs (not just auto-doc-healing labeled) to catch manual PRs too
+          gh pr list --repo strapi/documentation --state all --limit 200 \
+            --json body --jq '[.[].body // "" | scan("strapi/strapi/pull/([0-9]+)") | .[0] | tonumber] | unique' \
             > /tmp/existing-pr-numbers.json 2>/dev/null || echo "[]" > /tmp/existing-pr-numbers.json
 
           # Filter out PRs whose number appears in existing doc PRs


### PR DESCRIPTION
This PR removes the `--label auto-doc-healing` filter from the self-healing idempotency check, so it scans all doc PRs (not just auto-generated ones) when looking for existing coverage of a strapi/strapi PR.

The bug: PR #3113 (manually created by @butcherZ) already covered strapi/strapi#25689, but because it didn't have the `auto-doc-healing` label, the dedup missed it and the workflow created duplicate PR #3115.

The fix: scan all PRs with `--state all --limit 200` instead of `--label auto-doc-healing --state all`. The regex (`strapi/strapi/pull/([0-9]+)`) is unchanged.

Dry-run confirmed PR #3113 would have been detected with this change.