### PR TITLE
Make `inki:pr` derive the Vercel preview host robustly for long branch names

### DIFF
--- a/claude-plugins/inki/skills/pr/SKILL.md
+++ b/claude-plugins/inki/skills/pr/SKILL.md
@@ -19,19 +19,52 @@ Read and follow `../_shared/pr-rules.md` for: gathering context, analyzing chang
 
 ## Step 2: Add Vercel preview link
 
-Append a Vercel preview link as the last line of the PR body. Build it from the branch name:
-
-1. Get the branch name and replace `/` with `-` to get the slug (e.g., `cms/mcp-server` → `cms-mcp-server`)
-2. Identify the primary page path from the changed files (the most important new or modified `.md` file under `docusaurus/docs/`, stripped of the `docusaurus/docs/` prefix and `.md` extension)
-3. Append this line to the body:
+Append a Vercel preview link as the last line of the PR body, in the form:
 
 ```
-Direct preview link 👉 [here](https://documentation-git-<branch-slug>-strapijs.vercel.app/<page-path>)
+Direct preview link 👉 [here](<host><page-path>)
 ```
 
 For example: `https://documentation-git-cms-mcp-server-strapijs.vercel.app/cms/features/strapi-mcp-server`
 
-**When no page under `docusaurus/docs/` is changed** (for example a `repo/` PR touching only `claude-plugins/`, config, or tooling), there is no doc page to preview: **omit this line entirely** rather than building a link to a page that does not exist. Do not fall back to the preview root.
+The link has two parts: the **deployment host** and the **page path**. Build the page path first, then the host.
+
+### Page path
+
+Identify the primary page path from the changed files: the most important new or modified `.md`/`.mdx` file under `docusaurus/docs/`, stripped of the `docusaurus/docs/` prefix and the `.md`/`.mdx` extension (e.g. `docusaurus/docs/cms/features/users-permissions.md` → `/cms/features/users-permissions`). Prefer a newly added page over a modified one.
+
+**When no page under `docusaurus/docs/` is changed** (for example a `repo/` PR touching only `claude-plugins/`, config, or tooling), there is no doc page to preview: **omit the preview line entirely** rather than building a link to a page that does not exist. Do not fall back to the preview root. Skip the rest of this step.
+
+### Deployment host
+
+Vercel deploys this branch to `https://documentation-git-<slug>-strapijs.vercel.app`, where `<slug>` is the branch name with `/` replaced by `-` (e.g. `cms/mcp-server` → `cms-mcp-server`). **But Vercel truncates long branch slugs** to fit the ~63-char DNS label and appends a short hash, so the slug-built host is only reliable for short branches. The full host (`documentation-git-` + slug + `-strapijs`) must fit in 63 chars, which leaves **35 characters for the slug**.
+
+Note that at PR-creation time the Vercel bot comment does not exist yet (Vercel reacts to the PR after it is opened, ~1-2 min later), so the real host with its hash cannot be read up front. Handle the two cases:
+
+**A. Short branch (slug ≤ 35 characters):** the slug-built host is reliable. Use it directly:
+
+```
+https://documentation-git-<slug>-strapijs.vercel.app/<page-path>
+```
+
+Optionally verify with `curl -s -o /dev/null -w '%{http_code}' -L --max-time 25 "<url>"` (expect `200`).
+
+**B. Long branch (slug > 35 characters):** the slug-built host will be truncated and will not resolve. The real host is only known once Vercel posts its comment. After creating the PR (Step 3), poll for the Vercel bot comment, then edit the description:
+
+1. Poll up to 3 times, ~30s apart (≈90s total), for the Vercel comment host:
+   ```bash
+   gh pr view <num> --repo strapi/documentation --json comments \
+     -q '.comments[] | select(.author.login | test("vercel"; "i")) | .body' \
+     | grep -oE 'https://documentation-git-[a-z0-9-]+\.vercel\.app' | sort -u | head -1
+   ```
+2. If a host is found, assemble `<host>/<page-path>`, verify it returns `200` with `curl`, and edit the PR description (`gh pr edit <num> --repo strapi/documentation --body ...`) to use the correct link.
+3. If no host appears within the poll window, leave the slug-built link in place but append, on its own line right after the preview link, an explicit warning so it gets fixed later:
+   ```
+   ⚠️ The branch slug for this preview URL is <N> characters long (over the 35-character limit), so the URL above is likely truncated and incorrect. It must be fixed with `/inki:pr-fix` once Vercel has finished building the preview.
+   ```
+   where `<N>` is the actual slug length.
+
+Order note: the PR is created in Step 1 (via the shared PR rules). Build the preview link as part of the body you propose there, but case A's optional `curl` verification and case B's polling + description edit necessarily run **after** the PR exists.
 
 ## Step 3: Suggest push first if needed
 


### PR DESCRIPTION
This PR fixes the inki:pr skill so it no longer builds a broken Vercel preview link for long branch names. Vercel truncates branch slugs longer than 35 characters to fit the 63-char DNS label and appends a short hash, so the naive slug-built host fails to resolve. The skill now uses the slug directly only for short branches, and for long branches it polls the Vercel bot comment after PR creation to read the real host and edits the description, or leaves an explicit warning to fix the link with /inki:pr-fix once the build completes.