### PR TITLE
Add install step after clone in test-locally walkthrough for Data Transfer

### DIFF
--- a/docusaurus/docs/cms/data-management/transfer.md
+++ b/docusaurus/docs/cms/data-management/transfer.md
@@ -279,6 +279,29 @@ The `transfer` command is not intended for transferring data between two local i
    git clone <path to created git repository>.git/ <new-instance-name>
    ```
 
+5. Move into the cloned project and install its dependencies:
+
+<Tabs groupId="yarn-npm">
+<TabItem value="yarn" label="yarn">
+
+```bash
+cd <new-instance-name>
+yarn install
+```
+
+</TabItem>
+<TabItem value="npm" label="npm">
+
+```bash
+cd <new-instance-name>
+npm install
+```
+
+</TabItem>
+</Tabs>
+
+   Without this step, the next `build` and `start` commands fail because `strapi` is not yet on the project's local executable path.
+
 ### Add data to the first Strapi instance
 
 1. Return to the first Strapi instance and add data to the content type.


### PR DESCRIPTION
Closes #2054.

The reporter followed `cms/data-management/transfer#test-the-transfer-command-locally` step by step and hit `'strapi' is not recognized as an internal or external command` on the `npm run build` line under "Create a transfer token". The walkthrough has the user create a Strapi project, commit it to a git repo, and `git clone` it into a second directory, then jumps straight to running `npm run build && npm run start` in that second directory without first installing dependencies. On Windows that error is the literal Node-isn't-finding-the-binary message because `node_modules/.bin/strapi` does not exist yet.

This patch adds a step 5 to "Create and clone a new Strapi project" that has the user move into the cloned directory and run the install. I kept the yarn / npm Tabs/TabItem layout already used on the page so the rendering stays consistent.