### PR TITLE
Accept more target types in the inki review skill

### DIFF
--- a/claude-plugins/inki/CHANGELOG.md
+++ b/claude-plugins/inki/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Changed
 
 - `/inki:review` now accepts more target types: a docs.strapi.io URL, a bare markdown filename, or pasted Markdown content, in addition to a path, a PR, or no argument. Target resolution is centralized in `references/target-resolver.md`.
-- `/inki:review` resolves a docs.strapi.io URL against the published `origin/main` source (never a stale working copy or a destructive pull), and flags local uncommitted changes that were excluded.
+- `/inki:review` resolves a docs.strapi.io URL against the published `origin/main` source in a temporary worktree (never a stale working copy or a destructive pull), keeping coherence-check and code-verify fully functional, and flags local uncommitted changes that were excluded.
 
 ## v0.1.0 — 2026-05-22
 

--- a/claude-plugins/inki/CHANGELOG.md
+++ b/claude-plugins/inki/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Inki Changelog
 
+## Unreleased
+
+### Changed
+
+- `/inki:review` now accepts more target types: a docs.strapi.io URL, a bare markdown filename, or pasted Markdown content, in addition to a path, a PR, or no argument. Target resolution is centralized in `references/target-resolver.md`.
+
 ## v0.1.0 — 2026-05-22
 
 ### Added

--- a/claude-plugins/inki/CHANGELOG.md
+++ b/claude-plugins/inki/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - `/inki:review` now accepts more target types: a docs.strapi.io URL, a bare markdown filename, or pasted Markdown content, in addition to a path, a PR, or no argument. Target resolution is centralized in `references/target-resolver.md`.
+- `/inki:review` resolves a docs.strapi.io URL against the published `origin/main` source (never a stale working copy or a destructive pull), and flags local uncommitted changes that were excluded.
 
 ## v0.1.0 — 2026-05-22
 

--- a/claude-plugins/inki/README.md
+++ b/claude-plugins/inki/README.md
@@ -41,7 +41,7 @@ Find out what already exists, where to put new content, what's missing.
 
 ### Review — check what you wrote
 
-- `/inki:review [--yes] [--fix] <path>` — orchestrator: runs all 6 review sub-skills.
+- `/inki:review [--yes] [--fix] <path | filename | PR | docs.strapi.io URL | pasted content>` — orchestrator: runs all 6 review sub-skills against any supported target.
 - `/inki:style-check <path>` — style lint (deterministic + AI).
 - `/inki:outline-check <path>` — verify outline matches template.
 - `/inki:outline-ux-analyzer <path>` — audit pedagogical UX.

--- a/claude-plugins/inki/references/target-resolver.md
+++ b/claude-plugins/inki/references/target-resolver.md
@@ -58,26 +58,25 @@ Operates on the current working tree. `CLEANUP` is empty.
 
 ### 3 — docs.strapi.io URL
 
-A `docs.strapi.io` URL points at the *published* page, so the review must run against the published source, not a possibly-stale working copy. Map the URL to its source file and read that file from `origin/main`:
+A `docs.strapi.io` URL points at the *published* page, so the review must run against the published source on `origin/main`, not a possibly-stale working copy. Check the page out in a temporary worktree on `origin/main` so the file sits at its real path under `docusaurus/docs/` — this keeps coherence-check and code-verify fully functional (relative links and sibling pages resolve), unlike a loose temp file:
 
 1. Strip the origin (`https://docs.strapi.io`) and any trailing slash, query string, or `#anchor`.
 2. The remaining path is the doc route, e.g. `/cms/features/strapi-mcp-server`.
