### PR TITLE
Document React admin dependencies for v4 upgrades

### DIFF
--- a/docusaurus/docs/cms/faq.md
+++ b/docusaurus/docs/cms/faq.md
@@ -136,25 +136,6 @@ By default, most package managers enable hoisting, however, if it's not function
 - If you are using npm or pnpm: Add `hoist=true` to your project's `.npmrc` file. Learn more about this from the <ExternalLink to="https://pnpm.io/npmrc#hoist" text="official pnpm documentation"/>
 - If you are using Yarn: Set `nmHoistingLimits` in your `.yarnrc` file. More details can be found in the <ExternalLink to="https://yarnpkg.com/configuration/yarnrc#nmHoistingLimits" text="Yarn official documentation"/>
 
-## How to fix the build error `Cannot find module 'react'` when upgrading Strapi v4
-
-Patch upgrades across Strapi v4 minors can fail the admin build with `Cannot find module 'react'` (or similar). Newer v4 lines expect `react`, `react-dom`, `react-router-dom`, and `styled-components` to be listed explicitly in your app `package.json` instead of relying only on transitive resolution.
-
-Copy the versions from a fresh Strapi v4 project that matches your target release (for example `yarn create strapi-app` in a throwaway folder), then install and rebuild. A typical set looks like this:
-
-```json
-"react": "^18.0.0",
-"react-dom": "^18.0.0",
-"react-router-dom": "5.3.4",
-"styled-components": "5.3.3"
-```
-
-Using a tilde or caret range on `@strapi/strapi` (for example `~4.25.22`) is fine for patch updates; when you skip several minors, read the release notes and migration notes for each jump.
-
-:::note
-The archived v4 Developer Documentation still lives on <ExternalLink to="https://docs-v4.strapi.io/dev-docs/migration-guides" text="docs-v4.strapi.io"/>. This section is for teams who land on Strapi 5 docs while debugging a v4 upgrade.
-:::
-
 ## Is X feature available yet?
 
 You can see the <ExternalLink to="https://feedback.strapi.io/" text="public roadmap"/> to see which feature requests are currently being worked on and which have not been started yet, and to add new feature requests.

--- a/docusaurus/docs/cms/faq.md
+++ b/docusaurus/docs/cms/faq.md
@@ -136,6 +136,25 @@ By default, most package managers enable hoisting, however, if it's not function
 - If you are using npm or pnpm: Add `hoist=true` to your project's `.npmrc` file. Learn more about this from the <ExternalLink to="https://pnpm.io/npmrc#hoist" text="official pnpm documentation"/>
 - If you are using Yarn: Set `nmHoistingLimits` in your `.yarnrc` file. More details can be found in the <ExternalLink to="https://yarnpkg.com/configuration/yarnrc#nmHoistingLimits" text="Yarn official documentation"/>
 
+## How to fix the build error `Cannot find module 'react'` when upgrading Strapi v4
+
+Patch upgrades across Strapi v4 minors can fail the admin build with `Cannot find module 'react'` (or similar). Newer v4 lines expect `react`, `react-dom`, `react-router-dom`, and `styled-components` to be listed explicitly in your app `package.json` instead of relying only on transitive resolution.
+
+Copy the versions from a fresh Strapi v4 project that matches your target release (for example `yarn create strapi-app` in a throwaway folder), then install and rebuild. A typical set looks like this:
+
+```json
+"react": "^18.0.0",
+"react-dom": "^18.0.0",
+"react-router-dom": "5.3.4",
+"styled-components": "5.3.3"
+```
+
+Using a tilde or caret range on `@strapi/strapi` (for example `~4.25.22`) is fine for patch updates; when you skip several minors, read the release notes and migration notes for each jump.
+
+:::note
+The archived v4 Developer Documentation still lives on <ExternalLink to="https://docs-v4.strapi.io/dev-docs/migration-guides" text="docs-v4.strapi.io"/>. This section is for teams who land on Strapi 5 docs while debugging a v4 upgrade.
+:::
+
 ## Is X feature available yet?
 
 You can see the <ExternalLink to="https://feedback.strapi.io/" text="public roadmap"/> to see which feature requests are currently being worked on and which have not been started yet, and to add new feature requests.

--- a/docusaurus/docs/cms/migration/v4-to-v5/introduction-and-faq.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/introduction-and-faq.md
@@ -18,10 +18,10 @@ Whenever you feel ready to upgrade to Strapi 5, the present page will help you. 
 
 All of the following available resources will help you upgrade your application and plugins to Strapi 5, from the most common to the most specific use cases:
 
-<CustomDocCard emoji="1ï¸âƒ£" title="Step-by-step guide" description="Read this guide first to get an overview of the upgrade process." link="/cms/migration/v4-to-v5/step-by-step" />
-<CustomDocCard emoji="2ï¸âƒ£" title="Upgrade tool reference" description="Learn more about how the upgrade tool can automatically migrate some parts of your Strapi v4 application to Strapi 5." link="/cms/upgrade-tool" />
-<CustomDocCard emoji="3ï¸âƒ£" title="Breaking changes list" description="Read more about the differences between Strapi v4 and v5, the resulting breaking changes, and how to handle them manually or with the help of the codemods provided with the upgrade tool." link="/cms/migration/v4-to-v5/breaking-changes" />
-<CustomDocCard emoji="4ï¸âƒ£" title="Specific resources" description="Handle specific use cases such as the deprecation of the Entity Service API in favor of the new Document Service API, the plugins migration, and the deprecation of the helper-plugin." link="/cms/migration/v4-to-v5/additional-resources/introduction" />
+<CustomDocCard emoji="1️⃣" title="Step-by-step guide" description="Read this guide first to get an overview of the upgrade process." link="/cms/migration/v4-to-v5/step-by-step" />
+<CustomDocCard emoji="2️⃣" title="Upgrade tool reference" description="Learn more about how the upgrade tool can automatically migrate some parts of your Strapi v4 application to Strapi 5." link="/cms/upgrade-tool" />
+<CustomDocCard emoji="3️⃣" title="Breaking changes list" description="Read more about the differences between Strapi v4 and v5, the resulting breaking changes, and how to handle them manually or with the help of the codemods provided with the upgrade tool." link="/cms/migration/v4-to-v5/breaking-changes" />
+<CustomDocCard emoji="4️⃣" title="Specific resources" description="Handle specific use cases such as the deprecation of the Entity Service API in favor of the new Document Service API, the plugins migration, and the deprecation of the helper-plugin." link="/cms/migration/v4-to-v5/additional-resources/introduction" />
 
 ## Frequently asked questions
 

