### PR TITLE
Make Inki review verify docs against the strapi PR they document

### DIFF
--- a/claude-plugins/inki/agents/code-verifier.md
+++ b/claude-plugins/inki/agents/code-verifier.md
@@ -9,12 +9,32 @@ model: opus
 
 You verify that the fenced code blocks in ONE Strapi documentation page are correct, syntactically valid, and consistent with the actual Strapi APIs for the version the page targets. This is the highest-stakes check: a wrong code sample misleads every reader who copies it. Be rigorous and skeptical. You are read-only: you never edit the page.
 
+## Inputs
+
+- `TARGET`: an absolute path to the documentation page.
+- `UPSTREAM_PRS` (optional): a list of upstream code PRs the page documents, each `{repo, number}` with `repo` being `strapi/strapi` or `strapi/cloud`. The dispatcher passes this when the docs page comes from a `strapi/documentation` PR whose description references a code PR. When present, it is the **primary** source of truth (see below).
+
 ## Source of truth (in order of preference)
 
-1. A local clone of `strapi/strapi`. Fastest and most reliable. To find it: use the path the dispatcher passed if any; otherwise check the `STRAPI_SRC` environment variable, then a sibling `strapi/` directory next to the current repo, then ask the user for the path. Do not assume any hardcoded location.
+**0. A referenced upstream PR (`UPSTREAM_PRS`), when provided — this takes precedence over everything below.** A docs page under review often documents a code change that is *not yet merged*, so `develop` and a local clone do not reflect it. Verifying against them then yields false "this key/value does not exist" findings. When `UPSTREAM_PRS` is non-empty, fetch each referenced PR's changed code and verify the page's claims against that PR's **head**, not against `develop`:
+
+   - List and read the PR's changed files:
+
+     ```bash
+     gh pr diff <number> --repo <repo>
+     gh pr view <number> --repo <repo> --json files,headRefName,headRepositoryOwner
+     ```
+
+   - To read a full file at the PR's head (not just the diff), use `gh api` or the GitHub MCP `get_file_contents` with the PR's head ref, per `${CLAUDE_PLUGIN_ROOT}/references/prompts/shared/github-mcp-usage.md`.
+   - Verify each claim (config key, value, default, scaffolded file content) against what the PR actually changes. If a claim matches the PR but contradicts `develop`/a local clone, that is **expected** for an unmerged change — mark it `ok` and note "verified against <repo>#<number> (unmerged)". Only mark `broken`/`suspicious` if the claim contradicts the PR itself, or if no source confirms it.
+   - In the report, record which PR(s) you verified against in the `Source used` line.
+
+   If `gh`/MCP cannot reach the PR (auth, network), say so and fall back to the sources below, marking PR-dependent claims `unverified` rather than `broken`.
+
+1. A local clone of `strapi/strapi`. Fastest and most reliable. To find it: use the path the dispatcher passed if any; otherwise check the `STRAPI_SRC` environment variable, then a sibling `strapi/` directory next to the current repo, then ask the user for the path. Do not assume any hardcoded location. **Caveat:** a local clone may sit on a stale or unrelated branch — check what `git -C <clone> log -1 --format='%h %ci'` and the current branch are before trusting it, especially when `UPSTREAM_PRS` is empty but the page clearly documents recent work.
 2. Raw GitHub fetch: `https://raw.githubusercontent.com/strapi/strapi/develop/<path>` via WebFetch. Rate-limited but works without a clone.
 
-If neither is available, state that clearly and verify only what you can from the prose itself (syntax, internal consistency), marking API-existence checks as `unverified`.
+If none is available, state that clearly and verify only what you can from the prose itself (syntax, internal consistency), marking API-existence checks as `unverified`.
 
 ## Procedure
 
@@ -37,7 +57,7 @@ Return ONLY this report. Do not paste the full code blocks back.
 
 ```
 Target: <path>
-Source used: local clone | github fetch | prose-only (unverified)
+Source used: upstream PR <repo>#<n> (unmerged) | local clone (<branch> @ <date>) | github fetch | prose-only (unverified)
 Blocks:
 - Block <N> (lang=<lang>, lines <start>-<end>): ok | suspicious | broken, with <short note + evidence>
 Severity: low | medium | high

--- a/claude-plugins/inki/agents/coherence-checker.md
+++ b/claude-plugins/inki/agents/coherence-checker.md
@@ -12,6 +12,7 @@ You check whether ONE Strapi documentation page is coherent with the rest of the
 ## Inputs
 
 - `TARGET`: an absolute path to a documentation page.
+- `UPSTREAM_PRS` (optional): a list of upstream code PRs the page documents, each `{repo, number}`. The dispatcher passes this when the page comes from a `strapi/documentation` PR whose description references a code PR. Use it to distinguish a *real* contradiction from an *expected* one (see step 5).
 
 ## Procedure
 
@@ -25,6 +26,8 @@ You check whether ONE Strapi documentation page is coherent with the rest of the
 
 4. Compare the target against each related page: terminology drift, contradictory steps, links that point to moved/renamed pages, duplicated-but-divergent explanations.
 
+5. **Account for unmerged upstream changes.** When `UPSTREAM_PRS` is non-empty, the page may legitimately document behavior that the *currently published* sibling pages do not reflect yet (a new default, a re-introduced option, a renamed key). Before reporting a conflict with another page, consider whether the target is simply ahead of that page because of the referenced code PR. If so, do not report it as a flat contradiction: report it as a **coherence debt** — "the target documents <repo>#<number> (unmerged); page X still describes the old behavior and will need updating in the same release" — so the author syncs the pages together rather than reverting the new content. A genuine contradiction (the target disagrees with a page *and* with the upstream PR, or with a stable, unrelated page) is still reported normally. You may consult the PR with `gh pr diff <number> --repo <repo>` if you need to confirm which side is ahead.
+
 ## Output
 
 Return ONLY this report:
@@ -32,8 +35,9 @@ Return ONLY this report:
 ```
 Target: <path>
 Related pages compared: <list>
