### PR TITLE
Document nested sort within populate for join-table relations

### DIFF
--- a/docusaurus/docs/cms/api/document-service/populate.md
+++ b/docusaurus/docs/cms/api/document-service/populate.md
@@ -178,6 +178,58 @@ const documents = await strapi.documents("api::article.article").findMany({
 </Response>
 </ApiCall>
 
+### Sort populated relations
+
+Use the `sort` parameter inside a `populate` object to order related entries by an attribute. For many-to-many and other join-table relations, an explicit `sort` takes precedence over the default connect order.
+
+<!-- source: strapi/strapi#26361 packages/core/database/src/query/helpers/populate/apply.ts -->
+<ApiCall noSideBySide>
+<Request title="Example request">
+
+```js
+const documents = await strapi.documents("api::article.article").findMany({
+  populate: {
+    categories: {
+      sort: 'name:asc',
+    },
+  },
+});
+```
+
+</Request>
+
+<Response title="Example response">
+
+```json
+[
+  {
+    "id": "cjld2cjxh0000qzrmn831i7rn",
+    "title": "Test Article",
+    // ...
+    "categories": [
+      {
+        "id": 1,
+        "name": "Architecture"
+        // ...
+      },
+      {
+        "id": 3,
+        "name": "Technology"
+        // ...
+      }
+    ]
+  }
+  // ...
+]
+```
+
+</Response>
+</ApiCall>
+
+:::note
+Omit `sort` from a `populate` object to preserve the default connect order (the order in which entries were associated).
+:::
+
 ## Components & Dynamic Zones
 
 Components are populated the same way as relations:

--- a/docusaurus/docs/cms/api/rest/populate-select.md
+++ b/docusaurus/docs/cms/api/rest/populate-select.md
@@ -296,6 +296,10 @@ await request(`/api/articles?${query}`);
 </Response>
 </ApiCall>
 
+:::note
+For many-to-many and other join-table relations, an explicit `sort` within a `populate` object overrides the default connect order. Omit `sort` to preserve the connect order (the order in which entries were associated).
+:::
+
 :::tip Performance tip
 In production, always use explicit population instead of wildcards like `populate=*`. Limit population depth to 2-3 levels and consider centralizing population logic in route middlewares. See <ExternalLink to="https://strapi.io/blog/building-high-performance-strapi-applications-common-pitfalls-and-best-practices" text="Building High-Performance Strapi Applications" /> on the Strapi blog.
 :::


### PR DESCRIPTION
This PR updates documentation based on https://github.com/strapi/strapi/pull/26361.

**Changes:**
- `docusaurus/docs/cms/api/document-service/populate.md`: Added a new "Sort populated relations" subsection under "Relations and media fields" explaining that a `sort` parameter inside a `populate` object orders related entries by attribute and overrides the default join-table connect order for many-to-many relations.
- `docusaurus/docs/cms/api/rest/populate-select.md`: Added a `:::note` in the population section to mention that explicit nested sort overrides the default connect order for join-table relations.

Generated automatically by the docs self-healing workflow.
Review before merging.