--- a/docusaurus/docs/cms/migration/v4-to-v5/introduction-and-faq.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/introduction-and-faq.md
@@ -18,10 +18,10 @@ Whenever you feel ready to upgrade to Strapi 5, the present page will help you. 
 
 All of the following available resources will help you upgrade your application and plugins to Strapi 5, from the most common to the most specific use cases:
 
-<CustomDocCard emoji="1️⃣" title="Step-by-step guide" description="Read this guide first to get an overview of the upgrade process." link="/cms/migration/v4-to-v5/step-by-step" />
-<CustomDocCard emoji="2️⃣" title="Upgrade tool reference" description="Learn more about how the upgrade tool can automatically migrate some parts of your Strapi v4 application to Strapi 5." link="/cms/upgrade-tool" />
-<CustomDocCard emoji="3️⃣" title="Breaking changes list" description="Read more about the differences between Strapi v4 and v5, the resulting breaking changes, and how to handle them manually or with the help of the codemods provided with the upgrade tool." link="/cms/migration/v4-to-v5/breaking-changes" />
-<CustomDocCard emoji="4️⃣" title="Specific resources" description="Handle specific use cases such as the deprecation of the Entity Service API in favor of the new Document Service API, the plugins migration, and the deprecation of the helper-plugin." link="/cms/migration/v4-to-v5/additional-resources/introduction" />
+<CustomDocCard emoji="1ï¸âƒ£" title="Step-by-step guide" description="Read this guide first to get an overview of the upgrade process." link="/cms/migration/v4-to-v5/step-by-step" />
+<CustomDocCard emoji="2ï¸âƒ£" title="Upgrade tool reference" description="Learn more about how the upgrade tool can automatically migrate some parts of your Strapi v4 application to Strapi 5." link="/cms/upgrade-tool" />
+<CustomDocCard emoji="3ï¸âƒ£" title="Breaking changes list" description="Read more about the differences between Strapi v4 and v5, the resulting breaking changes, and how to handle them manually or with the help of the codemods provided with the upgrade tool." link="/cms/migration/v4-to-v5/breaking-changes" />
+<CustomDocCard emoji="4ï¸âƒ£" title="Specific resources" description="Handle specific use cases such as the deprecation of the Entity Service API in favor of the new Document Service API, the plugins migration, and the deprecation of the helper-plugin." link="/cms/migration/v4-to-v5/additional-resources/introduction" />
 
 ## Frequently asked questions
 
@@ -65,6 +65,27 @@ Strapi Cloud will deploy the updated code in Strapi 5 and will automatically run
 - REST responses continue to expose both `id` (legacy) and [`documentId`](/cms/migration/v4-to-v5/breaking-changes/use-document-id) when the header is enabled. GraphQL never exposes numeric `id`, so update your queries to use `documentId` even before you turn compatibility mode off.
 
 Once every consumer reads the flattened format, remove the header so Strapi emits the Strapi 5 response shape by default.
+<br/>
+
+</details>
+
+<details style={{backgroundColor: 'transparent', border: 'solid 1px #4945ff' }}>
+<summary style={{fontSize: '18px'}}>Why does the admin build fail with <code>Cannot find module &apos;react&apos;</code> while my project is still on Strapi v4?</summary>
+
+<p>Patch upgrades across Strapi v4 minors can fail the admin build with <code>Cannot find module &apos;react&apos;</code> (or similar). Newer v4 lines expect <code>react</code>, <code>react-dom</code>, <code>react-router-dom</code>, and <code>styled-components</code> to be listed explicitly in your app <code>package.json</code> instead of relying only on transitive resolution.</p>
+
+<p>Copy the versions from a fresh Strapi v4 project that matches your target release (for example run the official generator in a throwaway folder), then install and rebuild. A typical set looks like this:</p>
+
+```json
+"react": "^18.0.0",
+"react-dom": "^18.0.0",
+"react-router-dom": "5.3.4",
+"styled-components": "5.3.3"
+```
+
+<p>Using a tilde or caret range on <code>@strapi/strapi</code> (for example <code>~4.25.22</code>) is fine for patch updates; when you skip several minors, read the release notes and migration notes for each jump.</p>
+
+<p>The archived v4 Developer Documentation still lives on <ExternalLink to="https://docs-v4.strapi.io/dev-docs/migration-guides" text="docs-v4.strapi.io" />.</p>
 <br/>
 
 </details>


### PR DESCRIPTION
I hit the same gap described in #2576: jumping across late Strapi v4 minors can surface `Cannot find module 'react'` because the admin stack expects explicit `react`, `react-dom`, `react-router-dom`, and `styled-components` entries in the app `package.json`. The v4 migration site is separate, but many people search from the Strapi 5 docs tree.

I added a short FAQ entry under `cms/faq.md` that explains the fix, shows a concrete dependency block to align with a fresh v4 project at the target version, and points readers at docs-v4 for the archived migration guides.

Closes #2576
