### PR TITLE
Add folder sidebar navigation section to Media Library docs

### DIFF
--- a/docusaurus/docs/cms/features/media-library.md
+++ b/docusaurus/docs/cms/features/media-library.md
@@ -780,6 +780,20 @@ To navigate back to the parent folder, one level up, use the **Back** button at 
 The breadcrumb navigation can also be used to go back to a parent folder: click on a folder name to directly jump to it or click on the 3 dots `/img.` and select a parent folder from the drop-down list.
 :::
 
+#### Navigating with the folder sidebar
+
+<!-- TODO: Confirm whether this feature requires a future flag to enable the revamped Media Library -->
+
+The Media Library includes a persistent folder sidebar on the left side of the interface. The sidebar displays the complete folder hierarchy, loaded from the `GET /upload/folder-structure` endpoint, so you can browse nested folders without clicking through each level in the main content area.
+
+The sidebar shows a **Home** entry at the top, followed by all nested folders. Clicking a folder in the sidebar updates the main content area to show that folder's assets. The selected folder is reflected in the `?folder=` URL parameter.
+
+Ancestors of the active folder expand automatically in the sidebar, giving you a visual indicator of your current location within the hierarchy.
+
+If the URL contains an invalid or missing folder ID, the Media Library redirects to the root folder.
+
+<!-- unverified: sidebar component behavior based on PR #26551 description; exact feature flag name unknown -->
+
 #### Adding folders
 
 1. Click on **Add new folder** in the upper right of the Media Library interface.
@@ -788,8 +802,9 @@ The breadcrumb navigation can also be used to go back to a parent folder: click 
 4. Click **Create**.
 
 :::note
-There is no limit to how deep your folders hierarchy can go, but bear in mind it might take some effort to reach a deeply nested subfolder, as the Media Library currently has no visual hierarchy indication. Searching for files using the <Icon name="magnifying-glass" classes="ph-bold" /> on the right side of the user interface might be a faster alternative to finding the asset you are looking for.
+There is no limit to how deep your folders hierarchy can go, but bear in mind it might take some effort to reach a deeply nested subfolder. Searching for files using the <Icon name="magnifying-glass" classes="ph-bold" /> on the right side of the user interface might be a faster alternative to finding the asset you are looking for.
 :::
+<!-- TODO: Update or remove this note once the folder sidebar (see "Navigating with the folder sidebar") is confirmed as generally available, since the sidebar does provide visual hierarchy indication -->
 
 #### Moving assets to a folder
 


### PR DESCRIPTION
This PR updates documentation based on https://github.com/strapi/strapi/pull/26551.

Generated automatically by the docs self-healing workflow.
Review before merging.

## What changed

Added a new **"Navigating with the folder sidebar"** section (H4) inside `### Organizing assets with folders` in `docusaurus/docs/cms/features/media-library.md`.

The section documents:
- The persistent folder sidebar that displays the full folder hierarchy
- How the sidebar loads from `GET /upload/folder-structure`
- Folder selection behavior and `?folder=` URL parameter sync
- Automatic ancestor expansion for the active folder
- Redirect to root on invalid/missing folder ID

Also updated the `:::note` in `#### Adding folders` to remove the now-stale claim that the Media Library has no visual hierarchy indication.

## TODOs for reviewer

- **Feature flag**: Confirm whether this sidebar requires enabling a future flag for the revamped Media Library. If it does, add the appropriate flag documentation and badge. If it's GA, remove the `<!-- TODO -->` comment.
- **Screenshot**: Consider adding a screenshot showing the sidebar in context.
- **Stale note**: The `<!-- TODO -->` comment on the `Adding folders` note flags it for removal/update once the sidebar is confirmed GA.