### PR TITLE
Document dynamic zone __component in REST update section

### DIFF
--- a/docusaurus/docs/cms/api/rest.md
+++ b/docusaurus/docs/cms/api/rest.md
@@ -357,7 +357,7 @@ Send a `null` value to clear fields.
 * While updating a document, you can define its relations and their order (see [Managing relations through the REST API](/cms/api/rest/relations) for more details).
 :::
 
-:::note Dynamic zones
+:::info Dynamic zones
 Each entry you send for a [dynamic zone](/cms/backend-customization/models#dynamic-zones) must include `__component` with the target component's UID (for example `shared.media`). Strapi uses that field to pick the component schema when you create or update items in the zone; without it, writes can fail validation or return success without changing data. Use the UID shown in the Content-Type Builder for each component in the zone.
 :::
 

--- a/docusaurus/docs/cms/api/rest.md
+++ b/docusaurus/docs/cms/api/rest.md
@@ -357,6 +357,10 @@ Send a `null` value to clear fields.
 * While updating a document, you can define its relations and their order (see [Managing relations through the REST API](/cms/api/rest/relations) for more details).
 :::
 
+:::note Dynamic zones
+Each entry you send for a [dynamic zone](/cms/backend-customization/models#dynamic-zones) must include `__component` with the target component's UID (for example `shared.media`). Strapi uses that field to pick the component schema when you create or update items in the zone; without it, writes can fail validation or return success without changing data. Use the UID shown in the Content-Type Builder for each component in the zone.
+:::
+
 <ApiCall>
 
 <Request title="Example request">


### PR DESCRIPTION
Issue #2327 and the thread from Boegie19 spell out that dynamic zone payloads need a __component key on each entry so Strapi can pick the component schema. That was missing from the REST reference, so people were sending full arrays copied from GET responses and getting confusing results.

I added a short note under the update section of the REST API reference that calls this out and points readers at the Content-Type Builder UID (with shared.media as an example shape only).

Closes #2327.

Made with [Cursor](https://cursor.com)