### PR TITLE
Add middleware customization guide for Strapi Cloud production environment

### DIFF
--- a/docusaurus/docs/cloud/advanced/middlewares.md
+++ b/docusaurus/docs/cloud/advanced/middlewares.md
@@ -18,42 +18,69 @@ tags:
 # Middleware Configuration for Strapi Cloud
 
 <Tldr>
-On Strapi Cloud, middleware customizations must go in `config/env/production/middlewares.ts` (or `.js`) — changes to the global config file are overwritten on deploy.
+On Strapi Cloud, middleware customizations must go in `config/env/production/middlewares`. Changes to the global config file are overwritten on deploy.
 </Tldr>
 
 :::prerequisites
 
-- A local Strapi project running on `v4.8.2+`.
+- A local Strapi project.
 - A Strapi Cloud project (see [Getting Started](/cloud/getting-started/deployment)).
 
 :::
 
-On Strapi Cloud, `NODE_ENV` is always set to `production`. The platform injects its own middleware configuration at the production environment level, which means any customizations placed in the global `config/middlewares.ts` (or `.js`) file will be overwritten after deploy and will not take effect.
+On Strapi Cloud, `NODE_ENV` is always set to `production`. The platform applies its own production-level middleware configuration on deploy. Any changes to the global `config/middlewares` file are overwritten and will not take effect. For available middleware options, see [Middlewares configuration](/cms/configurations/middlewares).
 
 To apply custom middleware configuration on Strapi Cloud, place your changes in:
+
+<Tabs groupId="js-ts">
+<TabItem value="js" label="JavaScript" default>
+
+```
+config/env/production/middlewares.js
+```
+
+</TabItem>
+<TabItem value="ts" label="TypeScript">
 
 ```
 config/env/production/middlewares.ts
 ```
 
-or `.js` if your project uses JavaScript.
+</TabItem>
+</Tabs>
 
-:::note
-You can keep your existing `config/middlewares.ts` file as-is — it will not cause conflicts. The production-specific file takes precedence on Strapi Cloud.
+:::caution
+The `config/env/production/middlewares` file **fully replaces** the global middleware array. Your file must include the complete list:
+
+- `strapi::errors`
+- `strapi::security`
+- `strapi::cors`
+- `strapi::poweredBy`
+- `strapi::logger`
+- `strapi::query`
+- `strapi::body`
+- `strapi::session`
+- `strapi::favicon`
+- `strapi::public`
+
+Both CSP and CORS customizations can be combined in the same file.
 :::
 
-## Common use cases
+:::note
+- You can keep your existing `config/middlewares` file as-is as it will not cause conflicts. The production-specific file takes precedence on Strapi Cloud.
+- Upload size limits on Strapi Cloud are enforced at the infrastructure level (Cloudflare gateway) and cannot be overridden via the `strapi::body` config. For external storage options, see [Upload Provider Configuration](/cloud/advanced/upload).
+:::
 
-### Custom Content Security Policy (CSP)
+## Custom Content Security Policy (CSP)
 
-If you use an external upload provider (such as Cloudflare R2, AWS S3, or any custom domain), you need to allow those domains in the CSP directives. Without this, the Strapi Admin panel will block images and media from those sources.
+If you use an external upload provider, allow its domain in the CSP directives. Without this, the Strapi Admin panel will block images and media from those sources.
 
-Create or update `config/env/production/middlewares.ts`:
+Create or update `config/env/production/middlewares`:
 
 <Tabs groupId="js-ts">
-<TabItem value="js" label="JavaScript">
+<TabItem value="js" label="JavaScript" default>
 
