### PR TITLE
Detect title/content scope mismatch and inbound links in Inki review

### DIFF
--- a/claude-plugins/inki/references/prompts/integrity-coherence-checker.md
+++ b/claude-plugins/inki/references/prompts/integrity-coherence-checker.md
@@ -43,6 +43,8 @@ If these files are already loaded (e.g., the Router fetched them earlier in the 
 | Check | How to verify | Severity if wrong |
 |-------|---------------|-------------------|
 | Cross-reference targets exist | Fetch the linked page, verify the heading/anchor exists | **error** |
+| Inbound anchor links resolve | `grep` the docs tree for links to this page; verify each anchor still matches a heading here | **error** |
+| Section used as a shared destination | 2+ other pages deep-link to the same section of this page | **warning** |
 | Terminology consistency | Same concept uses the same term on both pages | **warning** |
 | Behavioral consistency | Same API/feature described identically on both pages | **error** |
 | No contradictions | Pages don't make conflicting claims about the same thing | **error** |
@@ -55,9 +57,17 @@ If these files are already loaded (e.g., the Router fetched them earlier in the 
 ### Step 1: Collect cross-references
 
 Scan the content and extract:
-- **Internal links**: All Markdown links to other doc pages (`/cms/...`, `#anchor`, relative paths)
+- **Outgoing links**: All Markdown links from this page to other doc pages (`/cms/...`, `#anchor`, relative paths)
 - **Component links**: `<CustomDocCard>` links, `<SideBySideColumn>` references
 - **Implicit references**: Mentions of features, APIs, or concepts that have their own doc pages (e.g., "the Content API" without a link could still create a coherence obligation)
+
+Then collect **inbound links** — pages elsewhere in the docs that link TO the page under review:
+
+- Search the other doc pages (via `grep` on the local docs tree, or the raw GitHub source) for links whose target is this page's route, including anchor links to a specific section (`/cloud/advanced/upload#strapi-cloud-upload-size-limits`).
+- For each inbound link, record the source page and the exact section anchor it points at.
+- This is cheap: a single `grep` across `docusaurus/docs/` finds them without per-page fetches.
+
+Inbound anchor links matter for coherence because they reveal how the rest of the docs treats this page. If two or more other pages deep-link to the SAME section of this page as a reference destination, that section is functioning as a standalone reference. Flag this (warning) and note it: the section may belong on its own page, and the Outline Checker's "title vs. content scope" rule should weight it accordingly. Always verify each inbound anchor still resolves to a real heading here — a renamed or moved heading silently breaks every inbound link.
 
 ### Step 2: Structure-first verification
 

--- a/claude-plugins/inki/references/prompts/outline-checker.md
+++ b/claude-plugins/inki/references/prompts/outline-checker.md
@@ -179,6 +179,18 @@ Headings at the same level should use the same grammatical form:
 
 When required, `<Tldr>` must appear immediately after the H1.
 
+#### 5. Title vs. Content Scope (warning if broken)
+
+The H1/`title` must describe the WHOLE page, not just its first or largest section. A page should cover one topic.
+
+**Detect:** A top-level (H2) section whose topic is not covered by the H1/`title` or `<Tldr>`. Concretely, flag when:
+- An H2's subject is absent from both the title and the `<Tldr>` (e.g. title "Upload Provider Configuration" with an H2 "Upload size limits" about infrastructure caps), AND
+- That section is a separate reference topic rather than a step/prerequisite of the page's stated task.
+
+When detected, recommend, in order: (1) extract the off-scope section to its own page and cross-link to it; (2) move it below the page's primary content; (3) only if neither fits, broaden the H1 and `<Tldr>` so the title honestly covers every top-level section. Treat the first top section as especially significant: it sets the reader's expectation against the title.
+
+A strong signal that an off-scope section should be its own page: other pages deep-link to it by anchor as a reference destination. The Coherence Checker reports such inbound links; weight this finding higher when they exist.
+
 ---
 
 ### Template-Specific Rules
@@ -303,6 +315,7 @@ When no specific template applies, or as additional quality feedback, evaluate t
 | Missing frontmatter field (title, description, displayed_sidebar, tags) | error | Field absent from YAML frontmatter |
 | Missing required section | error | Expected H2 not present |
 | Section out of order | warning | H2 sequence doesn't match template |
+| Off-scope section (title/content mismatch) | warning | An H2's topic is not covered by the H1/title or `<Tldr>` and is a separate reference topic |
 | Missing required component | warning | `<Tldr>`, `<IdentityCard>`, etc. not found |
 | Component malformed | warning | `<IdentityCard>` missing items, wrong props |
 | H3 without H2 parent | warning | H3 appears before any H2 |


### PR DESCRIPTION
This PR closes the cross-file blind spot that let a large off-topic section be added to the top of a page without any reviewer flagging it. It adds a "title vs. content scope" general rule to the outline-checker (warn when a top-level section's topic is not covered by the H1/title or Tldr and is a separate reference topic), and teaches the coherence-checker to collect inbound links (pages that deep-link to the page under review), verify those anchors still resolve, and flag a section that two or more other pages use as a shared reference destination. The two prompts reference each other so a section that other pages depend on is weighted higher as a candidate for its own page. Note: this touches outline-checker.md in different sections than the cloud-advanced-template PR, so a trivial rebase may be needed depending on merge order.