### PR TITLE
Document AWS RDS IAM auth with short-lived tokens

### DIFF
--- a/docusaurus/docs/cms/backend-customization/controllers.md
+++ b/docusaurus/docs/cms/backend-customization/controllers.md
@@ -18,7 +18,7 @@ tags:
 # Controllers
 
 <Tldr>
-Controllers bundle actions that handle business logic for each route within Strapi’s MVC pattern. This documentation demonstrates generating controllers, extending core ones with `createCoreController`, and delegating heavy logic to services.
+Controllers bundle actions that handle business logic for each route within StrapiÃ¢â‚¬â„¢s MVC pattern. This documentation demonstrates generating controllers, extending core ones with `createCoreController`, and delegating heavy logic to services.
 </Tldr>
 
 Controllers are JavaScript files that contain a set of methods, called actions, reached by the client according to the requested [route](/cms/backend-customization/routes). Whenever a client requests the route, the action performs the business logic code and sends back the [response](/cms/backend-customization/requests-responses). Controllers represent the C in the model-view-controller (MVC) pattern.
@@ -226,9 +226,13 @@ To see a possible advanced usage for custom controllers, read the [services and 
 
 ### Controllers & Routes: How routes reach controller actions
 
-- Core mapping is automatic: when you generate a content-type, Strapi creates the matching controller and a router file that already targets the standard actions (`find`, `findOne`, `create`, `update`, and `delete`). Overriding any of these actions inside the generated controller does not require touching the router — the route keeps the same handler string and executes your updated logic.
+- Core mapping is automatic: when you generate a content-type, Strapi creates the matching controller and a router file that already targets the standard actions (`find`, `findOne`, `create`, `update`, and `delete`). Overriding any of these actions inside the generated controller does not require touching the router - the route keeps the same handler string and executes your updated logic.
 - Adding a route should only be done for new actions or paths. If you introduce a brand-new method such as `exampleAction`, create or update a route entry whose `handler` points to the action so HTTP requests can reach it. Use the fully-qualified handler syntax `<scope>::<api-or-plugin-name>.<controllerName>.<actionName>` (e.g. `api::restaurant.restaurant.exampleAction` for an API controller or `plugin::menus.menu.exampleAction` for a plugin controller).
 - Regarding controller and route filenames: the default controller name comes from the filename inside `./src/api/[api-name]/controllers/`. Core routers created with `createCoreRouter` adopt the same name, so the generated handler string matches automatically. Custom routers can follow any file naming scheme, as long as the `handler` string references an exported controller action.
+
+:::note About core mapping
+The REST routes Strapi generates for a content-type point each HTTP method at a **handler** string (for example `api::restaurant.restaurant.find`). That string already identifies the controller file and the exported action name (`find`, `findOne`, `create`, `update`, or `delete`). When you change the implementation inside those exports but keep the names, the router still calls your code. Edit the route file only when you add a new action name or path outside that default CRUD set.
+:::
 
 The example below adds a new controller action and exposes it through a custom route without duplicating the existing CRUD route definitions:
 
@@ -261,7 +265,7 @@ module.exports = {
 It's strongly recommended you sanitize (v4.8.0+) and/or validate (v4.13.0+) your incoming request query utilizing the new `sanitizeQuery` and `validateQuery` functions to prevent the leaking of private data.
 :::
 
-Sanitization means that the object is “cleaned” and returned.
+Sanitization means that the object is Ã¢â‚¬Å“cleanedÃ¢â‚¬Â and returned.
 
 Validation means an assertion is made that the data is already clean and throws an error if something is found that shouldn't be there.
 

--- a/docusaurus/docs/cms/backend-customization/controllers.md
+++ b/docusaurus/docs/cms/backend-customization/controllers.md
@@ -231,7 +231,7 @@ To see a possible advanced usage for custom controllers, read the [services and 
 - Regarding controller and route filenames: the default controller name comes from the filename inside `./src/api/[api-name]/controllers/`. Core routers created with `createCoreRouter` adopt the same name, so the generated handler string matches automatically. Custom routers can follow any file naming scheme, as long as the `handler` string references an exported controller action.
 
 :::note About core mapping
-The REST routes Strapi generates for a content-type point each HTTP method at a **handler** string (for example `api::restaurant.restaurant.find`). That string already identifies the controller file and the exported action name (`find`, `findOne`, `create`, `update`, or `delete`). When you change the implementation inside those exports but keep the names, the router still calls your code. Edit the route file only when you add a new action name or path outside that default CRUD set.
+The REST routes Strapi generates for a content-type point each HTTP method at a handler string (for example `api::restaurant.restaurant.find`). That string already identifies the controller file and the exported action name (`find`, `findOne`, `create`, `update`, or `delete`). When you change the implementation inside those exports but keep the names, the router still calls your code. Edit the route file only when you add a new action name or path outside that default CRUD set.
 :::
 
 The example below adds a new controller action and exposes it through a custom route without duplicating the existing CRUD route definitions:

--- a/docusaurus/docs/cms/configurations/database.md
+++ b/docusaurus/docs/cms/configurations/database.md
@@ -262,7 +262,7 @@ module.exports = ({ env }) => ({
 ```
 
 :::tip
-Strapiâ€™s default SQLite database lives at `.tmp/data.db` at the root of the project. If you want to customise the path to store the database elsewhere, set the `DATABASE_FILENAME` environment variable.
+Strapi's default SQLite database lives at `.tmp/data.db` at the root of the project. If you want to customise the path to store the database elsewhere, set the `DATABASE_FILENAME` environment variable.
 :::
 
 </TabItem>

--- a/docusaurus/docs/cms/configurations/database.md
+++ b/docusaurus/docs/cms/configurations/database.md
@@ -80,6 +80,10 @@ The `connection.connection` object found in `./config/database.js` (or `./config
 Depending on the database client used, more parameters can be set (e.g., `charset` and `collation` for <ExternalLink to="https://github.com/mysqljs/mysql#connection-options" text="mysql"/>). Check the database client documentation to know what parameters are available, for instance the <ExternalLink to="https://node-postgres.com/apis/client#new-client" text="pg"/>, <ExternalLink to="https://github.com/mysqljs/mysql#connection-options" text="mysql"/>, and <ExternalLink to="https://github.com/WiseLibs/better-sqlite3/blob/master/docs/api.md#new-databasepath-options" text="better-sqlite3"/> documentations.
 :::
 
+:::tip
+The `connection` object is passed to Knex. If Knex supports additional options that are not listed on this page (for example `expirationChecker` for short-lived credentials), you can add them here.
+:::
+
 #### Database pooling options
 
 The `connection.pool` object optionally found in `./config/database.js` (or `./config/database.ts` for TypeScript) is used to pass <ExternalLink to="https://github.com/vincit/tarn.js" text="Tarn.js"/> database pooling options and accepts the following parameters:
@@ -247,6 +251,47 @@ export default ({ env }) => ({
 
 </TabItem>
 </Tabs>
+
+### Example: PostgreSQL with AWS RDS IAM authentication (dynamic password token)
+
+Knex supports short-lived credentials by letting you provide `connection.connection` as a function and by checking whether a token needs renewal via `expirationChecker`.
+
+```ts title="./config/database.ts"
+import { Signer } from '@aws-sdk/rds-signer';
+
+export default ({ env }) => {
+  const signer = new Signer({
+    hostname: env('DATABASE_HOST', 'localhost'),
+    port: env.int('DATABASE_PORT', 5432),
+    username: env('DATABASE_USERNAME', 'strapi'),
+  });
+
+  return {
+    connection: {
+      client: 'postgres',
+      connection: async () => {
+        const token = await signer.getAuthToken();
+        const expiresAt = Date.now() + 15 * 60 * 1000;
+
+        return {
+          host: env('DATABASE_HOST', 'localhost'),
+          port: env.int('DATABASE_PORT', 5432),
+          database: env('DATABASE_NAME', 'strapi'),
+          user: env('DATABASE_USERNAME', 'strapi'),
+          password: token,
+          schema: env('DATABASE_SCHEMA', 'public'),
+          ssl: true,
+          expirationChecker: () => expiresAt - Date.now() <= 5 * 60 * 1000,
+        };
+      },
+    },
+  };
+};
+```
+
+:::note
+AWS RDS IAM authentication requires SSL. Refer to the AWS documentation for the required certificate bundle and SSL parameters.
+:::
 
 ## Configuration in database
 

--- a/docusaurus/docs/cms/configurations/database.md
+++ b/docusaurus/docs/cms/configurations/database.md
@@ -214,7 +214,7 @@ export default ({ env }) => {
 ```
 
 :::note
-AWS RDS IAM authentication requires SSL. Refer to the AWS documentation for the required certificate bundle and SSL parameters.
+AWS RDS IAM authentication requires SSL. Refer to the <ExternalLink to="https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.html" text="AWS documentation"/> for the required certificate bundle and SSL parameters.
 :::
 
 </TabItem>

--- a/docusaurus/docs/cms/configurations/database.md
+++ b/docusaurus/docs/cms/configurations/database.md
@@ -176,6 +176,47 @@ module.exports = ({ env }) => ({
 });
 ```
 
+**Example: PostgreSQL with AWS RDS IAM authentication (dynamic password token)**
+
+Knex supports short-lived credentials by letting you provide `connection.connection` as a function and by checking whether a token needs renewal via `expirationChecker`.
+
+```ts title="./config/database.ts"
+import { Signer } from '@aws-sdk/rds-signer';
+
+export default ({ env }) => {
+  const signer = new Signer({
+    hostname: env('DATABASE_HOST', 'localhost'),
+    port: env.int('DATABASE_PORT', 5432),
+    username: env('DATABASE_USERNAME', 'strapi'),
+  });
+
+  return {
+    connection: {
+      client: 'postgres',
+      connection: async () => {
+        const token = await signer.getAuthToken();
+        const expiresAt = Date.now() + 15 * 60 * 1000;
+
+        return {
+          host: env('DATABASE_HOST', 'localhost'),
+          port: env.int('DATABASE_PORT', 5432),
+          database: env('DATABASE_NAME', 'strapi'),
+          user: env('DATABASE_USERNAME', 'strapi'),
+          password: token,
+          schema: env('DATABASE_SCHEMA', 'public'),
+          ssl: true,
+          expirationChecker: () => expiresAt - Date.now() <= 5 * 60 * 1000,
+        };
+      },
+    },
+  };
+};
+```
+
+:::note
+AWS RDS IAM authentication requires SSL. Refer to the AWS documentation for the required certificate bundle and SSL parameters.
+:::
+
 </TabItem>
 
  <TabItem value="MySQL/MariaDB" label="MySQL/MariaDB">
@@ -221,7 +262,7 @@ module.exports = ({ env }) => ({
 ```
 
 :::tip
-Strapi’s default SQLite database lives at `.tmp/data.db` at the root of the project. If you want to customise the path to store the database elsewhere, set the `DATABASE_FILENAME` environment variable.
+Strapiâ€™s default SQLite database lives at `.tmp/data.db` at the root of the project. If you want to customise the path to store the database elsewhere, set the `DATABASE_FILENAME` environment variable.
 :::
 
 </TabItem>
@@ -251,47 +292,6 @@ export default ({ env }) => ({
 
 </TabItem>
 </Tabs>
-
-### Example: PostgreSQL with AWS RDS IAM authentication (dynamic password token)
-
-Knex supports short-lived credentials by letting you provide `connection.connection` as a function and by checking whether a token needs renewal via `expirationChecker`.
-
-```ts title="./config/database.ts"
-import { Signer } from '@aws-sdk/rds-signer';
-
-export default ({ env }) => {
-  const signer = new Signer({
-    hostname: env('DATABASE_HOST', 'localhost'),
-    port: env.int('DATABASE_PORT', 5432),
-    username: env('DATABASE_USERNAME', 'strapi'),
-  });
-
-  return {
-    connection: {
-      client: 'postgres',
-      connection: async () => {
-        const token = await signer.getAuthToken();
-        const expiresAt = Date.now() + 15 * 60 * 1000;
-
-        return {
-          host: env('DATABASE_HOST', 'localhost'),
-          port: env.int('DATABASE_PORT', 5432),
-          database: env('DATABASE_NAME', 'strapi'),
-          user: env('DATABASE_USERNAME', 'strapi'),
-          password: token,
-          schema: env('DATABASE_SCHEMA', 'public'),
-          ssl: true,
-          expirationChecker: () => expiresAt - Date.now() <= 5 * 60 * 1000,
-        };
-      },
-    },
-  };
-};
-```
-
-:::note
-AWS RDS IAM authentication requires SSL. Refer to the AWS documentation for the required certificate bundle and SSL parameters.
-:::
 
 ## Configuration in database
 


### PR DESCRIPTION
This adds a short note that the database `connection` object is passed through to Knex, then includes an example for using AWS RDS IAM authentication with a short-lived token via Knex `expirationChecker`.

Closes strapi/documentation#1789.