-```js title=./config/env/production/middlewares.js
+```js title="config/env/production/middlewares.js"
 module.exports = [
   'strapi::errors',
   {
@@ -96,7 +123,7 @@ module.exports = [
 </TabItem>
 <TabItem value="ts" label="TypeScript">
 
-```ts title=./config/env/production/middlewares.ts
+```ts title="config/env/production/middlewares.ts"
 export default [
   'strapi::errors',
   {
@@ -143,14 +170,14 @@ export default [
 For a full list of upload providers and their required domains, see the <ExternalLink to="https://market.strapi.io/providers" text="Strapi Market"/>.
 :::
 
-### Custom CORS headers
+## Custom CORS headers
 
-If your frontend sends custom request headers (e.g. for authorization flows), you need to explicitly allow them in the CORS configuration. Placing this in the global `config/middlewares.ts` will not work on Strapi Cloud — it must be in `config/env/production/middlewares.ts`.
+If your frontend sends custom request headers (e.g. for authorization flows), you need to explicitly allow them in the CORS configuration. Placing this in the global `config/middlewares` file will not work on Strapi Cloud. Place it in `config/env/production/middlewares` instead.
 
 <Tabs groupId="js-ts">
-<TabItem value="js" label="JavaScript">
+<TabItem value="js" label="JavaScript" default>
 
-```js title=./config/env/production/middlewares.js
+```js title="config/env/production/middlewares.js"
 module.exports = ({ env }) => [
   'strapi::errors',
   'strapi::security',
@@ -182,7 +209,7 @@ module.exports = ({ env }) => [
 </TabItem>
 <TabItem value="ts" label="TypeScript">
 
-```ts title=./config/env/production/middlewares.ts
+```ts title="config/env/production/middlewares.ts"
 export default ({ env }) => [
   'strapi::errors',
   'strapi::security',
@@ -213,20 +240,3 @@ export default ({ env }) => [
 
 </TabItem>
 </Tabs>
-
-## Important notes
-
-:::caution
-The `config/env/production/middlewares.ts` (or `.js`) file **fully replaces** the global middleware array — it is not merged. Your file must always include the complete middleware list: `strapi::errors`, `strapi::security`, `strapi::cors`, `strapi::poweredBy`, `strapi::logger`, `strapi::query`, `strapi::body`, `strapi::session`, `strapi::favicon`, and `strapi::public`. Both CSP and CORS customizations can be combined in the same file.
-:::
-
-:::note
-Upload size limits on Strapi Cloud are enforced at the infrastructure level (Cloudflare gateway) and cannot be overridden via the `strapi::body` config. See [Upload Provider Configuration](/cloud/advanced/upload) for guidance on using external providers to handle larger file sizes.
-:::
-
-This behavior applies to all Strapi Cloud plans.
-
-## See also
-
-- [Middlewares configuration](/cms/configurations/middlewares) — full reference for all available middleware options, including `strapi::security` and `strapi::cors` parameters.
-- [Upload Provider Configuration for Strapi Cloud](/cloud/advanced/upload) — configure an external upload provider and the associated CSP settings.

--- a/docusaurus/docs/cloud/advanced/middlewares.md
+++ b/docusaurus/docs/cloud/advanced/middlewares.md
@@ -18,7 +18,7 @@ tags:
 # Middleware Configuration for Strapi Cloud
 
 <Tldr>
-On Strapi Cloud, middleware customizations must go in `config/env/production/middlewares.ts` — changes to the global config file are overwritten on deploy.
+On Strapi Cloud, middleware customizations must go in `config/env/production/middlewares.ts` (or `.js`) — changes to the global config file are overwritten on deploy.
 </Tldr>
 
 :::prerequisites
@@ -35,6 +35,8 @@ To apply custom middleware configuration on Strapi Cloud, place your changes in:
 ```
 config/env/production/middlewares.ts
 ```
+
+or `.js` if your project uses JavaScript.
 
 :::note
 You can keep your existing `config/middlewares.ts` file as-is — it will not cause conflicts. The production-specific file takes precedence on Strapi Cloud.
@@ -75,6 +77,7 @@ module.exports = [
             'market-assets.strapi.io',
             'your-custom-domain.com', // replace with your provider domain
           ],
+          upgradeInsecureRequests: null,
         },
       },
     },
@@ -117,6 +120,7 @@ export default [
             'market-assets.strapi.io',
             'your-custom-domain.com', // replace with your provider domain
           ],
+          upgradeInsecureRequests: null,
         },
       },
     },
@@ -147,14 +151,14 @@ If your frontend sends custom request headers (e.g. for authorization flows), yo
 <TabItem value="js" label="JavaScript">
 
 ```js title=./config/env/production/middlewares.js
-module.exports = [
+module.exports = ({ env }) => [
   'strapi::errors',
   'strapi::security',
   {
     name: 'strapi::cors',
     config: {
       enabled: true,
-      origin: [process.env.CLIENT_URL],
+      origin: [env('CLIENT_URL')],
       headers: [
         'Content-Type',
         'Authorization',
@@ -179,14 +183,14 @@ module.exports = [
 <TabItem value="ts" label="TypeScript">
 
 ```ts title=./config/env/production/middlewares.ts
-export default [
+export default ({ env }) => [
   'strapi::errors',
   'strapi::security',
   {
     name: 'strapi::cors',
     config: {
       enabled: true,
-      origin: [process.env.CLIENT_URL],
+      origin: [env('CLIENT_URL')],
       headers: [
         'Content-Type',
         'Authorization',
@@ -213,14 +217,14 @@ export default [
 ## Important notes
 
 :::caution
-Both CSP and CORS can be combined in a single `config/env/production/middlewares.ts` file. Make sure to include the full middleware array — partial configs may cause other middlewares to be dropped.
+The `config/env/production/middlewares.ts` (or `.js`) file **fully replaces** the global middleware array — it is not merged. Your file must always include the complete middleware list: `strapi::errors`, `strapi::security`, `strapi::cors`, `strapi::poweredBy`, `strapi::logger`, `strapi::query`, `strapi::body`, `strapi::session`, `strapi::favicon`, and `strapi::public`. Both CSP and CORS customizations can be combined in the same file.
 :::
 
 :::note
 Upload size limits on Strapi Cloud are enforced at the infrastructure level (Cloudflare gateway) and cannot be overridden via the `strapi::body` config. See [Upload Provider Configuration](/cloud/advanced/upload) for guidance on using external providers to handle larger file sizes.
 :::
 
-This behavior applies to all Strapi Cloud plans and to both Strapi v4 and v5.
+This behavior applies to all Strapi Cloud plans.
 
 ## See also
 

--- a/docusaurus/docs/cloud/advanced/middlewares.md
+++ b/docusaurus/docs/cloud/advanced/middlewares.md
@@ -1,0 +1,216 @@
+---
+title: Middleware Configuration for Strapi Cloud
+displayed_sidebar: cloudSidebar
+description: Configure custom middlewares for your Strapi Cloud production environment.
+canonicalUrl: https://docs.strapi.io/cloud/advanced/middlewares.html
+tags:
+- configuration
+- middlewares
+- CORS
+- Content Security Policy
+- CSP
+- production
+- Strapi Cloud
+- Strapi Cloud configuration
+- Strapi Cloud project
+---
+
+# Middleware Configuration for Strapi Cloud
+
+<Tldr>
+On Strapi Cloud, middleware customizations must go in `config/env/production/middlewares.ts` — changes to the global config file are overwritten on deploy.
+</Tldr>
+
+On Strapi Cloud, `NODE_ENV` is always set to `production`. The platform injects its own middleware configuration at the production environment level, which means any customizations placed in the global `config/middlewares.ts` (or `.js`) file will be overwritten after deploy and will not take effect.
+
+To apply custom middleware configuration on Strapi Cloud, place your changes in:
+
+```
+config/env/production/middlewares.ts
+```
+
+:::note
+You can keep your existing `config/middlewares.ts` file as-is — it will not cause conflicts. The production-specific file takes precedence on Strapi Cloud.
+:::
+
+## Common use cases
+
+### Custom Content Security Policy (CSP)
+
+If you use an external upload provider (such as Cloudflare R2, AWS S3, or any custom domain), you need to allow those domains in the CSP directives. Without this, the Strapi Admin panel will block images and media from those sources.
+
+Create or update `config/env/production/middlewares.ts`:
+
+<Tabs groupId="js-ts">
+<TabItem value="js" label="JavaScript">
+
+```js title=./config/env/production/middlewares.js
+module.exports = [
+  'strapi::errors',
+  {
+    name: 'strapi::security',
+    config: {
+      contentSecurityPolicy: {
+        useDefaults: true,
+        directives: {
+          'connect-src': ["'self'", 'https:'],
+          'img-src': [
+            "'self'",
+            'data:',
+            'blob:',
+            'market-assets.strapi.io',
+            'your-custom-domain.com', // replace with your provider domain
+          ],
+          'media-src': [
+            "'self'",
+            'data:',
+            'blob:',
+            'market-assets.strapi.io',
+            'your-custom-domain.com', // replace with your provider domain
+          ],
+        },
+      },
+    },
+  },
+  'strapi::cors',
+  'strapi::poweredBy',
+  'strapi::logger',
+  'strapi::query',
+  'strapi::body',
+  'strapi::session',
+  'strapi::favicon',
+  'strapi::public',
+];
+```
+
+</TabItem>
+<TabItem value="ts" label="TypeScript">
+
+```ts title=./config/env/production/middlewares.ts
+export default [
+  'strapi::errors',
+  {
+    name: 'strapi::security',
+    config: {
+      contentSecurityPolicy: {
+        useDefaults: true,
+        directives: {
+          'connect-src': ["'self'", 'https:'],
+          'img-src': [
+            "'self'",
+            'data:',
+            'blob:',
+            'market-assets.strapi.io',
+            'your-custom-domain.com', // replace with your provider domain
+          ],
+          'media-src': [
+            "'self'",
+            'data:',
+            'blob:',
+            'market-assets.strapi.io',
+            'your-custom-domain.com', // replace with your provider domain
+          ],
+        },
+      },
+    },
+  },
+  'strapi::cors',
+  'strapi::poweredBy',
+  'strapi::logger',
+  'strapi::query',
+  'strapi::body',
+  'strapi::session',
+  'strapi::favicon',
+  'strapi::public',
+];
+```
+
+</TabItem>
+</Tabs>
+
+:::tip
+For a full list of upload providers and their required domains, see the <ExternalLink to="https://market.strapi.io/providers" text="Strapi Market"/>.
+:::
+
+### Custom CORS headers
+
+If your frontend sends custom request headers (e.g. for authorization flows), you need to explicitly allow them in the CORS configuration. Placing this in the global `config/middlewares.ts` will not work on Strapi Cloud — it must be in `config/env/production/middlewares.ts`.
+
+<Tabs groupId="js-ts">
+<TabItem value="js" label="JavaScript">
+
+```js title=./config/env/production/middlewares.js
+module.exports = [
+  'strapi::errors',
+  'strapi::security',
+  {
+    name: 'strapi::cors',
+    config: {
+      enabled: true,
+      origin: [process.env.CLIENT_URL],
+      headers: [
+        'Content-Type',
+        'Authorization',
+        'Origin',
+        'Accept',
+        'X-Requested-With',
+        'your-custom-header', // add any custom headers your frontend sends
+      ],
+    },
+  },
+  'strapi::poweredBy',
+  'strapi::logger',
+  'strapi::query',
+  'strapi::body',
+  'strapi::session',
+  'strapi::favicon',
+  'strapi::public',
+];
+```
+
+</TabItem>
+<TabItem value="ts" label="TypeScript">
+
+```ts title=./config/env/production/middlewares.ts
+export default [
+  'strapi::errors',
+  'strapi::security',
+  {
+    name: 'strapi::cors',
+    config: {
+      enabled: true,
+      origin: [process.env.CLIENT_URL],
+      headers: [
+        'Content-Type',
+        'Authorization',
+        'Origin',
+        'Accept',
+        'X-Requested-With',
+        'your-custom-header', // add any custom headers your frontend sends
+      ],
+    },
+  },
+  'strapi::poweredBy',
+  'strapi::logger',
+  'strapi::query',
+  'strapi::body',
+  'strapi::session',
+  'strapi::favicon',
+  'strapi::public',
+];
+```
+
+</TabItem>
+</Tabs>
+
+## Important notes
+
+:::caution
+Both CSP and CORS can be combined in a single `config/env/production/middlewares.ts` file. Make sure to include the full middleware array — partial configs may cause other middlewares to be dropped.
+:::
+
+:::note
+Upload size limits on Strapi Cloud are enforced at the infrastructure level (Cloudflare gateway) and cannot be overridden via the `strapi::body` config. See [Upload Provider Configuration](/cloud/advanced/upload) for guidance on using external providers to handle larger file sizes.
+:::
+
+This behavior applies to all Strapi Cloud plans and to both Strapi v4 and v5.

--- a/docusaurus/docs/cloud/advanced/middlewares.md
+++ b/docusaurus/docs/cloud/advanced/middlewares.md
@@ -21,6 +21,13 @@ tags:
 On Strapi Cloud, middleware customizations must go in `config/env/production/middlewares.ts` — changes to the global config file are overwritten on deploy.
 </Tldr>
 
+:::prerequisites
+
+- A local Strapi project running on `v4.8.2+`.
+- A Strapi Cloud project (see [Getting Started](/cloud/getting-started/deployment)).
+
+:::
+
 On Strapi Cloud, `NODE_ENV` is always set to `production`. The platform injects its own middleware configuration at the production environment level, which means any customizations placed in the global `config/middlewares.ts` (or `.js`) file will be overwritten after deploy and will not take effect.
 
 To apply custom middleware configuration on Strapi Cloud, place your changes in:
@@ -214,3 +221,8 @@ Upload size limits on Strapi Cloud are enforced at the infrastructure level (Clo
 :::
 
 This behavior applies to all Strapi Cloud plans and to both Strapi v4 and v5.
+
+## See also
+
+- [Middlewares configuration](/cms/configurations/middlewares) — full reference for all available middleware options, including `strapi::security` and `strapi::cors` parameters.
+- [Upload Provider Configuration for Strapi Cloud](/cloud/advanced/upload) — configure an external upload provider and the associated CSP settings.

--- a/docusaurus/docs/cloud/advanced/upload.md
+++ b/docusaurus/docs/cloud/advanced/upload.md
@@ -252,7 +252,7 @@ To do this in your Strapi project:
 <Tabs groupId="upload-examples" >
 <TabItem value="cloudinary" label="Cloudinary">
 
-```js title=./config/middleware.js
+```js title=./config/env/production/middlewares.js
 module.exports = [
   // ...
   {
@@ -288,7 +288,7 @@ module.exports = [
 </TabItem>
 <TabItem value="amazon-s3" label="Amazon S3">
 
-```js title=./config/middleware.js
+```js title=./config/env/production/middlewares.js
 module.exports = [
   // ...
   {
@@ -328,7 +328,7 @@ module.exports = [
 <Tabs groupId="upload-examples" >
 <TabItem value="cloudinary" label="Cloudinary">
 
-```ts title=./config/middleware.ts
+```ts title=./config/env/production/middlewares.ts
 export default [
   // ...
   {
@@ -364,7 +364,7 @@ export default [
 </TabItem>
 <TabItem value="amazon-s3" label="Amazon S3">
 
-```ts title=./config/middleware.ts
+```ts title=./config/env/production/middlewares.ts
 export default [
   // ...
   {

--- a/docusaurus/docs/cloud/advanced/upload.md
+++ b/docusaurus/docs/cloud/advanced/upload.md
@@ -237,9 +237,13 @@ export default ({ env }) => ({
 
 Due to the default settings in the Strapi Security Middleware you will need to modify the `contentSecurityPolicy` settings to properly see thumbnail previews in the Media Library.
 
+:::caution
+On Strapi Cloud, `NODE_ENV` is always set to `production`. Changes to the global `config/middlewares.ts` file are overwritten on each deploy and will not take effect. Place your Security Middleware customizations in `config/env/production/middlewares.ts` instead. See [Middleware Configuration for Strapi Cloud](/cloud/advanced/middlewares) for details.
+:::
+
 To do this in your Strapi project:
 
-1. Navigate to `./config/middlewares.js` or `./config/middlewares.ts` in your Strapi project.
+1. Navigate to `./config/env/production/middlewares.js` or `./config/env/production/middlewares.ts` in your Strapi project.
 2. Replace the default `strapi::security` string with the object provided by the upload provider.
 
 **Example:**

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -745,6 +745,14 @@ const sidebars = {
             new: false,
           },
         },
+        {
+          type: 'doc',
+          id: 'cloud/advanced/middlewares',
+          label: 'Middleware configuration for Cloud',
+          customProps: {
+            new: false,
+          },
+        },
       ],
     },
   ],


### PR DESCRIPTION
### Description

Adds a new page `cloud/advanced/middlewares` documenting how to correctly configure custom middlewares on Strapi Cloud.

**Why it's needed:** On Strapi Cloud, `NODE_ENV` is always `production` and the platform injects its own middleware configuration at the production env level. This means changes made to the global `config/middlewares.ts` are silently overwritten on each deploy. Users must place their customizations in `config/env/production/middlewares.ts` instead, but this behavior is not currently documented anywhere.

**What the page covers:**
- Explanation of why `config/middlewares.ts` changes don't apply on Cloud
- How to use `config/env/production/middlewares.ts` as the correct override path
- Common use case: custom CSP directives for external upload providers (Cloudflare R2, S3, etc.)
- Common use case: custom CORS headers for frontend authorization flows
- JavaScript and TypeScript examples for both cases
- Notes on combining CSP + CORS in a single file, upload size limits, and Strapi v4/v5 compatibility

Also adds the new page to the Cloud sidebar under "Advanced configuration".

### Related issue(s)/PR(s)

- Closes #8943
- Closes #8944