### PR TITLE
Note Keycloak registry migration for v5 in users-permissions docs

### DIFF
--- a/docusaurus/docs/cms/configurations/users-and-permissions-providers/keycloak.md
+++ b/docusaurus/docs/cms/configurations/users-and-permissions-providers/keycloak.md
@@ -50,9 +50,7 @@ The use of `ngrok` is not needed.
 
 <ConfigDone />
 
-## Migration from Strapi v4
-
-:::note
+:::note Migration from Strapi v4
 Strapi v4 extensions often registered Keycloak through `providersRegistry.register()`. That method is no longer available in Strapi 5.
 
 In Strapi 5, call `add()` on the `providers-registry` service from the [`register()` function](/cms/configurations/functions#register) in `/src/index.js|ts`.

--- a/docusaurus/docs/cms/configurations/users-and-permissions-providers/keycloak.md
+++ b/docusaurus/docs/cms/configurations/users-and-permissions-providers/keycloak.md
@@ -22,7 +22,11 @@ You have read the [Users & Permissions providers documentation](/cms/configurati
 ## Custom Keycloak integrations after upgrading from Strapi v4
 
 :::note
-If you upgrade a project that registered Keycloak through a Users & Permissions extension and called `providersRegistry.register()`, update the integration for Strapi 5. Call `add()` on the `providers-registry` service from the application [`register()` function](/cms/configurations/functions#register) in `/src/index.js|ts`, following [Creating and adding a custom Users & Permissions provider](/cms/configurations/users-and-permissions-providers/new-provider-guide#creating-a-custom-provider). Using the old `register()` method on the registry object results in `TypeError: providersRegistry.register is not a function`.
+Projects that registered Keycloak through a Users & Permissions extension in Strapi v4 often called `providersRegistry.register()`. That method is not available on the registry object in Strapi 5.
+
+Register the provider with `add()` on the `providers-registry` service from the application [`register()` function](/cms/configurations/functions#register) in `/src/index.js|ts`. Follow [Creating and adding a custom Users & Permissions provider](/cms/configurations/users-and-permissions-providers/new-provider-guide#creating-a-custom-provider).
+
+If you still call `register()` on the registry object, Strapi throws `TypeError: providersRegistry.register is not a function`.
 :::
 
 ## Keycloak configuration

--- a/docusaurus/docs/cms/configurations/users-and-permissions-providers/keycloak.md
+++ b/docusaurus/docs/cms/configurations/users-and-permissions-providers/keycloak.md
@@ -19,16 +19,6 @@ The present page explains how to setup the Keycloak provider for the [Users & Pe
 You have read the [Users & Permissions providers documentation](/cms/configurations/users-and-permissions-providers).
 :::
 
-## Custom Keycloak integrations after upgrading from Strapi v4
-
-:::note
-Projects that registered Keycloak through a Users & Permissions extension in Strapi v4 often called `providersRegistry.register()`. That method is not available on the registry object in Strapi 5.
-
-Register the provider with `add()` on the `providers-registry` service from the application [`register()` function](/cms/configurations/functions#register) in `/src/index.js|ts`. Follow [Creating and adding a custom Users & Permissions provider](/cms/configurations/users-and-permissions-providers/new-provider-guide#creating-a-custom-provider).
-
-If you still call `register()` on the registry object, Strapi throws `TypeError: providersRegistry.register is not a function`.
-:::
-
 ## Keycloak configuration
 
 :::note
@@ -59,3 +49,15 @@ The use of `ngrok` is not needed.
    - (Optional) Set the JWKS URL if you have a custom JWKS URL, example is like `https://keycloak.example.com/auth/realms/strapitest/protocol/openid-connect/certs`
 
 <ConfigDone />
+
+## Migration from Strapi v4
+
+:::note
+Strapi v4 extensions often registered Keycloak through `providersRegistry.register()`. That method is no longer available in Strapi 5.
+
+In Strapi 5, call `add()` on the `providers-registry` service from the [`register()` function](/cms/configurations/functions#register) in `/src/index.js|ts`.
+
+See the [custom provider guide](/cms/configurations/users-and-permissions-providers/new-provider-guide#creating-a-custom-provider) for details.
+
+If you still call `register()` on the registry object, Strapi throws `TypeError: providersRegistry.register is not a function`.
+:::

--- a/docusaurus/docs/cms/configurations/users-and-permissions-providers/keycloak.md
+++ b/docusaurus/docs/cms/configurations/users-and-permissions-providers/keycloak.md
@@ -19,6 +19,12 @@ The present page explains how to setup the Keycloak provider for the [Users & Pe
 You have read the [Users & Permissions providers documentation](/cms/configurations/users-and-permissions-providers).
 :::
 
+## Custom Keycloak integrations after upgrading from Strapi v4
+
+:::note
+If you upgrade a project that registered Keycloak through a Users & Permissions extension and called `providersRegistry.register()`, update the integration for Strapi 5. Call `add()` on the `providers-registry` service from the application [`register()` function](/cms/configurations/functions#register) in `/src/index.js|ts`, following [Creating and adding a custom Users & Permissions provider](/cms/configurations/users-and-permissions-providers/new-provider-guide#creating-a-custom-provider). Using the old `register()` method on the registry object results in `TypeError: providersRegistry.register is not a function`.
+:::
+
 ## Keycloak configuration
 
 :::note


### PR DESCRIPTION
### Description

Adds a short section on the Keycloak provider page for projects that still use Strapi v4 extension patterns calling `providersRegistry.register()`. Strapi 5 expects `providers-registry.add()` from the application `register()` lifecycle, as already documented in the new provider guide. This closes the documentation gap called out when the issue was moved to this repository.

### Related issue(s)/PR(s)

- https://github.com/strapi/documentation/issues/2465