+Documents upstream: <repo>#<number>[, …] | none
 Coherence issues:
-- <description>: <where it conflicts (page + section)>
+- <description>: <where it conflicts (page + section)> [tag a conflict caused by an unmerged upstream change as "coherence debt", not a contradiction]
 Severity: low | medium | high
 ```
 

--- a/claude-plugins/inki/references/target-resolver.md
+++ b/claude-plugins/inki/references/target-resolver.md
@@ -6,6 +6,7 @@ The resolver takes whatever the user passed (after flags are stripped) and retur
 
 - `FILES`: a list of local file paths the sub-skills operate on.
 - `SCOPE`: a short human label describing the target (used in report headers), e.g. `PR #3204 (1 doc file)`, `docusaurus/docs/cms/intro.md`, or `pasted content`.
+- `UPSTREAM_PRS`: a list of referenced upstream code PRs (in `strapi/strapi` or `strapi/cloud`) that the documentation under review is documenting. Each entry is `{repo, number}`. Empty unless the target is a `strapi/documentation` PR whose description references one (see "Detecting upstream code PRs" below). The code-verifier and coherence-checker use it as the primary source of truth, because a docs PR that documents an unmerged code change must be verified against *that change*, not against `develop` or a stale local clone.
 - `CLEANUP`: an optional command to run after the skill finishes (worktree teardown, temp-file removal). May be empty.
 
 The repo is always `strapi/documentation`. Docs live under `docusaurus/docs/`.
@@ -38,11 +39,13 @@ Operates on the current working tree. `CLEANUP` is empty.
 ### 2. GitHub PR
 
 1. Extract the PR number: strip a leading `#`, strip URL tails (`/files`, `/changes`), then take the trailing `[0-9]+`.
-2. Fetch the PR's changed files:
+2. Fetch the PR's changed files **and its title/body** (the body is needed to detect upstream code-PR references, see step 7):
 
    ```bash
-   gh pr view <num> --repo strapi/documentation --json files,headRefName --jq '.files[].path'
+   gh pr view <num> --repo strapi/documentation --json files,headRefName,title,body
    ```
+
+   Take the changed paths from `.files[].path`.
 
 3. Filter to `.md` and `.mdx` only. If the PR changes no documentation file, report that and stop.
 4. Check the PR out in a temporary worktree so sub-skills see the PR's version, not `main`:
@@ -53,8 +56,9 @@ Operates on the current working tree. `CLEANUP` is empty.
 
 5. `FILES` = each path from step 3, prefixed with `$WORKTREE/`.
 6. `CLEANUP` = `./claude-plugins/inki/scripts/pr-worktree.sh destroy <num>`.
+7. Detect upstream code PRs referenced in the title/body and populate `UPSTREAM_PRS` (see "Detecting upstream code PRs" below).
 
-`SCOPE` = `PR #<num> (<count> doc file[s])`.
+`SCOPE` = `PR #<num> (<count> doc file[s])`. When `UPSTREAM_PRS` is non-empty, append ` — documents <repo>#<number>[, …]` so the report header makes the source of truth explicit.
 
 ### 3. docs.strapi.io URL
 
@@ -110,6 +114,22 @@ The user pasted Markdown directly (frontmatter, headings, prose) instead of a re
 `SCOPE` = `pasted content (<slug>)`.
 
 Note: coherence-check and code-verify are less reliable on pasted content, because the file is outside the docs tree (relative links and sibling-page lookups will not resolve). Note this limitation in the report when the target is pasted content.
