### PR TITLE
Raise self-healing workflow max-turns to prevent mid-run failures

### DIFF
--- a/.github/workflows/docs-self-healing.yml
+++ b/.github/workflows/docs-self-healing.yml
@@ -273,7 +273,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_SELF_HEALING_DOCS_API_KEY }}
           github_token: ${{ secrets.PAT_TOKEN_PIWI }}
           prompt: ${{ steps.load-triage-prompt.outputs.prompt }}
-          claude_args: '--model claude-haiku-4-5-20251001 --max-turns 10 --allowedTools "Bash,Read"'
+          claude_args: '--model claude-haiku-4-5-20251001 --max-turns 20 --allowedTools "Bash,Read"'
           show_full_output: true
         env:
           FILTERED_PRS: ${{ steps.check-prs.outputs.pr_list }}
@@ -484,7 +484,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_SELF_HEALING_DOCS_API_KEY }}
           github_token: ${{ secrets.PAT_TOKEN_PIWI }}
           prompt: ${{ steps.load-drafter-prompt.outputs.prompt }}
-          claude_args: '--model claude-sonnet-4-6 --max-turns 25 --allowedTools "Bash,Read,Write,Edit,Glob,Grep"'
+          claude_args: '--model claude-sonnet-4-6 --max-turns 50 --allowedTools "Bash,Read,Write,Edit,Glob,Grep"'
           show_full_output: true
         env:
           DOC_REPO: ${{ github.workspace }}


### PR DESCRIPTION
This PR raises the `--max-turns` limits in the docs self-healing workflow, which were too low and occasionally caused the run to fail mid-pipeline. The triage step (Haiku) goes from 10 to 20 and the drafter step (Sonnet) goes from 25 to 50. This is the same change already included in the v7 redesign PR (#3281), split out as a standalone PR so it can land in main right away.