### PR TITLE
Update pnpm mention to warn about Strapi Cloud compatibility

### DIFF
--- a/docusaurus/docs/cms/installation/cli.md
+++ b/docusaurus/docs/cms/installation/cli.md
@@ -60,7 +60,7 @@ Follow the steps below to create a new Strapi project, being sure to use the app
     <TabItem value="pnpm" label="pnpm">
 
     :::caution
-    You might have issues with projects created with pnpm on Strapi Cloud. Strapi Cloud does not support pnpm yet, so it's recommended to use yarn or npm if you plan to eventually host your project on Strapi Cloud.
+    You might have issues with projects created with pnpm on Strapi Cloud. Strapi Cloud is fixed to pnpm v9, so it's recommended to use npm if you plan to eventually host your project on Strapi Cloud.
     :::
 
     ```bash

--- a/docusaurus/docs/snippets/installation-prerequisites.md
+++ b/docusaurus/docs/snippets/installation-prerequisites.md
@@ -3,6 +3,6 @@ Before installing Strapi, the following requirements must be installed on your c
 - <ExternalLink to="https://nodejs.org" text="Node.js"/>: Only <ExternalLink to="https://nodejs.org/en/about/previous-releases" text="Active LTS or Maintenance LTS versions"/> are supported (currently `v20`, `v22`, and `v24`). Odd-number releases of Node, known as "current" versions of Node.js, are not supported (e.g. v23, v25).
 - Your preferred Node.js package manager:
     - <ExternalLink to="https://docs.npmjs.com/cli/v6/commands/npm-install" text="npm"/> (`v6` and above)
-    - <ExternalLink to="https://pnpm.io/" text="pnpm" />
+    - <ExternalLink to="https://pnpm.io/" text="pnpm" /> (pnpm is fixed to v9 on Strapi Cloud)
 - <ExternalLink to="https://www.python.org/downloads/" text="Python"/> (if using a SQLite database)
 - A supported web browser: The Admin panel targets browsers matching the default <ExternalLink to="https://github.com/browserslist/browserslist" text="Browserslist"/> query: `last 3 major versions`, `Firefox ESR`, `last 2 Opera versions`, and `not dead`. See <ExternalLink to="https://browsersl.ist/#q=last+3+major+versions%2C+Firefox+ESR%2C+last+2+Opera+versions%2C+not+dead" text="browsersl.ist"/> for the current coverage matrix. Projects can override these defaults with a Browserslist configuration at the project root.


### PR DESCRIPTION
### Description

I am updating the mention of pnpm in the documentation to warn that pnpm is fixed to v9 on Strapi Cloud
