### PR TITLE
Move the MCP server Plugin API reference to plugins-development

### DIFF
--- a/docusaurus/docs/cms/features/strapi-mcp-server.md
+++ b/docusaurus/docs/cms/features/strapi-mcp-server.md
@@ -364,9 +364,9 @@ The MCP server has the following limitations:
 - **Custom fields**: Custom fields registered via plugins are mapped to their underlying Strapi type. If the custom field registry is not populated when MCP tools are registered, the custom field falls back to an `unknown` type.
 - **Circular component references**: Components that reference themselves (directly or indirectly) fall back to an open `record<string, unknown>` schema at the point of the cycle, rather than an infinite recursive structure.
 
-## Plugin API
+### Plugin API
 
-Strapi plugins can register additional MCP tools through the `strapi.ai.mcp` service, so AI clients can trigger plugin-specific actions.
+Strapi plugins can register additional MCP tools through the `strapi.ai.mcp` service, so AI clients can trigger plugin-specific actions. Click on the card below to read more details:
 
 <CustomDocCardsWrapper>
 <CustomDocCard icon="puzzle-piece" title="Extending the MCP server" description="Register custom MCP tools from a Strapi plugin through the strapi.ai.mcp service." link="/cms/plugins-development/extend-mcp-server" />

--- a/docusaurus/docs/cms/features/strapi-mcp-server.md
+++ b/docusaurus/docs/cms/features/strapi-mcp-server.md
@@ -10,9 +10,6 @@ tags:
 toc_max_heading_level: 4
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 # MCP server
 <BetaBadge /> <VersionBadge version="5.47.0"/> 
 

--- a/docusaurus/docs/cms/features/strapi-mcp-server.md
+++ b/docusaurus/docs/cms/features/strapi-mcp-server.md
@@ -222,7 +222,7 @@ The MCP server exposes 2 categories of tools: content-type tools generated from 
 
 The tools generated differ depending on whether the content type is a collection type or a single type.
 
-**Collection types** generate up to 8 tools — 5 for CRUD operations and 3 for [Draft & Publish](/cms/features/draft-and-publish) actions:
+**Collection types** generate up to 8 tools: 5 for CRUD operations and 3 for [Draft & Publish](/cms/features/draft-and-publish) actions:
 
 | Tool | Action | Permission required | Description |
 |------|--------|-------------------|-------------|
@@ -369,101 +369,8 @@ The MCP server has the following limitations:
 
 ## Plugin API
 
-Strapi plugins can register additional MCP tools, prompts, and resources through the `strapi.ai.mcp` service. All registrations must happen during the plugin's `register()` lifecycle phase, before the MCP server starts.
+Strapi plugins can register additional MCP tools through the `strapi.ai.mcp` service, so AI clients can trigger plugin-specific actions.
 
