### PR TITLE
Rename Inki autonomy flag to `--non-interactive`

### DIFF
--- a/claude-plugins/inki/.claude-plugin/plugin.json
+++ b/claude-plugins/inki/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "inki",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Inki: research, write, review, submit your docs. A Claude Code plugin encapsulating the Strapi documentation toolkit.",
   "author": {
     "name": "Pierre Wizla"

--- a/claude-plugins/inki/CHANGELOG.md
+++ b/claude-plugins/inki/CHANGELOG.md
@@ -1,28 +1,35 @@
 # Inki Changelog
 
+## v0.2.2 (2026-06-16)
+
+### Changed
+
+- The autonomy flag is now canonically named `--non-interactive` across every skill that takes it (`/inki:document`, `/inki:review`, `/inki:write`, `/inki:outline`, `/inki:submit`, `/inki:pr-fix`, `/inki:pitfalls-add`). The previous name `--auto-approve` is kept as an alias, along with `--auto`, `--yes`, `-y`, and `--no-questions-asked`. The rename makes the flag's effect self-evident: it suppresses confirmation prompts (asks no questions); it does not, on its own, change what gets written.
+- `/inki:review` documentation now spells out the two independent flags: `--non-interactive` runs the review silently (report only, no questions), `--fix` applies the auto-fixable findings, and `--non-interactive --fix` does both. Omitting both prompts, reports, and changes nothing.
+
 ## v0.2.1 (2026-06-16)
 
 ### Changed
 
-- Orchestrator skills (`/inki:submit`, `/inki:document`, `/inki:review`) now state as a hard rule that they must run each step by **invoking the named sub-skill**, never by re-implementing it with raw `git` / `gh` commands or inline logic. Re-implementing a step by hand silently drops behavior the sub-skill owns (for example, the `/inki:pr` Vercel preview link). `--auto-approve` removes confirmation prompts but does not authorize bypassing a sub-skill.
+- Orchestrator skills (`/inki:submit`, `/inki:document`, `/inki:review`) now state as a hard rule that they must run each step by **invoking the named sub-skill**, never by re-implementing it with raw `git` / `gh` commands or inline logic. Re-implementing a step by hand silently drops behavior the sub-skill owns (for example, the `/inki:pr` Vercel preview link). `--non-interactive` removes confirmation prompts but does not authorize bypassing a sub-skill.
 - `/inki:pr`: when a PR changes no page under `docusaurus/docs/` (for example a `repo/` PR touching only `claude-plugins/`, config, or tooling), the Vercel preview link is now omitted rather than pointing at a non-existent page.
 
 ## v0.2.0 (2026-06-16)
 
 ### Added
 
-- `/inki:document [--auto-approve] [--fix-rounds <N>] <subject>` skill: end-to-end orchestrator chaining all four families (research → write → review → submit) for a single subject. Gated between each phase by default; `--auto-approve` chains without pauses and runs a review-fix loop (review → apply fixes → re-review, up to `--fix-rounds` iterations, default 3). Stops if research finds the subject is already documented (no duplicate pages). The `<subject>` is flexible: keywords, a Notion page URL, a Linear issue, a PDF (path or URL), a local file, or pasted text.
+- `/inki:document [--non-interactive] [--fix-rounds <N>] <subject>` skill: end-to-end orchestrator chaining all four families (research → write → review → submit) for a single subject. Gated between each phase by default; `--non-interactive` chains without pauses and runs a review-fix loop (review → apply fixes → re-review, up to `--fix-rounds` iterations, default 3). Stops if research finds the subject is already documented (no duplicate pages). The `<subject>` is flexible: keywords, a Notion page URL, a Linear issue, a PDF (path or URL), a local file, or pasted text.
 - `references/subject-resolver.md`: centralized resolution of a *subject to document* into a normalized brief (keywords, a Strapi code PR, Notion, Linear, PDF, local file, pasted content). Distinct from `target-resolver.md`, which resolves an existing file *to review*. Consumed by `/inki:document`. A `strapi/strapi` or `strapi/cloud` PR (given as a URL, `owner/repo number`, a bare number, or prose) is routed through `/inki:route` into a brief; a bare number prompts for the repo; a `strapi/documentation` PR is redirected to `/inki:review`; a PR on any other repo stops (not documented on docs.strapi.io).
-- `/inki:pitfalls-add [--auto-approve] <pitfall>` skill: adds a new, source-verified entry to the known-pitfalls catalog. The writing counterpart to the read-only `pitfalls-checker` agent (which stays read-only and only suggests running this skill).
+- `/inki:pitfalls-add [--non-interactive] <pitfall>` skill: adds a new, source-verified entry to the known-pitfalls catalog. The writing counterpart to the read-only `pitfalls-checker` agent (which stays read-only and only suggests running this skill).
 - Run logging: every run writes a verbose Markdown report tree to `~/.inki/logs/<YYYY-MM-DD-slug>/` with one subdirectory per phase (research/write/review/submit), including each reviewer agent's raw report by default. Overridable with `--log-dir <path>` or the `INKI_LOG_DIR` env var; never written inside the worked-on repo (`.inki/` is also gitignored as a safety net). `--no-log` disables it; `--short-log` trims to the consolidated per-phase reports. Centralized in `references/logging.md`.
 - `agents/` layer: six read-only review subagents (`style-checker`, `outline-checker`, `ux-analyzer`, `code-verifier`, `coherence-checker`, `pitfalls-checker`), each with a write-excluding tool allowlist and a model tier matched to its task (opus for code/coherence/UX, sonnet for outline/pitfalls, haiku for style).
 - `references/STYLE_GUIDE.pdf`: the authoritative Strapi style guide, synced from the repo root. Wired into the `style-checker` agent for formatting and capitalization judgment.
 - `COMMANDS.md`: a per-command reference (every skill, its description, and its argument signature), curated (not auto-generated) and mirroring each skill's frontmatter. Linked from the README.
 - `--help` / `-h` support on the skills that take flags (`document`, `review`, `submit`, `write`, `outline`, `pr-fix`, `pitfalls-add`): prints the command's usage and stops, per `references/help.md`. (Claude Code has no built-in `--help`; each skill handles it.)
 - `/inki:pr-fix <action>` skill, with `action` being `title`, `description`, or `body` (alias of `description`). Replaces the previous separate `pr-title-fix`, `pr-description-fix`, and `pr-body-fix` skills.
-- `--auto-approve` non-interactive auto mode (with `--auto`, `--yes`, `-y` kept as aliases) on `/inki:document`, `/inki:pr-fix`, `/inki:review`, `/inki:submit`, `/inki:write`, and `/inki:outline`. Skips confirmation prompts so the skills can be chained or scripted.
+- `--non-interactive` non-interactive auto mode (with `--auto-approve`, `--auto`, `--yes`, `-y`, `--no-questions-asked` kept as aliases) on `/inki:document`, `/inki:pr-fix`, `/inki:review`, `/inki:submit`, `/inki:write`, and `/inki:outline`. Skips confirmation prompts so the skills can be chained or scripted.
 - `--include-old` flag on `/inki:pr-fix`: when no PR IDs are listed, include open PRs older than 30 days. By default, stale PRs are excluded to avoid bumping them with a title/description change notification.
-- Safety bracket on `--auto-approve` mode: when `--auto-approve` is used without explicit PR IDs, the skill presents a batch-review prompt (`y` / `n` / `s <PR#>` to skip individual items) before applying any edit.
+- Safety bracket on `--non-interactive` mode: when `--non-interactive` is used without explicit PR IDs, the skill presents a batch-review prompt (`y` / `n` / `s <PR#>` to skip individual items) before applying any edit.
 - URL parsing across skills: `/inki:pr-fix`, `/inki:route`, and `/inki:review` accept bare PR numbers (`3204`), hashed numbers (`#3204`), full URLs (`https://github.com/.../pull/3204`), and URLs with sub-paths (`/files`, `/commits`).
 - `references/target-resolver.md`: centralized target resolution for `/inki:review`. The skill now accepts a path, a directory, a bare markdown filename, a GitHub PR, a `docs.strapi.io` URL, pasted Markdown content, or no argument (changed files on the current branch).
 - `scripts/main-worktree.sh` helper: create or destroy a detached `origin/main` worktree, used by `/inki:review` for docs.strapi.io URL resolution.

--- a/claude-plugins/inki/COMMANDS.md
+++ b/claude-plugins/inki/COMMANDS.md
@@ -8,17 +8,17 @@ Every Inki skill is invoked as `/inki:<skill>`. This page lists each command, wh
 
 ### `/inki:document`
 
-End-to-end documentation orchestrator: chains all four inki phases (research, write, review, submit) for a single subject. Gates between each phase by default; --auto-approve chains without pauses and runs a review-fix loop. The simplest way to document a subject from scratch.
+End-to-end documentation orchestrator: chains all four inki phases (research, write, review, submit) for a single subject. Gates between each phase by default; --non-interactive chains without pauses and runs a review-fix loop. The simplest way to document a subject from scratch.
 
 ```
-/inki:document [--auto-approve] [--fix-rounds <N>] <subject: keywords | Strapi PR (url/number) | Notion URL | Linear issue | PDF path | pasted text>
+/inki:document [--non-interactive] [--fix-rounds <N>] <subject: keywords | Strapi PR (url/number) | Notion URL | Linear issue | PDF path | pasted text>
 ```
 
 The command accepts the following flags:
 
 | Flag | Description |
 |------|-------------|
-| `--auto-approve` | Chain all phases without pausing, and approve the review-fix loop. Aliases: `--auto`, `--yes`, `-y`. |
+| `--non-interactive` | Chain all phases without pausing, and approve the review-fix loop. Canonical; aliases: `--auto-approve`, `--auto`, `--yes`, `-y`, `--no-questions-asked`. |
 | `--fix-rounds <N>` | Cap the review→fix→re-review iterations. Default 3. |
 | `--no-log` | Disable run logging for this run. |
 | `--log-dir <path>` | Write logs under `<path>` instead of the default `~/.inki/logs/`. |
@@ -98,14 +98,14 @@ The command accepts the following flags:
 Top-level write orchestrator: outline a new page, get user approval, then draft from the outline.
 
 ```
-/inki:write [--auto-approve] [--no-log] <topic brief or path to a brief file>
+/inki:write [--non-interactive] [--no-log] <topic brief or path to a brief file>
 ```
 
 The command accepts the following flags:
 
 | Flag | Description |
 |------|-------------|
-| `--auto-approve` | Generate the outline and draft without pausing at the outline approval gate. Aliases: `--auto`, `--yes`, `-y`. |
+| `--non-interactive` | Generate the outline and draft without pausing at the outline approval gate. Canonical; aliases: `--auto-approve`, `--auto`, `--yes`, `-y`, `--no-questions-asked`. |
 | `--no-log` | Disable run logging for this run. |
 | `--log-dir <path>` | Write logs under `<path>` instead of the default `~/.inki/logs/`. |
 | `--short-log` | Trim logs to the consolidated per-phase reports (omit per-agent raw reports). |
@@ -116,14 +116,14 @@ The command accepts the following flags:
 Generate an outline for a new documentation page from a topic brief and the appropriate template.
 
 ```
-/inki:outline [--auto-approve] [--no-log] <topic brief or path to a brief file>
+/inki:outline [--non-interactive] [--no-log] <topic brief or path to a brief file>
 ```
 
 The command accepts the following flags:
 
 | Flag | Description |
 |------|-------------|
-| `--auto-approve` | Skip the approval gate and save the outline to the default path. Aliases: `--auto`, `--yes`, `-y`. |
+| `--non-interactive` | Skip the approval gate and save the outline to the default path. Canonical; aliases: `--auto-approve`, `--auto`, `--yes`, `-y`, `--no-questions-asked`. |
 | `--no-log` | Disable run logging for this run. |
 | `--log-dir <path>` | Write logs under `<path>` instead of the default `~/.inki/logs/`. |
 | `--short-log` | Trim logs to the consolidated per-phase reports (omit per-agent raw reports). |
@@ -152,14 +152,14 @@ The command accepts the following flags:
 Top-level review orchestrator: runs style-check, outline-check, outline-ux-analyzer, code-verify, coherence-check, and pitfalls-check on a file, directory, or PR.
 
 ```
-/inki:review [--auto-approve] [--fix] [--no-log] <path | filename | PR# | PR URL | docs.strapi.io URL | pasted content>
+/inki:review [--non-interactive] [--fix] [--no-log] <path | filename | PR# | PR URL | docs.strapi.io URL | pasted content>
 ```
 
 The command accepts the following flags:
 
 | Flag | Description |
 |------|-------------|
-| `--auto-approve` | Non-interactive: skip confirmation gates inside the sub-skills. Aliases: `--auto`, `--yes`, `-y`. |
+| `--non-interactive` | Skip confirmation gates inside the sub-skills. Canonical; aliases: `--auto-approve`, `--auto`, `--yes`, `-y`, `--no-questions-asked`. |
 | `--fix` | Apply the auto-fixable findings from `style-check` (others stay suggestions). |
 | `--no-log` | Disable run logging for this run. |
 | `--log-dir <path>` | Write logs under `<path>` instead of the default `~/.inki/logs/`. |
@@ -268,14 +268,14 @@ The command accepts the following flags:
 Add a new entry to the known-pitfalls catalog that pitfalls-check audits against. Verifies the correct pattern against the Strapi source before adding, and confirms with the user. Use when you have found a documentation mistake worth catching automatically in future reviews.
 
 ```
-/inki:pitfalls-add [--auto-approve] [--no-log] <description of the pitfall, or a pitfalls-check / code-verify finding to promote>
+/inki:pitfalls-add [--non-interactive] [--no-log] <description of the pitfall, or a pitfalls-check / code-verify finding to promote>
 ```
 
 The command accepts the following flags:
 
 | Flag | Description |
 |------|-------------|
-| `--auto-approve` | Skip the confirmation prompt (the source verification still runs as the safety gate). Aliases: `--auto`, `--yes`, `-y`. |
+| `--non-interactive` | Skip the confirmation prompt (the source verification still runs as the safety gate). Canonical; aliases: `--auto-approve`, `--auto`, `--yes`, `-y`, `--no-questions-asked`. |
 | `--no-log` | Disable run logging for this run. |
 | `--log-dir <path>` | Write logs under `<path>` instead of the default `~/.inki/logs/`. |
 | `--short-log` | Trim logs to the consolidated per-phase reports (omit per-agent raw reports). |
@@ -285,17 +285,17 @@ The command accepts the following flags:
 
 ### `/inki:submit`
 
-Top-level orchestrator: branch (if needed), commit, push, then open a PR. Each step asks for confirmation before continuing, unless --auto-approve is passed.
+Top-level orchestrator: branch (if needed), commit, push, then open a PR. Each step asks for confirmation before continuing, unless --non-interactive is passed.
 
 ```
-/inki:submit [--auto-approve] [--no-log] [issue reference or topic hint, e.g. 'Fixes #2143']
+/inki:submit [--non-interactive] [--no-log] [issue reference or topic hint, e.g. 'Fixes #2143']
 ```
 
 The command accepts the following flags:
 
 | Flag | Description |
 |------|-------------|
-| `--auto-approve` | Run branch + commit + push + PR without per-step prompts (informed decisions are still surfaced). Aliases: `--auto`, `--yes`, `-y`. |
+| `--non-interactive` | Run branch + commit + push + PR without per-step prompts (informed decisions are still surfaced). Canonical; aliases: `--auto-approve`, `--auto`, `--yes`, `-y`, `--no-questions-asked`. |
 | `--no-log` | Disable run logging for this run. |
 | `--log-dir <path>` | Write logs under `<path>` instead of the default `~/.inki/logs/`. |
 | `--short-log` | Trim logs to the consolidated per-phase reports (omit per-agent raw reports). |
@@ -335,17 +335,17 @@ Create a pull request on strapi/documentation following [git-rules.md](./referen
 
 ### `/inki:pr-fix`
 
-Rewrite the title or description/body of one or more open PRs on strapi/documentation to match [git-rules.md](./references/git-rules.md). Strict one-by-one confirmation, or auto-edit with --auto-approve.
+Rewrite the title or description/body of one or more open PRs on strapi/documentation to match [git-rules.md](./references/git-rules.md). Strict one-by-one confirmation, or auto-edit with --non-interactive.
 
 ```
-/inki:pr-fix <title|description|body> [--auto-approve] [--include-old] [--no-log] [PR# or URL] [PR# or URL] ...
+/inki:pr-fix <title|description|body> [--non-interactive] [--include-old] [--no-log] [PR# or URL] [PR# or URL] ...
 ```
 
 The command accepts the following flags:
 
 | Flag | Description |
 |------|-------------|
-| `--auto-approve` | Edit without per-PR confirmation (a batch-review gate still applies when no PR IDs are given). Aliases: `--auto`, `--yes`, `-y`. |
+| `--non-interactive` | Edit without per-PR confirmation (a batch-review gate still applies when no PR IDs are given). Canonical; aliases: `--auto-approve`, `--auto`, `--yes`, `-y`, `--no-questions-asked`. |
 | `--include-old` | When no PR IDs are given, include open PRs older than 30 days (excluded by default). |
 | `--no-log` | Disable run logging for this run. |
 | `--log-dir <path>` | Write logs under `<path>` instead of the default `~/.inki/logs/`. |

--- a/claude-plugins/inki/README.md
+++ b/claude-plugins/inki/README.md
@@ -50,9 +50,9 @@ If you just want to document a subject from scratch, `/inki:document <subject>` 
    └─ 4. submit ──── branch + commit + push + PR                        → [gate]
 ```
 
-It pauses for your approval between each stage by default, so you stay in control. Add `--auto-approve` to chain all four without stopping (you review the resulting PR at the end). The `<subject>` is flexible: keywords, a Strapi code PR (`strapi/strapi` or `strapi/cloud`, the two repos published to docs.strapi.io, given by URL, `owner/repo number`, a bare number, or prose naming the PR), a Notion page URL, a Linear issue, a PDF (spec/RFC), a local file, or pasted notes. `/inki:document` resolves it into a brief and runs from there. A `strapi/documentation` PR is not a subject to document: `/inki:document` redirects you to `/inki:review`. A PR on a repo that is not published to docs.strapi.io (e.g. `strapi/design-system`) stops with an explanation.
+It pauses for your approval between each stage by default, so you stay in control. Add `--non-interactive` to chain all four without stopping (you review the resulting PR at the end). The `<subject>` is flexible: keywords, a Strapi code PR (`strapi/strapi` or `strapi/cloud`, the two repos published to docs.strapi.io, given by URL, `owner/repo number`, a bare number, or prose naming the PR), a Notion page URL, a Linear issue, a PDF (spec/RFC), a local file, or pasted notes. `/inki:document` resolves it into a brief and runs from there. A `strapi/documentation` PR is not a subject to document: `/inki:document` redirects you to `/inki:review`. A PR on a repo that is not published to docs.strapi.io (e.g. `strapi/design-system`) stops with an explanation.
 
-One guard always holds, even with `--auto-approve`: if the research stage finds the subject is **already documented**, `/inki:document` stops and points you at the existing page rather than creating a duplicate. This detection is strongest for keyword or topic subjects (where research runs `exists` and gets a clear coverage verdict); for a feature name or a code PR it leans on the coverage and routing reports, which are less categorical.
+One guard always holds, even with `--non-interactive`: if the research stage finds the subject is **already documented**, `/inki:document` stops and points you at the existing page rather than creating a duplicate. This detection is strongest for keyword or topic subjects (where research runs `exists` and gets a clear coverage verdict); for a feature name or a code PR it leans on the coverage and routing reports, which are less categorical.
 
 ### 1. 🔍 Research: figure out where the doc goes
 
@@ -133,9 +133,9 @@ The summary below covers the most common usage. For a per-command reference of e
 
 ### Document: the full chain in one command
 
-👉 `/inki:document [--auto-approve] <subject>`: run all four stages (research → write → review → submit) for one subject. Gated between each stage by default.
+👉 `/inki:document [--non-interactive] <subject>`: run all four stages (research → write → review → submit) for one subject. Gated between each stage by default.
 
-* `--auto-approve` chains without pauses. When omitted, the process will stop after each of the 4 stages, and ask for approval before continuing.
+* `--non-interactive` chains without pauses. When omitted, the process will stop after each of the 4 stages, and ask for approval before continuing.
 * `<subject>` can be keywords, a Strapi code PR (`strapi/strapi` or `strapi/cloud`; URL, `owner/repo number`, bare number, or prose), a Notion URL, a Linear issue, a PDF path/URL, a local file, or pasted text. 
 * The whole process stops if research finds the subject is already documented.
 * Providing a `strapi/documentation` PR redirects to `/inki:review`, and a providing a PR on any other repo stops the process as this content is not documented on docs.strapi.io.
@@ -151,33 +151,37 @@ Find out what already exists, where to put new content, what's missing.
 
 ### Write: produce new content
 
-👉 `/inki:write [--auto-approve] <brief>`: orchestrator: outline then draft.
+👉 `/inki:write [--non-interactive] <brief>`: orchestrator: outline then draft.
 - `/inki:outline <brief>`: generate an outline from a brief and template.
 - `/inki:draft <outline>`: draft a page from an outline + template + authoring guide.
 
 ### Review: check what you wrote
 
-👉 `/inki:review [--auto-approve] [--fix] <path | filename | PR | docs.strapi.io URL | pasted content>`: orchestrator: runs all 6 review sub-skills against any supported target. When `--fix` is passed, the tool will auto-fix its finding; when omitted it will simply report them.
+👉 `/inki:review [--non-interactive] [--fix] <path | filename | PR | docs.strapi.io URL | pasted content>`: orchestrator: runs all 6 review sub-skills against any supported target. Two independent flags:
+
+* `--non-interactive`: ask no questions (review runs silently). Alone, it still only produces a report.
+* `--fix`: apply the auto-fixable findings. Alone, it still prompts first.
+* Combine them (`--non-interactive --fix`) to fix silently; omit both for the default (prompts + report, no changes).
 - `/inki:style-check <path>`: style lint (deterministic + AI).
 - `/inki:outline-check <path>`: verify outline matches template.
 - `/inki:outline-ux-analyzer <path>`: audit pedagogical UX.
 - `/inki:code-verify <path>`: verify code blocks.
 - `/inki:coherence-check <path>`: check cross-page coherence.
 - `/inki:pitfalls-check <path>`: audit against known pitfalls.
-- `/inki:pitfalls-add [--auto-approve] <pitfall>`: add a new, source-verified entry to the known-pitfalls catalog (the writing counterpart to the read-only `pitfalls-check`).
+- `/inki:pitfalls-add [--non-interactive] <pitfall>`: add a new, source-verified entry to the known-pitfalls catalog (the writing counterpart to the read-only `pitfalls-check`).
 
 ### Submit: get it to GitHub
 
-👉 `/inki:submit [--auto-approve] [hint]`: orchestrator: branch + commit + push + PR.
+👉 `/inki:submit [--non-interactive] [hint]`: orchestrator: branch + commit + push + PR.
 - `/inki:branch`: create a properly prefixed branch.
 - `/inki:commit`: stage + commit with a compliant message.
 - `/inki:push`: push with validation.
 - `/inki:pr [issue]`: open a PR with a compliant title and description.
-- `/inki:pr-fix <title|description|body> [--auto-approve] [--include-old] [PR# or URL...]`: rewrite the title or body of existing PRs (`body` is an alias of `description`).
+- `/inki:pr-fix <title|description|body> [--non-interactive] [--include-old] [PR# or URL...]`: rewrite the title or body of existing PRs (`body` is an alias of `description`).
 
 ### Common flags
 
-- `--auto-approve` (aliases `--auto` / `--yes` / `-y`): non-interactive mode: skip confirmation prompts. Useful for chaining skills or scripting. `--auto-approve` is the canonical form; `--auto`, `--yes`, and `-y` are kept as aliases. On `/inki:document` it also runs the review-fix loop automatically.
+- `--non-interactive` (aliases `--auto-approve` / `--auto` / `--yes` / `-y` / `--no-questions-asked`): skip confirmation prompts; ask no questions. Useful for chaining skills or scripting. `--non-interactive` is the canonical form; the others are kept as aliases. On `/inki:document` it also runs the review-fix loop automatically.
 - `--fix-rounds <N>` (on `/inki:document`): cap the number of review→fix→re-review iterations. Default 3.
 - `--no-log` / `--log-dir <path>` / `--short-log`: logging controls. By default, every skill that produces a report or modifies files writes a verbose Markdown report tree to `~/.inki/logs/<YYYY-MM-DD-slug>/` (override with `--log-dir` or the `INKI_LOG_DIR` env var; logs never go inside the worked-on repo). `--no-log` disables it; `--short-log` trims the verbose per-agent reports, keeping only the consolidated per-phase reports. The git-plumbing skills (`branch`, `commit`, `push`, `pr`) do not take these flags: a single git step has no report of its own, and its work is captured in `submit`'s log.
 - `--include-old` (only on `pr-fix`): when no PR IDs are listed, include open PRs older than 30 days. By default, stale PRs are excluded to avoid bumping them with a title/description change notification.

--- a/claude-plugins/inki/references/target-resolver.md
+++ b/claude-plugins/inki/references/target-resolver.md
@@ -93,7 +93,7 @@ find docusaurus/docs -type f \( -name '<name>' \) 2>/dev/null
 ```
 
 - Exactly one match: use it.
-- Multiple matches: list them and ask the user which one (or, with `--auto-approve`, review all of them).
+- Multiple matches: list them and ask the user which one (or, with `--non-interactive`, review all of them).
 - No match: report that the file was not found and stop.
 
 `SCOPE` = the resolved path.

--- a/claude-plugins/inki/skills/document/SKILL.md
+++ b/claude-plugins/inki/skills/document/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: document
-description: "End-to-end documentation orchestrator: chains all four inki phases (research, write, review, submit) for a single subject. Gates between each phase by default; --auto-approve chains without pauses and runs a review-fix loop. The simplest way to document a subject from scratch."
-argument-hint: "[--auto-approve] [--fix-rounds <N>] <subject: keywords | Strapi PR (url/number) | Notion URL | Linear issue | PDF path | pasted text>"
+description: "End-to-end documentation orchestrator: chains all four inki phases (research, write, review, submit) for a single subject. Gates between each phase by default; --non-interactive chains without pauses and runs a review-fix loop. The simplest way to document a subject from scratch."
+argument-hint: "[--non-interactive] [--fix-rounds <N>] <subject: keywords | Strapi PR (url/number) | Notion URL | Linear issue | PDF path | pasted text>"
 user-invocable: true
 ---
 
 # /inki:document: document a subject end to end
 
-`/inki:document` is the one-shot entry point to the whole inki workflow. Given a subject to document, it runs the four families in order (**research → write → review → submit**), pausing for your approval between each phase so you stay in control. Pass `--auto-approve` to chain all four without stopping; in that mode the review phase also runs a fix loop (review → fix → re-review) until the draft is clean or `--fix-rounds` is reached.
+`/inki:document` is the one-shot entry point to the whole inki workflow. Given a subject to document, it runs the four families in order (**research → write → review → submit**), pausing for your approval between each phase so you stay in control. Pass `--non-interactive` to chain all four without stopping; in that mode the review phase also runs a fix loop (review → fix → re-review) until the draft is clean or `--fix-rounds` is reached.
 
 It is a thin orchestrator: each phase is delegated to its existing top-level skill (`/inki:research`, `/inki:write`, `/inki:review`, `/inki:submit`). This skill adds no review logic of its own; it resolves the subject, sequences the phases, runs the fix loop, and manages the gates.
 
@@ -17,7 +17,7 @@ If `$ARGUMENTS` contains `--help` or `-h`, print usage and stop, per `../../refe
 
 Otherwise, from `$ARGUMENTS`, detect these flags anywhere in the list, then remove them:
 
-- `--auto-approve` (canonical), or its aliases `--auto`, `--yes`, `-y` (all equivalent) → set `AUTO=true`. Chains all phases without pausing AND approves the review-fix loop in Step 4 (see below).
+- `--non-interactive` (canonical), aliases `--auto-approve`, `--auto`, `--yes`, `-y`, `--no-questions-asked` (all equivalent) → set `AUTO=true`. Chains all phases without pausing AND approves the review-fix loop in Step 4 (see below).
 - `--fix-rounds <N>` → set `MAX_FIX_ROUNDS=<N>`. Caps how many review→fix iterations Step 4 runs. Defaults to `3` if not given.
 - `--no-log`, `--log-dir <path>`, `--short-log` → logging flags, handled per `../../references/logging.md`.
 
@@ -52,14 +52,14 @@ Invoke `/inki:research` on the subject (pass the brief's topic/keywords, or the 
 
 **Gate on the result before continuing:**
 
-- **If research concludes the subject is already documented** (an existing page covers it): **STOP.** Report the existing page path(s) from the research output and end the workflow. Do not chain into write. The user decides what to do next (they can run `/inki:review <path>` themselves to update the existing page). This stop happens even in `--auto-approve` mode: documenting a duplicate is never the intended outcome.
+- **If research concludes the subject is already documented** (an existing page covers it): **STOP.** Report the existing page path(s) from the research output and end the workflow. Do not chain into write. The user decides what to do next (they can run `/inki:review <path>` themselves to update the existing page). This stop happens even in `--non-interactive` mode: documenting a duplicate is never the intended outcome.
 - **Otherwise:** the research output enriches the brief (gaps, related pages, routing). Carry the enriched brief forward.
 
 **Phase gate (skipped when `AUTO=true`):** show the research summary and ask whether to proceed to writing. On no, stop.
 
 ## Step 3: Phase 2, Write
 
-Invoke `/inki:write` with the enriched brief. In interactive mode `/inki:write` already gates on outline approval before drafting; let it. In `AUTO=true` mode, pass `--auto-approve` through so outline and draft are produced without an inner pause.
+Invoke `/inki:write` with the enriched brief. In interactive mode `/inki:write` already gates on outline approval before drafting; let it. In `AUTO=true` mode, pass `--non-interactive` through so outline and draft are produced without an inner pause.
 
 The output is a drafted page (and its outline file).
 
@@ -71,7 +71,7 @@ This phase reviews the fresh draft and iteratively fixes it until it is clean or
 
 **Behaviour depends on `AUTO`:**
 
-- **`AUTO=true` (`--auto-approve`):** run the fix loop below without prompting. `--auto-approve` means "approve everything", which explicitly *includes* applying the review fixes.
+- **`AUTO=true` (`--non-interactive`):** run the fix loop below without prompting. `--non-interactive` means "approve everything", which explicitly *includes* applying the review fixes.
 - **`AUTO=false` (default):** first run a single read-only `/inki:review` and show the report. Then ask whether to (a) run the fix loop, (b) proceed to submit as-is, or (c) stop. Only run the loop on (a).
 
 **The fix loop:**
@@ -79,7 +79,7 @@ This phase reviews the fresh draft and iteratively fixes it until it is clean or
 ```
 round = 1
 loop:
-  run /inki:review --auto-approve --fix <draft>   # applies every fix it safely can this round
+  run /inki:review --non-interactive --fix <draft>   # applies every fix it safely can this round
   re-read the resulting findings
   if no actionable findings remain  → break (clean)
   if round >= MAX_FIX_ROUNDS        → break (cap reached)
@@ -96,11 +96,11 @@ Record `ROUNDS_RUN` and the final open-findings count for the summary.
 
 ## Step 5: Phase 4, Submit
 
-Invoke `/inki:submit` to branch (if on `main`), commit, push, and open the PR. In `AUTO=true` mode, pass `--auto-approve` through.
+Invoke `/inki:submit` to branch (if on `main`), commit, push, and open the PR. In `AUTO=true` mode, pass `--non-interactive` through.
 
-`/inki:submit` retains its own safety behavior, which `--auto-approve` does NOT override. Concretely, even in auto mode:
+`/inki:submit` retains its own safety behavior, which `--non-interactive` does NOT override. Concretely, even in auto mode:
 
-- **Deployment-infrastructure paths are never touched in auto mode.** `.github/workflows/` and `docusaurus.config.js` always require explicit human confirmation; `/inki:document` never writes them and never auto-approves a commit that includes them. (`sidebars.js` is NOT in this set: adding a new page legitimately requires a navigation entry, so `--auto-approve` may edit it. It stays visible in the diff and in the draft PR for human review.)
+- **Deployment-infrastructure paths are never touched in auto mode.** `.github/workflows/` and `docusaurus.config.js` always require explicit human confirmation; `/inki:document` never writes them and never auto-approves a commit that includes them. (`sidebars.js` is NOT in this set: adding a new page legitimately requires a navigation entry, so `--non-interactive` may edit it. It stays visible in the diff and in the draft PR for human review.)
 - **Branch discipline holds.** Commits land on a properly prefixed feature branch (`cms/`, `cloud/`, `repo/`), never directly on `main` or `next`.
 - **git-rules.md governs the PR.** The commit message and PR title/description follow `git-rules.md` (imperative title, flat "This PR…" description, no headings, no test plan).
 - **The PR opens as a draft** for human review; auto mode does not merge it.
@@ -131,11 +131,11 @@ In a workflow stopped at a gate, show the summary up to the phase reached and st
 ## Rules
 
 - This skill never duplicates phase logic. It only resolves the subject, sequences phases, runs the fix loop, gates, and summarizes. Each phase is run by **invoking its top-level skill** (`/inki:research`, `/inki:write`, `/inki:review`, `/inki:submit`), never by re-implementing that phase's steps inline. In particular, the submit phase MUST go through `/inki:submit` (which itself invokes `/inki:branch` / `/inki:commit` / `/inki:push` / `/inki:pr`); do NOT branch, commit, push, or open the PR with raw `git` / `gh` commands here, as that drops behavior the sub-skills own (e.g. the `/inki:pr` Vercel preview link). Read-only git/gh inspection is fine; mutating git/gh by hand in place of a phase skill is a defect.
-- Default is **gated**: pause between every phase (research→write, write→review, review→submit). `--auto-approve` (aliases `--auto`, `--yes`, `-y`) removes the pauses but never the "already documented → stop" guard, the protected-path guard, or the branch discipline.
-- `--auto-approve` approves the review fix loop too: it applies fixes, it does not just surface them. This is safe here only because the draft was generated within this same run. Outside `/inki:document` (e.g. a bare `/inki:review` on an existing human-authored page), fixes still require explicit `--fix`.
+- Default is **gated**: pause between every phase (research→write, write→review, review→submit). `--non-interactive` (canonical), aliases `--auto-approve`, `--auto`, `--yes`, `-y`, `--no-questions-asked` (all equivalent) removes the pauses but never the "already documented → stop" guard, the protected-path guard, or the branch discipline.
+- `--non-interactive` approves the review fix loop too: it applies fixes, it does not just surface them. This is safe here only because the draft was generated within this same run. Outside `/inki:document` (e.g. a bare `/inki:review` on an existing human-authored page), fixes still require explicit `--fix`.
 - The fix loop runs at most `MAX_FIX_ROUNDS` times (default 3, `--fix-rounds <N>` to change). It never loops unbounded; remaining findings are reported, not forced.
 - If any phase fails, stop. Do not skip a phase.
-- The submit phase's safety guards are not optional and `--auto-approve` does not lift them: protected paths stay untouched, commits stay on a prefixed feature branch (never `main`/`next`), the PR follows `git-rules.md` and opens as a draft. See Step 5 for the explicit list.
+- The submit phase's safety guards are not optional and `--non-interactive` does not lift them: protected paths stay untouched, commits stay on a prefixed feature branch (never `main`/`next`), the PR follows `git-rules.md` and opens as a draft. See Step 5 for the explicit list.
 
 ## Examples
 
@@ -146,12 +146,12 @@ Document a topic from keywords, gating between each phase:
 
 Document from a Notion spec, fully automatic up to the draft PR (review-fix loop runs up to 3 rounds):
 ```
-/inki:document --auto-approve https://www.notion.so/strapi/Realtime-API-spec-abc123
+/inki:document --non-interactive https://www.notion.so/strapi/Realtime-API-spec-abc123
 ```
 
 Fully automatic, allowing up to 5 review-fix rounds for a tricky page:
 ```
-/inki:document --auto-approve --fix-rounds 5 "Document Service API filters"
+/inki:document --non-interactive --fix-rounds 5 "Document Service API filters"
 ```
 
 Document from a Linear issue:

--- a/claude-plugins/inki/skills/outline/SKILL.md
+++ b/claude-plugins/inki/skills/outline/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: outline
 description: "Generate an outline for a new documentation page from a topic brief and the appropriate template."
-argument-hint: "[--auto-approve] [--no-log] <topic brief or path to a brief file>"
+argument-hint: "[--non-interactive] [--no-log] <topic brief or path to a brief file>"
 user-invocable: true
 ---
 
@@ -11,7 +11,7 @@ user-invocable: true
 
 If `$ARGUMENTS` contains `--help` or `-h`, print usage and stop, per `../../references/help.md`. Do not run the skill.
 
-Otherwise, from `$ARGUMENTS`, detect the auto-approve flag anywhere in the list: `--auto-approve` (canonical), or its aliases `--auto`, `--yes`, `-y` (all equivalent). If present, set `AUTO=true` and remove the flag. What remains is the brief.
+Otherwise, from `$ARGUMENTS`, detect the autonomy flag anywhere in the list: `--non-interactive` (canonical), aliases `--auto-approve`, `--auto`, `--yes`, `-y`, `--no-questions-asked` (all equivalent). If present, set `AUTO=true` and remove the flag. What remains is the brief.
 
 Logging: unless `--no-log` is passed, write this skill's report to the run log per `../../references/logging.md` (`--log-dir <path>` and `--short-log` are also accepted). When invoked as part of an orchestrator (e.g. `/inki:write`), write into that run's existing directory instead of creating a new one.
 

--- a/claude-plugins/inki/skills/pitfalls-add/SKILL.md
+++ b/claude-plugins/inki/skills/pitfalls-add/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pitfalls-add
 description: "Add a new entry to the known-pitfalls catalog that pitfalls-check audits against. Verifies the correct pattern against the Strapi source before adding, and confirms with the user. Use when you have found a documentation mistake worth catching automatically in future reviews."
-argument-hint: "[--auto-approve] [--no-log] <description of the pitfall, or a pitfalls-check / code-verify finding to promote>"
+argument-hint: "[--non-interactive] [--no-log] <description of the pitfall, or a pitfalls-check / code-verify finding to promote>"
 user-invocable: true
 ---
 
@@ -13,7 +13,7 @@ The `pitfalls-checker` agent is read-only: it consults the catalog but never edi
 
 If `$ARGUMENTS` contains `--help` or `-h`, print usage and stop, per `../../references/help.md`. Do not modify the catalog.
 
-Otherwise, from `$ARGUMENTS`, detect `--auto-approve` (aliases `--auto`, `--yes`, `-y`) → `AUTO=true`. What remains describes the pitfall: either free text, or a finding copied from a `pitfalls-check` / `code-verify` report.
+Otherwise, from `$ARGUMENTS`, detect `--non-interactive` (canonical), aliases `--auto-approve`, `--auto`, `--yes`, `-y`, `--no-questions-asked` (all equivalent) → `AUTO=true`. What remains describes the pitfall: either free text, or a finding copied from a `pitfalls-check` / `code-verify` report.
 
 Logging: unless `--no-log` is passed, write this skill's report to the run log per `../../references/logging.md` (`--log-dir <path>` and `--short-log` are also accepted). This skill normally runs standalone (it creates its own run directory); if ever invoked as part of an orchestrator, write into that run's existing directory instead of creating a new one.
 

--- a/claude-plugins/inki/skills/pr-fix/SKILL.md
+++ b/claude-plugins/inki/skills/pr-fix/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pr-fix
-description: "Rewrite the title or description/body of one or more open PRs on strapi/documentation to match git-rules.md. Strict one-by-one confirmation, or auto-edit with --auto-approve."
-argument-hint: "<title|description|body> [--auto-approve] [--include-old] [--no-log] [PR# or URL] [PR# or URL] ..."
+description: "Rewrite the title or description/body of one or more open PRs on strapi/documentation to match git-rules.md. Strict one-by-one confirmation, or auto-edit with --non-interactive."
+argument-hint: "<title|description|body> [--non-interactive] [--include-old] [--no-log] [PR# or URL] [PR# or URL] ..."
 user-invocable: true
 ---
 
@@ -25,7 +25,7 @@ If no action is given, or if the first token is not one of the above, report the
 
 ### Optional flags (anywhere after the action)
 
-- `--auto-approve` (aliases `--auto`, `--yes`, `-y`) → `AUTO=true` (non-interactive: skip confirmation prompts)
+- `--non-interactive` (canonical), aliases `--auto-approve`, `--auto`, `--yes`, `-y`, `--no-questions-asked` (all equivalent) → `AUTO=true` (skip confirmation prompts)
 - `--include-old` → `INCLUDE_OLD=true` (only meaningful when no PR identifiers are given; includes open PRs older than 30 days)
 
 ### Optional PR identifiers
@@ -49,7 +49,7 @@ The 30-day cutoff uses `createdAt` (not `updatedAt`) because bot activity bumps 
 
 Logging: unless `--no-log` is passed, write this skill's report to the run log per `../../references/logging.md` (`--log-dir <path>` and `--short-log` are also accepted). This skill normally runs standalone (it creates its own run directory); if ever invoked as part of an orchestrator, write into that run's existing directory instead of creating a new one.
 1. Read the first positional token as `ACTION` (must be `title`, `description`, or `body`). Normalize `body` → `description` internally.
-2. Detect `--auto-approve` (aliases `--auto`/`--yes`/`-y`) → `AUTO=true`. Remove from list.
+2. Detect `--non-interactive` (canonical), aliases `--auto-approve`, `--auto`, `--yes`, `-y`, `--no-questions-asked` (all equivalent) → `AUTO=true`. Remove from list.
 3. Detect `--include-old` → `INCLUDE_OLD=true`. Remove from list.
 4. For each remaining token, extract trailing digits to get the PR number:
    - `2143` → `2143`
@@ -122,7 +122,7 @@ PR #<num>: edited (description rewritten)   (for description)
 A batch confirmation is required as a safety bracket. Display the full list of proposed edits first:
 
 ```
-Review batch (--auto-approve without PR IDs targets all recent open PRs):
+Review batch (--non-interactive without PR IDs targets all recent open PRs):
 
 | PR# | Author | Current | Proposed | Reason |     (for title)
 | PR# | Author | Reason | Preview of new description |  (for description)
@@ -281,15 +281,15 @@ Body alias (same behavior as description):
 
 Auto title rewrite on multiple PRs:
 ```
-/inki:pr-fix title --auto-approve 3204 3202 #3199
+/inki:pr-fix title --non-interactive 3204 3202 #3199
 ```
 
 Auto title rewrite on all recent open PRs (with batch review):
 ```
-/inki:pr-fix title --auto-approve
+/inki:pr-fix title --non-interactive
 ```
 
 Auto title rewrite on all open PRs including stale ones:
 ```
-/inki:pr-fix title --auto-approve --include-old
+/inki:pr-fix title --non-interactive --include-old
 ```

--- a/claude-plugins/inki/skills/review/SKILL.md
+++ b/claude-plugins/inki/skills/review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: review
 description: "Top-level review orchestrator: runs style-check, outline-check, outline-ux-analyzer, code-verify, coherence-check, and pitfalls-check on a file, directory, or PR."
-argument-hint: "[--auto-approve] [--fix] [--no-log] <path | filename | PR# | PR URL | docs.strapi.io URL | pasted content>"
+argument-hint: "[--non-interactive] [--fix] [--no-log] <path | filename | PR# | PR URL | docs.strapi.io URL | pasted content>"
 user-invocable: true
 ---
 
@@ -13,7 +13,7 @@ If `$ARGUMENTS` contains `--help` or `-h`, print usage and stop, per `../../refe
 
 Otherwise, from `$ARGUMENTS`, detect optional flags anywhere in the list:
 
-- `--auto-approve` (aliases `--auto`, `--yes`, `-y`) → `AUTO=true` (non-interactive: skip any confirmation gates inside sub-skills)
+- `--non-interactive` (canonical), aliases `--auto-approve`, `--auto`, `--yes`, `-y`, `--no-questions-asked` (all equivalent) → `AUTO=true` (skip any confirmation gates inside sub-skills; no questions asked)
 - `--fix` → `FIX=true` (apply auto-fixable findings from `style-check`)
 - `--no-log`, `--log-dir <path>`, `--short-log` → logging flags, handled per `../../references/logging.md`.
 
@@ -92,7 +92,7 @@ Run the `CLEANUP` command returned by the resolver (worktree teardown or temp-fi
 - `--fix` on a PR-scope review applies fixes inside the temporary worktree only (the one created by the resolver). The PR itself is NOT modified by `/inki:review`. To push the fixes, the user must `gh pr checkout <num>` themselves and apply the suggestions manually (or use `/inki:commit` + `/inki:push` after a manual checkout).
 - `--fix` on a `docs.strapi.io` URL review applies fixes inside the temporary `origin/main` worktree only (created by the resolver); that worktree is detached and torn down at cleanup, so nothing is written back. Surface the corrected content in the report, and tell the user to apply it on a real branch.
 - `--fix` on a pasted-content review applies fixes to the temp file only; there is no source file to write back to. Surface the corrected content in the report instead.
-- `--auto-approve` only changes interaction behavior (no extra prompts). It does NOT change what gets auto-fixed; that stays controlled by `--fix`.
+- `--non-interactive` only changes interaction behavior (no extra prompts). It does NOT change what gets auto-fixed; that stays controlled by `--fix`. So `--non-interactive --fix` means "ask no questions AND apply the auto-fixable findings"; `--non-interactive` alone reviews silently but changes nothing.
 - Never push, commit, or modify the PR directly. The review is read-only by default.
 
 ## Examples
@@ -136,5 +136,5 @@ title: My page
 
 Non-interactive review with auto-fixes applied locally:
 ```
-/inki:review --auto-approve --fix docusaurus/docs/cms/features/strapi-mcp-server.md
+/inki:review --non-interactive --fix docusaurus/docs/cms/features/strapi-mcp-server.md
 ```

--- a/claude-plugins/inki/skills/submit/SKILL.md
+++ b/claude-plugins/inki/skills/submit/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: submit
-description: "Top-level orchestrator: branch (if needed), commit, push, then open a PR. Each step asks for confirmation before continuing, unless --auto-approve is passed."
-argument-hint: "[--auto-approve] [--no-log] [issue reference or topic hint, e.g. 'Fixes #2143']"
+description: "Top-level orchestrator: branch (if needed), commit, push, then open a PR. Each step asks for confirmation before continuing, unless --non-interactive is passed."
+argument-hint: "[--non-interactive] [--no-log] [issue reference or topic hint, e.g. 'Fixes #2143']"
 user-invocable: true
 ---
 
@@ -11,7 +11,7 @@ user-invocable: true
 
 If `$ARGUMENTS` contains `--help` or `-h`, print usage and stop, per `../../references/help.md`. Do not run the workflow.
 
-Otherwise, from `$ARGUMENTS`, detect the auto-approve flag anywhere in the list: `--auto-approve` (canonical), or its aliases `--auto`, `--yes`, `-y` (all equivalent). If present, set `AUTO=true` and remove the flag. What remains is the optional issue reference passed through to `/inki:pr`.
+Otherwise, from `$ARGUMENTS`, detect the autonomy flag anywhere in the list: `--non-interactive` (canonical), aliases `--auto-approve`, `--auto`, `--yes`, `-y`, `--no-questions-asked` (all equivalent). If present, set `AUTO=true` and remove the flag. What remains is the optional issue reference passed through to `/inki:pr`.
 
 Logging: unless `--no-log` is passed, write this skill's report to the run log per `../../references/logging.md` (`--log-dir <path>` and `--short-log` are also accepted). When invoked as part of an orchestrator (e.g. `/inki:document`), write into that run's existing directory instead of creating a new one.
 
@@ -30,13 +30,13 @@ The user confirms at each gate. If any sub-step fails or the user cancels, stop 
 
 ### Auto (`AUTO=true`)
 
-Pass `--auto-approve` to each sub-skill that supports it. The chain runs without prompts. If any sub-skill genuinely needs a decision that isn't trivially auto-derivable (e.g., branch prefix is ambiguous and no hint was provided), it will still ask. `--auto-approve` skips confirmations, not informed decisions.
+Pass `--non-interactive` to each sub-skill that supports it. The chain runs without prompts. If any sub-skill genuinely needs a decision that isn't trivially auto-derivable (e.g., branch prefix is ambiguous and no hint was provided), it will still ask. `--non-interactive` skips confirmations, not informed decisions.
 
 The safety bracket from `pr-fix` does NOT apply here, because `/inki:submit` operates only on the current branch (single PR scope by construction).
 
 ## Rules
 
-- **Always invoke the sub-skills; never substitute raw `git` / `gh` commands for them.** Each of branch, commit, push, and PR is delegated to `/inki:branch`, `/inki:commit`, `/inki:push`, `/inki:pr` respectively. Running `git commit`, `git push`, or `gh pr create` by hand instead is a defect, even when it appears to produce the same result: it bypasses checks and additions the sub-skills own (branch-prefix validation, commit-message rules, the `/inki:pr` Vercel preview link, draft-PR defaults). `--auto-approve` removes confirmation prompts; it does NOT authorize bypassing the sub-skills. The only direct git/gh allowed here is read-only inspection (`git status`, `git rev-parse`, `gh pr view`) to decide what to pass to a sub-skill.
+- **Always invoke the sub-skills; never substitute raw `git` / `gh` commands for them.** Each of branch, commit, push, and PR is delegated to `/inki:branch`, `/inki:commit`, `/inki:push`, `/inki:pr` respectively. Running `git commit`, `git push`, or `gh pr create` by hand instead is a defect, even when it appears to produce the same result: it bypasses checks and additions the sub-skills own (branch-prefix validation, commit-message rules, the `/inki:pr` Vercel preview link, draft-PR defaults). `--non-interactive` removes confirmation prompts; it does NOT authorize bypassing the sub-skills. The only direct git/gh allowed here is read-only inspection (`git status`, `git rev-parse`, `gh pr view`) to decide what to pass to a sub-skill.
 - If any sub-step fails, stop. Do not skip a step.
 - Pass through the issue reference (if any) to `/inki:pr`.
 - In `AUTO=true` mode, surface a summary at the end showing branch name, commit SHA, and PR URL.

--- a/claude-plugins/inki/skills/write/SKILL.md
+++ b/claude-plugins/inki/skills/write/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: write
 description: "Top-level write orchestrator: outline a new page, get user approval, then draft from the outline."
-argument-hint: "[--auto-approve] [--no-log] <topic brief or path to a brief file>"
+argument-hint: "[--non-interactive] [--no-log] <topic brief or path to a brief file>"
 user-invocable: true
 ---
 
@@ -11,7 +11,7 @@ user-invocable: true
 
 If `$ARGUMENTS` contains `--help` or `-h`, print usage and stop, per `../../references/help.md`. Do not run the workflow.
 
-Otherwise, from `$ARGUMENTS`, detect the auto-approve flag anywhere in the list: `--auto-approve` (canonical), or its aliases `--auto`, `--yes`, `-y` (all equivalent). If present, set `AUTO=true` and remove the flag. What remains is the topic brief (text or path to a `.md` file).
+Otherwise, from `$ARGUMENTS`, detect the autonomy flag anywhere in the list: `--non-interactive` (canonical), aliases `--auto-approve`, `--auto`, `--yes`, `-y`, `--no-questions-asked` (all equivalent). If present, set `AUTO=true` and remove the flag. What remains is the topic brief (text or path to a `.md` file).
 
 Logging: unless `--no-log` is passed, write this skill's report to the run log per `../../references/logging.md` (`--log-dir <path>` and `--short-log` are also accepted). When invoked as part of an orchestrator (e.g. `/inki:document`), write into that run's existing directory instead of creating a new one.
 
@@ -26,10 +26,10 @@ If the user rejects the outline, stop. Do not draft.
 
 ### Auto (`AUTO=true`)
 
-1. Invoke `/inki:outline --auto-approve $ARGUMENTS`. The outline is generated and saved without an approval gate.
+1. Invoke `/inki:outline --non-interactive $ARGUMENTS`. The outline is generated and saved without an approval gate.
 2. Immediately invoke `/inki:draft <outline-path>` on the resulting outline.
 
-In auto mode, the user sees the outline and the draft only after both are produced. They can still discard the outputs if they don't fit; nothing is committed automatically. `--auto-approve` here means "don't pause between outline and draft," not "trust the output blindly."
+In auto mode, the user sees the outline and the draft only after both are produced. They can still discard the outputs if they don't fit; nothing is committed automatically. `--non-interactive` here means "don't pause between outline and draft," not "trust the output blindly."
 
 ## Rules
 


### PR DESCRIPTION
This PR renames the inki autonomy flag to `--non-interactive` (canonical) across every skill that takes it, keeping `--auto-approve`, `--auto`, `--yes`, `-y`, and `--no-questions-asked` as aliases. The new name makes the effect self-evident: it suppresses confirmation prompts and does not, on its own, change what gets written. Also clarifies in the README and the review skill that `--non-interactive` and `--fix` are two independent flags, and bumps inki to v0.2.2.