### PR TITLE
Add TypeScript workaround for Document Service relational operators

### DIFF
--- a/docusaurus/docs/cms/api/rest/relations.md
+++ b/docusaurus/docs/cms/api/rest/relations.md
@@ -44,7 +44,25 @@ await strapi.documents('api::restaurant.restaurant').update({
     }
   }
 })
+
 ```
+
+:::tip TypeScript Workaround
+When using connect, disconnect, or set with the Document Service API in TypeScript, you may encounter a TS2353 error stating that these properties do not exist on type LongHandEntity.
+
+While the runtime engine fully supports this syntax, the current typings do not. You can safely bypass this validation by casting your data payload to any or a broader object type:
+
+```js
+await strapi.documents('api::cart.cart').update({
+  documentId: cart.documentId,
+  data: {
+    status: 'checked_out',
+    order: { connect: [order.documentId] } as any, // Temporary workaround
+  },
+});
+
+```
+
 
 If no locale is passed, the default locale will be assumed.
 :::


### PR DESCRIPTION
### Description
This PR enhances the Document Service relations documentation by introducing a troubleshooting workaround for TypeScript environments.

### Changes Included
- Resolved a minor layout issue by properly closing a note callout container block.
- Added a `:::tip` block detailing the `TS2353` compiler error that occurs when developers use `connect`, `disconnect`, or `set` inside the Document Service API in TypeScript.
- Provided a clean type-casting workaround (`as any`) to help developers bypass the temporary typing limitation.