### PR TITLE
Require Inki orchestrators to invoke sub-skills and bump to 0.2.1

### DIFF
--- a/claude-plugins/inki/.claude-plugin/plugin.json
+++ b/claude-plugins/inki/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "inki",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Inki: research, write, review, submit your docs. A Claude Code plugin encapsulating the Strapi documentation toolkit.",
   "author": {
     "name": "Pierre Wizla"

--- a/claude-plugins/inki/CHANGELOG.md
+++ b/claude-plugins/inki/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Inki Changelog
 
+## v0.2.1 (2026-06-16)
+
+### Changed
+
+- Orchestrator skills (`/inki:submit`, `/inki:document`, `/inki:review`) now state as a hard rule that they must run each step by **invoking the named sub-skill**, never by re-implementing it with raw `git` / `gh` commands or inline logic. Re-implementing a step by hand silently drops behavior the sub-skill owns (for example, the `/inki:pr` Vercel preview link). `--auto-approve` removes confirmation prompts but does not authorize bypassing a sub-skill.
+- `/inki:pr`: when a PR changes no page under `docusaurus/docs/` (for example a `repo/` PR touching only `claude-plugins/`, config, or tooling), the Vercel preview link is now omitted rather than pointing at a non-existent page.
+
 ## v0.2.0 (2026-06-16)
 
 ### Added

--- a/claude-plugins/inki/README.md
+++ b/claude-plugins/inki/README.md
@@ -186,10 +186,6 @@ Find out what already exists, where to put new content, what's missing.
 - Edit the canonical rules at the **repo root**, not in `claude-plugins/inki/references/`. The plugin copies are synced automatically. CI fails if you edit only the plugin copies.
 - Edit agent prompts, templates, and authoring guides inside `claude-plugins/inki/references/`. These are now the canonical home.
 
-## Status
-
-v0.2.1: orchestrators now always invoke their sub-skills (never raw git/gh), and `/inki:pr` omits the preview link when no docs page changed. v0.2.0 added review agents, the `/inki:document` orchestrator, run logging, and command tooling. See `CHANGELOG.md` for details.
-
 ## For plugin developers: refreshing changes
 
 When you edit a skill in this plugin and want to see your changes locally, the marketplace cache keeps the previously-installed version of each `SKILL.md` until you fully reinstall the plugin. `/plugin marketplace update` refreshes metadata (skill names and descriptions visible in the skill list) but does not refresh the content of skill files.

--- a/claude-plugins/inki/README.md
+++ b/claude-plugins/inki/README.md
@@ -188,7 +188,7 @@ Find out what already exists, where to put new content, what's missing.
 
 ## Status
 
-v0.2.0: review agents, the `/inki:document` orchestrator, run logging, and command tooling. See `CHANGELOG.md` for details.
+v0.2.1: orchestrators now always invoke their sub-skills (never raw git/gh), and `/inki:pr` omits the preview link when no docs page changed. v0.2.0 added review agents, the `/inki:document` orchestrator, run logging, and command tooling. See `CHANGELOG.md` for details.
 
 ## For plugin developers: refreshing changes
 

--- a/claude-plugins/inki/skills/document/SKILL.md
+++ b/claude-plugins/inki/skills/document/SKILL.md
@@ -130,7 +130,7 @@ In a workflow stopped at a gate, show the summary up to the phase reached and st
 
 ## Rules
 
-- This skill never duplicates phase logic. It only resolves the subject, sequences phases, runs the fix loop, gates, and summarizes.
+- This skill never duplicates phase logic. It only resolves the subject, sequences phases, runs the fix loop, gates, and summarizes. Each phase is run by **invoking its top-level skill** (`/inki:research`, `/inki:write`, `/inki:review`, `/inki:submit`), never by re-implementing that phase's steps inline. In particular, the submit phase MUST go through `/inki:submit` (which itself invokes `/inki:branch` / `/inki:commit` / `/inki:push` / `/inki:pr`); do NOT branch, commit, push, or open the PR with raw `git` / `gh` commands here, as that drops behavior the sub-skills own (e.g. the `/inki:pr` Vercel preview link). Read-only git/gh inspection is fine; mutating git/gh by hand in place of a phase skill is a defect.
 - Default is **gated**: pause between every phase (research→write, write→review, review→submit). `--auto-approve` (aliases `--auto`, `--yes`, `-y`) removes the pauses but never the "already documented → stop" guard, the protected-path guard, or the branch discipline.
 - `--auto-approve` approves the review fix loop too: it applies fixes, it does not just surface them. This is safe here only because the draft was generated within this same run. Outside `/inki:document` (e.g. a bare `/inki:review` on an existing human-authored page), fixes still require explicit `--fix`.
 - The fix loop runs at most `MAX_FIX_ROUNDS` times (default 3, `--fix-rounds <N>` to change). It never loops unbounded; remaining findings are reported, not forced.

--- a/claude-plugins/inki/skills/pr/SKILL.md
+++ b/claude-plugins/inki/skills/pr/SKILL.md
@@ -31,6 +31,8 @@ Direct preview link 👉 [here](https://documentation-git-<branch-slug>-strapijs
 
 For example: `https://documentation-git-cms-mcp-server-strapijs.vercel.app/cms/features/strapi-mcp-server`
 
+**When no page under `docusaurus/docs/` is changed** (for example a `repo/` PR touching only `claude-plugins/`, config, or tooling), there is no doc page to preview: **omit this line entirely** rather than building a link to a page that does not exist. Do not fall back to the preview root.
+
 ## Step 3: Suggest push first if needed
 
 If no upstream exists, suggest running `/inki:push` first.

--- a/claude-plugins/inki/skills/review/SKILL.md
+++ b/claude-plugins/inki/skills/review/SKILL.md
@@ -87,7 +87,7 @@ Run the `CLEANUP` command returned by the resolver (worktree teardown or temp-fi
 
 ## Rules
 
-- Each check stays atomic inside its agent (`inki:<name>`). Do not duplicate their rubric logic here; this skill only dispatches, synthesizes, and applies the style auto-fixes.
+- Each check stays atomic inside its agent (`inki:<name>`). This skill only dispatches the checks, synthesizes their reports, and applies the style auto-fixes; it never re-implements a check's rubric inline. Always run a check by **dispatching its agent** (Step 2), never by performing the check yourself in this context. An orchestrator that quietly does a sub-step's work by hand drops behavior that sub-step owns and is a defect, even if the output looks equivalent.
 - If `--fix` is passed, only the auto-fixable findings flagged by `inki:style-checker` are applied automatically (in Step 3b). All others remain suggestions.
 - `--fix` on a PR-scope review applies fixes inside the temporary worktree only (the one created by the resolver). The PR itself is NOT modified by `/inki:review`. To push the fixes, the user must `gh pr checkout <num>` themselves and apply the suggestions manually (or use `/inki:commit` + `/inki:push` after a manual checkout).
 - `--fix` on a `docs.strapi.io` URL review applies fixes inside the temporary `origin/main` worktree only (created by the resolver); that worktree is detached and torn down at cleanup, so nothing is written back. Surface the corrected content in the report, and tell the user to apply it on a real branch.

--- a/claude-plugins/inki/skills/submit/SKILL.md
+++ b/claude-plugins/inki/skills/submit/SKILL.md
@@ -17,6 +17,8 @@ Logging: unless `--no-log` is passed, write this skill's report to the run log p
 
 ## Workflow
 
+Each step below is performed by **invoking the named sub-skill**, never by running the equivalent `git` / `gh` commands directly. The sub-skills carry behavior that is not visible from `git-rules.md` alone (for example, `/inki:pr` appends the Vercel preview link as the last line of the PR body). Re-implementing a step by hand silently drops that behavior. This is a hard rule, see the Rules section.
+
 1. **Branch**: if currently on `main`, invoke `/inki:branch` to create a properly prefixed branch.
 2. **Commit**: invoke `/inki:commit` to stage and write a commit message.
 3. **Push**: invoke `/inki:push` (with explicit confirmation).
@@ -34,6 +36,7 @@ The safety bracket from `pr-fix` does NOT apply here, because `/inki:submit` ope
 
 ## Rules
 
+- **Always invoke the sub-skills; never substitute raw `git` / `gh` commands for them.** Each of branch, commit, push, and PR is delegated to `/inki:branch`, `/inki:commit`, `/inki:push`, `/inki:pr` respectively. Running `git commit`, `git push`, or `gh pr create` by hand instead is a defect, even when it appears to produce the same result: it bypasses checks and additions the sub-skills own (branch-prefix validation, commit-message rules, the `/inki:pr` Vercel preview link, draft-PR defaults). `--auto-approve` removes confirmation prompts; it does NOT authorize bypassing the sub-skills. The only direct git/gh allowed here is read-only inspection (`git status`, `git rev-parse`, `gh pr view`) to decide what to pass to a sub-skill.
 - If any sub-step fails, stop. Do not skip a step.
 - Pass through the issue reference (if any) to `/inki:pr`.
 - In `AUTO=true` mode, surface a summary at the end showing branch name, commit SHA, and PR URL.


### PR DESCRIPTION
This PR makes the inki orchestrator skills (`/inki:submit`, `/inki:document`, `/inki:review`) require invoking their sub-skills rather than re-implementing steps with raw git/gh, so behavior the sub-skills own (like the `/inki:pr` Vercel preview link) is never silently dropped. It also makes `/inki:pr` omit the preview link when no `docusaurus/docs/` page is changed, and bumps the plugin to 0.2.1.