### PR TITLE
Document Strapi Cloud upload size limits

### DIFF
--- a/docusaurus/docs/cloud/advanced/middlewares.md
+++ b/docusaurus/docs/cloud/advanced/middlewares.md
@@ -68,7 +68,8 @@ Both CSP and CORS customizations can be combined in the same file.
 
 :::note
 - You can keep your existing `config/middlewares` file as-is as it will not cause conflicts. The production-specific file takes precedence on Strapi Cloud.
-- Upload size limits on Strapi Cloud are enforced at the infrastructure level (Cloudflare gateway) and cannot be overridden via the `strapi::body` config. For external storage options, see [Upload Provider Configuration](/cloud/advanced/upload).
+- Upload size limits on Strapi Cloud are enforced at the infrastructure level and cannot be overridden via the `strapi::body` config.
+- For per-plan values and the memory-based recommendation for image uploads, see [Upload size limits for Strapi Cloud](/cloud/advanced/upload-size-limits). For external storage options, see [Upload Provider Configuration](/cloud/advanced/upload).
 :::
 
 ## Custom Content Security Policy (CSP)

--- a/docusaurus/docs/cloud/advanced/upload-size-limits.md
+++ b/docusaurus/docs/cloud/advanced/upload-size-limits.md
@@ -1,0 +1,79 @@
+---
+title: Upload size limits for Strapi Cloud
+displayed_sidebar: cloudSidebar
+description: Reference for the file size and memory-based upload limits that apply to Strapi Cloud projects.
+canonicalUrl: https://docs.strapi.io/cloud/advanced/upload-size-limits.html
+tags:
+- configuration
+- upload provider
+- Media Library
+- Strapi Cloud
+- Strapi Cloud configuration
+- Strapi Cloud project
+---
+
+# Upload size limits for Strapi Cloud
+
+<Tldr>
+Non-image files are capped at 200 MB on all plans. Image files have a memory-based recommended maximum that varies by format, plan, and Media Library settings. To upload larger images, disable Responsive friendly upload and Size optimization.
+</Tldr>
+
+Strapi Cloud applies 2 distinct limits to uploads. The first is a hard maximum file size, enforced at the infrastructure level for non-image files. The second is a memory-based recommendation for image files that depends on your CMS settings.
+
+## Maximum upload file size for non-image files
+
+Non-image uploads are capped at 200 MB on all Strapi Cloud plans (Free, Essential, Pro, and Scale). The cap is enforced at the infrastructure level and cannot be overridden via the `strapi::body` middleware configuration.
+
+## Recommended maximum upload size for image files
+
+Image uploads are subject to an additional, memory-driven recommendation that is independent of the non-image cap and varies by image format.
+
+:::tip Uploading a large image?
+To upload an image larger than the recommended maximum, disable both Responsive friendly upload and Size optimization in the [Media Library settings](/cms/features/media-library#configuring-settings). The CMS then stores the source file as-is without in-process processing, which raises the recommended maximum (see the _Processing off_ values in the tables below).
+:::
+
+When Responsive friendly upload and Size optimization are both enabled in the [Media Library settings](/cms/features/media-library#configuring-settings), the CMS resizes the source image and generates a set of thumbnails (small, medium, large) in the instance's memory before persisting them. This processing happens in-process, regardless of the configured upload provider.
+
+Switching to a third-party provider (Amazon S3, Cloudinary, etc.) is not a workaround. The resize and thumbnail generation step still runs inside the Strapi Cloud instance and still requires memory proportional to the source image dimensions.
+
+Actual memory usage depends on the image dimensions, format, and your Media Library settings. The values in the following tables are a recommendation, not a hard limit. Uploads above the recommended size are likely to cause the instance to run out of memory and restart.
+
+The recommendation depends on whether Responsive friendly upload and Size optimization are enabled in the [Media Library settings](/cms/features/media-library#configuring-settings):
+
+- _Processing on_: both settings enabled, with the default `small`, `medium`, and `large` sizes. Strapi generates the thumbnails in memory, so the safe upload size is lower.
+- _Processing off_: both settings disabled. The source image is stored as-is with no in-process processing, so the safe upload size is higher.
+
+Recommended maximum image size, expressed in megapixels (MP), per format and plan:
+
+<Tabs groupId="processing">
+<TabItem value="on" label="Processing on">
+
+| Format | Free & Essential | Pro & Scale |
+|--------|------------------|-------------|
+| JPEG   | 24 MP            | 135 MP      |
+| PNG    | 8 MP             | 90 MP       |
+| WebP   | 4 MP             | 12 MP       |
+| TIFF   | 16 MP            | 125 MP      |
+| AVIF   | 66 MP            | 80 MP       |
+
+</TabItem>
+<TabItem value="off" label="Processing off">
+
+| Format | Free & Essential | Pro & Scale |
+|--------|------------------|-------------|
+| JPEG   | 200 MP           | 265 MP      |
+| PNG    | 20 MP            | 115 MP      |
+| WebP   | 15 MP            | 40 MP       |
+| TIFF   | 20 MP            | 125 MP      |
+| AVIF   | 74 MP            | 90 MP       |
+
+</TabItem>
+</Tabs>
+
+:::note Converting pixels to megapixels
+The number of megapixels of an image is its width multiplied by its height in pixels, divided by 1,000,000. The pixel dimensions that match a given megapixel count depend on the aspect ratio. For a square image, 1 MP is roughly 1000×1000 px, 4 MP is roughly 2000×2000 px, and 100 MP is roughly 10000×10000 px.
+:::
+
+:::strapi Configuring a provider
+To configure external storage such as Amazon S3 or Cloudinary, see [Upload Provider Configuration for Strapi Cloud](/cloud/advanced/upload).
+:::

--- a/docusaurus/docs/cloud/advanced/upload.md
+++ b/docusaurus/docs/cloud/advanced/upload.md
@@ -1,7 +1,7 @@
 ---
 title: Upload Provider Configuration for Strapi Cloud
 displayed_sidebar: cloudSidebar
-description: Configure Strapi Cloud to use a third-party upload provider.
+description: Configure Strapi Cloud upload provider or use a third-party upload provider.
 canonicalUrl: https://docs.strapi.io/cloud/advanced/upload.html
 tags:
 - configuration
@@ -20,7 +20,13 @@ tags:
 External storage like S3 or Cloudinary requires plugin setup, security middleware, and Cloud variables.
 </Tldr>
 
-Strapi Cloud comes with a local upload provider out of the box. However, it can also be configured to utilize a third-party upload provider, if needed.
+Strapi Cloud comes with a local upload provider out of the box. However, it can also be configured to use a third-party upload provider, if needed.
+
+:::note
+For the file size and memory-based limits that apply to uploads, see [Upload size limits for Strapi Cloud](/cloud/advanced/upload-size-limits).
+:::
+
+## Configuring a third-party upload provider
 
 :::caution
 Please be advised that Strapi is unable to provide support for third-party upload providers.
@@ -33,27 +39,25 @@ Please be advised that Strapi is unable to provide support for third-party uploa
 
 :::
 
-## Configuration
-
-Configuring a third-party upload provider for use with Strapi Cloud requires 4 steps:
+Configuring a third-party upload provider for use with Strapi Cloud requires the following 4 configuration steps, followed by a deployment:
 
 1. Install the provider plugin in your local Strapi project.
 2. Configure the provider in your local Strapi project.
-3. Configure the Security Middleware in your local Strapi project.
+3. Configure the security middleware in your local Strapi project.
 4. Add environment variables to the Strapi Cloud project.
 
-### Install the Provider Plugin
+### Install the provider plugin
 
 Using either `npm` or `yarn`, install the provider plugin in your local Strapi project as a package dependency by following the instructions in the respective entry for that provider in the <ExternalLink to="https://market.strapi.io/providers" text="Marketplace"/>.
 
-### Configure the Provider
+### Configure the provider
 
-To configure a 3rd-party upload provider in your Strapi project, create or edit the plugins configuration file for your production environment `./config/env/production/plugins.js|ts` by adding upload configuration options as follows:
+To configure a third-party upload provider in your Strapi project, create or edit the plugins configuration file for your production environment `/config/env/production/plugins.js|ts` by adding upload configuration options as follows:
 
 <Tabs groupId="js-ts">
 <TabItem value="js" label="JavaScript">
 
-```js title=./config/env/production/plugins.js
+```js title=/config/env/production/plugins.js
 
 module.exports = ({ env }) => ({
 // … some unrelated plugins configuration options
@@ -71,7 +75,7 @@ upload: {
 </TabItem>
 <TabItem value="ts" label="TypeScript">
 
-```ts title=./config/env/production/plugins.ts
+```ts title=/config/env/production/plugins.ts
 
 export default ({ env }) => ({
 // … some unrelated plugins configuration options
@@ -101,7 +105,7 @@ Each provider will have different configuration settings available. Review the r
 <Tabs groupId="upload-examples" >
 <TabItem value="cloudinary" label="Cloudinary">
 
-```js title=./config/env/production/plugins.js
+```js title=/config/env/production/plugins.js
 module.exports = ({ env }) => ({
   // ...
   upload: {
@@ -130,7 +134,7 @@ module.exports = ({ env }) => ({
 For full S3 provider configuration details (credential formats, extended options, S3-compatible services), see the [Amazon S3 provider](/cms/configurations/media-library-providers/amazon-s3) page in the CMS documentation.
 :::
 
-```js title=./config/env/production/plugins.js
+```js title=/config/env/production/plugins.js
 module.exports = ({ env }) => ({
   // ...
   upload: {
@@ -170,7 +174,7 @@ module.exports = ({ env }) => ({
 <Tabs groupId="upload-examples" >
 <TabItem value="cloudinary" label="Cloudinary">
 
-```ts title=./config/env/production/plugins.ts
+```ts title=/config/env/production/plugins.ts
 export default ({ env }) => ({
   // ...
   upload: {
@@ -195,7 +199,7 @@ export default ({ env }) => ({
 </TabItem >
 <TabItem value="amazon-s3" label="Amazon S3">
 
-```ts title=./config/env/production/plugins.ts
+```ts title=/config/env/production/plugins.ts
 export default ({ env }) => ({
   // ...
   upload: {
@@ -233,9 +237,9 @@ export default ({ env }) => ({
 </TabItem>
 </Tabs>
 
-### Configure the Security Middleware
+### Configure the security middleware
 
-Due to the default settings in the Strapi Security Middleware you will need to modify the `contentSecurityPolicy` settings to properly see thumbnail previews in the Media Library.
+Due to the default settings in the Strapi security middleware you will need to modify the `contentSecurityPolicy` settings to properly see thumbnail previews in the Media Library.
 
 :::caution
 On Strapi Cloud, `NODE_ENV` is always set to `production`. Changes to the global `config/middlewares.ts` file are overwritten on each deploy and will not take effect. Place your Security Middleware customizations in `config/env/production/middlewares.ts` instead. See [Middleware Configuration for Strapi Cloud](/cloud/advanced/middlewares) for details.
@@ -243,7 +247,7 @@ On Strapi Cloud, `NODE_ENV` is always set to `production`. Changes to the global
 
 To do this in your Strapi project:
 
-1. Navigate to `./config/env/production/middlewares.js` or `./config/env/production/middlewares.ts` in your Strapi project.
+1. Navigate to `/config/env/production/middlewares.js` or `/config/env/production/middlewares.ts` in your Strapi project.
 2. Replace the default `strapi::security` string with the object provided by the upload provider.
 
 **Example:**
@@ -252,7 +256,7 @@ To do this in your Strapi project:
 <Tabs groupId="upload-examples" >
 <TabItem value="cloudinary" label="Cloudinary">
 
-```js title=./config/env/production/middlewares.js
+```js title=/config/env/production/middlewares.js
 module.exports = [
   // ...
   {
@@ -288,7 +292,7 @@ module.exports = [
 </TabItem>
 <TabItem value="amazon-s3" label="Amazon S3">
 
-```js title=./config/env/production/middlewares.js
+```js title=/config/env/production/middlewares.js
 module.exports = [
   // ...
   {
@@ -328,7 +332,7 @@ module.exports = [
 <Tabs groupId="upload-examples" >
 <TabItem value="cloudinary" label="Cloudinary">
 
-```ts title=./config/env/production/middlewares.ts
+```ts title=/config/env/production/middlewares.ts
 export default [
   // ...
   {
@@ -364,7 +368,7 @@ export default [
 </TabItem>
 <TabItem value="amazon-s3" label="Amazon S3">
 
-```ts title=./config/env/production/middlewares.ts
+```ts title=/config/env/production/middlewares.ts
 export default [
   // ...
   {
@@ -406,7 +410,7 @@ export default [
 Before pushing the above changes to GitHub, add environment variables to the Strapi Cloud project to prevent triggering a rebuild and new deployment of the project before the changes are complete.
 :::
 
-### Strapi Cloud Configuration
+### Strapi Cloud configuration
 
 1. Log into Strapi Cloud and click on the corresponding project on the Projects page.
 2. Click on the **Settings** tab and choose **Variables** in the left menu.
@@ -439,12 +443,13 @@ Before pushing the above changes to GitHub, add environment variables to the Str
 </TabItem>
 </Tabs>
 
-## Deployment
+### Deployment
 
-To deploy the project and utilize the third-party upload provider, push the changes from earlier. This will trigger a rebuild and new deployment of the Strapi Cloud project.
+To deploy the project and use the third-party upload provider, push the changes from earlier. This will trigger a rebuild and new deployment of the Strapi Cloud project.
 
 Once the application finishes building, the project will use the new upload provider.
 
 :::strapi Custom Provider
 If you want to create a custom upload provider, please refer to the [Providers](/cms/features/media-library#providers) documentation in the CMS Documentation.
 :::
+

--- a/docusaurus/docs/cms/features/media-library.md
+++ b/docusaurus/docs/cms/features/media-library.md
@@ -109,7 +109,7 @@ When using the default upload provider, the following specific configuration opt
 | Parameter                                   | Description                                                                                                         | Type    | Default |
 | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ------- | ------- |
 | `providerOptions.localServer`        | Options that will be passed to <ExternalLink to="https://github.com/koajs/static" text="koa-static"/> upon which the Upload server is build (see [local server configuration](#local-server)) | Object  | -       |
-| `sizeLimit`                                  | Maximum file size in bytes (see [max file size](#max-file-size)) | Integer | `209715200`<br/><br/>(200 MB in bytes, i.e., 200 x 1024 x 1024 bytes) |
+| `sizeLimit`                                  | Maximum file size in bytes (see [max file size](#max-file-size)) | Integer | `1000000000`<br/><br/>(1 GB in bytes) |
 | `breakpoints`             | Allows to override the breakpoints sizes at which responsive images are generated when the "Responsive friendly upload" option is set to `true` (see [responsive images](#responsive-images)) | Object | `{ large: 1000, medium: 750, small: 500 }` |
 | `sharp`             | Configures <ExternalLink to="https://sharp.pixelplumbing.com/" text="sharp"/> image processing options (see [sharp configuration](#sharp-configuration)) | Object | `{ cache: false, concurrency: 1 }` |
 | `security`             | Configures validation rules for uploaded files to enhance media security | Object | - |
@@ -248,7 +248,11 @@ export default ({ env }) => ({
 
 #### Max file size
 
-The Strapi middleware in charge of parsing requests needs to be configured to support file sizes larger than the default of 200MB. This must be done in addition to provider options passed to the Upload package for `sizeLimit`.
+:::note Strapi Cloud
+On Strapi Cloud, upload size limits are enforced at the infrastructure level. They cannot be raised via the `strapi::body` middleware config. See [Upload size limits for Strapi Cloud](/cloud/advanced/upload-size-limits) for per-plan values and the memory-based recommendation for image uploads.
+:::
+
+The Strapi middleware in charge of parsing requests needs to be configured to support file sizes larger than the default of 1 GB. This must be done in addition to provider options passed to the Upload package for `sizeLimit`.
 
 :::caution
 You may also need to adjust any upstream proxies, load balancers, or firewalls to allow for larger file sizes. For instance, <ExternalLink to="http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size" text="Nginx"/> has a configuration setting called `client_max_body_size` that must be adjusted, since its default is only 1mb.
@@ -399,7 +403,7 @@ By default, the value of `strapi.server.httpServer.requestTimeout` is set to 330
 
 To make it possible for users with slow internet connection to upload large files, it might be required to increase this timeout limit. The recommended way to do it is by setting the `http.serverOptions.requestTimeout` parameter in [the `config/servers` file](/cms/configurations/server).
 
-An alternate method is to set the `requestTimeout` value in [the `bootstrap` function](/cms/configurations/functions#bootstrap) that runs before Strapi gets started. This is useful in cases where it needs to change programmatically—for example, to temporarily disable and re-enable it:
+An alternate method is to set the `requestTimeout` value in [the `bootstrap` function](/cms/configurations/functions#bootstrap) that runs before Strapi gets started. This is useful in cases where it needs to change programmatically, for example to temporarily disable and re-enable it:
 
 <Tabs groupId="js-ts">
 

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -764,6 +764,14 @@ const sidebars = {
         },
         {
           type: 'doc',
+          id: 'cloud/advanced/upload-size-limits',
+          label: 'Upload size limits for Cloud',
+          customProps: {
+            new: true,
+          },
+        },
+        {
+          type: 'doc',
           id: 'cloud/advanced/middlewares',
           label: 'Middleware configuration for Cloud',
           customProps: {

--- a/docusaurus/static/llms-code.txt
+++ b/docusaurus/static/llms-code.txt
@@ -377,12 +377,12 @@ export default ({ env }) => [
 # Upload Provider Configuration for Strapi Cloud
 Source: https://docs.strapi.io/cloud/advanced/upload
 
-## Configure the Provider
-Description: To configure a 3rd-party upload provider in your Strapi project, create or edit the plugins configuration file for your production environment ./config/env/production/plugins.js|ts by adding upload configuration options as follows:
+## Configure the provider
+Description: To configure a third-party upload provider in your Strapi project, create or edit the plugins configuration file for your production environment /config/env/production/plugins.js|ts by adding upload configuration options as follows:
 (Source: https://docs.strapi.io/cloud/advanced/upload#configure-the-provider)
 
 Language: JavaScript
-File path: ./config/env/production/plugins.js
+File path: /config/env/production/plugins.js
 
 ```js
 
@@ -401,7 +401,7 @@ upload: {
 
 ---
 Language: TypeScript
-File path: ./config/env/production/plugins.ts
+File path: /config/env/production/plugins.ts
 
 ```ts
 
@@ -419,7 +419,7 @@ upload: {
 ```
 
 Language: JavaScript
-File path: ./config/env/production/plugins.js
+File path: /config/env/production/plugins.js
 
 ```js
 module.exports = ({ env }) => ({
@@ -445,7 +445,7 @@ module.exports = ({ env }) => ({
 
 ---
 Language: JavaScript
-File path: ./config/env/production/plugins.js
+File path: /config/env/production/plugins.js
 
 ```js
 module.exports = ({ env }) => ({
@@ -481,7 +481,7 @@ module.exports = ({ env }) => ({
 ```
 
 Language: TypeScript
-File path: ./config/env/production/plugins.ts
+File path: /config/env/production/plugins.ts
 
 ```ts
 export default ({ env }) => ({
@@ -507,7 +507,7 @@ export default ({ env }) => ({
 
 ---
 Language: TypeScript
-File path: ./config/env/production/plugins.ts
+File path: /config/env/production/plugins.ts
 
 ```ts
 export default ({ env }) => ({
@@ -543,12 +543,12 @@ export default ({ env }) => ({
 ```
 
 
-## Configure the Security Middleware
+## Configure the security middleware
 Description: Example:
 (Source: https://docs.strapi.io/cloud/advanced/upload#configure-the-security-middleware)
 
 Language: JavaScript
-File path: ./config/env/production/middlewares.js
+File path: /config/env/production/middlewares.js
 
 ```js
 module.exports = [
@@ -585,7 +585,7 @@ module.exports = [
 
 ---
 Language: JavaScript
-File path: ./config/env/production/middlewares.js
+File path: /config/env/production/middlewares.js
 
 ```js
 module.exports = [
@@ -621,7 +621,7 @@ module.exports = [
 ```
 
 Language: TypeScript
-File path: ./config/env/production/middlewares.ts
+File path: /config/env/production/middlewares.ts
 
 ```ts
 export default [
@@ -658,7 +658,7 @@ export default [
 
 ---
 Language: TypeScript
-File path: ./config/env/production/middlewares.ts
+File path: /config/env/production/middlewares.ts
 
 ```ts
 export default [

--- a/docusaurus/static/llms-full.txt
+++ b/docusaurus/static/llms-full.txt
@@ -243,7 +243,8 @@ Both CSP and CORS customizations can be combined in the same file.
 
 :::note
 - You can keep your existing `config/middlewares` file as-is as it will not cause conflicts. The production-specific file takes precedence on Strapi Cloud.
-- Upload size limits on Strapi Cloud are enforced at the infrastructure level (Cloudflare gateway) and cannot be overridden via the `strapi::body` config. For external storage options, see [Upload Provider Configuration](/cloud/advanced/upload).
+- Upload size limits on Strapi Cloud are enforced at the infrastructure level and cannot be overridden via the `strapi::body` config.
+- For per-plan values and the memory-based recommendation for image uploads, see [Upload size limits for Strapi Cloud](/cloud/advanced/upload-size-limits). For external storage options, see [Upload Provider Configuration](/cloud/advanced/upload).
 :::
 
 ## Custom Content Security Policy (CSP)
@@ -266,7 +267,13 @@ Source: https://docs.strapi.io/cloud/advanced/upload
 
 # Upload Provider Configuration for Strapi Cloud
 
-Strapi Cloud comes with a local upload provider out of the box. However, it can also be configured to utilize a third-party upload provider, if needed.
+Strapi Cloud comes with a local upload provider out of the box. However, it can also be configured to use a third-party upload provider, if needed.
+
+:::note
+For the file size and memory-based limits that apply to uploads, see [Upload size limits for Strapi Cloud](/cloud/advanced/upload-size-limits).
+:::
+
+## Configuring a third-party upload provider
 
 :::caution
 Please be advised that Strapi is unable to provide support for third-party upload providers.
@@ -291,9 +298,9 @@ Each provider will have different configuration settings available. Review the r
 </TabItem>
 </Tabs>
 
-### Configure the Security Middleware
+### Configure the security middleware
 
-Due to the default settings in the Strapi Security Middleware you will need to modify the `contentSecurityPolicy` settings to properly see thumbnail previews in the Media Library.
+Due to the default settings in the Strapi security middleware you will need to modify the `contentSecurityPolicy` settings to properly see thumbnail previews in the Media Library.
 
 :::caution
 On Strapi Cloud, `NODE_ENV` is always set to `production`. Changes to the global `config/middlewares.ts` file are overwritten on each deploy and will not take effect. Place your Security Middleware customizations in `config/env/production/middlewares.ts` instead. See [Middleware Configuration for Strapi Cloud](/cloud/advanced/middlewares) for details.
@@ -301,7 +308,7 @@ On Strapi Cloud, `NODE_ENV` is always set to `production`. Changes to the global
 
 To do this in your Strapi project:
 
-1. Navigate to `./config/env/production/middlewares.js` or `./config/env/production/middlewares.ts` in your Strapi project.
+1. Navigate to `/config/env/production/middlewares.js` or `/config/env/production/middlewares.ts` in your Strapi project.
 2. Replace the default `strapi::security` string with the object provided by the upload provider.
 
 **Example:**
@@ -317,7 +324,7 @@ To do this in your Strapi project:
 Before pushing the above changes to GitHub, add environment variables to the Strapi Cloud project to prevent triggering a rebuild and new deployment of the project before the changes are complete.
 :::
 
-### Strapi Cloud Configuration
+### Strapi Cloud configuration
 
 1. Log into Strapi Cloud and click on the corresponding project on the Projects page.
 2. Click on the **Settings** tab and choose **Variables** in the left menu.
@@ -328,14 +335,58 @@ Before pushing the above changes to GitHub, add environment variables to the Str
 
 </Tabs>
 
-## Deployment
+### Deployment
 
-To deploy the project and utilize the third-party upload provider, push the changes from earlier. This will trigger a rebuild and new deployment of the Strapi Cloud project.
+To deploy the project and use the third-party upload provider, push the changes from earlier. This will trigger a rebuild and new deployment of the Strapi Cloud project.
 
 Once the application finishes building, the project will use the new upload provider.
 
 :::strapi Custom Provider
 If you want to create a custom upload provider, please refer to the [Providers](/cms/features/media-library#providers) documentation in the CMS Documentation.
+:::
+
+
+
+# Upload size limits for Strapi Cloud
+Source: https://docs.strapi.io/cloud/advanced/upload-size-limits
+
+# Upload size limits for Strapi Cloud
+
+Strapi Cloud applies 2 distinct limits to uploads. The first is a hard maximum file size, enforced at the infrastructure level for non-image files. The second is a memory-based recommendation for image files that depends on your CMS settings.
+
+## Maximum upload file size for non-image files
+
+Non-image uploads are capped at 200 MB on all Strapi Cloud plans (Free, Essential, Pro, and Scale). The cap is enforced at the infrastructure level and cannot be overridden via the `strapi::body` middleware configuration.
+
+## Recommended maximum upload size for image files
+
+Image uploads are subject to an additional, memory-driven recommendation that is independent of the non-image cap and varies by image format.
+
+:::tip Uploading a large image?
+To upload an image larger than the recommended maximum, disable both Responsive friendly upload and Size optimization in the [Media Library settings](/cms/features/media-library#configuring-settings). The CMS then stores the source file as-is without in-process processing, which raises the recommended maximum (see the _Processing off_ values in the tables below).
+:::
+
+When Responsive friendly upload and Size optimization are both enabled in the [Media Library settings](/cms/features/media-library#configuring-settings), the CMS resizes the source image and generates a set of thumbnails (small, medium, large) in the instance's memory before persisting them. This processing happens in-process, regardless of the configured upload provider.
+
+Switching to a third-party provider (Amazon S3, Cloudinary, etc.) is not a workaround. The resize and thumbnail generation step still runs inside the Strapi Cloud instance and still requires memory proportional to the source image dimensions.
+
+Actual memory usage depends on the image dimensions, format, and your Media Library settings. The values in the following tables are a recommendation, not a hard limit. Uploads above the recommended size are likely to cause the instance to run out of memory and restart.
+
+The recommendation depends on whether Responsive friendly upload and Size optimization are enabled in the [Media Library settings](/cms/features/media-library#configuring-settings):
+
+- _Processing on_: both settings enabled, with the default `small`, `medium`, and `large` sizes. Strapi generates the thumbnails in memory, so the safe upload size is lower.
+- _Processing off_: both settings disabled. The source image is stored as-is with no in-process processing, so the safe upload size is higher.
+
+Recommended maximum image size, expressed in megapixels (MP), per format and plan:
+
+</Tabs>
+
+:::note Converting pixels to megapixels
+The number of megapixels of an image is its width multiplied by its height in pixels, divided by 1,000,000. The pixel dimensions that match a given megapixel count depend on the aspect ratio. For a square image, 1 MP is roughly 1000×1000 px, 4 MP is roughly 2000×2000 px, and 100 MP is roughly 10000×10000 px.
+:::
+
+:::strapi Configuring a provider
+To configure external storage such as Amazon S3 or Cloudinary, see [Upload Provider Configuration for Strapi Cloud](/cloud/advanced/upload).
 :::
 
 
@@ -9223,7 +9274,11 @@ By default Strapi accepts `localServer` configurations for locally uploaded file
 
 #### Max file size
 
-The Strapi middleware in charge of parsing requests needs to be configured to support file sizes larger than the default of 200MB. This must be done in addition to provider options passed to the Upload package for `sizeLimit`.
+:::note Strapi Cloud
+On Strapi Cloud, upload size limits are enforced at the infrastructure level. They cannot be raised via the `strapi::body` middleware config. See [Upload size limits for Strapi Cloud](/cloud/advanced/upload-size-limits) for per-plan values and the memory-based recommendation for image uploads.
+:::
+
+The Strapi middleware in charge of parsing requests needs to be configured to support file sizes larger than the default of 1 GB. This must be done in addition to provider options passed to the Upload package for `sizeLimit`.
 
 :::caution
 You may also need to adjust any upstream proxies, load balancers, or firewalls to allow for larger file sizes. For instance, 
@@ -9244,7 +9299,7 @@ By default, the value of `strapi.server.httpServer.requestTimeout` is set to 330
 
 To make it possible for users with slow internet connection to upload large files, it might be required to increase this timeout limit. The recommended way to do it is by setting the `http.serverOptions.requestTimeout` parameter in [the `config/servers` file](/cms/configurations/server).
 
-An alternate method is to set the `requestTimeout` value in [the `bootstrap` function](/cms/configurations/functions#bootstrap) that runs before Strapi gets started. This is useful in cases where it needs to change programmatically—for example, to temporarily disable and re-enable it:
+An alternate method is to set the `requestTimeout` value in [the `bootstrap` function](/cms/configurations/functions#bootstrap) that runs before Strapi gets started. This is useful in cases where it needs to change programmatically, for example to temporarily disable and re-enable it:
 
 </Tabs>
 

--- a/docusaurus/static/llms.txt
+++ b/docusaurus/static/llms.txt
@@ -6,6 +6,7 @@
 - [Email Provider](https://docs.strapi.io/cloud/advanced/email): Third‑party email services integrate through plugins and environment variables to replace the default sender.
 - [Middleware Configuration for Strapi Cloud](https://docs.strapi.io/cloud/advanced/middlewares): On Strapi Cloud, middleware customizations must go in config/env/production/middlewares. Changes to the global config file are overwritten on deploy.
 - [Upload Provider Configuration for Strapi Cloud](https://docs.strapi.io/cloud/advanced/upload): External storage like S3 or Cloudinary requires plugin setup, security middleware, and Cloud variables.
+- [Upload size limits for Strapi Cloud](https://docs.strapi.io/cloud/advanced/upload-size-limits): Non-image files are capped at 200 MB on all plans. Image files have a memory-based recommended maximum that varies by format, plan, and Media Library settings. To upload larger images, disable Responsive friendly upload and Size optimization.
 - [Command Line Interface (CLI)](https://docs.strapi.io/cloud/cli/cloud-cli): CLI commands handle login, project deploy, linking, listing, and logout without needing a remote repository.
 - [Strapi Cloud fundamentals](https://docs.strapi.io/cloud/getting-started/cloud-fundamentals): Before going any further into this Strapi Cloud documentation, we recommend you to acknowledge the main concepts below. They will help you to understa...
 - [Strapi Cloud - Dashboard deployment](https://docs.strapi.io/cloud/getting-started/deployment): Learn how to deploy your Strapi application on Strapi Cloud.


### PR DESCRIPTION
This PR adds an "Upload size limits" section to the Cloud Upload page, covering the 200MB infrastructure cap for non-image files and per-plan memory-based recommendations for image uploads by format. Cross-links are added from the Cloud Middlewares page and the CMS Media Library "Max file size" section.

Direct preview link 👉 [here](https://documentation-git-cloud-upload-size-limits-strapijs.vercel.app/cloud/advanced/upload)