### PR TITLE
Cms/document factory controller overrides

### DIFF
--- a/docusaurus/docs/cms/configurations/users-and-permissions-providers/new-provider-guide.md
+++ b/docusaurus/docs/cms/configurations/users-and-permissions-providers/new-provider-guide.md
@@ -57,7 +57,7 @@ For additional information on parameters passed to `grantConfig`, please refer t
 
 The object returned by the `authCallback` function must contain at least `username` and `email` properties. Strapi uses this returned email address to automatically resolve the authentication flow for both registration and login:
 
-* **If the user does not exist**: Strapi registers a new user under the returned `email` and `username` and then logs them in, returning the JWT and user object.
+* If the user does not exist: Strapi registers a new user under the returned `email` and `username` and then logs them in, returning the JWT and user object.
 * **If the user already exists**: Strapi retrieves the existing user matching that `email` and logs them in, returning the JWT and user object.
 
 Because of this design, you do not need to implement separate lookup or registration logic inside your custom provider. You only need to ensure your `authCallback` fetches the user's profile from the external provider and returns the user's `email` and `username`.

--- a/docusaurus/docs/cms/configurations/users-and-permissions-providers/new-provider-guide.md
+++ b/docusaurus/docs/cms/configurations/users-and-permissions-providers/new-provider-guide.md
@@ -53,6 +53,15 @@ module.exports = {
 
 For additional information on parameters passed to `grantConfig`, please refer to the  <ExternalLink to="https://github.com/simov/grant" text="`grant` documentation"/>. For additional information about `purest` please refer to <ExternalLink to="https://github.com/simov/purest" text="`purest` documentation"/>.
 
+### How authentication flow works
+
+The object returned by the `authCallback` function must contain at least `username` and `email` properties. Strapi uses this returned email address to automatically resolve the authentication flow for both registration and login:
+
+* **If the user does not exist**: Strapi registers a new user under the returned `email` and `username` and then logs them in, returning the JWT and user object.
+* **If the user already exists**: Strapi retrieves the existing user matching that `email` and logs them in, returning the JWT and user object.
+
+Because of this design, you do not need to implement separate lookup or registration logic inside your custom provider. You only need to ensure your `authCallback` fetches the user's profile from the external provider and returns the user's `email` and `username`.
+
 ### Frontend setup
 
 Once you have configured Strapi and the provider, in your frontend application you must:
@@ -65,6 +74,9 @@ Now you can make authenticated requests, as described in [token usage](/cms/feat
 
 :::caution Troubleshooting
 
+- **Email not provided**: This error occurs when the `authCallback` fails to return a valid `email` address.
+  - Make sure that your provider application is configured with the correct OAuth scopes (e.g. `email` or `profile`) to request the user's email.
+  - Check that the identity provider actually returns the email in the payload. Note that some users may have their email address hidden or set to private on the identity provider side.
 - **Error 429**: It's most likely because your login flow fell into a loop. To make new requests to the backend, you need to wait a few minutes or restart the backend.
 - **Grant: missing session or misconfigured provider**: It may be due to many things.
   - **The redirect url can't be built**: Make sure you have set the backend url in `config/server.js`: [Setting up the server url](/cms/configurations/users-and-permissions-providers#setting-up-the-server-url)

--- a/docusaurus/docs/cms/configurations/users-and-permissions-providers/new-provider-guide.md
+++ b/docusaurus/docs/cms/configurations/users-and-permissions-providers/new-provider-guide.md
@@ -58,7 +58,7 @@ For additional information on parameters passed to `grantConfig`, please refer t
 The object returned by the `authCallback` function must contain at least `username` and `email` properties. Strapi uses this returned email address to automatically resolve the authentication flow for both registration and login:
 
 * If the user does not exist: Strapi registers a new user under the returned `email` and `username` and then logs them in, returning the JWT and user object.
-* **If the user already exists**: Strapi retrieves the existing user matching that `email` and logs them in, returning the JWT and user object.
+* If the user already exists: Strapi retrieves the existing user matching that `email` and logs them in, returning the JWT and user object.
 
 Because of this design, you do not need to implement separate lookup or registration logic inside your custom provider. You only need to ensure your `authCallback` fetches the user's profile from the external provider and returns the user's `email` and `username`.
 

--- a/docusaurus/docs/cms/plugins-development/plugins-extension.md
+++ b/docusaurus/docs/cms/plugins-development/plugins-extension.md
@@ -114,7 +114,7 @@ module.exports = (plugin) => {
 ```
 </details>
 
-:::warning Factory-based controllers
+:::note Factory-based controllers
 Some plugin controllers, such as the `auth` controller in the Users & Permissions plugin, use a factory pattern (i.e. they are exported as functions: `({ strapi }) => ({ ... })`). 
 
 Trying to override actions on these controllers directly (e.g., `plugin.controllers.auth.callback = ...`) will not work because the factory has not yet been resolved when your extension code runs. 

--- a/docusaurus/docs/cms/plugins-development/plugins-extension.md
+++ b/docusaurus/docs/cms/plugins-development/plugins-extension.md
@@ -114,6 +114,41 @@ module.exports = (plugin) => {
 ```
 </details>
 
+:::warning Factory-based controllers
+Some plugin controllers, such as the `auth` controller in the Users & Permissions plugin, use a factory pattern (i.e. they are exported as functions: `({ strapi }) => ({ ... })`). 
+
+Trying to override actions on these controllers directly (e.g., `plugin.controllers.auth.callback = ...`) will not work because the factory has not yet been resolved when your extension code runs. 
+
+To override factory-based controller actions, wrap the factory function itself:
+
+```js title="./src/extensions/users-permissions/strapi-server.js"
+module.exports = (plugin) => {
+  const originalAuthFactory = plugin.controllers.auth;
+
+  plugin.controllers.auth = ({ strapi }) => {
+    // Resolve the original factory to get the controller methods
+    const originalAuth = originalAuthFactory({ strapi });
+
+    // Store the original action to avoid recursion
+    const originalCallback = originalAuth.callback;
+
+    // Override the action
+    originalAuth.callback = async (ctx) => {
+      // Custom pre-auth logic
+      await originalCallback(ctx);
+      // Custom post-auth logic
+    };
+
+    return originalAuth;
+  };
+
+  return plugin;
+};
+```
+For more information, see the [Customizing Users & Permissions plugin routes guide](/cms/backend-customization/guides/customizing-users-permissions-plugin-routes#override-auth-route).
+:::
+
+
 :::note
 The `strapi-server.js|ts` file is also where you can override the image function, by replacing the Upload plugin's `generateFileName()` function so that it generates custom image names.
 

--- a/docusaurus/static/llms-code.txt
+++ b/docusaurus/static/llms-code.txt
@@ -32177,6 +32177,34 @@ module.exports = (plugin) => {
 ```
 
 Language: JavaScript
+File path: ./src/extensions/users-permissions/strapi-server.js
+
+```js
+module.exports = (plugin) => {
+  const originalAuthFactory = plugin.controllers.auth;
+
+  plugin.controllers.auth = ({ strapi }) => {
+    // Resolve the original factory to get the controller methods
+    const originalAuth = originalAuthFactory({ strapi });
+
+    // Store the original action to avoid recursion
+    const originalCallback = originalAuth.callback;
+
+    // Override the action
+    originalAuth.callback = async (ctx) => {
+      // Custom pre-auth logic
+      await originalCallback(ctx);
+      // Custom post-auth logic
+    };
+
+    return originalAuth;
+  };
+
+  return plugin;
+};
+```
+
+Language: JavaScript
 File path: ./src/extensions/upload/strapi-server.js|ts
 
 ```js

--- a/docusaurus/static/llms-full.txt
+++ b/docusaurus/static/llms-full.txt
@@ -12207,6 +12207,40 @@ module.exports = (plugin) => {
 ```
 </details>
 
+:::warning Factory-based controllers
+Some plugin controllers, such as the `auth` controller in the Users & Permissions plugin, use a factory pattern (i.e. they are exported as functions: `({ strapi }) => ({ ... })`). 
+
+Trying to override actions on these controllers directly (e.g., `plugin.controllers.auth.callback = ...`) will not work because the factory has not yet been resolved when your extension code runs. 
+
+To override factory-based controller actions, wrap the factory function itself:
+
+```js title="./src/extensions/users-permissions/strapi-server.js"
+module.exports = (plugin) => {
+  const originalAuthFactory = plugin.controllers.auth;
+
+  plugin.controllers.auth = ({ strapi }) => {
+    // Resolve the original factory to get the controller methods
+    const originalAuth = originalAuthFactory({ strapi });
+
+    // Store the original action to avoid recursion
+    const originalCallback = originalAuth.callback;
+
+    // Override the action
+    originalAuth.callback = async (ctx) => {
+      // Custom pre-auth logic
+      await originalCallback(ctx);
+      // Custom post-auth logic
+    };
+
+    return originalAuth;
+  };
+
+  return plugin;
+};
+```
+For more information, see the [Customizing Users & Permissions plugin routes guide](/cms/backend-customization/guides/customizing-users-permissions-plugin-routes#override-auth-route).
+:::
+
 :::note
 The `strapi-server.js|ts` file is also where you can override the image function, by replacing the Upload plugin's `generateFileName()` function so that it generates custom image names.
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request!

To help us merge your PR, make sure to follow the instructions detailed in the Contributing Guide: 
https://github.com/strapi/documentation/blob/main/CONTRIBUTING.md

Note that all documentation updates should be made against the `main` branch.
Keep your PR in Draft mode until it's ready to be reviewed and merged.


As part of the Docs Contribution Program, all external contribution PRs are labeled `contribution`.
Feel free to read more details on the Contribution Program in the dedicated guide:
https://strapi.notion.site/Documentation-Contribution-Program-1d08f359807480d480fdde68bb7a5a71

Let us know if you do not wish to take part in the Docs Contribution Program, and remove the `contribution` label.
-->

### Description

This PR documents how to extend or override plugin controllers that are exported as factory functions, using the Users & Permissions auth controller as a reference.

### Related issue(s)/PR(s)

Closes issue #2336
