### PR TITLE
Add v5 to v4 rollback FAQ entry to migration documentation

### DIFF
--- a/docusaurus/docs/cms/migration/v4-to-v5/introduction-and-faq.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/introduction-and-faq.md
@@ -89,3 +89,15 @@ Once every consumer reads the flattened format, remove the header so Strapi emit
 <br/>
 
 </details>
+
+<details style={{backgroundColor: 'transparent', border: 'solid 1px #4945ff' }}>
+<summary style={{fontSize: '18px'}}>Can I downgrade from Strapi 5 back to Strapi 4?</summary>
+
+<p>Strapi does not ship an automated downgrade from Strapi 5 to Strapi 4. Data migration scripts that run when Strapi 5 starts are not reversed by the product.</p>
+
+<p>If you must return to Strapi 4, restore the database backup you created before the upgrade and check out the git branch or tag that still matches Strapi 4. Reinstall dependencies so <code>package.json</code> and the lockfile match that snapshot.</p>
+
+<p>Plan backups and staging environments using the <a href="/cms/migration/v4-to-v5/step-by-step">step-by-step guide</a> before you upgrade production.</p>
+<br/>
+
+</details>

--- a/docusaurus/docs/cms/migration/v4-to-v5/introduction-and-faq.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/introduction-and-faq.md
@@ -93,9 +93,13 @@ Once every consumer reads the flattened format, remove the header so Strapi emit
 <details style={{backgroundColor: 'transparent', border: 'solid 1px #4945ff' }}>
 <summary style={{fontSize: '18px'}}>Can I downgrade from Strapi 5 back to Strapi 4?</summary>
 
-<p>Strapi does not ship an automated downgrade from Strapi 5 to Strapi 4. Data migration scripts that run when Strapi 5 starts are not reversed by the product.</p>
+<p>Strapi does not ship an automated downgrade from Strapi 5 to Strapi 4.</p>
 
-<p>If you must return to Strapi 4, restore the database backup you created before the upgrade and check out the git branch or tag that still matches Strapi 4. Reinstall dependencies so <code>package.json</code> and the lockfile match that snapshot.</p>
+<p>Data migration scripts that run when Strapi 5 starts are not reversed by the product.</p>
+
+<p>If you must return to Strapi 4, restore the database backup you created before the upgrade. Check out the Git branch or tag that still matches Strapi 4.</p>
+
+<p>Reinstall dependencies so <code>package.json</code> and the lockfile match that snapshot.</p>
 
 <p>Plan backups and staging environments using the <a href="/cms/migration/v4-to-v5/step-by-step">step-by-step guide</a> before you upgrade production.</p>
 <br/>


### PR DESCRIPTION
### Description

Adds a migration FAQ entry that states Strapi does not provide an automated downgrade from Strapi 5 to Strapi 4 and points readers to database backup restore plus matching Strapi 4 code, with a link to the step-by-step guide for planning.

### Related issue(s)/PR(s)

- https://github.com/strapi/documentation/issues/3187
