### PR TITLE
Add Cloud Advanced page type and template to Inki outline-checker

### DIFF
--- a/claude-plugins/inki/references/prompts/outline-checker.md
+++ b/claude-plugins/inki/references/prompts/outline-checker.md
@@ -58,6 +58,7 @@ The Outline Checker determines the document type using this priority:
 | `cms/api/*` | API | `claude-plugins/inki/references/templates/api-template.md` |
 | `cms/migration/**/breaking-changes/*.md` | Breaking Change | `claude-plugins/inki/references/templates/breaking-change-template.md` |
 | `**/guides/*` or title starts with "How to" | Guide | `claude-plugins/inki/references/templates/guide-template.md` |
+| `cloud/advanced/*` | Cloud Advanced | `claude-plugins/inki/references/templates/cloud-advanced-template.md` |
 | No match | General | No specific template — apply general rules only |
 
 ### Outputs
@@ -236,6 +237,20 @@ When required, `<Tldr>` must appear immediately after the H1.
 - `<Tldr>` — Required
 
 **Fallback — Expected sections:** TL;DR → Location → Available options → Environment variables
+
+---
+
+#### Cloud Advanced Pages (`cloud/advanced/*`)
+
+**Template (SSOT):** `claude-plugins/inki/references/templates/cloud-advanced-template.md`
+
+**Fallback — Key components:**
+- `<Tldr>` — Required, immediately after H1
+- `displayed_sidebar: cloudSidebar` — Required in frontmatter
+
+**Fallback — Expected sections:** No fixed H2 skeleton. TL;DR → Intro naming the topic → thematic H2s scoped to the topic.
+
+**Key rule:** One page = one topic. The H1 title must describe ALL of the page's content. Flag (warning) any top-level section that broadens the page past what its title and `<Tldr>` promise — for example a size-limits reference section added to a page titled "Upload Provider Configuration". Such a section usually belongs on its own `cloud/advanced/*` page that this page links to, not inlined (especially if other pages deep-link to it as a destination).
 
 ---
 

--- a/claude-plugins/inki/references/templates/cloud-advanced-template.md
+++ b/claude-plugins/inki/references/templates/cloud-advanced-template.md
@@ -1,0 +1,68 @@
+---
+title: TEMPLATE — Cloud Advanced Topic Title
+displayed_sidebar: cloudSidebar
+description: One-sentence summary of the Strapi Cloud topic this page covers.
+canonicalUrl: https://docs.strapi.io/cloud/advanced/<slug>.html
+tags:
+  - configuration
+---
+# Template — Cloud Advanced Topic Title
+
+<Tldr>
+What this page covers, scoped to Strapi Cloud, and the key takeaway at a glance.
+</Tldr>
+
+Intro paragraph stating what the page covers and how it applies to Strapi Cloud.
+
+<!--
+  STRUCTURE GUIDANCE
+  ==================
+  Pages under `cloud/advanced/` document a single advanced Strapi Cloud topic
+  (e.g. database, email, middlewares, upload provider configuration). They do
+  NOT follow a fixed H2 skeleton — H2 sections are thematic and depend on the
+  topic. The existing pages (database.md, email.md, middlewares.md, upload.md)
+  are the reference for tone and depth.
+
+  Common core (always present):
+  - Frontmatter (title, displayed_sidebar: cloudSidebar, description, tags),
+    H1, <Tldr>, intro paragraph naming the topic.
+
+  Then thematic H2s scoped to the topic.
+
+  ONE PAGE = ONE TOPIC (most important rule for this type)
+  ========================================================
+  The H1 title must describe ALL the page's content, not just its first or
+  largest section. Before adding a new top-level section, ask:
+
+  - Does the page title still describe the whole page once this section is in?
+    If the title says "Upload Provider Configuration" but the new section is
+    about infrastructure size limits, the title no longer covers the page.
+  - Is the new section a prerequisite/step of the page's stated task, or a
+    separate reference topic that merely relates to it? Separate reference
+    topics belong on their own page that this page links to, NOT inlined at
+    the top.
+  - Do other pages deep-link to the new section as a destination? If so, it
+    wants to be its own page, not a sub-section of an unrelated page.
+
+  If a section would broaden the page past its title, prefer one of:
+  1. Extract it to its own `cloud/advanced/<topic>.md` page and cross-link.
+  2. Place it below the page's primary content, not above it.
+  3. Only if neither fits: broaden the H1 and <Tldr> so the title honestly
+     reflects every top-level section.
+
+  BUILDING BLOCKS (use where applicable):
+  - Parameter / environment-variable tables
+  - JS/TS Tabs for code examples (<Tabs groupId="js-ts">)
+  - :::caution / :::note / :::tip callouts
+  - <details> for advanced or edge-case examples
+
+  Delete this comment block before publishing.
+-->
+
+## [Thematic section 1]
+
+Description scoped to the page topic.
+
+## [Thematic section 2]
+
+...


### PR DESCRIPTION
This PR gives pages under cloud/advanced/ a dedicated document type in the Inki outline-checker, which previously fell through to the generic "No match" path and received almost no structural review. It adds a cloud-advanced-template.md (thematic guidance, not a fixed H2 skeleton, modeled on the existing database/email/middlewares/upload pages), maps the cloud/advanced/* path to it, and adds a matching fallback section to the outline-checker prompt. The template and fallback both carry a "one page = one topic" rule so the checker flags top-level sections that broaden a page past what its title promises.