### PR TITLE
Detect emphasis, button-icon, and admonition conventions in Inki style review

### DIFF
--- a/claude-plugins/inki/references/prompts/integrity-known-pitfalls.md
+++ b/claude-plugins/inki/references/prompts/integrity-known-pitfalls.md
@@ -39,6 +39,17 @@ This file lists documented patterns where AI-generated documentation has produce
 | `const { primitives } = require('@strapi/utils')` | `const { strings, objects, arrays, dates } = require('@strapi/utils')` | `@strapi/utils` does `export * from './primitives'` (flattened), not `export * as primitives` |
 | `validateYupSchema` under the `yup` namespace | `validateYupSchema` is a top-level export from `@strapi/utils` | Exported from `./validators`, not from `./yup`. Import as `const { validateYupSchema } = require('@strapi/utils')`. |
 
+### Documentation formatting conventions
+
+These are not code hallucinations but recurring Strapi-docs formatting mistakes. Verified against `STYLE_GUIDE.pdf` and `docusaurus/src/components/Icon.js`.
+
+| Hallucinated pattern | Correct pattern | Context |
+|---------------------|-----------------|---------|
+| `**Copy**` (button name in bold, no icon) | `<Icon name="copy" /> **Copy**` | UI button names must be prefixed with their Phosphor icon (lowercase kebab-case name from phosphoricons.com). `<Icon>` is a global MDX component, no import needed. |
+| `**Timestamp**` in a table cell | `Timestamp` (plain text) | Bold is reserved for UI button names only. Table cell labels and headers must be plain text. |
+| `*Error*`, `*Warning*`, `*Info*` (log levels / values in italic) | `Error`, `Warning`, `Info` (plain text) | Italic is reserved for admin panel section, window, tab, and field names. Values, enum members, and log levels are not UI section names. |
+| `:::caution` for non-destructive informational content | `:::note` | `:::caution` is for mistake prevention / unstable behavior; `:::warning` for data loss or crashes. Neutral side information with nothing risky is a `:::note`. |
+
 ---
 
 ## How to add a new pitfall

--- a/claude-plugins/inki/references/prompts/style-checker.md
+++ b/claude-plugins/inki/references/prompts/style-checker.md
@@ -176,6 +176,10 @@ For each of the 12 rules, here is how to detect violations and what severity to 
 ### Rule 12: Don't overuse capitals and bold
 - **Detect:** ALL CAPS used for emphasis (not acronyms); more than 3 bolded terms in a single paragraph; bold used for elements that should be inline code (file names, commands, parameters)
 - **Severity:** warning
+- **Strapi-specific (bold is reserved for UI button names):** Per the Strapi style guide, **bold** is used **only** for UI button names. Flag bold used for anything else:
+  - Bold inside table cells (e.g. `| **Timestamp** | ... |`). Table cell labels must be plain text. **Severity:** warning.
+  - Bold used for emphasis on regular prose words, field values, or log levels. **Severity:** warning.
+  - Do NOT flag a bold span that is an actual UI button name (it should additionally carry an `<Icon>` prefix, see "UI element formatting" below).
 
 ## Additional Style Checks
 
@@ -185,6 +189,34 @@ Beyond the 12 rules, also check for:
 - **Detect:** File paths, function names, commands, or parameters not wrapped in backticks
 - **Severity:** warning
 - **Strapi-specific exception:** Programming casing conventions (e.g., kebab-case, camelCase, PascalCase, snake_case, SCREAMING_SNAKE_CASE) do NOT require backticks. Do NOT flag these terms.