-### Registering a custom tool
-
-Use `strapi.ai.mcp.registerTool()` to expose a custom tool to AI clients:
-
-<Tabs groupId="js-ts">
-<TabItem value="javascript" label="JavaScript">
-
-```js title="src/plugins/my-plugin/strapi-server.js"
-const { z } = require('@strapi/utils');
-
-module.exports = {
-  register({ strapi }) {
-    if (strapi.ai.mcp.isEnabled()) {
-      strapi.ai.mcp.registerTool({
-        name: 'my_custom_tool',
-        title: 'My Custom Tool',
-        description: 'A short description shown to the AI client.',
-        auth: {
-          // The session gate passes when the token satisfies ANY policy in the array.
-          policies: [{ action: 'plugin::my-plugin.my-action' }],
-        },
-        // resolveInputSchema and resolveOutputSchema are called per request,
-        // so they can narrow schemas based on the token's permissions.
-        resolveInputSchema: (context) =>
-          z.object({
-            message: z.string().describe('The message to echo.'),
-          }),
-        resolveOutputSchema: (context) =>
-          z.object({
-            result: z.string(),
-          }),
-        createHandler: (strapi, context) => async ({ args }) => ({
-          content: [{ type: 'text', text: args.message }],
-          structuredContent: { result: args.message },
-        }),
-      });
-    }
-  },
-};
-```
-
-</TabItem>
-<TabItem value="typescript" label="TypeScript">
-
-```ts title="src/plugins/my-plugin/strapi-server.ts"
-import { z } from '@strapi/utils';
-
-export default {
-  register({ strapi }) {
-    if (strapi.ai.mcp.isEnabled()) {
-      strapi.ai.mcp.registerTool({
-        name: 'my_custom_tool',
-        title: 'My Custom Tool',
-        description: 'A short description shown to the AI client.',
-        auth: {
-          // The session gate passes when the token satisfies ANY policy in the array.
-          policies: [{ action: 'plugin::my-plugin.my-action' }],
-        },
-        resolveInputSchema: (context) =>
-          z.object({
-            message: z.string().describe('The message to echo.'),
-          }),
-        resolveOutputSchema: (context) =>
-          z.object({
-            result: z.string(),
-          }),
-        createHandler: (strapi, context) => async ({ args }) => ({
-          content: [{ type: 'text', text: args.message }],
-          structuredContent: { result: args.message },
-        }),
-      });
-    }
-  },
-};
-```
-
-</TabItem>
-</Tabs>
-
-#### Tool definition options
-
-| Option | Type | Required | Description |
-|--------|------|----------|-------------|
-| `name` | String | Yes | Unique tool name. Must be unique across all registered MCP tools. |
-| `title` | String | Yes | Human-readable title shown to the AI client. |
-| `description` | String | Yes | Short description of what the tool does. |
-| `auth` | Object | Yes (or `devModeOnly`) | Auth requirement. The session gate passes when the token satisfies **any** policy in the `policies` array. Each policy is `{ action, subject? }`. |
-| `devModeOnly` | Boolean | Yes (or `auth`) | Set to `true` to restrict the tool to development mode only (equivalent to the built-in `log` tool). |
-| `resolveInputSchema` | Function | No | Returns a Zod schema for the tool's input arguments. Called per request so RBAC constraints can be applied dynamically. Omit for tools with no input. |
-| `resolveOutputSchema` | Function | Yes | Returns a Zod schema for the tool's structured output. Called per request. |
-| `createHandler` | Function | Yes | Factory that returns the async tool handler. Receives the Strapi instance and per-request context (including `userAbility` and `user`). |
-| `telemetry` | Object | No | Optional analytics metadata: `{ source?: string; name?: string }`. Use `source` to identify the plugin and `name` to override the raw tool name in analytics events. |
-
-:::note
-`resolveInputSchema` and `resolveOutputSchema` are called once per incoming MCP request, so you can narrow schemas dynamically based on the token's permissions (via `context.userAbility`).
-:::
+<CustomDocCardsWrapper>
+<CustomDocCard icon="puzzle-piece" title="Extending the MCP server" description="Register custom MCP tools from a Strapi plugin through the strapi.ai.mcp service." link="/cms/plugins-development/extend-mcp-server" />
+</CustomDocCardsWrapper>

--- a/docusaurus/docs/cms/plugins-development/developing-plugins.md
+++ b/docusaurus/docs/cms/plugins-development/developing-plugins.md
@@ -37,6 +37,7 @@ Strapi provides the following programmatic APIs for plugins to hook into some of
 <CustomDocCardsWrapper>
 <CustomDocCard emoji="" title="Admin Panel API" description="Use the Admin Panel API to have your plugin interact with the admin panel of Strapi." link="/cms/plugins-development/admin-panel-api" />
 <CustomDocCard emoji="" title="Server API" description="Use the Server API to have your plugin interact with the backend server of Strapi." link="/cms/plugins-development/server-api" />
+<CustomDocCard emoji="" title="Extending the MCP server" description="Use the strapi.ai.mcp service to register custom MCP tools so AI clients can trigger plugin-specific actions." link="/cms/plugins-development/extend-mcp-server" />
 </CustomDocCardsWrapper>
 
 :::strapi Custom fields plugins

--- a/docusaurus/docs/cms/plugins-development/extend-mcp-server.md
+++ b/docusaurus/docs/cms/plugins-development/extend-mcp-server.md
@@ -13,9 +13,6 @@ tags:
   - AI
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 # Extending the MCP server
 
 <Tldr>

