### PR TITLE
Document mcp builder helpers for plugin MCP capabilities

### DIFF
--- a/docusaurus/docs/cms/plugins-development/extend-mcp-server.md
+++ b/docusaurus/docs/cms/plugins-development/extend-mcp-server.md
@@ -23,6 +23,110 @@ Strapi includes a built-in [Model Context Protocol (MCP) server](/cms/features/s
 
 Registrations must happen while the MCP server is idle, before it starts. In Strapi's load lifecycle, register a tool during the plugin's `register()` or `bootstrap()` phase. Prefer `bootstrap()` when a tool depends on synced content-types, permissions, or database state.
 
+## Using builder helpers
+
+`@strapi/strapi` exposes a `mcp` namespace (under `ai`) with 3 builder helpers that make MCP definitions easier to author in TypeScript: `mcp.defineTool`, `mcp.defineResource`, and `mcp.definePrompt`. They play the same role for MCP capabilities (tools, prompts, and resources) that `factories` plays for core controllers, services, and routers.
+
+Each helper returns its definition unchanged at runtime: they exist only to help TypeScript. A builder infers the `name`, schemas, and handler types from the object you pass, and narrows the access variant so the result is directly assignable to the matching `strapi.ai.mcp.register*()` method. Without them, you would type each definition by hand against `Modules.MCP.*` from `@strapi/types`.
+
+Every capability must declare exactly one access variant: either `devModeOnly: true` (the capability is available in development mode only, with no authentication) or an `auth` object with at least one policy. Never set both. The builders enforce this constraint at the type level.
+
+The workflow is always the same: define the capability with a builder, then register the result during the plugin's `register()` or `bootstrap()` phase.
+
+### Defining a tool
+
+Use `mcp.defineTool()` to build a tool definition, then pass it to [`strapi.ai.mcp.registerTool()`](#registering-a-custom-tool):
+
+```ts title="src/plugins/my-plugin/strapi-server.ts"
+import { ai } from '@strapi/strapi';
+import { z } from '@strapi/utils';
+
+const { mcp } = ai;
+
+const greet = mcp.defineTool({
+  name: 'greet',
+  title: 'Greet',
+  description: 'Greets a user by name',
+  devModeOnly: true,
+  resolveInputSchema: () => z.object({ name: z.string() }),
+  resolveOutputSchema: () => z.object({ message: z.string() }),
+  createHandler: (strapi) => async ({ args }) => {
+    const message = `Hello, ${args.name}!`;
+    return { content: [{ type: 'text', text: message }], structuredContent: { message } };
+  },
+});
+
+export default {
+  register({ strapi }) {
+    if (strapi.ai.mcp.isEnabled()) {
+      strapi.ai.mcp.registerTool(greet);
+    }
+  },
+};
+```
+
+The accepted fields are the same as those passed directly to `registerTool()`, listed in the [tool definition options](#tool-definition-options) table below.
+
+### Defining a prompt
+
+Use `mcp.definePrompt()` to build a prompt definition, then pass it to `strapi.ai.mcp.registerPrompt()`:
+
+```ts title="src/plugins/my-plugin/strapi-server.ts"
+import { ai } from '@strapi/strapi';
+
+const { mcp } = ai;
+
+const context = mcp.definePrompt({
+  name: 'app-context',
+  title: 'App Context',
+  description: 'Provides context about the app',
+  devModeOnly: true,
+  createHandler: (strapi) => async () => ({
+    messages: [
+      { role: 'user', content: { type: 'text', text: 'You are connected to Strapi.' } },
+    ],
+  }),
+});
+
+export default {
+  register({ strapi }) {
+    if (strapi.ai.mcp.isEnabled()) {
+      strapi.ai.mcp.registerPrompt(context);
+    }
+  },
+};
+```
+
+### Defining a resource
+
+Use `mcp.defineResource()` to build a resource definition, then pass it to `strapi.ai.mcp.registerResource()`:
+
+```ts title="src/plugins/my-plugin/strapi-server.ts"
+import { ai } from '@strapi/strapi';
+
+const { mcp } = ai;
+
+const appInfo = mcp.defineResource({
+  name: 'app-info',
+  uri: 'strapi://app/info',
+  metadata: { description: 'Metadata about the app', mimeType: 'application/json' },
+  devModeOnly: true,
+  createHandler: (strapi) => async (uri) => ({
+    contents: [
+      { uri: uri.href, mimeType: 'application/json', text: JSON.stringify({ ok: true }) },
+    ],
+  }),
+});
+
+export default {
+  register({ strapi }) {
+    if (strapi.ai.mcp.isEnabled()) {
+      strapi.ai.mcp.registerResource(appInfo);
+    }
+  },
+};
+```
+
 ## Registering a custom tool
 
 Use `strapi.ai.mcp.registerTool()` to expose a custom tool to AI clients:

--- a/docusaurus/docs/cms/plugins-development/extend-mcp-server.md
+++ b/docusaurus/docs/cms/plugins-development/extend-mcp-server.md
@@ -16,116 +16,14 @@ tags:
 # Extending the MCP server with plugins
 
 <Tldr>
-Strapi plugins can register additional MCP tools through the `strapi.ai.mcp` service. Registrations must happen while the MCP server is idle (during the plugin's `register()` or `bootstrap()` lifecycle phase), before the server starts.
+Strapi plugins can register additional MCP tools through the `strapi.ai.mcp` service. You can pass capability definitions directly to the `register*()` methods, or author them with the optional `mcp` builder helpers exported from `@strapi/strapi`. Registrations must happen while the MCP server is idle (during the plugin's `register()` or `bootstrap()` lifecycle phase), before the server starts.
 </Tldr>
 
 Strapi includes a built-in [Model Context Protocol (MCP) server](/cms/features/strapi-mcp-server) that exposes content management tools to AI clients. In addition to the content-type tools generated from your schema, plugins can register their own custom tools so AI clients can trigger plugin-specific actions.
 
 Registrations must happen while the MCP server is idle, before it starts. In Strapi's load lifecycle, register a tool during the plugin's `register()` or `bootstrap()` phase. Prefer `bootstrap()` when a tool depends on synced content-types, permissions, or database state.
 
-## Using builder helpers
-
-`@strapi/strapi` exposes a `mcp` namespace (under `ai`) with 3 builder helpers that make MCP definitions easier to author in TypeScript: `mcp.defineTool`, `mcp.defineResource`, and `mcp.definePrompt`. They play the same role for MCP capabilities (tools, prompts, and resources) that `factories` plays for core controllers, services, and routers.
-
-Each helper returns its definition unchanged at runtime: they exist only to help TypeScript. A builder infers the `name`, schemas, and handler types from the object you pass, and narrows the access variant so the result is directly assignable to the matching `strapi.ai.mcp.register*()` method. Without them, you would type each definition by hand against `Modules.MCP.*` from `@strapi/types`.
-
-Every capability must declare exactly one access variant: either `devModeOnly: true` (the capability is available in development mode only, with no authentication) or an `auth` object with at least one policy. Never set both. The builders enforce this constraint at the type level.
-
-The workflow is always the same: define the capability with a builder, then register the result during the plugin's `register()` or `bootstrap()` phase.
-
-### Defining a tool
-
-Use `mcp.defineTool()` to build a tool definition, then pass it to [`strapi.ai.mcp.registerTool()`](#registering-a-custom-tool):
-
-```ts title="src/plugins/my-plugin/strapi-server.ts"
-import { ai } from '@strapi/strapi';
-import { z } from '@strapi/utils';
-
-const { mcp } = ai;
-
-const greet = mcp.defineTool({
-  name: 'greet',
-  title: 'Greet',
-  description: 'Greets a user by name',
-  devModeOnly: true,
-  resolveInputSchema: () => z.object({ name: z.string() }),
-  resolveOutputSchema: () => z.object({ message: z.string() }),
-  createHandler: (strapi) => async ({ args }) => {
-    const message = `Hello, ${args.name}!`;
-    return { content: [{ type: 'text', text: message }], structuredContent: { message } };
-  },
-});
-
-export default {
-  register({ strapi }) {
-    if (strapi.ai.mcp.isEnabled()) {
-      strapi.ai.mcp.registerTool(greet);
-    }
-  },
-};
-```
-
-The accepted fields are the same as those passed directly to `registerTool()`, listed in the [tool definition options](#tool-definition-options) table below.
-
-### Defining a prompt
-
-Use `mcp.definePrompt()` to build a prompt definition, then pass it to `strapi.ai.mcp.registerPrompt()`:
-
-```ts title="src/plugins/my-plugin/strapi-server.ts"
-import { ai } from '@strapi/strapi';
-
-const { mcp } = ai;
-
-const context = mcp.definePrompt({
-  name: 'app-context',
-  title: 'App Context',
-  description: 'Provides context about the app',
-  devModeOnly: true,
-  createHandler: (strapi) => async () => ({
-    messages: [
-      { role: 'user', content: { type: 'text', text: 'You are connected to Strapi.' } },
-    ],
-  }),
-});
-
-export default {
-  register({ strapi }) {
-    if (strapi.ai.mcp.isEnabled()) {
-      strapi.ai.mcp.registerPrompt(context);
-    }
-  },
-};
-```
-
-### Defining a resource
-
-Use `mcp.defineResource()` to build a resource definition, then pass it to `strapi.ai.mcp.registerResource()`:
-
-```ts title="src/plugins/my-plugin/strapi-server.ts"
-import { ai } from '@strapi/strapi';
-
-const { mcp } = ai;
-
-const appInfo = mcp.defineResource({
-  name: 'app-info',
-  uri: 'strapi://app/info',
-  metadata: { description: 'Metadata about the app', mimeType: 'application/json' },
-  devModeOnly: true,
-  createHandler: (strapi) => async (uri) => ({
-    contents: [
-      { uri: uri.href, mimeType: 'application/json', text: JSON.stringify({ ok: true }) },
-    ],
-  }),
-});
-
-export default {
-  register({ strapi }) {
-    if (strapi.ai.mcp.isEnabled()) {
-      strapi.ai.mcp.registerResource(appInfo);
-    }
-  },
-};
-```
+There are 2 ways to author a capability: pass a definition object directly to the matching `strapi.ai.mcp.register*()` method, or build that definition with the optional `mcp` builder helpers for stronger TypeScript inference. Both are covered below, starting with the direct registration API the helpers wrap.
 
 ## Registering a custom tool
 
@@ -225,3 +123,104 @@ export default {
 `resolveInputSchema` and `resolveOutputSchema` are called once per incoming MCP request, so you can narrow schemas dynamically based on the token's permissions (via `context.userAbility`).
 :::
 
+## Using builder helpers
+
+`@strapi/strapi` exposes a `mcp` namespace (under `ai`) with 3 builder helpers that make MCP definitions easier to author in TypeScript: `mcp.defineTool`, `mcp.defineResource`, and `mcp.definePrompt`. They play the same role for MCP capabilities (tools, prompts, and resources) that `factories` plays for core controllers, services, and routers.
+
+Each helper returns its definition unchanged at runtime: they exist only to help TypeScript. A builder infers the `name`, schemas, and handler types from the object you pass, and narrows the access variant so the result is directly assignable to the matching `strapi.ai.mcp.register*()` method. Without them, you would type each definition by hand against `Modules.MCP.*` from `@strapi/types`.
+
+Every capability must declare exactly one access variant: either `devModeOnly: true` (the capability is available in development mode only, with no authentication) or an `auth` object with at least one policy. Never set both. The builders enforce this constraint at the type level.
+
+The workflow is always the same: define the capability with a builder, then register the result during the plugin's `register()` or `bootstrap()` phase.
+
+### Defining a tool
+
+Use `mcp.defineTool()` to build a tool definition, then pass it to [`strapi.ai.mcp.registerTool()`](#registering-a-custom-tool). It accepts the same fields as a definition passed directly to `registerTool()`, listed in the [tool definition options](#tool-definition-options) table above:
+
+```ts title="src/plugins/my-plugin/strapi-server.ts"
+import { ai } from '@strapi/strapi';
+import { z } from '@strapi/utils';
+
+const { mcp } = ai;
+
+const greet = mcp.defineTool({
+  name: 'greet',
+  title: 'Greet',
+  description: 'Greets a user by name',
+  devModeOnly: true,
+  resolveInputSchema: () => z.object({ name: z.string() }),
+  resolveOutputSchema: () => z.object({ message: z.string() }),
+  createHandler: (strapi) => async ({ args }) => {
+    const message = `Hello, ${args.name}!`;
+    return { content: [{ type: 'text', text: message }], structuredContent: { message } };
+  },
+});
+
+export default {
+  register({ strapi }) {
+    if (strapi.ai.mcp.isEnabled()) {
+      strapi.ai.mcp.registerTool(greet);
+    }
+  },
+};
+```
+
+### Defining a prompt
+
+Use `mcp.definePrompt()` to build a prompt definition, then pass it to `strapi.ai.mcp.registerPrompt()`:
+
+```ts title="src/plugins/my-plugin/strapi-server.ts"
+import { ai } from '@strapi/strapi';
+
+const { mcp } = ai;
+
+const context = mcp.definePrompt({
+  name: 'app-context',
+  title: 'App Context',
+  description: 'Provides context about the app',
+  devModeOnly: true,
+  createHandler: (strapi) => async () => ({
+    messages: [
+      { role: 'user', content: { type: 'text', text: 'You are connected to Strapi.' } },
+    ],
+  }),
+});
+
+export default {
+  register({ strapi }) {
+    if (strapi.ai.mcp.isEnabled()) {
+      strapi.ai.mcp.registerPrompt(context);
+    }
+  },
+};
+```
+
+### Defining a resource
+
+Use `mcp.defineResource()` to build a resource definition, then pass it to `strapi.ai.mcp.registerResource()`:
+
+```ts title="src/plugins/my-plugin/strapi-server.ts"
+import { ai } from '@strapi/strapi';
+
+const { mcp } = ai;
+
+const appInfo = mcp.defineResource({
+  name: 'app-info',
+  uri: 'strapi://app/info',
+  metadata: { description: 'Metadata about the app', mimeType: 'application/json' },
+  devModeOnly: true,
+  createHandler: (strapi) => async (uri) => ({
+    contents: [
+      { uri: uri.href, mimeType: 'application/json', text: JSON.stringify({ ok: true }) },
+    ],
+  }),
+});
+
+export default {
+  register({ strapi }) {
+    if (strapi.ai.mcp.isEnabled()) {
+      strapi.ai.mcp.registerResource(appInfo);
+    }
+  },
+};
+```


### PR DESCRIPTION
This PR documents the new `mcp.defineTool`, `mcp.defineResource`, and `mcp.definePrompt` builder helpers exported from `@strapi/strapi`, added in strapi/strapi#26603.
- Adds a "Using builder helpers" section to the Extending the MCP server with plugins page, with one TypeScript example per builder feeding into the existing `strapi.ai.mcp.register*()` methods.
- The helpers are imported as `import { ai } from '@strapi/strapi'` then `ai.mcp.*` (the `mcp` namespace is nested under `ai`).

Note for reviewers: strapi/strapi#26603 is not merged yet, so the helpers are not in a released `@strapi/strapi`. Please version-gate this page to the release that ships the PR before merging.

Direct preview link 👉 [here](https://documentation-git-cms-mcp-builder-helpers-strapijs.vercel.app/cms/plugins-development/extend-mcp-server)