+
+## Detecting upstream code PRs
+
+A `strapi/documentation` PR usually documents a change that ships in a `strapi/strapi` (CMS) or `strapi/cloud` (Cloud) PR. When the docs PR is still open, that code PR is frequently **unmerged**, so neither `develop` nor a local clone reflects the behavior being documented yet. Verifying the docs against `develop` then produces false "this config key/value does not exist" findings (a real failure mode: a security-defaults PR was flagged as wrong because the scaffolding change lived in an unmerged upstream PR). Detecting the reference lets the code-verifier and coherence-checker target the right source.
+
+This runs **only for type 2 (a `strapi/documentation` GitHub PR)**; for all other target types `UPSTREAM_PRS` is empty.
+
+1. Take the PR `title` and `body` fetched in step 2.
+2. Scan for references to a code PR in either documented repo. Match all of these forms, case-insensitive:
+   - `strapi/strapi#<n>` and `strapi/cloud#<n>` (cross-repo shorthand)
+   - full URLs: `https://github.com/strapi/strapi/pull/<n>`, `https://github.com/strapi/cloud/pull/<n>` (ignore any `/files`, `/commits` tail)
+   - Do **not** match a bare `#<n>` with no `owner/repo` prefix: inside a `strapi/documentation` PR body, `#1234` refers to documentation, not code.
+3. Deduplicate by `(repo, number)`. For each unique hit, add `{repo, number}` to `UPSTREAM_PRS`, preserving the order they appear in the body.
+4. If nothing matches, `UPSTREAM_PRS` is empty — verification falls back to its normal source order (local clone, then `develop`).
+
+These references are passed through to the dispatched agents (the `review` skill hands `UPSTREAM_PRS` to the code-verifier and coherence-checker); the resolver only detects them, it does not fetch the code itself. Fetching the PR diff/files is the code-verifier's job, using `gh pr diff <number> --repo <repo>` or `gh pr view <number> --repo <repo> --json files`, or GitHub MCP per `references/prompts/shared/github-mcp-usage.md`.
 
 ## Cleanup contract
 

--- a/claude-plugins/inki/skills/review/SKILL.md
+++ b/claude-plugins/inki/skills/review/SKILL.md
@@ -30,6 +30,7 @@ The resolver returns:
 
 - `FILES`: the list of local files the sub-skills operate on.
 - `SCOPE`: a short label for the report header.
+- `UPSTREAM_PRS`: any `strapi/strapi` / `strapi/cloud` code PRs the docs PR's description references (each `{repo, number}`); empty for non-PR targets or a PR that references none. The docs under review document *those* code changes, so they are the right source of truth even when unmerged.
 - `CLEANUP`: a command to run when the review finishes (worktree teardown or temp-file removal); may be empty.
 
 If resolution fails (PR has no doc files, filename not found, URL maps to nothing), report why and stop.
@@ -50,6 +51,8 @@ Map each check to its bundled agent (`agentType`):
 | Known pitfalls | `inki:pitfalls-checker` | cataloged hallucination matches |
 
 Pass each agent the absolute `TARGET` path. For the style check, pass `FIX=true` when `FIX` is set (the agent still does not edit files; it flags the auto-fixable subset). The other five agents always return their findings with enough detail (file, location, the precise correction) for the caller to judge in Step 3b whether each one has a single unambiguous fix.
+
+When `UPSTREAM_PRS` is non-empty, additionally pass it to the **code-verifier** and the **coherence-checker** in their prompts (e.g. "UPSTREAM_PRS: strapi/strapi#26737"). The code-verifier verifies against that PR's head as its primary source of truth instead of `develop`/a local clone; the coherence-checker uses it to tell a real contradiction apart from an expected gap with a not-yet-updated sibling page. This is what prevents the false "this config key/value does not exist" and "this contradicts page X" findings that occur when a docs PR documents an unmerged code change. The other four agents do not need it.
 
 The agents are read-only by construction (their `tools` allowlists exclude write/commit/push), so neither `AUTO` nor `FIX` changes their behavior. They never edit files. All edits happen in Step 3b, applied by *this* skill. `AUTO` only governs whether this skill prompts before applying those edits.
 
@@ -147,6 +150,11 @@ Review all `.md`/`.mdx` files modified by a PR:
 /inki:review https://github.com/strapi/documentation/pull/3204
 /inki:review 3204
 /inki:review #3204
+```
+
+When the PR's description references a code PR (e.g. `strapi/strapi#26737`), the review auto-detects it and verifies the docs against that code PR's head, not against `develop`. This is correct even when the code PR is unmerged — the docs are documenting *that* change:
+```
+/inki:review 3302
 ```
 
 Review a published page by its docs.strapi.io URL:


### PR DESCRIPTION
This PR makes /inki:review detect when a strapi/documentation PR description references a strapi/strapi or strapi/cloud code PR (e.g. strapi/strapi#26737) and verify the documentation against that code PR's head instead of develop or a possibly-stale local clone. The target resolver now reads the PR body and exposes the referenced code PRs, the code-verifier treats the referenced PR as its primary source of truth so an unmerged change is no longer flagged as a nonexistent config key or value, and the coherence checker uses it to tell a real contradiction apart from a sibling page that has not been updated yet.