### PR TITLE
Add missing Draft & Publish availability note to methods overview

### DIFF
--- a/docusaurus/docs/cms/api/document-service.md
+++ b/docusaurus/docs/cms/api/document-service.md
@@ -78,7 +78,7 @@ Each section below documents the parameters and examples for a specific method:
 | [`count()`](#count) | Count how many documents match the parameters. |
 
 :::note Draft & Publish method availability
-The [`publish()`](#publish), [`unpublish()`](#unpublish), and [`discardDraft()`](#discarddraft) methods are only available when the **Draft & Publish** feature is enabled on the content-type. Calling these methods on a content-type that does not have Draft & Publish enabled will throw an error. To enable Draft & Publish, see the [Draft & Publish documentation](/cms/features/draft-and-publish).
+The [`publish()`](#publish), [`unpublish()`](#unpublish), and [`discardDraft()`](#discarddraft) methods are only available when the Draft & Publish feature is enabled on the content-type. Calling these methods on a content-type that does not have Draft & Publish enabled will throw an error. To enable Draft & Publish, see the [Draft & Publish documentation](/cms/features/draft-and-publish).
 :::
 
 ### `findOne()`

--- a/docusaurus/docs/cms/api/document-service.md
+++ b/docusaurus/docs/cms/api/document-service.md
@@ -77,6 +77,10 @@ Each section below documents the parameters and examples for a specific method:
 | [`discardDraft()`](#discarddraft) | Drop draft data and keep only the published version. |
 | [`count()`](#count) | Count how many documents match the parameters. |
 
+:::note Draft & Publish method availability
+The [`publish()`](#publish), [`unpublish()`](#unpublish), and [`discardDraft()`](#discarddraft) methods are only available when the **Draft & Publish** feature is enabled on the content-type. Calling these methods on a content-type that does not have Draft & Publish enabled will throw an error. To enable Draft & Publish, see the [Draft & Publish documentation](/cms/features/draft-and-publish).
+:::
+
 ### `findOne()`
 
 Find a document matching the passed `documentId` and parameters.
@@ -102,9 +106,9 @@ If only a `documentId` is passed without any other parameters, `findOne()` retur
 <Request title="Find a document by passing its documentId">
 
 ```js
-await strapi.documents('api::restaurant.restaurant').findOne({
-  documentId: 'a1b2c3d4e5f6g7h8i9j0klm'
-})
+strapi.documents.discardDraft({
+  documentId: 'a1b2c3d4e5f6g7h8i9j0klm', 
+});
 ```
 
 </Request>
@@ -696,8 +700,8 @@ If no `locale` parameter is passed, `discardDraft()` discards draft data and ove
 <Request title="Discard draft for the default locale of a document">
 
 ```js
-strapi.documents.discardDraft({
-  documentId: 'a1b2c3d4e5f6g7h8i9j0klm', 
+await strapi.documents('api::restaurant.restaurant').discardDraft({
+  documentId: 'a1b2c3d4e5f6g7h8i9j0klm',
 });
 ```
 

--- a/docusaurus/docs/cms/api/document-service.md
+++ b/docusaurus/docs/cms/api/document-service.md
@@ -106,7 +106,7 @@ If only a `documentId` is passed without any other parameters, `findOne()` retur
 <Request title="Find a document by passing its documentId">
 
 ```js
-strapi.documents.discardDraft({
+await strapi.documents('api::restaurant.restaurant').findOne({
   documentId: 'a1b2c3d4e5f6g7h8i9j0klm', 
 });
 ```


### PR DESCRIPTION
## What does this PR do?
Adds a missing availability note after the Method Overview 
table in the Document Service API reference page.

## What was wrong?
The Method Overview table lists all 10 methods including 
publish(), unpublish(), and discardDraft(). However, there 
is no indication anywhere in the overview that these three 
methods require Draft & Publish to be enabled on the 
content-type.

A developer who has Draft & Publish disabled will see these 
methods listed, call them, receive a confusing runtime error, 
and find no explanation on this page.

## Fix applied
Added a :::note admonition directly after the Method Overview 
table clarifying that publish(), unpublish(), and 
discardDraft() require Draft & Publish to be enabled.

## Why it matters
Improves discoverability of a critical requirement at the 
point where developers are first scanning the available 
methods before they start writing code.

## Related issue
No specific issue gap identified during architectural 
analysis of the Strapi v5 Document Service API.