### PR TITLE
Document `__component` for dynamic zones on REST create

### DIFF
--- a/docusaurus/docs/cms/api/rest.md
+++ b/docusaurus/docs/cms/api/rest.md
@@ -288,7 +288,7 @@ If the [Internationalization (i18n) plugin](/cms/features/internationalization) 
 While creating a document, you can define its relations and their order (see [Managing relations through the REST API](/cms/api/rest/relations.md) for more details).
 :::
 
-:::note Dynamic zones
+:::info Dynamic zones
 When you POST a document, each object inside a dynamic zone array must include `__component` with that variant's UID (for example `shared.slider`). Put `__component` on the object that represents one row in the dynamic zone. Nested fields inside that object should mirror the JSON you get back when the same document is fetched with `populate` so you do not place `__component` on inner objects unless the schema treats that level as another discriminated structure.
 :::
 

--- a/docusaurus/docs/cms/api/rest.md
+++ b/docusaurus/docs/cms/api/rest.md
@@ -288,6 +288,10 @@ If the [Internationalization (i18n) plugin](/cms/features/internationalization) 
 While creating a document, you can define its relations and their order (see [Managing relations through the REST API](/cms/api/rest/relations.md) for more details).
 :::
 
+:::note Dynamic zones
+When you POST a document, each object inside a dynamic zone array must include `__component` with that variant's UID (for example `shared.slider`). Put `__component` on the object that represents one row in the dynamic zone. Nested fields inside that object should mirror the JSON you get back when the same document is fetched with `populate` so you do not place `__component` on inner objects unless the schema treats that level as another discriminated structure.
+:::
+
 <ApiCall>
 
 <Request title="Example request">


### PR DESCRIPTION
Issue #2335 shows POST payloads failing when `__component` is missing on dynamic zone rows or when it is nested at the wrong level. The REST reference already documents create for flat fields and relations, but it did not spell out dynamic zones on create.

I added a short note under the create section of `cms/api/rest.md` that each dynamic zone entry must carry the variant UID on the object that represents that row, and that inner fields should follow the populated GET shape.

Closes #2335
