### PR TITLE
Add Need help admonition with support link on CMS and Cloud intros

### DIFF
--- a/docusaurus/docs/cloud/getting-started/intro.md
+++ b/docusaurus/docs/cloud/getting-started/intro.md
@@ -55,3 +55,7 @@ Strapi Cloud is built on top of Strapi, an open-source, community-oriented proje
 
 You can also join <ExternalLink to="https://github.com/strapi/strapi" text="GitHub"/>, the <ExternalLink to="https://forum.strapi.io/" text="Forum"/>, and the <ExternalLink to="https://discord.strapi.io" text="Discord"/> and benefit from the years of experience, knowledge, and contributions by the Strapi community as a whole.
 :::
+
+:::tip Need help?
+Strapi Cloud customers on eligible plans can contact the Strapi team through the <ExternalLink to="https://support.strapi.io/support/home" text="Strapi Support platform"/>. Support level depends on your plan (see the [Cloud fundamentals](/cloud/cloud-fundamentals) page).
+:::

--- a/docusaurus/docs/cloud/getting-started/intro.md
+++ b/docusaurus/docs/cloud/getting-started/intro.md
@@ -53,9 +53,9 @@ The Strapi Cloud documentation is organised in topics in a order that should cor
 :::strapi Welcome to the Strapi community!
 Strapi Cloud is built on top of Strapi, an open-source, community-oriented project. The Strapi team has at heart to share their vision and build the future of Strapi with the Strapi community. This is why the <ExternalLink to="https://feedback.strapi.io" text="roadmap"/> is open: as all insights are very important and will help steer the project in the right direction. Any community member is most welcome to share ideas and opinions there.
 
-You can also join <ExternalLink to="https://github.com/strapi/strapi" text="GitHub"/>, the <ExternalLink to="https://forum.strapi.io/" text="Forum"/>, and the <ExternalLink to="https://discord.strapi.io" text="Discord"/> and benefit from the years of experience, knowledge, and contributions by the Strapi community as a whole.
+You can also join <ExternalLink to="https://github.com/strapi/strapi" text="GitHub"/>, <ExternalLink to="https://github.com/strapi/strapi/discussions" text="GitHub Discussions"/>, and the <ExternalLink to="https://discord.strapi.io" text="Discord"/> and benefit from the years of experience, knowledge, and contributions by the Strapi community as a whole.
 :::
 
 :::tip Need help?
-Strapi Cloud customers on eligible plans can contact the Strapi team through the <ExternalLink to="https://support.strapi.io/support/home" text="Strapi Support platform"/>. Support level depends on your plan (see the [Cloud fundamentals](/cloud/cloud-fundamentals) page).
+Strapi Cloud customers on eligible plans can contact the Strapi team through the <ExternalLink to="https://support.strapi.io/support/home" text="Strapi Support platform"/>. Community users can ask questions on <ExternalLink to="https://github.com/strapi/strapi/discussions" text="GitHub Discussions"/> or <ExternalLink to="https://discord.strapi.io" text="Discord"/>. Support level depends on your plan (see the [Cloud fundamentals](/cloud/cloud-fundamentals) page).
 :::

--- a/docusaurus/docs/cloud/getting-started/usage-billing.md
+++ b/docusaurus/docs/cloud/getting-started/usage-billing.md
@@ -131,7 +131,7 @@ If you do not resolve the issue within 30 days, your suspended project will be d
 
 #### Project suspension for other reasons
 
-If your project was suspended for reasons other than unpaid invoice leading to subscription cancellation, you may not have the possibility to reactivate your project yourself. You should receive an email with instructions on how to resolve the issue. If you do not receive the email notification, please contact [Strapi Support](mailto:support@strapi.io).
+If your project was suspended for reasons other than unpaid invoice leading to subscription cancellation, you may not have the possibility to reactivate your project yourself. You should receive an email with instructions on how to resolve the issue. If you do not receive the email notification, please contact the <ExternalLink to="https://support.strapi.io/support/home" text="Strapi Support platform"/>.
 
 ### Subscription cancellation
 

