### PR TITLE
Document documentId support in Users & Permissions relation updates

### DIFF
--- a/docusaurus/docs/cms/features/users-permissions/rest-api.md
+++ b/docusaurus/docs/cms/features/users-permissions/rest-api.md
@@ -596,7 +596,7 @@ Possible errors:
 | 400 | `"Username already taken"` or `"Email already taken"` | Duplicate value |
 
 :::note Relation inputs support both `documentId` and numeric IDs
-When updating a user with custom relations, you can use either `documentId` (recommended for v5) or numeric `id` in relation payloads:
+When updating a user with custom relations, you can use either `documentId` (recommended for Strapi 5) or numeric `id` in relation payloads:
 ```json
 {
   "customRelation": {

--- a/docusaurus/docs/cms/features/users-permissions/rest-api.md
+++ b/docusaurus/docs/cms/features/users-permissions/rest-api.md
@@ -595,6 +595,26 @@ Possible errors:
 | 404 | `"User not found"` | No user with the given `id` |
 | 400 | `"Username already taken"` or `"Email already taken"` | Duplicate value |
 
+:::note Relation inputs support both `documentId` and numeric IDs
+When updating a user with custom relations, you can use either `documentId` (recommended for v5) or numeric `id` in relation payloads:
+```json
+{
+  "customRelation": {
+    "connect": ["x74detpqybxw0bn6ormua5g2"]  // documentId
+  }
+}
+```
+or
+```json
+{
+  "customRelation": {
+    "connect": [1]  // numeric ID (legacy)
+  }
+}
+```
+Both formats are accepted for backward compatibility.
+:::
+
 ### Delete a user
 
 `DELETE /api/users/:id`


### PR DESCRIPTION
This PR updates documentation based on https://github.com/strapi/strapi/pull/26607.

## Summary

Documents that the Users & Permissions REST API now supports `documentId` in relation payloads when updating users, in addition to legacy numeric IDs.

Generated automatically by the docs self-healing workflow (micro-edit, Haiku).
Review before merging.