+
+### Text emphasis (bold and italic)
+Per the Strapi style guide, the two emphasis styles have a single allowed use each. Flag any other use.
+- **Bold (`**text**`)** is reserved for **UI button names** only. See Rule 12 above for the full detection list (bold in tables, bold on prose/values, bold on log levels).
+- **Italic (`*text*`)** is reserved for **admin panel section names, window names, tab names, and field/label names** (e.g. *Content Manager*, *Settings*, the *Logs* tab). Flag italic used for:
+  - Emphasis on ordinary prose words. **Severity:** warning.
+  - Values, enum members, or log levels presented as a list or in running text (e.g. log levels `*Error*`, `*Warning*`, `*Info*`). These are values, not UI section names, so they must be plain text (or inline code where appropriate), not italic. **Severity:** warning.
+- **Suggestion:** When in doubt whether an italicized term is a genuine UI section/tab name, check whether the exact string appears in the product UI (screenshots on the page often confirm it). If it is not a UI section/window/field/tab name, the italic is incorrect.
+
+### UI element formatting (button icons)
+- **Detect:** A UI button name (typically rendered in **bold**) that is not prefixed with its Phosphor icon component.
+- **Severity:** warning
+- **Strapi-specific rule:** UI button names must be prefixed with an `<Icon>` component naming the button's Phosphor icon, in the form:
+  - `<Icon name="copy" /> **Copy**` (icon name from https://phosphoricons.com, lowercase, kebab-case)
+  - The `<Icon>` component is a global MDX component in the docs; no import is needed.
+- **Note:** If you cannot determine the correct icon from the page or a screenshot, still flag the missing icon and tell the author to add `<Icon name="..." />` with the icon matching the button in the UI. Do not invent an icon name with false confidence; say which button needs one.
+
+### Admonition severity
+- **Detect:** An admonition whose type does not match the severity of its content.
+- **Severity:** warning
+- **Strapi-specific rule (lowest to highest importance):**
+  - `:::tip` — tips and tricks; useful but not required to understand Strapi.
+  - `:::note` — helpful, time-saving information. Use this for neutral side information with nothing destructive.
+  - `:::prerequisites` — conditions required to complete a procedure.
+  - `:::caution` — important information: mistake prevention, recommendations, unstable or unreliable behavior.
+  - `:::warning` — highly important: data loss, project crash, unsupported behavior.
+  - `:::strapi` — links to other Strapi resources, marketing-style; Strapi team only.
+- **Common error to flag:** `:::caution` (or `:::warning`) used for content that is merely informational with nothing destructive or risky. Suggest downgrading to `:::note`. Conversely, flag `:::note`/`:::tip` wrapping a genuine data-loss or crash warning and suggest upgrading.
 
 ### File paths
 - **Detect:** File paths using `./` prefix (e.g., `./config/server`) instead of `/` prefix (e.g., `/config/server`)

--- a/claude-plugins/inki/scripts/style-lint.sh
+++ b/claude-plugins/inki/scripts/style-lint.sh
@@ -299,6 +299,19 @@ lint_file() {
       has_warnings=1
     fi
 
+    # Bold inside table cells. Per the Strapi style guide, bold is reserved for
+    # UI button names. A table row (a line starting with `|`) that carries a
+    # **bold** span is almost always emphasising a cell label, not a button, so
+    # it is flagged. The known false positive -- a button name legitimately
+    # mentioned in a cell -- is acceptable at warning level and noted in the message.
+    # Skip the header-separator row (| --- | --- |).
+    if echo "$line" | grep -qE '^[[:space:]]*\|' && ! echo "$line" | grep -qE '^[[:space:]]*\|[[:space:]:|-]+\|?[[:space:]]*$'; then
+      if echo "$line" | grep -qE '\*\*[^*]+\*\*'; then
+        echo "warning:${line_num}:bold-in-table:Bold inside a table cell -- bold is reserved for UI button names; remove emphasis from cell labels"
+        has_warnings=1
+      fi
+    fi
+
     # =====================
     # SUGGESTION-LEVEL
     # =====================
@@ -306,6 +319,18 @@ lint_file() {
     # Standalone cross-reference sentences
     if echo "$line" | grep -qE '^See \[.*\]\(.*\)\.[[:space:]]*$'; then
       echo "suggestion:${line_num}:standalone-xref:Standalone \"See [link].\" -- consider integrating into preceding sentence"
+    fi
+
+    # UI button name without a leading <Icon> component. The Strapi docs convention
+    # prefixes a button name with its Phosphor icon, e.g. `<Icon name="copy" /> **Copy**`.
+    # Heuristic: a **bold** span on the same line as the word "button" (the bold is
+    # the button label) that is NOT preceded by an <Icon .../> tag. Suggestion-level
+    # because not every "button" mention is a UI button and the author may add the
+    # icon deliberately elsewhere; keep it non-blocking but visible.
+    if echo "$line" | grep -qiE "${word_boundary_start}buttons?${word_boundary_end}" && echo "$line" | grep -qE '\*\*[^*]+\*\*'; then
+      if ! echo "$line" | grep -qE '<Icon[[:space:]]+name='; then
+        echo "suggestion:${line_num}:button-missing-icon:Button name without a leading <Icon name=\"...\" /> -- prefix UI button names with their Phosphor icon"
+      fi
     fi
 
   done <<< "$stripped"


### PR DESCRIPTION
This PR teaches the Inki style review to catch Strapi formatting conventions it was missing: bold reserved for UI button names (flags bold in table cells), italic reserved for UI section/tab/field names (flags italic on values like log levels), UI button names needing an `<Icon>` prefix, and admonition type matching content severity (`:::caution` vs `:::note`). It adds two deterministic checks to style-lint.sh (bold-in-table, button-missing-icon), extends the style-checker prompt, and adds a "Documentation formatting conventions" category to the known-pitfalls catalog.