### PR TITLE
[Auto-sync] Clarify nested component required metadata gap in OpenAPI guide (#3128)

### DIFF
--- a/docusaurus/docs/cms/api/openapi.md
+++ b/docusaurus/docs/cms/api/openapi.md
@@ -23,6 +23,12 @@ The OpenAPI generation feature is currently experimental. Its behavior and outpu
 
 The OpenAPI generation tool is included with Strapi core and doesn't require additional installation. You can use it directly from the command line in any Strapi project to generate comprehensive API documentation.
 
+:::note Known limitation for nested component `required` metadata
+The Admin panel can mark inner fields on a component as required, yet the generated OpenAPI file may still skip a `required` entry for those scalars. The parent object (for instance a component inside a dynamic zone) might list `required` while the nested properties do not. There is more background in [GitHub issue #2236](https://github.com/strapi/documentation/issues/2236). Client generators that trust the raw schema alone can therefore emit types that look looser than what Strapi actually enforces.
+
+This area is still experimental, same as the warning banner at the top of the page, so keep validating nested payloads in application code or with the [REST validation helpers](/cms/backend-customization/controllers#sanitization-and-validation-in-controllers) from the controllers guide instead of assuming every Admin rule is mirrored in the exported JSON schema yet.
+:::
+
 ### CLI usage
 
 Executing the command without any arguments will generate a `specification.json` file at the root of your Strapi folder project:


### PR DESCRIPTION
Automatic sync of commit from main