### PR TITLE
Add an Install Strapi Docs MCP entry to the toolbar dropdown

### DIFF
--- a/docusaurus/src/components/AiToolbar/config/aiToolsConfig.js
+++ b/docusaurus/src/components/AiToolbar/config/aiToolsConfig.js
@@ -42,6 +42,14 @@ export const aiToolsConfig = {
       openIn: '_blank',
     },
     {
+      id: 'install-mcp',
+      label: 'Install Strapi Docs MCP',
+      description: 'Connect your AI assistant to the Strapi docs MCP server',
+      icon: 'plugs',
+      actionType: 'navigate',
+      url: '/cms/ai/docs-mcp-server',
+    },
+    {
       id: 'view-llms',
       label: 'View LLMs.txt',
       description: 'Lightweight version for AI models',


### PR DESCRIPTION
This PR adds an Install Strapi Docs MCP entry to the page toolbar dropdown, right after Open with Claude. The existing Open with ChatGPT and Open with Claude buttons let non-technical readers use the docs with an LLM in one click; this new entry points users who want a persistent connection to the [docs MCP server instructions](/cms/ai/docs-mcp-server). It reuses the existing navigate action, opening the page in a new tab.

Direct preview link 👉 [here](https://documentation-git-cms-add-mcp-button-toolbar-strapijs.vercel.app/cms/api/rest) (open the dropdown next to Copy Markdown)