### PR TITLE
Fix `delete()` row description in REST client API reference

### DIFF
--- a/docusaurus/docs/cms/api/client.md
+++ b/docusaurus/docs/cms/api/client.md
@@ -139,7 +139,7 @@ Collection types in Strapi are entities with multiple entries (e.g., a blog with
 | `findOne(documentID, queryParams?)`    | Retrieve a single document by its unique ID.        |
 | `create(data, queryParams?)`  | Create a new document in the collection. |
 | `update(documentID, data, queryParams?)`  | Update an existing document. |
-| `delete(documentID, queryParams?)`  | Update an existing document. |
+| `delete(documentID, queryParams?)`  | Delete an existing document. |
 
 **Usage examples:**
 <Tabs groupId="js-ts"> 


### PR DESCRIPTION
In the collection-type methods table on the JS/TS client API reference page, the `delete()` row carries the same description as the `update()` row above it:

| Method | Description |
| --- | --- |
| `update(documentID, data, queryParams?)` | Update an existing document. |
| `delete(documentID, queryParams?)` | Update an existing document. |

The `delete()` method removes a document, it doesn't update one. The usage example just below (`await articles.delete('article-id')`) and the parallel single-type and files tables both describe it as a removal. This corrects the one row to "Delete an existing document."