### PR TITLE
Add conditional retrieval budgets and drafting guardrails to agent prompts

### DIFF
--- a/agents/prompts/drafter.md
+++ b/agents/prompts/drafter.md
@@ -589,37 +589,42 @@ For Patch mode, metadata is embedded in the output header (File, Section, Edits 
 
 3. **Don't hallucinate.** Only include information present in the source material or reasonably inferable from it. When source material is insufficient, use a `<!-- TODO -->` placeholder rather than inventing details.
 
-4. **Match the neighbors.** For `add_section`, Patch, and Micro-edit, read the existing page content (when available) to match its tone, terminology, and level of detail. Edits and insertions should feel like they were always there.
+4. **Separate facts from prose.** Distinguish source-backed technical facts from freely written connective prose:
+   - **Must come from source material or codebase:** method names, parameter names and types, default values, configuration keys, API endpoints, lifecycle ordering, behavioral claims, version numbers, plan/feature availability.
+   - **May be freely written:** introductory sentences, section transitions, explanatory context, analogies, procedural phrasing ("Click **Save**"), and `<Tldr>` summaries (as long as they don't introduce unsourced technical claims).
+   - If you cannot find a specific technical detail in the source material, do not invent a plausible-sounding value. Use a `<!-- TODO: Confirm [specific detail] -->` placeholder instead. A visible gap is better than a confident error.
 
-5. **Keep it concise.** Developers scan documentation. Front-load the important information. Use the minimum words needed to be clear and complete.
+5. **Match the neighbors.** For `add_section`, Patch, and Micro-edit, read the existing page content (when available) to match its tone, terminology, and level of detail. Edits and insertions should feel like they were always there.
 
-6. **Code > prose** for technical details. When explaining a configuration option, show the code first, then explain in 1-2 sentences. Don't describe in prose what a code example already shows.
+6. **Keep it concise.** Developers scan documentation. Front-load the important information. Use the minimum words needed to be clear and complete.
 
-7. **Flag uncertainties visibly.** Use `<!-- TODO: ... -->` HTML comments for anything requiring human review. These are invisible in rendered docs but visible in source.
+7. **Code > prose** for technical details. When explaining a configuration option, show the code first, then explain in 1-2 sentences. Don't describe in prose what a code example already shows.
 
-8. **Don't duplicate the Style Checker's job.** The Drafter follows the 12 Rules proactively (writing clean prose from the start), but it does not self-audit or produce a style report. The Style Checker handles post-hoc review.
+8. **Flag uncertainties visibly.** Use `<!-- TODO: ... -->` HTML comments for anything requiring human review. These are invisible in rendered docs but visible in source.
 
-9. **Import snippets explicitly, not components.** MDX components (<Tabs>, <ThemedImage>, badges, <IdentityCard>, etc.) are globally registered by the Strapi documentation build system — do NOT add import statements for them. However, snippets from docusaurus/docs/snippets/ must be explicitly imported after the frontmatter and before the H1. Use the pattern: import ComponentName from '/docs/snippets/file-name.md'. Check the template and AGENTS guide for the target doc type to know which snippet imports are required (e.g., breaking change pages require Intro and MigrationIntro snippets).
+9. **Don't duplicate the Style Checker's job.** The Drafter follows the 12 Rules proactively (writing clean prose from the start), but it does not self-audit or produce a style report. The Style Checker handles post-hoc review.
 
-10. **Respect the IdentityCard contract.** When writing an `<IdentityCard>`, always include exactly 4 items in this order with these exact titles: "Plan", "Role & permission", "Activation", "Environment". Use the Lucide icon names specified in the template.
+10. **Import snippets explicitly, not components.** MDX components (<Tabs>, <ThemedImage>, badges, <IdentityCard>, etc.) are globally registered by the Strapi documentation build system — do NOT add import statements for them. However, snippets from docusaurus/docs/snippets/ must be explicitly imported after the frontmatter and before the H1. Use the pattern: import ComponentName from '/docs/snippets/file-name.md'. Check the template and AGENTS guide for the target doc type to know which snippet imports are required (e.g., breaking change pages require Intro and MigrationIntro snippets).
 
-11. **Micro-edit: fix, don't reject.** In Micro-edit mode, if the provided `content` has minor style issues (wrong link format, missing backticks), fix them silently. Only flag issues that require human judgment. The goal is a ready-to-apply insertion, not a review report.
+11. **Respect the IdentityCard contract.** When writing an `<IdentityCard>`, always include exactly 4 items in this order with these exact titles: "Plan", "Role & permission", "Activation", "Environment". Use the Lucide icon names specified in the template.
 
-12. **Micro-edit: keep it minimal.** Do not expand a Micro-edit beyond its instruction. If asked to add a cross-link, add the cross-link. Do not add surrounding prose, callouts, or additional context unless the instruction explicitly requests it.
+12. **Micro-edit: fix, don't reject.** In Micro-edit mode, if the provided `content` has minor style issues (wrong link format, missing backticks), fix them silently. Only flag issues that require human judgment. The goal is a ready-to-apply insertion, not a review report.
 
-13. **Patch: show your reasoning.** Always include a `Reason` for each derived instruction. The reviewer needs to understand *why* each edit was made, not just *what* changed. Trace each edit back to the source material or `target.notes`.
+13. **Micro-edit: keep it minimal.** Do not expand a Micro-edit beyond its instruction. If asked to add a cross-link, add the cross-link. Do not add surrounding prose, callouts, or additional context unless the instruction explicitly requests it.
 
-14. **Patch: minimum viable edit.** Use the smallest edit type that achieves the goal. If one sentence is outdated, use `replace` on that sentence — do not rewrite the entire section. Prefer `add_row` over rewriting a whole table. Escalate to "rewritten section" output only when edits interact or exceed 3 in number.
+14. **Patch: show your reasoning.** Always include a `Reason` for each derived instruction. The reviewer needs to understand *why* each edit was made, not just *what* changed. Trace each edit back to the source material or `target.notes`.
 
-15. **Patch: never invent context.** When deriving instructions, only produce edits that are directly supported by the source material. If `target.notes` suggests a change but the source material does not contain the technical details to write it, produce the instruction with a `<!-- TODO -->` placeholder in the content rather than guessing.
+15. **Patch: minimum viable edit.** Use the smallest edit type that achieves the goal. If one sentence is outdated, use `replace` on that sentence — do not rewrite the entire section. Prefer `add_row` over rewriting a whole table. Escalate to "rewritten section" output only when edits interact or exceed 3 in number.
 
-16. **Match component patterns exactly.** In Patch mode, study the existing page's MDX component structure before writing. Pay attention to how the page wraps code examples (for instance, `<ApiCall>`, `<Tabs>`, `<details>`), which snippet imports it uses (`<QsForQueryBody />`, etc.), and how Request/Response pairs are structured. Replicate these patterns in new content. Generic Markdown (plain code blocks, standalone `<details>`) should not be used when the page already uses custom components for the same purpose.
+16. **Patch: never invent context.** When deriving instructions, only produce edits that are directly supported by the source material. If `target.notes` suggests a change but the source material does not contain the technical details to write it, produce the instruction with a `<!-- TODO -->` placeholder in the content rather than guessing.
 
-17. **Preserve structural coherence.** When adding a new section at a given heading level, check whether parallel content at the same level also has explicit headings. If the new section introduces an H2 but existing content of comparable scope sits directly under the H1 without its own H2, wrap the existing content in a matching H2 to maintain symmetry. Similarly, update the H1 title if the page's scope has expanded (e.g., from covering `status` to covering both `status` and `hasPublishedVersion`).
+17. **Match component patterns exactly.** In Patch mode, study the existing page's MDX component structure before writing. Pay attention to how the page wraps code examples (for instance, `<ApiCall>`, `<Tabs>`, `<details>`), which snippet imports it uses (`<QsForQueryBody />`, etc.), and how Request/Response pairs are structured. Replicate these patterns in new content. Generic Markdown (plain code blocks, standalone `<details>`) should not be used when the page already uses custom components for the same purpose.
 
-18. **Read-proof example data.** After writing API examples, re-read each response from the reader's perspective: could any field value seem contradictory to the query's purpose? If so, add a brief explanatory sentence before the response block (preferred) or an inline comment in the code. For instance, a query for "drafts of published documents" returns `publishedAt: null` because the draft version is returned — this is technically correct but needs clarification for readers.
+18. **Preserve structural coherence.** When adding a new section at a given heading level, check whether parallel content at the same level also has explicit headings. If the new section introduces an H2 but existing content of comparable scope sits directly under the H1 without its own H2, wrap the existing content in a matching H2 to maintain symmetry. Similarly, update the H1 title if the page's scope has expanded (e.g., from covering `status` to covering both `status` and `hasPublishedVersion`).
 
-19. **Annotate sources for the Integrity Checker.** For every code example and significant technical claim you produce, annotate the source to enable downstream verification. This applies to Compose and Patch modes.
+19. **Read-proof example data.** After writing API examples, re-read each response from the reader's perspective: could any field value seem contradictory to the query's purpose? If so, add a brief explanatory sentence before the response block (preferred) or an inline comment in the code. For instance, a query for "drafts of published documents" returns `publishedAt: null` because the draft version is returned — this is technically correct but needs clarification for readers.
+
+20. **Annotate sources for the Integrity Checker.** For every code example and significant technical claim you produce, annotate the source to enable downstream verification. This applies to Compose and Patch modes.
 
     **For code examples:**
     1. Search the codebase for the primary identifiers (method names, configuration options, parameter names).

--- a/agents/prompts/integrity-code-verifier.md
+++ b/agents/prompts/integrity-code-verifier.md
@@ -169,6 +169,18 @@ Run Pass 1 first, then Pass 2 within the fetch budget.
 
 Pass 1 (surface) should consume a small fraction of the budget (typically 1–5 fetches: entry-point index + a few re-export files). The remainder is allocated to Pass 2 (deep verification).
 
+**Early stop condition:** After each Pass 2 fetch, evaluate: "Can I already confirm or falsify every high-risk item in the inventory?" If yes, stop fetching and report. Do not spend remaining budget on low-risk items just because the budget allows it.
+
+**Conditional re-fetch rule:** Make an additional fetch only when:
+- A high-priority item (Drafter `<!-- unverified -->` annotation, code example without source annotation, or specific parameter/signature claim) cannot be resolved from files already fetched.
+- A falsified finding needs a second source file to confirm the scope of the error (e.g., checking if a deprecated method has a replacement).
+- The entry-point index references a re-export file that contains signatures needed for Pass 2.
+
+Do not fetch additional files to:
+- Verify low-risk items (general scope claims, version-specific claims) when high-risk items remain unchecked.
+- Double-check a finding that is already confirmed by a single authoritative source.
+- Improve the report's completeness ratio when all high-severity items are resolved.
+
 When the budget is exhausted, stop and report what was verified vs. what remains. Flag unfinished items with their risk level. The report must state the budget used and the budget limit.
 
 ### Step 4: Report

--- a/agents/prompts/integrity-coherence-checker.md
+++ b/agents/prompts/integrity-coherence-checker.md
@@ -80,7 +80,17 @@ From the cross-references, build a list of pages to fetch for **content comparis
 2. **Sidebar siblings** — pages in the same sidebar section often describe related features and share terminology
 3. **Pages covering the same API** — if the current page documents `findMany()`, find other pages that also mention `findMany()`
 
-**Fetch budget:** 10 page fetches (hard cap). This is intentionally lower than the Code Verifier's budget because each page fetch returns a large document. Prioritize explicitly linked pages. Note that the structural files (`sidebars.js`, `llms.txt`) do not count toward this budget — they are shared pipeline resources.
+**Fetch budget:** 10 page fetches (hard cap). This is intentionally lower than the Code Verifier's budget because each page fetch returns a large document. Prioritize explicitly linked pages. Note that the structural files (`sidebars.js`, `llms.txt`) do not count toward this budget -- they are shared pipeline resources.
+
+**Conditional fetch rule:** Make another page fetch only when:
+- An explicitly linked page has not been checked and the link includes an anchor that cannot be verified from `sidebars.js` or `llms.txt` alone.
+- A sidebar sibling covers the same API or feature and a terminology or behavioral inconsistency is suspected from the current page's content.
+- A contradiction has been found and a third page is needed to determine which of the two conflicting claims is canonical.
+
+Do not fetch additional pages to:
+- Verify links that were already confirmed via structural files (existence check without anchor).
+- Check pages that are only tangentially related (different API, different feature area).
+- Improve coverage when all explicit cross-references and high-priority siblings are already resolved.
 
 For anchor links on other pages (`/cms/path#section-name`), the target page must be fetched to confirm the heading exists. These fetches count toward the budget but also serve double duty: the fetched page can be used for content comparison in Step 4.
 

--- a/git-rules.md
+++ b/git-rules.md
@@ -86,7 +86,22 @@ Pushing and PRs
 - When pushing a new branch, set upstream: `git push -u origin <branch>` (this does not create a PR).
 - Open PRs only when explicitly requested and follow the title/description rules above.
 - Titles must not start with feat:/chore:/fix:; use action verbs or clear feature nouns.
-- PR descriptions must start with “This PR …” and remain minimal; bullets allowed; no sections.
+- PR descriptions must start with “This PR ...” and remain minimal; bullets allowed; no sections.
+- No headings (##), no “Test plan” section, no checklists. Flat text only.
+- Keep it short: 1-3 sentences or a short bullet list summarizing what changed and why.
+- Issue references go at the end: “Fixes #2143”.
+
+PR Description Examples (good)
+- This PR adds conditional retrieval rules to the Code Verifier and Coherence Checker agent prompts, and a new “separate facts from prose” behavioral note to the Drafter.
+- This PR documents the new `hasPublishedVersion` parameter added in strapi/strapi#2847.
+  - Adds parameter to the findMany() parameters table
+  - Updates the filtering description
+  - Adds usage tip
+
+PR Description Anti-examples (and why)
+- “## Summary\n\n## Test plan\n- [ ] Run tests” -- headings and test plan are not allowed
+- “Updated docs” -- too vague; say what changed
+- Empty description -- always include at least one sentence
 
 Optional Validation Hints
 - Disallow prefixes: `^(?:feat|chore|fix)\s*:`


### PR DESCRIPTION
This PR adds conditional retrieval rules to the Code Verifier and Coherence Checker agent prompts, and a new "separate facts from prose" behavioral note to the Drafter prompt. Inspired by patterns observed in OpenAI's docs skill (analysis in Obsidian: Knowledge/Decisions/2026-05-12-openai-docs-skill-analysis.md).

- Code Verifier: early stop condition + conditional re-fetch rules (when to fetch more, when to stop early)
- Coherence Checker: conditional fetch rules matching its 10-page budget
- Drafter: new behavioral note #4 distinguishing source-backed facts from freely written prose, renumbered subsequent notes