### PR TITLE
Add tip about filtering by assignee and review stage in list view

### DIFF
--- a/docusaurus/docs/cms/features/review-workflows.md
+++ b/docusaurus/docs/cms/features/review-workflows.md
@@ -131,3 +131,7 @@ Entries of a review workflow content type can be assigned to any admin user in S
     dark: '/img/assets/content-manager/review-assignee-dropdown_DARK.png',
   }}
 />
+
+:::tip
+You can filter entries in the Content Manager list view by **Assignee** and **Review Stage** to quickly find entries assigned to specific users or in specific review stages. Open the filters menu in the list view to access these filtering options.
+:::


### PR DESCRIPTION
This PR updates documentation based on https://github.com/strapi/strapi/pull/26171.

PR #26171 adds new filters to the Content Manager list view for Review Workflows (Assignee and Review Stage filters). This documentation update adds a tip mentioning these new filtering capabilities.

Generated automatically by the docs self-healing workflow (micro-edit, Haiku).
Review before merging.