### PR TITLE
Distinguish admin extensions from server plugin overrides

### DIFF
--- a/docusaurus/docs/cms/admin-panel-customization/extension.md
+++ b/docusaurus/docs/cms/admin-panel-customization/extension.md
@@ -30,7 +30,7 @@ There are 2 use cases where you might want to extend the admin panel:
 <HotReloading />
 
 :::note
-This section is about the **admin panel** bundle under `/src/admin`. If you need to change **server** behaviour for a core plugin (for example upload APIs used while browsing `/admin/plugins/upload`), use `./src/extensions/<plugin-name>/strapi-server.js|ts` as described in [Plugins extension](/cms/plugins-development/plugins-extension).
+This section is about the admin panel bundle under `/src/admin`. To change server behaviour for a core plugin (for example upload APIs used while browsing `/admin/plugins/upload`), use `./src/extensions/<plugin-name>/strapi-server.js|ts` as described in [Plugins extension](/cms/plugins-development/plugins-extension).
 :::
 
 ## When to consider a plugin instead

--- a/docusaurus/docs/cms/admin-panel-customization/extension.md
+++ b/docusaurus/docs/cms/admin-panel-customization/extension.md
@@ -29,6 +29,10 @@ There are 2 use cases where you might want to extend the admin panel:
 
 <HotReloading />
 
+:::note
+This section is about the **admin panel** bundle under `/src/admin`. If you need to change **server** behaviour for a core plugin (for example upload APIs used while browsing `/admin/plugins/upload`), use `./src/extensions/<plugin-name>/strapi-server.js|ts` as described in [Plugins extension](/cms/plugins-development/plugins-extension).
+:::
+
 ## When to consider a plugin instead
 
 Starting with a direct customization in `/src/admin/app` is the right default for project-specific needs. Consider moving to a plugin-based approach when one or more of these signals appear:


### PR DESCRIPTION
Issue #2397 points at the admin panel extension page while describing a **server** override for the Upload plugin. That page only covers `/src/admin`, so the search path feels like a dead end.

I added a short note after the hot-reload snippet on `cms/admin-panel-customization/extension.md` that sends readers to [Plugins extension](/cms/plugins-development/plugins-extension) for `./src/extensions/<plugin-name>/strapi-server.js|ts` work.

Closes #2397
