### PR TITLE
Document that the Deploy widget only shows in local development

### DIFF
--- a/docusaurus/docs/cms/admin-panel-customization/homepage.md
+++ b/docusaurus/docs/cms/admin-panel-customization/homepage.md
@@ -23,7 +23,7 @@ The <Icon name="house" /> Homepage is the landing page of the Strapi admin panel
 - _Profile_: Displays a short summary of your profile, including your name, email address, and role.
 - _Entries_: Displays the total number of Draft & Published entries.
 - _Project statistics_: Displays statistics about your entries, content-types, locales, assets, and more.
-- _Deploy_: Displays a **Deploy Now** button that links to [Strapi Cloud](https://cloud.strapi.io/login) for deploying your project.
+- _Deploy_: Displays a **Deploy Now** button that links to [Strapi Cloud](https://cloud.strapi.io/login) for deploying your project. This widget is only displayed in local development and is hidden when the application runs in production.
 
 
 <ThemedImage


### PR DESCRIPTION
This PR documents that the Homepage Deploy widget is now only displayed in local development and is hidden in production. Documents [#26549](https://github.com/strapi/strapi/pull/26549)

Direct preview link 👉 [here](https://documentation-git-cms-deploy-widget-local-only-strapijs.vercel.app/cms/admin-panel-customization/homepage)