### PR TITLE
Document license sync delay when changing Growth plan seats

### DIFF
--- a/docusaurus/docs/cms/billing-portal.md
+++ b/docusaurus/docs/cms/billing-portal.md
@@ -77,7 +77,7 @@ When you add seats or enable the SSO add-on, you are charged a prorated amount i
 
 When you remove seats or disable the SSO add-on, the change takes effect at the next renewal. Your current seat count and add-ons stay active until then.
 
-If you add seats and disable SSO in the same change, the seat increase is charged immediately (with the sync delay above). SSO removal is still deferred to the next renewal.
+If you add seats and disable SSO in the same change, the seat increase is charged immediately. SSO removal is still deferred to the next renewal.
 :::
 
 ### Canceling a Growth subscription

--- a/docusaurus/docs/cms/billing-portal.md
+++ b/docusaurus/docs/cms/billing-portal.md
@@ -80,6 +80,10 @@ When you remove seats or disable the SSO add-on, the change takes effect at the 
 If you add seats and disable SSO in the same change, the seat increase applies immediately with a prorated charge. SSO removal is still deferred to the next renewal.
 :::
 
+:::tip
+Your Strapi CMS instance checks for license updates on startup and every 12 hours. After adding seats, new seats may take up to 12 hours to appear in the admin panel. To apply changes immediately, restart your Strapi instance.
+:::
+
 ### Canceling a Growth subscription
 
 To cancel an active Growth subscription:

--- a/docusaurus/docs/cms/billing-portal.md
+++ b/docusaurus/docs/cms/billing-portal.md
@@ -73,15 +73,11 @@ To update the seat count or add-ons of an active Growth subscription:
 4. Click **Confirm** to apply the changes.
  
 :::note
-When you add seats or enable the SSO add-on, the billing change applies immediately. You are charged a prorated amount for the remainder of the current billing period.
+When you add seats or enable the SSO add-on, you are charged a prorated amount immediately. However, your Strapi CMS instance checks for license updates on startup and every 12 hours, so new seats may take up to 12 hours to appear in the admin panel. To apply the change sooner, restart your Strapi instance.
 
 When you remove seats or disable the SSO add-on, the change takes effect at the next renewal. Your current seat count and add-ons stay active until then.
 
-If you add seats and disable SSO in the same change, the seat increase applies immediately with a prorated charge. SSO removal is still deferred to the next renewal.
-:::
-
-:::tip
-Your Strapi CMS instance checks for license updates on startup and every 12 hours, so new seats may take up to 12 hours to appear in the admin panel. To apply the change sooner, restart your Strapi instance.
+If you add seats and disable SSO in the same change, the seat increase is charged immediately (with the sync delay above). SSO removal is still deferred to the next renewal.
 :::
 
 ### Canceling a Growth subscription

--- a/docusaurus/docs/cms/billing-portal.md
+++ b/docusaurus/docs/cms/billing-portal.md
@@ -73,7 +73,7 @@ To update the seat count or add-ons of an active Growth subscription:
 4. Click **Confirm** to apply the changes.
  
 :::note
-When you add seats or enable the SSO add-on, the change applies immediately. You are charged a prorated amount for the remainder of the current billing period.
+When you add seats or enable the SSO add-on, the billing change applies immediately. You are charged a prorated amount for the remainder of the current billing period.
 
 When you remove seats or disable the SSO add-on, the change takes effect at the next renewal. Your current seat count and add-ons stay active until then.
 
@@ -81,7 +81,7 @@ If you add seats and disable SSO in the same change, the seat increase applies i
 :::
 
 :::tip
-Your Strapi CMS instance checks for license updates on startup and every 12 hours. After adding seats, new seats may take up to 12 hours to appear in the admin panel. To apply changes immediately, restart your Strapi instance.
+Your Strapi CMS instance checks for license updates on startup and every 12 hours, so new seats may take up to 12 hours to appear in the admin panel. To apply the change sooner, restart your Strapi instance.
 :::
 
 ### Canceling a Growth subscription


### PR DESCRIPTION
This PR adds a tip to the billing portal page explaining that Strapi reloads the online license on startup and every 12 hours. After adding seats, users may need to restart their Strapi instance for changes to appear immediately.

Direct preview link 👉 [here](https://documentation-git-docs-billing-portal-license-sync-strapijs.vercel.app/cms/billing-portal)