### PR TITLE
Document admin translation contribution path in FAQ

### DIFF
--- a/docusaurus/docs/cms/faq.md
+++ b/docusaurus/docs/cms/faq.md
@@ -18,6 +18,8 @@ tags:
 - typescript
 - database
 - foreign keys
+- i18n
+- translations
 
 ---
 
@@ -135,6 +137,14 @@ By default, most package managers enable hoisting, however, if it's not function
 
 - If you are using npm or pnpm: Add `hoist=true` to your project's `.npmrc` file. Learn more about this from the <ExternalLink to="https://pnpm.io/npmrc#hoist" text="official pnpm documentation"/>
 - If you are using Yarn: Set `nmHoistingLimits` in your `.yarnrc` file. More details can be found in the <ExternalLink to="https://yarnpkg.com/configuration/yarnrc#nmHoistingLimits" text="Yarn official documentation"/>
+
+## How can I contribute translations for the admin panel?
+
+The documentation you are reading is written and reviewed in English in the `strapi/documentation` repository. There is no separate community translation workflow for these Markdown pages here.
+
+If you want to fix **built-in admin interface** strings for a shipped locale (for example incomplete Simplified Chinese labels), open a pull request against the [Strapi monorepo](https://github.com/strapi/strapi). Core keys live in JSON files under [`packages/core/admin/admin/src/translations/`](https://github.com/strapi/strapi/tree/develop/packages/core/admin/admin/src/translations), and other packages or plugins with an admin UI ship sibling `translations` directories in their own folders. Follow that repository's [`CONTRIBUTING.md`](https://github.com/strapi/strapi/blob/develop/CONTRIBUTING.md) (CLA required) and keep each change scoped to the locale files you are improving so reviewers can verify the language.
+
+If you only need wording changes inside **one project** without upstreaming them, use [`config.translations` in `src/admin/app`](/cms/admin-panel-customization/locales-translations#extending-translations) as described in the admin customization guide.
 
 ## Is X feature available yet?
 


### PR DESCRIPTION
#2769 asked how to help with incomplete admin translations (for example Chinese). The confusion was that this repository only ships English prose for docs.strapi.io, so there is no Crowdin-style flow here.

The new FAQ entry points locale work at the Strapi monorepo JSON trees, links CONTRIBUTING there for the CLA path, and points single-tenant teams at config.translations in the existing admin customization guide.

I did not run yarn build in this agent shell; CI should cover the Docusaurus gate.

Closes https://github.com/strapi/documentation/issues/2769