### PR TITLE
Note that REST filter examples need populate to surface traversed relations

### DIFF
--- a/docusaurus/docs/cms/api/rest/filters.md
+++ b/docusaurus/docs/cms/api/rest/filters.md
@@ -293,6 +293,11 @@ await request(`/api/books?${query}`);
 </Response>
 </ApiCall>
 
+:::note
+The response above only contains a book's own attributes. The `author` relation traversed by the `$and` filter is not returned unless requested through the [`populate` parameter](/cms/api/rest/populate-select#population), for example by adding `&populate=author` to the request.
+:::
+
+
 ## Deep filtering
 
 Deep filtering is filtering on a relation's fields.
@@ -369,3 +374,8 @@ await request(`/api/restaurants?${query}`);
 
 </Response>
 </ApiCall>
+
+:::note
+The response above mirrors the default REST output, which excludes the relations traversed by the filter. Add a [`populate` parameter](/cms/api/rest/populate-select#population) such as `&populate[chef][populate][restaurants]=true` to also return the `chef.restaurants` relation referenced in the filter.
+:::
+


### PR DESCRIPTION
### What

Two open issues report the same root cause on the same page:

- [#2066](https://github.com/strapi/documentation/issues/2066) flags that the **Complex filtering** example filters books on `author.name` but the response example only shows the book's own attributes (`name`, `date`), with no `author` field anywhere.
- [#2067](https://github.com/strapi/documentation/issues/2067) flags the same shape for **Deep filtering**: the filter traverses `chef.restaurants.stars`, but the response example only shows the restaurant's own `name` and `stars`.

Both are correct: the bare REST response does not include relations unless they are populated, so the example output reads as if the filter never matched on those keys.

### Where

`docusaurus/docs/cms/api/rest/filters.md`, immediately after the existing response example in each section. The two sections already have a generic `:::note` mentioning that relations are not populated by default; the new notes are scoped to "this specific example" and link to the populate docs with a copy-pasteable parameter.

### Diff intent

- Add a `:::note` after the **Complex filtering** response example pointing to `&populate=author`.
- Add a `:::note` after the **Deep filtering** response example pointing to `&populate[chef][populate][restaurants]=true`.

Closes #2066
Closes #2067
