### PR TITLE
Add deleteMany method documentation to Document Service API

### DIFF
--- a/docusaurus/docs/cms/api/document-service.md
+++ b/docusaurus/docs/cms/api/document-service.md
@@ -78,6 +78,7 @@ Each section below documents the parameters and examples for a specific method:
 | [`create()`](#create) | Create a document, optionally targeting a locale. |
 | [`update()`](#update) | Update a document by `documentId`. |
 | [`delete()`](#delete) | Delete a document or a specific locale version. |
+| [`deleteMany()`](#deletemany) | Delete multiple documents matching filters and relation parameters. |
 | [`publish()`](#publish) | Publish the draft version of a document. |
 | [`unpublish()`](#unpublish) | Move a published document back to draft. |
 | [`discardDraft()`](#discarddraft) | Drop draft data and keep only the published version. |
@@ -558,6 +559,52 @@ await strapi.documents('api::restaurant.restaurant').delete(
 ```
 
 </Request> -->
+
+### `deleteMany()`
+
+Delete multiple documents matching filters and relation parameters.
+
+Syntax: `deleteMany(parameters: Params): Promise<{ documentId: ID, entries: Number }>`
+
+#### Parameters
+
+| Parameter | Description | Default | Type |
+|-----------|-------------|---------|------|
+| [`locale`](/cms/api/document-service/locale#delete) | Locale version of documents to delete. | `null`<br/>(deletes only the default locale) | String, `'*'`, or `null` |
+| [`filters`](/cms/api/document-service/filters) | [Filters](/cms/api/document-service/filters) to use | `null` | Object |
+| [`fields`](/cms/api/document-service/fields#delete)   | [Select fields](/cms/api/document-service/fields#delete) to return   | All fields<br/>(except those not populate by default)  | Object |
+| [`populate`](/cms/api/document-service/populate) | [Populate](/cms/api/document-service/populate) results with additional fields. | `null` | Object |
+
+#### Example
+
+Delete multiple documents matching filters, including filters on related fields:
+
+<Request>
+
+```js
+await strapi.documents('api::restaurant.restaurant').deleteMany({
+  filters: {
+    city: {
+      name: {
+        $eq: 'New York'
+      }
+    }
+  }
+})
+```
+
+</Request>
+
+<Response>
+
+```js
+{
+  documentId: "multiple_documents",
+  entries: 3
+}
+```
+
+</Response>
 
 ### `publish()`
 


### PR DESCRIPTION
This PR updates documentation based on https://github.com/strapi/strapi/pull/25420.

Adds comprehensive documentation for the deleteMany() method, including method signature, parameters table, and example demonstrating relation filter usage.

Generated automatically by the docs self-healing workflow (micro-edit, Haiku).