### PR TITLE
Update parameter name from 'id' to 'documentId'

### DIFF
--- a/docusaurus/docs/cms/api/rest.md
+++ b/docusaurus/docs/cms/api/rest.md
@@ -352,7 +352,7 @@ When you POST a document, each object inside a dynamic zone array must include `
 
 ### Update a document {#update}
 
-Partially updates a document by `id` and returns its value.
+Partially updates a document by `documentId` and returns its value.
 
 Send a `null` value to clear fields.
 


### PR DESCRIPTION
### Description

Describe the changes you did: What does it do? Why is it needed?
SInce Strapi 5 has Document Service, we need use `documentId` as a main identificator of entities