-3. The source file is that route under `docusaurus/docs/`, trying `.md` then `.mdx`:
-   - `docusaurus/docs/cms/features/strapi-mcp-server.md`
-   - if absent, `…/strapi-mcp-server.mdx`
-   - if the route ends in a segment that is a directory, try `…/<segment>/index.md` / `index.mdx`.
-4. Refresh the remote ref, then pick the first of the `<path>` candidates from step 3 that exists on `origin/main` (`git cat-file -e origin/main:<path>`). Materialize that published version into a temp file, so the review matches what the URL shows regardless of the local branch or working-tree state. This never touches the working tree, so no stash or commit is needed first. `<slug>` is the route's last segment (e.g. `strapi-mcp-server`):
+3. Create the worktree (it fetches `origin/main` first); sub-skills see the published version, not the current branch. This never touches the working tree, so no stash or commit is needed first:
 
    ```bash
-   git fetch origin main
-   git show origin/main:<path> > /tmp/inki-review-url-<slug>.md
+   WORKTREE=$(./claude-plugins/inki/scripts/main-worktree.sh create)
    ```
 
-   `FILES` = that temp file. `CLEANUP` = `rm -f /tmp/inki-review-url-<slug>.md`.
-5. If the local working tree has uncommitted changes to `<path>` (`git diff --quiet -- <path>` fails, or the file differs from `origin/main`), note in the report header that the review ran against `origin/main` and that local uncommitted changes to this file were **not** included.
-6. If none of the candidates exist on `origin/main` (e.g. the page is generated, or the route uses a sidebar alias), fall back to fetching the rendered page with WebFetch and treat the result as **pasted content** (type 6), noting in the report that the review ran against the published HTML, not local source.
+4. The source file is that route under `$WORKTREE/docusaurus/docs/`, trying `.md` then `.mdx`:
+   - `$WORKTREE/docusaurus/docs/cms/features/strapi-mcp-server.md`
+   - if absent, `…/strapi-mcp-server.mdx`
+   - if the route ends in a segment that is a directory, try `…/<segment>/index.md` / `index.mdx`.
+5. `FILES` = the first candidate that exists. `CLEANUP` = `./claude-plugins/inki/scripts/main-worktree.sh destroy`.
+6. If the local working tree (in the main checkout) has uncommitted changes to the same path, note in the report header that the review ran against `origin/main` and that those local uncommitted changes were **not** included.
+7. If no candidate exists on `origin/main` (e.g. the page is generated, or the route uses a sidebar alias), destroy the worktree and fall back to fetching the rendered page with WebFetch, treating the result as **pasted content** (type 6) — note in the report that the review ran against the published HTML, not local source.
 
-`SCOPE` = `docs.strapi.io<route> (origin/main)`, or `docs.strapi.io<route> (fetched)` for the WebFetch fallback. `CLEANUP` removes any temp file written.
+`SCOPE` = `docs.strapi.io<route> (origin/main)`, or `docs.strapi.io<route> (fetched)` for the WebFetch fallback. `CLEANUP` tears down the worktree (or removes the WebFetch temp file in the fallback).
 
 ### 4 — Local path
 

