### PR TITLE
Track ask_user router decisions in Notion metrics for docs self-healing system

### DIFF
--- a/.github/workflows/docs-self-healing.yml
+++ b/.github/workflows/docs-self-healing.yml
@@ -629,9 +629,11 @@ jobs:
           # Router results
           SONNET_DRAFTED=0
           ROUTER_SKIPPED=0
+          ASK_HUMANS=0
           if [ -f "/tmp/router-results.json" ]; then
             SONNET_DRAFTED=$(jq '[.prs[] | select(.decision == "has_targets" and .complexity == "full")] | length' /tmp/router-results.json 2>/dev/null || echo "0")
             ROUTER_SKIPPED=$(jq '[.prs[] | select(.decision == "skip")] | length' /tmp/router-results.json 2>/dev/null || echo "0")
+            ASK_HUMANS=$(jq '[.prs[] | select(.decision == "ask_user")] | length' /tmp/router-results.json 2>/dev/null || echo "0")
           fi
 
           # Drafter results
@@ -681,6 +683,7 @@ jobs:
             --argjson merged_as_is "$MERGED_AS_IS" \
             --argjson merged_with_edits "$MERGED_WITH_EDITS" \
             --argjson rejected "$REJECTED" \
+            --argjson ask_humans "$ASK_HUMANS" \
             '{
               parent: { database_id: $db },
               properties: {
@@ -696,6 +699,7 @@ jobs:
                 "Merged as-is": { number: $merged_as_is },
                 "Merged with edits": { number: $merged_with_edits },
                 "Rejected by Pierre": { number: $rejected },
+                "Ask humans": { number: $ask_humans },
                 "Status": { select: { name: $status } },
                 "Error": { rich_text: [{ text: { content: ($error | if length > 2000 then .[:2000] else . end) } }] },
                 "Run URL": { url: $run_url }


### PR DESCRIPTION
The self-healing Router can output `decision: "ask_user"` when doc placement is ambiguous, but this metric was never logged to the Notion database. Adds the "Ask humans" number field to the Notion payload so every run now tracks how many PRs were escalated for manual review.

Existing Notion entries were backfilled from GitHub Actions logs.