### PR TITLE
Restrict MCP capability registration to register() and rename the tools group

### DIFF
--- a/docusaurus/docs/cms/features/strapi-mcp-server.md
+++ b/docusaurus/docs/cms/features/strapi-mcp-server.md
@@ -213,9 +213,9 @@ The MCP server uses the Streamable HTTP transport protocol. Any MCP-compatible c
 
 ### Available tools
 
-The MCP server exposes 2 categories of tools: content-type tools generated from your schema, and built-in utility tools.
+The MCP server exposes 2 categories of tools: content management tools generated from your schema, and built-in utility tools.
 
-#### Content-type tools
+#### Content management tools
 
 The tools generated differ depending on whether the content type is a collection type or a single type.
 
@@ -248,7 +248,7 @@ The publish, unpublish, and discard_draft tools are only generated when [Draft &
 
 #### Built-in utility tools
 
-In addition to content-type tools, Strapi registers the following built-in tools:
+In addition to content management tools, Strapi registers the following built-in tools:
 
 | Tool | Availability | Description |
 |------|-------------|-------------|

--- a/docusaurus/docs/cms/plugins-development/extend-mcp-server.md
+++ b/docusaurus/docs/cms/plugins-development/extend-mcp-server.md
@@ -16,12 +16,12 @@ tags:
 # Extending the MCP server with plugins
 
 <Tldr>
-Strapi plugins can register additional MCP tools through the `strapi.ai.mcp` service. Registrations must happen while the MCP server is idle (during the plugin's `register()` or `bootstrap()` lifecycle phase), before the server starts.
+Strapi plugins can register additional MCP tools through the `strapi.ai.mcp` service. Registrations must happen while the MCP server is idle (during the plugin's `register()` lifecycle phase), before the server starts.
 </Tldr>
 
 Strapi includes a built-in [Model Context Protocol (MCP) server](/cms/features/strapi-mcp-server) that exposes content management tools to AI clients. In addition to the content-type tools generated from your schema, plugins can register their own custom tools so AI clients can trigger plugin-specific actions.
 
-Registrations must happen while the MCP server is idle, before it starts. In Strapi's load lifecycle, register a tool during the plugin's `register()` or `bootstrap()` phase. Prefer `bootstrap()` when a tool depends on synced content-types, permissions, or database state.
+Registrations must happen while the MCP server is idle, before it starts. In Strapi's load lifecycle, register a tool during the plugin's `register()` phase.
 
 ## Registering a custom tool
 


### PR DESCRIPTION
This PR corrects the MCP server documentation on two points:
* It restricts plugin capability registration to the register() lifecycle phase only (removing bootstrap() as a documented option, since its edge cases are too narrow to recommend), 
* and renames the schema-generated "Content-type tools" group to "Content management tools" for clarity.

Direct preview link 👉 [here](https://documentation-git-cms-mcp-register-lifecycle-an-cd61bf-strapijs.vercel.app/cms/features/strapi-mcp-server)