--- a/claude-plugins/inki/references/target-resolver.md
+++ b/claude-plugins/inki/references/target-resolver.md
@@ -1,0 +1,108 @@
+# Target resolver
+
+Shared logic for resolving an inki skill's target argument to a concrete set of local files to operate on. Skills that accept a review target (`review`, and any future skill that reviews existing content) reference this file instead of duplicating the parsing rules.
+
+The resolver takes whatever the user passed (after flags are stripped) and returns:
+
+- `FILES`: a list of local file paths the sub-skills operate on.
+- `SCOPE`: a short human label describing the target (used in report headers), e.g. `PR #3204 (1 doc file)`, `docusaurus/docs/cms/intro.md`, or `pasted content`.
+- `CLEANUP`: an optional command to run after the skill finishes (worktree teardown, temp-file removal). May be empty.
+
+The repo is always `strapi/documentation`. Docs live under `docusaurus/docs/`.
+
+## Accepted input types
+
+The target is classified by inspecting its shape, in this order (first match wins):
+
+| # | Input type | How to detect | Resolves to |
+|---|-----------|---------------|-------------|
+| 1 | Empty | No argument left after stripping flags | Changed `.md` files on the current branch |
+| 2 | GitHub PR | URL `github.com/strapi/documentation/pull/<n>`, `#<n>`, or a bare integer | The PR's changed doc files, in a temporary worktree |
+| 3 | docs.strapi.io URL | Starts with `https://docs.strapi.io/` (or `http://`) | The matching local source file |
+| 4 | Local path | Contains a `/` or ends in `.md`/`.mdx`, and exists on disk | That file, or all docs under it if a directory |
+| 5 | Bare filename | A `.md`/`.mdx` name with no directory part, not found as a literal path | The unique file of that name under `docusaurus/docs/` |
+| 6 | Pasted content | None of the above; the argument is multi-line or clearly Markdown body/frontmatter | A temp file written from the pasted text |
+
+When a target is ambiguous (e.g. a bare integer that is also a plausible filename), prefer the PR interpretation only when the value is purely numeric; otherwise treat it as a filename. State the chosen interpretation in the report header so the user can correct it.
+
+## Resolution by type
+
+### 1 — Empty
+
+```bash
+git diff main...HEAD --name-only -- '*.md' '*.mdx'
+```
+
+Operates on the current working tree. `CLEANUP` is empty.
+
+### 2 — GitHub PR
+
+1. Extract the PR number: strip a leading `#`, strip URL tails (`/files`, `/changes`), then take the trailing `[0-9]+`.
+2. Fetch the PR's changed files:
+
+   ```bash
+   gh pr view <num> --repo strapi/documentation --json files,headRefName --jq '.files[].path'
+   ```
+
+3. Filter to `.md` and `.mdx` only. If the PR changes no documentation file, report that and stop.
+4. Check the PR out in a temporary worktree so sub-skills see the PR's version, not `main`:
+
+   ```bash
+   WORKTREE=$(./claude-plugins/inki/scripts/pr-worktree.sh create <num>)
+   ```
+
+5. `FILES` = each path from step 3, prefixed with `$WORKTREE/`.
+6. `CLEANUP` = `./claude-plugins/inki/scripts/pr-worktree.sh destroy <num>`.
+
+`SCOPE` = `PR #<num> (<count> doc file[s])`.
+
+### 3 — docs.strapi.io URL
+
+Map the public URL to a local source file:
+
+1. Strip the origin (`https://docs.strapi.io`) and any trailing slash, query string, or `#anchor`.
+2. The remaining path is the doc route, e.g. `/cms/features/strapi-mcp-server`.
+3. The source file is that route under `docusaurus/docs/`, trying `.md` then `.mdx`:
+   - `docusaurus/docs/cms/features/strapi-mcp-server.md`
+   - if absent, `…/strapi-mcp-server.mdx`
+   - if the route ends in a segment that is a directory, try `…/<segment>/index.md` / `index.mdx`.
+4. If no local file matches (e.g. the page is generated, or the route uses a sidebar alias), fall back to fetching the rendered page with WebFetch and treat the result as **pasted content** (type 6), noting in the report that the review ran against the published HTML, not local source.
+
+`SCOPE` = the resolved local path, or `docs.strapi.io<route> (fetched)` for the fallback. `CLEANUP` is empty unless the fallback wrote a temp file.
+
+### 4 — Local path
+
+Use the path directly. If it is a directory, recursively collect `.md` and `.mdx` files under it. `CLEANUP` is empty.
+
+`SCOPE` = the path.
+
+### 5 — Bare filename
+
+The user passed a filename with no directory, e.g. `strapi-mcp-server.md`:
+
+```bash
+find docusaurus/docs -type f \( -name '<name>' \) 2>/dev/null
+```
+
+- Exactly one match: use it.
+- Multiple matches: list them and ask the user which one (or, with `--yes`, review all of them).
+- No match: report that the file was not found and stop.
+
+`SCOPE` = the resolved path.
+
+### 6 — Pasted content
+
+The user pasted Markdown directly (frontmatter, headings, prose) instead of a reference:
+
+1. Derive a slug from the first `# H1` or frontmatter `title:`, falling back to `pasted`.
+2. Write the content verbatim to `/tmp/inki-review-paste-<slug>.md`.
+3. `FILES` = that temp file.
+4. `CLEANUP` = `rm -f /tmp/inki-review-paste-<slug>.md`.
+
+`SCOPE` = `pasted content (<slug>)`.
+
+Note: coherence-check and code-verify are less reliable on pasted content, because the file is outside the docs tree (relative links and sibling-page lookups will not resolve). Note this limitation in the report when the target is pasted content.
+
+## Cleanup contract
+
+Always run `CLEANUP` after the skill finishes, including on failure. In a Claude-Code-driven run (where a bash `trap` may not survive across separate tool calls), invoke the `CLEANUP` command explicitly as the final step rather than relying on `trap`.

