### PR TITLE
Document custom provider auth flow and troubleshooting

### DIFF
--- a/docusaurus/docs/cms/configurations/users-and-permissions-providers/new-provider-guide.md
+++ b/docusaurus/docs/cms/configurations/users-and-permissions-providers/new-provider-guide.md
@@ -53,6 +53,15 @@ module.exports = {
 
 For additional information on parameters passed to `grantConfig`, please refer to the  <ExternalLink to="https://github.com/simov/grant" text="`grant` documentation"/>. For additional information about `purest` please refer to <ExternalLink to="https://github.com/simov/purest" text="`purest` documentation"/>.
 
+### How authentication flow works
+
+The object returned by the `authCallback` function must contain at least `username` and `email` properties. Strapi uses this returned email address to automatically resolve the authentication flow for both registration and login:
+
+* **If the user does not exist**: Strapi registers a new user under the returned `email` and `username` and then logs them in, returning the JWT and user object.
+* **If the user already exists**: Strapi retrieves the existing user matching that `email` and logs them in, returning the JWT and user object.
+
+Because of this design, you do not need to implement separate lookup or registration logic inside your custom provider. You only need to ensure your `authCallback` fetches the user's profile from the external provider and returns the user's `email` and `username`.
+
 ### Frontend setup
 
 Once you have configured Strapi and the provider, in your frontend application you must:
@@ -65,6 +74,9 @@ Now you can make authenticated requests, as described in [token usage](/cms/feat
 
 :::caution Troubleshooting
 
+- **Email not provided**: This error occurs when the `authCallback` fails to return a valid `email` address.
+  - Make sure that your provider application is configured with the correct OAuth scopes (e.g. `email` or `profile`) to request the user's email.
+  - Check that the identity provider actually returns the email in the payload. Note that some users may have their email address hidden or set to private on the identity provider side.
 - **Error 429**: It's most likely because your login flow fell into a loop. To make new requests to the backend, you need to wait a few minutes or restart the backend.
 - **Grant: missing session or misconfigured provider**: It may be due to many things.
   - **The redirect url can't be built**: Make sure you have set the backend url in `config/server.js`: [Setting up the server url](/cms/configurations/users-and-permissions-providers#setting-up-the-server-url)


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request!

To help us merge your PR, make sure to follow the instructions detailed in the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md

Note that all documentation updates should be made against the `main` branch.
Keep your PR in Draft mode until it's ready to be reviewed and merged.


As part of the Docs Contribution Program, all external contribution PRs are labeled `contribution`.
Feel free to read more details on the Contribution Program in the dedicated guide:
https://strapi.notion.site/Documentation-Contribution-Program-1d08f359807480d480fdde68bb7a5a71

Let us know if you do not wish to take part in the Docs Contribution Program, and remove the `contribution` label.
-->

### Description

This PR updates the custom Users & Permissions provider documentation to clarify the automatic lookup/registration mechanism using the returned email. 

* **What does it do?** It adds a new section explaining the logic flow of custom authentication providers and clarifies that returning `email` in the `authCallback` handles both login and registration automatically. It also adds a troubleshooting section for the `"Email not provided"` error.

* **Why is it needed?** Users implementing custom providers are often confused about whether they need to handle the lookup and registration flow of existing users manually. Additionally, they frequently hit the `"Email not provided"` error when scopes or permissions are misconfigured.

### Related issue(s)/PR(s)

Closes #2316