### PR TITLE
Document admin logo transfer in data export/import

### DIFF
--- a/docusaurus/docs/cms/features/data-management.md
+++ b/docusaurus/docs/cms/features/data-management.md
@@ -126,6 +126,10 @@ export default ({ env }) => ({
 
 </Tabs>
 
+:::info
+When exporting or transferring data, the admin panel configuration includes project settings such as logos (admin menu logo and authentication logo). These logo files are embedded in the export and re-uploaded to the destination instance during import. This ensures that transferred instances maintain their branding without additional manual setup.
+:::
+
 ## Usage
 
 The Data Management system is CLI-based only, meaning any import, export, or transfer command must be executed from the terminal. Exhaustive documentation for each command is accessible from the following pages:


### PR DESCRIPTION
This PR updates documentation based on https://github.com/strapi/strapi/pull/26425.

## Summary
- Clarifies that admin panel logos (menu and authentication logos) are transferred during data export, import, and transfer operations
- Explains that logos are embedded in the configuration stage and re-uploaded during import
- Notes that users no longer need manual setup after transfer to restore branding

Generated automatically by the docs self-healing workflow (micro-edit, Haiku).