### PR TITLE
Fix Marketplace custom fields links in CMS feature docs

### DIFF
--- a/docusaurus/docs/cms/features/content-type-builder.md
+++ b/docusaurus/docs/cms/features/content-type-builder.md
@@ -844,7 +844,7 @@ When using dynamic zones, different components cannot have the same field name w
 
 [Custom fields](/cms/features/custom-fields) are a way to extend Strapi’s capabilities by adding new types of fields to content-types or components. Once installed (see [Marketplace](/cms/plugins/installing-plugins-via-marketplace) documentation), custom fields are listed in the _Custom_ tab when selecting a field for a content-type.
 
-Each custom field type can have basic and advanced settings. The <ExternalLink to="https://market.strapi.io/plugins?categories=Custom+fields" text="Marketplace"/> lists available custom fields, and hosts dedicated documentation for each custom field, including specific settings.
+Each custom field type can have basic and advanced settings. The <ExternalLink to="https://market.strapi.io/?categories=Custom+fields" text="Marketplace"/> lists available custom fields, and hosts dedicated documentation for each custom field, including specific settings.
 
 ### Deleting content-types
 

--- a/docusaurus/docs/cms/features/custom-fields.md
+++ b/docusaurus/docs/cms/features/custom-fields.md
@@ -32,7 +32,7 @@ Custom fields extend Strapi’s capabilities by adding new types of fields to co
 
 ## Configuration
 
-Ready-made custom fields can be found on the [Marketplace](https://market.strapi.io/plugins?categories=Custom+fields). Once installed these, no other configuration is required, and you can start using them (see [usage](#usage)).
+Ready-made custom fields can be found on the [Marketplace](https://market.strapi.io/?categories=Custom+fields). Once installed these, no other configuration is required, and you can start using them (see [usage](#usage)).
 
 You can also develop your own custom field.
 
@@ -674,7 +674,7 @@ Once added to Strapi, custom fields can be added to any content type. Custom fie
 
 <!-- TODO: add screenshot of content-type builder with custom fields tab here -->
 
-Each custom field type can have basic and advanced settings. The <ExternalLink to="https://market.strapi.io/plugins?categories=Custom+fields" text="Marketplace"/> lists available custom fields, and hosts dedicated documentation for each custom field, including specific settings.
+Each custom field type can have basic and advanced settings. The <ExternalLink to="https://market.strapi.io/?categories=Custom+fields" text="Marketplace"/> lists available custom fields, and hosts dedicated documentation for each custom field, including specific settings.
 
 ### In the code
 


### PR DESCRIPTION
This PR fixes outdated Marketplace URLs for custom fields in CMS feature docs. It updates the links to use the correct `https://market.strapi.io/?categories=Custom+fields` URL.