### PR TITLE
Prevent editors from running Prettier

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,5 +13,5 @@ quote_type = single
 indent_style = space
 indent_size = 2
 
-[*.md]
+[{*.md,*.mdx}]
 trim_trailing_whitespace = false

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+# Prettier (and editors using the Prettier extension) skip these paths.
+# Prettier reformats Markdown tables, list markers, and MDX — avoid on documentation.
+docusaurus/docs/**
+docs/**
+agents/**

--- a/docusaurus/.prettierignore
+++ b/docusaurus/.prettierignore
@@ -1,0 +1,2 @@
+# See repo root .prettierignore — documentation is not Prettier-formatted.
+docs/**


### PR DESCRIPTION
### Description

adds a .prettierignore so that editors will not try to autoformat documents

### Related issue(s)/PR(s)

n/a
