### PR TITLE
Fix docs-next parking: redirect docs sections to the landing page

### DIFF
--- a/docusaurus/vercel.json
+++ b/docusaurus/vercel.json
@@ -1,6 +1,51 @@
 {
   "redirects": [
     {
+      "source": "/",
+      "destination": "/docs-next-parked.html",
+      "permanent": false
+    },
+    {
+      "source": "/cms/:path*",
+      "destination": "/docs-next-parked.html",
+      "permanent": false
+    },
+    {
+      "source": "/cloud/:path*",
+      "destination": "/docs-next-parked.html",
+      "permanent": false
+    },
+    {
+      "source": "/snippets/:path*",
+      "destination": "/docs-next-parked.html",
+      "permanent": false
+    },
+    {
+      "source": "/tags/:path*",
+      "destination": "/docs-next-parked.html",
+      "permanent": false
+    },
+    {
+      "source": "/tags",
+      "destination": "/docs-next-parked.html",
+      "permanent": false
+    },
+    {
+      "source": "/whats-new",
+      "destination": "/docs-next-parked.html",
+      "permanent": false
+    },
+    {
+      "source": "/release-notes",
+      "destination": "/docs-next-parked.html",
+      "permanent": false
+    },
+    {
+      "source": "/release-notes-archives",
+      "destination": "/docs-next-parked.html",
+      "permanent": false
+    },
+    {
       "source": "/cloud",
       "destination": "/cloud/intro",
       "permanent": true
@@ -3733,12 +3778,6 @@
       "source": "/cms/providers#configuring-providers",
       "destination": "/cms/features/media-library#providers",
       "permanent": true
-    }
-  ],
-  "rewrites": [
-    {
-      "source": "/(.*)",
-      "destination": "/docs-next-parked.html"
     }
   ]
 }


### PR DESCRIPTION
This PR fixes the docs-next parking from #3295, which did not work: Vercel serves existing build files before applying a `rewrite`, so the Docusaurus pages (`/`, `/cms/*`, `/cloud/*`, ...) were still served and only unknown URLs reached the landing. Redirects run before static file serving, so this switches to redirects: at the top of the redirects list it sends the site root and every top-level docs section (cms, cloud, snippets, tags, whats-new, release-notes, release-notes-archives) to `/docs-next-parked.html`. These sources never match the landing or `robots.txt`, so there is no loop, and they all compile with Vercel path-to-regexp. This targets the `next` branch only and must not reach `main`.