--- a/claude-plugins/inki/references/target-resolver.md
+++ b/claude-plugins/inki/references/target-resolver.md
@@ -18,7 +18,7 @@ The target is classified by inspecting its shape, in this order (first match win
 |---|-----------|---------------|-------------|
 | 1 | Empty | No argument left after stripping flags | Changed `.md` files on the current branch |
 | 2 | GitHub PR | URL `github.com/strapi/documentation/pull/<n>`, `#<n>`, or a bare integer | The PR's changed doc files, in a temporary worktree |
-| 3 | docs.strapi.io URL | Starts with `https://docs.strapi.io/` (or `http://`) | The matching local source file |
+| 3 | docs.strapi.io URL | Starts with `https://docs.strapi.io/` (or `http://`) | The published source file the URL maps to, read from `origin/main` |
 | 4 | Local path | Contains a `/` or ends in `.md`/`.mdx`, and exists on disk | That file, or all docs under it if a directory |
 | 5 | Bare filename | A `.md`/`.mdx` name with no directory part, not found as a literal path | The unique file of that name under `docusaurus/docs/` |
 | 6 | Pasted content | None of the above; the argument is multi-line or clearly Markdown body/frontmatter | A temp file written from the pasted text |
@@ -58,7 +58,7 @@ Operates on the current working tree. `CLEANUP` is empty.
 
 ### 3 — docs.strapi.io URL
 
-Map the public URL to a local source file:
+A `docs.strapi.io` URL points at the *published* page, so the review must run against the published source, not a possibly-stale working copy. Map the URL to its source file and read that file from `origin/main`:
 
 1. Strip the origin (`https://docs.strapi.io`) and any trailing slash, query string, or `#anchor`.
 2. The remaining path is the doc route, e.g. `/cms/features/strapi-mcp-server`.
@@ -66,9 +66,18 @@ Map the public URL to a local source file:
    - `docusaurus/docs/cms/features/strapi-mcp-server.md`
    - if absent, `…/strapi-mcp-server.mdx`
    - if the route ends in a segment that is a directory, try `…/<segment>/index.md` / `index.mdx`.
-4. If no local file matches (e.g. the page is generated, or the route uses a sidebar alias), fall back to fetching the rendered page with WebFetch and treat the result as **pasted content** (type 6), noting in the report that the review ran against the published HTML, not local source.
+4. Refresh the remote ref, then pick the first of the `<path>` candidates from step 3 that exists on `origin/main` (`git cat-file -e origin/main:<path>`). Materialize that published version into a temp file, so the review matches what the URL shows regardless of the local branch or working-tree state. This never touches the working tree, so no stash or commit is needed first. `<slug>` is the route's last segment (e.g. `strapi-mcp-server`):
 
-`SCOPE` = the resolved local path, or `docs.strapi.io<route> (fetched)` for the fallback. `CLEANUP` is empty unless the fallback wrote a temp file.
+   ```bash
+   git fetch origin main
+   git show origin/main:<path> > /tmp/inki-review-url-<slug>.md
+   ```
+
+   `FILES` = that temp file. `CLEANUP` = `rm -f /tmp/inki-review-url-<slug>.md`.
+5. If the local working tree has uncommitted changes to `<path>` (`git diff --quiet -- <path>` fails, or the file differs from `origin/main`), note in the report header that the review ran against `origin/main` and that local uncommitted changes to this file were **not** included.
+6. If none of the candidates exist on `origin/main` (e.g. the page is generated, or the route uses a sidebar alias), fall back to fetching the rendered page with WebFetch and treat the result as **pasted content** (type 6), noting in the report that the review ran against the published HTML, not local source.
+
+`SCOPE` = `docs.strapi.io<route> (origin/main)`, or `docs.strapi.io<route> (fetched)` for the WebFetch fallback. `CLEANUP` removes any temp file written.
 
 ### 4 — Local path
 

--- a/claude-plugins/inki/scripts/main-worktree.sh
+++ b/claude-plugins/inki/scripts/main-worktree.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# main-worktree.sh — Helper to manage a temporary, detached git worktree on origin/main.
+#
+# Used to review a published page (resolved from a docs.strapi.io URL) against the
+# version on origin/main, with the file at its real path inside docusaurus/docs/ so
+# that coherence-check and code-verify can resolve relative links and sibling pages.
+#
+# Subcommands:
+#   create   Fetch origin/main and create a detached worktree at /tmp/inki-review-main.
+#            Prints the worktree path on stdout.
+#   destroy  Remove the worktree.
+#
+# Usage in a skill (bash):
+#   WORKTREE=$(./main-worktree.sh create)
+#   # ... review files inside $WORKTREE (e.g. $WORKTREE/docusaurus/docs/<path>) ...
+#   ./main-worktree.sh destroy
+#
+# Detached (no temporary branch): the worktree only needs to read origin/main, never commit.
+
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 {create|destroy}" >&2
+  exit 1
+}
+
+[ $# -eq 1 ] || usage
+ACTION="$1"
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+WORKTREE_DIR="/tmp/inki-review-main"
+
+case "$ACTION" in
+  create)
+    # Clean up any leftover from a previous run.
+    git -C "$REPO_ROOT" worktree remove --force "$WORKTREE_DIR" 2>/dev/null || true
+    rm -rf "$WORKTREE_DIR"
+
+    # Refresh origin/main, then create a detached worktree pointing at it.
+    git -C "$REPO_ROOT" fetch origin main >&2
+    git -C "$REPO_ROOT" worktree add --detach "$WORKTREE_DIR" origin/main >&2
+    echo "$WORKTREE_DIR"
+    ;;
+  destroy)
+    git -C "$REPO_ROOT" worktree remove --force "$WORKTREE_DIR" 2>/dev/null || true
+    ;;
+  *)
+    usage
+    ;;
+esac

