### PR TITLE
Note that internal entity-validator is not public API

### DIFF
--- a/docusaurus/docs/cms/backend-customization/controllers.md
+++ b/docusaurus/docs/cms/backend-customization/controllers.md
@@ -272,6 +272,10 @@ In Strapi 5, both query parameters and input data (i.e., create and update body 
 - non-writable fields and internal timestamps like `createdAt` and `createdBy` fields
 - setting or updating an `id` field (except for connecting relations)
 
+:::note Internal `entity-validator` service
+Strapi exposes a low-level `entity-validator` service (accessible through `strapi.service('entity-validator')`) with `validateEntityCreation` and `validateEntityUpdate` methods that the document service uses internally. These are not part of the public API and their semantics can change between releases. From a custom controller, service, or middleware, use the documented `validateInput` factory helper or the [`strapi.contentAPI.validate.*` helpers](#sanitize-validate-custom-controllers) instead. They apply the same content-type schema rules and additionally account for permissions, non-writable fields, and the request authentication strategy.
+:::
+
 #### Sanitization when utilizing controller factories
 
 Within the Strapi factories the following functions are exposed that can be used for sanitization and validation:


### PR DESCRIPTION
Closes #2984.

The reporter asked how to choose between `validateEntityCreation` and `validateEntityUpdate` on the `entity-validator` service they had found in core. Those methods are part of the internal `entity-validator` used by the document service and are not in the documented public surface, so the supported answer is to use the existing `validateInput` / `strapi.contentAPI.validate.*` helpers instead, which the controllers page already documents in detail. This patch adds a short note to that section saying so explicitly, so the next reader who finds the internal service in the source has somewhere in the docs that points them back at the public API.

I checked the page after the change in a local Docusaurus build and the note slots in between the v5 validation overview and the existing `Sanitization when utilizing controller factories` subheading. The link target `#sanitize-validate-custom-controllers` is the existing anchor on the Custom Controllers section further down.