### PR TITLE
Fix selection feedback failing on the n8n webhook

### DIFF
--- a/docusaurus/src/components/PageFeedback/index.jsx
+++ b/docusaurus/src/components/PageFeedback/index.jsx
@@ -38,6 +38,12 @@ const PageFeedback = forwardRef(function PageFeedback({ pagePath, pageId, pageTi
       setLastComment(comment);
       setStage('submitting');
       try {
+        // The n8n webhook treats `selection` as a plain string (it calls
+        // .slice() on it). Sending the {text, sectionHeading, anchor} object
+        // here broke it with "(body.selection || '').slice is not a function".
+        // Send the selected text as a string, and pass the heading/anchor
+        // context in separate fields so nothing is lost.
+        const sel = selectionData?.selection;
         await submitFeedback({
           kind: selectionData?.kind || 'page',
           vote,
@@ -45,7 +51,9 @@ const PageFeedback = forwardRef(function PageFeedback({ pagePath, pageId, pageTi
           pagePath,
           pageId,
           pageTitle,
-          selection: selectionData?.selection || undefined,
+          selection: sel?.text || undefined,
+          selectionHeading: sel?.sectionHeading || undefined,
+          selectionAnchor: sel?.anchor || undefined,
           _hp: hp || undefined,
         });
         setStage('done');


### PR DESCRIPTION
This PR fixes the page-feedback widget failing when leaving feedback on a text or code selection. The widget sent `selection` as an object, but the n8n webhook treats it as a string and calls `.slice()` on it, which threw `(body.selection || "").slice is not a function`. It now sends `selection` as the selected text string and passes the heading and anchor context in separate `selectionHeading` and `selectionAnchor` fields. Page votes are unaffected and the in-page selection preview is unchanged.