### PR TITLE
Fix scrollbar and unequal heights on doc cards

### DIFF
--- a/docusaurus/docs/cloud/getting-started/intro.md
+++ b/docusaurus/docs/cloud/getting-started/intro.md
@@ -48,8 +48,8 @@ The typical workflow, which is recommended by the Strapi team, is:
 The Strapi Cloud documentation is organised in topics in a order that should correspond to your journey with the product. The following cards, on which you can click, will redirect you to the main topics and steps.
 
 <CustomDocCardsWrapper>
-  <CustomDocCard emoji="☁️" title="Project creation" description="Step-by-step guide to guide you through the creation and deployment of a Strapi Cloud project." link="/cloud/getting-started/deployment" />
-  <CustomDocCard emoji="💸" title="Information on billing & usage" description="All details on Strapi Cloud plans & billing, including overages and project suspension." link="/cloud/getting-started/usage-billing" />
+  <CustomDocCard emoji="☁️" title="Project creation" description="Step-by-step guide to creating and deploying a Strapi Cloud project." link="/cloud/getting-started/deployment" />
+  <CustomDocCard emoji="💸" title="Information on billing & usage" description="Strapi Cloud plans, billing, overages, and project suspension." link="/cloud/getting-started/usage-billing" />
   <CustomDocCard emoji="🗃️" title="Projects overview" description="Information on how to access Strapi Cloud projects to view their details & usage, and manage them." link="/cloud/projects/overview" />
   <CustomDocCard emoji="⚙️" title="Projects settings" description="Details on all the available settings for Strapi Cloud projects and how to configure them." link="/cloud/projects/settings"/>
   <CustomDocCard emoji="🤝" title="Collaboration" description="Documentation for the Collaboration feature to invite other users to access and manage a project." link="/cloud/projects/collaboration"/>

--- a/docusaurus/src/scss/custom-doc-cards.scss
+++ b/docusaurus/src/scss/custom-doc-cards.scss
@@ -17,6 +17,14 @@
     margin-bottom: 0;
     flex: initial;
     min-width: 0;
+    // The visible card border lives on the inner `<a.cardContainer>`, not on
+    // this `<article>` grid cell. `align-items: stretch` stretches the cell to
+    // the tallest card in the row, but the inner `<a>` would otherwise hug its
+    // own content height — leaving visible cards in a row at unequal heights
+    // when one title wraps to two lines. Making the cell a flex column lets the
+    // inner `<a>` (height: 100% below) fill the stretched cell, so every visible
+    // card in a row matches the tallest one.
+    display: flex;
   }
 
   article.custom-doc-card:first-of-type {
@@ -28,7 +36,13 @@
     display: flex;
     flex-direction: column;
     justify-content: flex-start;
-    height: 136px;
+    // `min-height` (not a fixed `height`) so a card whose title wraps to two
+    // lines can grow to fit its clamped description instead of clipping the
+    // last line mid-text. `height: 100%` makes the visible card fill its
+    // stretched grid cell (see the `.custom-doc-card` flex rule above), so all
+    // visible cards in a row stay exactly the same height as the tallest one.
+    min-height: 136px;
+    height: 100%;
   }
 
   .cardDescription {
@@ -69,9 +83,18 @@
   }
 
   .text--truncate.cardDescription {
-    // cancel --truncate styles since we can't remove the' class
-    overflow: auto;
+    // Override the `.text--truncate` utility (single-line ellipsis) since we
+    // can't remove that class from the markup. Use a multi-line clamp instead:
+    // wrap the text, then clip to 3 lines with an ellipsis. `overflow: hidden`
+    // (NOT `auto`) is required for `-webkit-line-clamp` to truncate; `auto`
+    // produces a scrollbar when the title wraps to 2 lines or the text is long.
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    text-overflow: ellipsis;
     white-space: normal;
+    min-width: 0;
   }
 
   .cardDescription {


### PR DESCRIPTION
This PR fixes a scrollbar that appeared on the Strapi Cloud intro page doc cards when a card title wrapped to two lines or a description was long. The cards used overflow: auto on a fixed-height box, which defeated the line-clamp truncation; the description now clamps to three lines with overflow: hidden, the card uses min-height instead of a fixed height, and the visible card fills its stretched grid cell so cards in a row keep equal heights. Two overlong card descriptions are also shortened.

Direct preview link 👉 [here](https://documentation-git-repo-fix-cloud-doc-card-overflow-strapijs.vercel.app/cloud/intro)