--- a/claude-plugins/inki/skills/review/SKILL.md
+++ b/claude-plugins/inki/skills/review/SKILL.md
@@ -60,7 +60,7 @@ Review of: <SCOPE>
 | pitfalls-check | ... | ... |
 ```
 
-Then list issues by file, ordered by severity. For PR-scope reviews, prefix file paths with `(PR #<num>)` so it's clear the issues are in the PR's version. For a `docs.strapi.io` URL review, note that the review ran against the published `origin/main` version (and flag any local uncommitted changes that were excluded, per the resolver). For a pasted-content or URL review, also note that coherence and code-verification findings may be incomplete because the file sits outside the docs tree (see the resolver's note).
+Then list issues by file, ordered by severity. For PR-scope reviews, prefix file paths with `(PR #<num>)` so it's clear the issues are in the PR's version. For a `docs.strapi.io` URL review, note that the review ran against the published `origin/main` version, and flag any local uncommitted changes that were excluded (per the resolver). For a pasted-content review, note that coherence and code-verification findings may be incomplete because the file sits outside the docs tree (see the resolver's note).
 
 ## Step 4: Cleanup
 
@@ -71,7 +71,8 @@ Run the `CLEANUP` command returned by the resolver (worktree teardown or temp-fi
 - Each sub-skill stays atomic. Do not duplicate their logic here.
 - If `--fix` is passed, only the auto-fixable findings from `style-check` are applied automatically. All others remain suggestions.
 - `--fix` on a PR-scope review applies fixes inside the temporary worktree only (the one created by the resolver). The PR itself is NOT modified by `/inki:review`. To push the fixes, the user must `gh pr checkout <num>` themselves and apply the suggestions manually (or use `/inki:commit` + `/inki:push` after a manual checkout).
-- `--fix` on a pasted-content or URL review applies fixes to the temp file only; there is no writable source file (the URL version is read from `origin/main`). Surface the corrected content in the report instead.
+- `--fix` on a `docs.strapi.io` URL review applies fixes inside the temporary `origin/main` worktree only (created by the resolver); that worktree is detached and torn down at cleanup, so nothing is written back. Surface the corrected content in the report, and tell the user to apply it on a real branch.
+- `--fix` on a pasted-content review applies fixes to the temp file only; there is no source file to write back to. Surface the corrected content in the report instead.
 - `--yes` only changes interaction behavior (no extra prompts). It does NOT change what gets auto-fixed — that stays controlled by `--fix`.
 - Never push, commit, or modify the PR directly. The review is read-only by default.
 

--- a/claude-plugins/inki/skills/review/SKILL.md
+++ b/claude-plugins/inki/skills/review/SKILL.md
@@ -60,7 +60,7 @@ Review of: <SCOPE>
 | pitfalls-check | ... | ... |
 ```
 
-Then list issues by file, ordered by severity. For PR-scope reviews, prefix file paths with `(PR #<num>)` so it's clear the issues are in the PR's version. For a pasted-content or fetched-URL review, note that coherence and code-verification findings may be incomplete because the file sits outside the docs tree (see the resolver's note).
+Then list issues by file, ordered by severity. For PR-scope reviews, prefix file paths with `(PR #<num>)` so it's clear the issues are in the PR's version. For a `docs.strapi.io` URL review, note that the review ran against the published `origin/main` version (and flag any local uncommitted changes that were excluded, per the resolver). For a pasted-content or URL review, also note that coherence and code-verification findings may be incomplete because the file sits outside the docs tree (see the resolver's note).
 
 ## Step 4: Cleanup
 
@@ -71,7 +71,7 @@ Run the `CLEANUP` command returned by the resolver (worktree teardown or temp-fi
 - Each sub-skill stays atomic. Do not duplicate their logic here.
 - If `--fix` is passed, only the auto-fixable findings from `style-check` are applied automatically. All others remain suggestions.
 - `--fix` on a PR-scope review applies fixes inside the temporary worktree only (the one created by the resolver). The PR itself is NOT modified by `/inki:review`. To push the fixes, the user must `gh pr checkout <num>` themselves and apply the suggestions manually (or use `/inki:commit` + `/inki:push` after a manual checkout).
-- `--fix` on a pasted-content or fetched-URL review applies fixes to the temp file only; there is no source file to write back to. Surface the corrected content in the report instead.
+- `--fix` on a pasted-content or URL review applies fixes to the temp file only; there is no writable source file (the URL version is read from `origin/main`). Surface the corrected content in the report instead.
 - `--yes` only changes interaction behavior (no extra prompts). It does NOT change what gets auto-fixed — that stays controlled by `--fix`.
 - Never push, commit, or modify the PR directly. The review is read-only by default.
 

--- a/claude-plugins/inki/skills/review/SKILL.md
+++ b/claude-plugins/inki/skills/review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: review
 description: "Top-level review orchestrator: runs style-check, outline-check, outline-ux-analyzer, code-verify, coherence-check, and pitfalls-check on a file, directory, or PR."
-argument-hint: "[--yes|-y] [--fix] <path | PR# | PR URL>"
+argument-hint: "[--yes|-y] [--fix] <path | filename | PR# | PR URL | docs.strapi.io URL | pasted content>"
 user-invocable: true
 ---
 
@@ -14,54 +14,23 @@ From `$ARGUMENTS`, detect optional flags anywhere in the list:
 - `--yes` or `-y` → `AUTO=true` (non-interactive: skip any confirmation gates inside sub-skills)
 - `--fix` → `FIX=true` (apply auto-fixable findings from `style-check`)
 
-Remove the flags. What remains is the target, which can be:
-
-- **A local path**: file or directory under `docusaurus/docs/`, e.g. `docusaurus/docs/cms/intro.md`.
-- **A PR identifier**: bare number (`3204`), hashed (`#3204`), or URL (`https://github.com/strapi/documentation/pull/3204`, with optional `/files` or `/changes` suffix).
-- **Empty**: defaults to the changed `.md` files on the current branch (`git diff main...HEAD --name-only -- '*.md'`).
+Remove the flags. What remains is the **target**.
 
 ## Step 1: Resolve target to a set of files
 
-Three branches depending on what the user passed:
+Resolve the target by following `../../references/target-resolver.md`. It accepts any of: a local path or directory, a bare markdown filename, a GitHub PR (number, `#number`, or URL), a docs.strapi.io URL, pasted Markdown content, or nothing (changed files on the current branch).
 
-### 1a — Local path
+The resolver returns:
 
-Use directly. If it's a directory, recursively collect `.md` and `.mdx` files under it.
+- `FILES` — the list of local files the sub-skills operate on.
+- `SCOPE` — a short label for the report header.
+- `CLEANUP` — a command to run when the review finishes (worktree teardown or temp-file removal); may be empty.
 
-### 1b — PR identifier
-
-1. Extract the PR number from the identifier (use `[0-9]+$` after stripping URL tail like `/files`, `/changes`, and a leading `#`).
-2. Fetch the PR's changed files:
-
-   ```bash
-   gh pr view <num> --repo strapi/documentation --json files,headRefName --jq '.files[].path'
-   ```
-
-3. Filter to `.md` and `.mdx` files only. If the PR changes no documentation file, report that and stop.
-4. Create a temporary worktree with the PR checked out (so sub-skills see the PR's version of the files, not `main`):
-
-   ```bash
-   WORKTREE=$(./claude-plugins/inki/scripts/pr-worktree.sh create <num>)
-   trap "./claude-plugins/inki/scripts/pr-worktree.sh destroy <num>" EXIT
-   ```
-
-   The helper handles fetching, creating the temporary branch (`inki-tmp-review-<num>`), and the worktree (`/tmp/inki-review-pr-<num>`). The `trap` ensures cleanup even on failure.
-
-5. Prepend `$WORKTREE/` to each file path collected in step 3. These prefixed paths are what sub-skills will receive as `<target>`.
-
-### 1c — Empty
-
-Default to:
-
-```bash
-git diff main...HEAD --name-only -- '*.md'
-```
-
-Operates on the current working tree.
+If resolution fails (PR has no doc files, filename not found, URL maps to nothing), report why and stop.
 
 ## Step 2: Run the 6 sub-skills in parallel where possible
 
-For each target file (or set of files), invoke:
+For each file in `FILES`, invoke:
 
 - `/inki:style-check <target>` (with `--fix` if `FIX=true`)
 - `/inki:outline-check <target>`
@@ -79,7 +48,7 @@ Collect each report.
 Output a combined table:
 
 ```
-Review of: <target description, e.g., "PR #3203 (1 doc file)" or "docusaurus/docs/cms/intro.md">
+Review of: <SCOPE>
 
 | Sub-skill | Issues found | Severity |
 |-----------|--------------|----------|
@@ -91,25 +60,31 @@ Review of: <target description, e.g., "PR #3203 (1 doc file)" or "docusaurus/doc
 | pitfalls-check | ... | ... |
 ```
 
-Then list issues by file, ordered by severity. For PR-scope reviews, prefix file paths with `(PR #<num>)` so it's clear the issues are in the PR's version.
+Then list issues by file, ordered by severity. For PR-scope reviews, prefix file paths with `(PR #<num>)` so it's clear the issues are in the PR's version. For a pasted-content or fetched-URL review, note that coherence and code-verification findings may be incomplete because the file sits outside the docs tree (see the resolver's note).
 
-## Step 4: Cleanup (PR scope only)
+## Step 4: Cleanup
 
-If a temporary worktree was created in step 1b, the `trap` set there handles cleanup automatically via `pr-worktree.sh destroy`. In a Claude-Code-driven execution (where bash trap may not propagate cleanly across tool calls), invoke `pr-worktree.sh destroy <num>` explicitly after step 3.
+Run the `CLEANUP` command returned by the resolver (worktree teardown or temp-file removal), even if the review failed. In a Claude-Code-driven execution, invoke it explicitly after Step 3 rather than relying on a bash `trap`. If `CLEANUP` is empty, there is nothing to do.
 
 ## Rules
 
 - Each sub-skill stays atomic. Do not duplicate their logic here.
 - If `--fix` is passed, only the auto-fixable findings from `style-check` are applied automatically. All others remain suggestions.
-- `--fix` on a PR-scope review applies fixes inside the temporary worktree only. The PR itself is NOT modified by `/inki:review`. To push the fixes, the user must `gh pr checkout <num>` themselves and apply the suggestions manually (or use `/inki:commit` + `/inki:push` after a manual checkout).
+- `--fix` on a PR-scope review applies fixes inside the temporary worktree only (the one created by the resolver). The PR itself is NOT modified by `/inki:review`. To push the fixes, the user must `gh pr checkout <num>` themselves and apply the suggestions manually (or use `/inki:commit` + `/inki:push` after a manual checkout).
+- `--fix` on a pasted-content or fetched-URL review applies fixes to the temp file only; there is no source file to write back to. Surface the corrected content in the report instead.
 - `--yes` only changes interaction behavior (no extra prompts). It does NOT change what gets auto-fixed — that stays controlled by `--fix`.
 - Never push, commit, or modify the PR directly. The review is read-only by default.
 
 ## Examples
 
-Review a single file on the current branch:
+Review a single file by path:
 ```
 /inki:review docusaurus/docs/cms/intro.md
+```
+
+Review by bare filename (resolved under `docusaurus/docs/`):
+```
+/inki:review strapi-mcp-server.md
 ```
 
 Review changed files on the current branch (no argument):
@@ -122,6 +97,21 @@ Review all `.md`/`.mdx` files modified by a PR:
 /inki:review https://github.com/strapi/documentation/pull/3204
 /inki:review 3204
 /inki:review #3204
+```
+
+Review a published page by its docs.strapi.io URL:
+```
+/inki:review https://docs.strapi.io/cms/features/strapi-mcp-server
+```
+
+Review pasted Markdown content (paste the page body as the argument):
+```
+/inki:review ---
+title: My page
+---
+
+# My page
+...
 ```
 
 Non-interactive review with auto-fixes applied locally:


### PR DESCRIPTION
This PR extends /inki:review so its target can be a docs.strapi.io URL, a bare markdown filename, or pasted Markdown content, in addition to the existing path, PR, and no-argument cases.

- Adds references/target-resolver.md as the single source of truth for target resolution
- Slims review/SKILL.md to delegate parsing to the resolver and adds matching examples
- Updates the README and CHANGELOG

Targets repo/inki-plugin-init since the inki plugin is introduced by #3200 and is not yet on main.