### PR TITLE
Document Strapi Cloud admin variable limitation

### DIFF
--- a/docusaurus/docs/cloud/projects/settings.md
+++ b/docusaurus/docs/cloud/projects/settings.md
@@ -535,6 +535,10 @@ Media library queries over REST or GraphQL always return the project media domai
 
 Environment variables (more information in the [CMS Documentation](/cms/configurations/environment)) are used to configure the environment of your Strapi application, such as the database connection.
 
+:::note
+Custom variables are available to the Strapi server at runtime. Variables prefixed with `STRAPI_ADMIN_` are not exposed to the admin front end on Strapi Cloud.
+:::
+
 <ThemedImage
   alt="Project variables"
   sources={{

--- a/docusaurus/docs/cms/configurations/environment.md
+++ b/docusaurus/docs/cms/configurations/environment.md
@@ -52,6 +52,8 @@ Strapi provides the following environment variables:
 
 :::tip
 Prefixing an environment variable name with `STRAPI_ADMIN_` exposes the variable to the admin front end (e.g., `STRAPI_ADMIN_MY_PLUGIN_VARIABLE` is accessible through `process.env.STRAPI_ADMIN_MY_PLUGIN_VARIABLE`).
+
+This works when the admin panel is built from your project, for example in self-hosted deployments. Strapi Cloud does not expose `STRAPI_ADMIN_*` variables to the admin front end.
 :::
 
 ### Example `.env` file

--- a/docusaurus/docs/cms/plugins-development/admin-panel-api.md
+++ b/docusaurus/docs/cms/plugins-development/admin-panel-api.md
@@ -247,7 +247,9 @@ The WYSIWYG editor can be replaced by taking advantage of [custom fields](/cms/f
 :::
 
 :::info
-The admin panel supports dotenv variables.
+The admin panel supports dotenv variables in self-hosted projects.
 
 All variables defined in a `.env` file and prefixed by `STRAPI_ADMIN_` are available while customizing the admin panel through `process.env`.
+
+This dotenv exposure does not apply to Strapi Cloud projects.
 :::


### PR DESCRIPTION
This PR documents that `STRAPI_ADMIN_*` variables are available when the admin panel is built from a self-hosted project, but are not exposed to the admin front end on Strapi Cloud.
- Adds the limitation to the environment variables reference
- Adds the same distinction to the plugin Admin Panel API note
- Adds a Cloud variables note for Cloud users

Closes #2666