### PR TITLE
Add workflow to comment a soft-freeze notice on new external PRs

### DIFF
--- a/.github/workflows/soft-freeze-notice.yml
+++ b/.github/workflows/soft-freeze-notice.yml
@@ -1,0 +1,40 @@
+name: Soft freeze notice
+
+# Posts a friendly heads-up comment on each new PR opened against `main`
+# while the temporary "soft" contribution freeze is in effect (see #3283).
+# Skips PRs opened by the maintainer (pwizla) and by Claude.
+
+on:
+  pull_request_target:
+    types: [opened]
+    branches: [main]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    # Skip PRs from the maintainer or from Claude.
+    if: >-
+      github.event.pull_request.user.login != 'pwizla' &&
+      github.event.pull_request.user.login != 'claude'
+    steps:
+      - name: Post soft-freeze notice
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = [
+              '👋 Thanks for your contribution!',
+              '',
+              'We\'re currently in a **temporary "soft" contribution freeze** while finalizing a major redesign of the docs (see #3283).',
+              '',
+              'Your PR is welcome and will be reviewed, but merging may take a little longer than usual over the next few days. Thanks for your patience! 🙏',
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body,
+            });


### PR DESCRIPTION
This PR adds a GitHub Actions workflow that posts a short, friendly notice on each new PR opened against main during the temporary soft contribution freeze, letting contributors know review and merging may take a little longer. It skips PRs opened by pwizla and claude. Relates to #3283