--- a/docusaurus/docs/cms/plugins-development/extend-mcp-server.md
+++ b/docusaurus/docs/cms/plugins-development/extend-mcp-server.md
@@ -123,5 +123,4 @@ export default {
 :::note
 `resolveInputSchema` and `resolveOutputSchema` are called once per incoming MCP request, so you can narrow schemas dynamically based on the token's permissions (via `context.userAbility`).
 :::
-</content>
-</invoke>
+

--- a/docusaurus/docs/cms/plugins-development/extend-mcp-server.md
+++ b/docusaurus/docs/cms/plugins-development/extend-mcp-server.md
@@ -1,5 +1,5 @@
 ---
-title: Extending the MCP server
+title: Extending the MCP server with plugins
 displayed_sidebar: cmsSidebar
 toc_max_heading_level: 4
 pagination_prev: cms/plugins-development/server-getters-usage
@@ -13,7 +13,7 @@ tags:
   - AI
 ---
 
-# Extending the MCP server
+# Extending the MCP server with plugins
 
 <Tldr>
 Strapi plugins can register additional MCP tools through the `strapi.ai.mcp` service. Registrations must happen while the MCP server is idle (during the plugin's `register()` or `bootstrap()` lifecycle phase), before the server starts.

--- a/docusaurus/docs/cms/plugins-development/extend-mcp-server.md
+++ b/docusaurus/docs/cms/plugins-development/extend-mcp-server.md
@@ -1,0 +1,127 @@
+---
+title: Extending the MCP server
+displayed_sidebar: cmsSidebar
+toc_max_heading_level: 4
+pagination_prev: cms/plugins-development/server-getters-usage
+pagination_next: cms/plugins-development/plugins-extension
+description: Register additional MCP tools from a Strapi plugin through the strapi.ai.mcp service.
+tags:
+  - plugin APIs
+  - server API
+  - plugins development
+  - MCP
+  - AI
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Extending the MCP server
+
+<Tldr>
+Strapi plugins can register additional MCP tools through the `strapi.ai.mcp` service. Registrations must happen while the MCP server is idle (during the plugin's `register()` or `bootstrap()` lifecycle phase), before the server starts.
+</Tldr>
+
+Strapi includes a built-in [Model Context Protocol (MCP) server](/cms/features/strapi-mcp-server) that exposes content management tools to AI clients. In addition to the content-type tools generated from your schema, plugins can register their own custom tools so AI clients can trigger plugin-specific actions.
+
+Registrations must happen while the MCP server is idle, before it starts. In Strapi's load lifecycle, register a tool during the plugin's `register()` or `bootstrap()` phase. Prefer `bootstrap()` when a tool depends on synced content-types, permissions, or database state.
+
+## Registering a custom tool
+
+Use `strapi.ai.mcp.registerTool()` to expose a custom tool to AI clients:
+
+<Tabs groupId="js-ts">
+<TabItem value="javascript" label="JavaScript">
+
+```js title="src/plugins/my-plugin/strapi-server.js"
+const { z } = require('@strapi/utils');
+
+module.exports = {
+  register({ strapi }) {
+    if (strapi.ai.mcp.isEnabled()) {
+      strapi.ai.mcp.registerTool({
+        name: 'my_custom_tool',
+        title: 'My Custom Tool',
+        description: 'A short description shown to the AI client.',
+        auth: {
+          // The session gate passes when the token satisfies ANY policy in the array.
+          policies: [{ action: 'plugin::my-plugin.my-action' }],
+        },
+        // resolveInputSchema and resolveOutputSchema are called per request,
+        // so they can narrow schemas based on the token's permissions.
+        resolveInputSchema: (context) =>
+          z.object({
+            message: z.string().describe('The message to echo.'),
+          }),
+        resolveOutputSchema: (context) =>
+          z.object({
+            result: z.string(),
+          }),
+        createHandler: (strapi, context) => async ({ args }) => ({
+          content: [{ type: 'text', text: args.message }],
+          structuredContent: { result: args.message },
+        }),
+      });
+    }
+  },
+};
+```
+
+</TabItem>
+<TabItem value="typescript" label="TypeScript">
+
+```ts title="src/plugins/my-plugin/strapi-server.ts"
+import { z } from '@strapi/utils';
+
+export default {
+  register({ strapi }) {
+    if (strapi.ai.mcp.isEnabled()) {
+      strapi.ai.mcp.registerTool({
+        name: 'my_custom_tool',
+        title: 'My Custom Tool',
+        description: 'A short description shown to the AI client.',
+        auth: {
+          // The session gate passes when the token satisfies ANY policy in the array.
+          policies: [{ action: 'plugin::my-plugin.my-action' }],
+        },
+        // resolveInputSchema and resolveOutputSchema are called per request,
+        // so they can narrow schemas based on the token's permissions.
+        resolveInputSchema: (context) =>
+          z.object({
+            message: z.string().describe('The message to echo.'),
+          }),
+        resolveOutputSchema: (context) =>
+          z.object({
+            result: z.string(),
+          }),
+        createHandler: (strapi, context) => async ({ args }) => ({
+          content: [{ type: 'text', text: args.message }],
+          structuredContent: { result: args.message },
+        }),
+      });
+    }
+  },
+};
+```
+
+</TabItem>
+</Tabs>
+
+### Tool definition options
+
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `name` | String | Yes | Unique tool name. Must be unique across all registered MCP tools. |
+| `title` | String | Yes | Human-readable title shown to the AI client. |
+| `description` | String | Yes | Short description of what the tool does. |
+| `auth` | Object | Yes (or `devModeOnly`) | Auth requirement. The session gate passes when the token satisfies **any** policy in the `policies` array. Each policy is `{ action, subject? }`. |
+| `devModeOnly` | Boolean | Yes (or `auth`) | Set to `true` to restrict the tool to development mode only (equivalent to the built-in `log` tool). |
+| `resolveInputSchema` | Function | No | Returns a Zod schema for the tool's input arguments. Called per request so RBAC constraints can be applied dynamically. Omit for tools with no input. |
+| `resolveOutputSchema` | Function | Yes | Returns a Zod schema for the tool's structured output. Called per request. |
+| `createHandler` | Function | Yes | Factory that returns the async tool handler. Receives the Strapi instance and per-request context (including `userAbility` and `user`). |
+
+:::note
+`resolveInputSchema` and `resolveOutputSchema` are called once per incoming MCP request, so you can narrow schemas dynamically based on the token's permissions (via `context.userAbility`).
+:::
+</content>
+</invoke>

--- a/docusaurus/docs/cms/plugins-development/server-api.md
+++ b/docusaurus/docs/cms/plugins-development/server-api.md
@@ -151,6 +151,7 @@ The following cards link directly to each dedicated page:
 <CustomDocCard icon="layout" title="Controllers & services" description="Handle requests in controllers and organize reusable business logic in services." link="/cms/plugins-development/server-controllers-services" />
 <CustomDocCard icon="shield" title="Policies & middlewares" description="Enforce access rules with policies and intercept request flow with middlewares." link="/cms/plugins-development/server-policies-middlewares" />
 <CustomDocCard icon="database" title="Getters & usage" description="Access plugin controllers, services, content-types, and config through top-level and global getters." link="/cms/plugins-development/server-getters-usage" />
+<CustomDocCard icon="puzzle-piece" title="Extending the MCP server" description="Register custom MCP tools through the strapi.ai.mcp service so AI clients can trigger plugin-specific actions." link="/cms/plugins-development/extend-mcp-server" />
 </CustomDocCardsWrapper>
 
 :::strapi Backend customization

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -573,6 +573,7 @@ const sidebars = {
             'cms/plugins-development/server-controllers-services',
             'cms/plugins-development/server-policies-middlewares',
             'cms/plugins-development/server-getters-usage',
+            'cms/plugins-development/extend-mcp-server',
           ],
         },
         {


### PR DESCRIPTION
This PR moves the developer-facing Plugin API reference off the MCP server feature page into a dedicated page under plugin development, where it belongs alongside the other plugin server APIs.

- Adds cms/plugins-development/extend-mcp-server documenting how to register custom MCP tools via strapi.ai.mcp.registerTool()
- Replaces the Plugin API section on cms/features/strapi-mcp-server with a short lead-in and a card linking to the new page
- Links the new page from the plugin development overview and Server API overview pages
- Drops the non-existent telemetry tool option and corrects the registration lifecycle to register() or bootstrap()

Direct preview link 👉 [here](https://documentation-git-cms-move-mcp-plugin-api-to-pl-704ff2-strapijs.vercel.app/cms/plugins-development/extend-mcp-server)