--- a/docusaurus/docs/cms/community.md
+++ b/docusaurus/docs/cms/community.md
@@ -30,11 +30,11 @@ Strapi is a community-oriented project with an emphasis on transparency. The Str
 Community members also take great part in providing the whole community a plethora of resources about Strapi. You can find <ExternalLink to="https://strapi.io/tutorials/" text="tutorials"/> on the Strapi website, where you can also create your own. Also, as an open-source project, the documentation of Strapi is open to contributions (see [Open-source & Contribution](#open-source--contribution)).
 
 :::strapi Want to join the community?
-You can join <ExternalLink to="https://github.com/strapi/strapi" text="GitHub"/>, the <ExternalLink to="https://forum.strapi.io/" text="Forum"/>, and the <ExternalLink to="https://discord.strapi.io" text="Discord"/> to share your ideas and opinions with other community members and members of the Strapi team. If you're looking for news and updates about Strapi, <ExternalLink to="https://twitter.com/strapijs" text="Twitter"/> and the <ExternalLink to="https://strapi.io/blog" text="blog"/> are pretty good places to start!
+You can join <ExternalLink to="https://github.com/strapi/strapi" text="GitHub"/>, <ExternalLink to="https://github.com/strapi/strapi/discussions" text="GitHub Discussions"/>, and the <ExternalLink to="https://discord.strapi.io" text="Discord"/> to share your ideas and opinions with other community members and members of the Strapi team. If you're looking for news and updates about Strapi, <ExternalLink to="https://twitter.com/strapijs" text="Twitter"/> and the <ExternalLink to="https://strapi.io/blog" text="blog"/> are pretty good places to start!
 :::
 
 ## Support
 
-Strapi's Community plan is a free and open-source option for users who wish to self-host the software. If you have an issue or a question, the <ExternalLink to="https://forum.strapi.io" text="forum"/> is great first place to reach out for help. Both the Strapi community and core developers often check this platform and answer posts.
+Strapi's Community plan is a free and open-source option for users who wish to self-host the software. If you have an issue or a question, <ExternalLink to="https://github.com/strapi/strapi/discussions" text="GitHub Discussions"/> and the community <ExternalLink to="https://discord.strapi.io" text="Discord"/> are great first places to reach out for help. Both the Strapi community and core developers often check these platforms and answer posts.
 
 For customers on our paid plans, you can reference our <ExternalLink to="https://support.strapi.io/support/home" text="Support platform"/> to determine your support level and check out our Support platform for more information. Please note that you must have an active <GrowthBadge /> or <EnterpriseBadge /> plan to submit a ticket.

--- a/docusaurus/docs/cms/database-migrations.md
+++ b/docusaurus/docs/cms/database-migrations.md
@@ -12,7 +12,7 @@ Database migrations run one‑time scripts before schema sync to preserve data d
 Database migrations exist to run one-time queries against the database, typically to modify the tables structure or the data when upgrading the Strapi application. These migrations are run automatically when the application starts and are executed before the automated schema migrations that Strapi also performs on boot.
 
 :::callout 🚧  Experimental feature
-Database migrations are experimental. This feature is still a work in progress and will continue to be updated and improved. In the meantime, feel free to ask for help on the <ExternalLink to="https://forum.strapi.io/" text="forum"/> or on the community <ExternalLink to="https://discord.strapi.io" text="Discord"/>.
+Database migrations are experimental. This feature is still a work in progress and will continue to be updated and improved. In the meantime, feel free to ask for help on <ExternalLink to="https://github.com/strapi/strapi/discussions" text="GitHub Discussions"/> or on the community <ExternalLink to="https://discord.strapi.io" text="Discord"/>.
 :::
 
 ## Understanding database migration files

--- a/docusaurus/docs/cms/intro.md
+++ b/docusaurus/docs/cms/intro.md
@@ -63,3 +63,7 @@ Some parts of the CMS documentation (e.g. APIs, Configuration, Development) are 
 
 If you also make your first steps with JavaScript web development while discovering Strapi, we encourage you to read more about <ExternalLink to="https://developer.mozilla.org/en-US/docs/Learn/Getting_started_with_the_web/JavaScript_basics" text="JavaScript" /> and <ExternalLink to="https://docs.npmjs.com/about-npm" text="npm" />. If applicable to your project, you can also learn about <ExternalLink text="TypeScript" to="https://www.typescriptlang.org/docs/handbook/typescript-in-5-minutes.html" /> before diving deeper into these technical parts of the CMS documentation.
 :::
+
+:::tip Need help?
+Customers on paid plans can reach the Strapi team through the <ExternalLink to="https://support.strapi.io/support/home" text="Strapi Support platform"/>. Community users can ask questions on the <ExternalLink to="https://forum.strapi.io/" text="forum"/> or <ExternalLink to="https://discord.strapi.io" text="Discord"/>.
+:::

--- a/docusaurus/docs/cms/intro.md
+++ b/docusaurus/docs/cms/intro.md
@@ -65,5 +65,5 @@ If you also make your first steps with JavaScript web development while discover
 :::
 
 :::tip Need help?
-Customers on paid plans can reach the Strapi team through the <ExternalLink to="https://support.strapi.io/support/home" text="Strapi Support platform"/>. Community users can ask questions on the <ExternalLink to="https://forum.strapi.io/" text="forum"/> or <ExternalLink to="https://discord.strapi.io" text="Discord"/>.
+Customers on paid plans can reach the Strapi team through the <ExternalLink to="https://support.strapi.io/support/home" text="Strapi Support platform"/>. Community users can ask questions on <ExternalLink to="https://github.com/strapi/strapi/discussions" text="GitHub Discussions"/> or <ExternalLink to="https://discord.strapi.io" text="Discord"/>.
 :::


### PR DESCRIPTION
This PR adds a short "Need help?" admonition at the bottom of the CMS and Cloud documentation intro pages, pointing readers on paid plans to the Strapi Support platform and community users to the forum and Discord.

Direct preview link 👉 [here](https://documentation-git-repo-contact-support-mention-strapijs.vercel.app/cms/intro)