### PR TITLE
Fix MeiliSearch scraper failing on PR-merge event with empty secrets

### DIFF
--- a/.github/workflows/meilisearch-scraper.yml
+++ b/.github/workflows/meilisearch-scraper.yml
@@ -4,10 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    types: [closed]
-    branches:
-      - main
   workflow_dispatch:
   schedule:
     - cron: '0 2 * * *'
@@ -15,7 +11,7 @@ on:
 jobs:
   scrape-docs:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
     
     steps:
       - name: Checkout repository


### PR DESCRIPTION
This PR removes the redundant pull_request:closed trigger from the MeiliSearch scraper workflow. On a PR-merge event GitHub runs the workflow against the merged PR's ephemeral head branch, where secrets intermittently resolve to empty strings and the backup step fails with "Missing env vars". Every merge to main already fires a reliable push:[main] run that performs the same scrape, so the pull_request trigger only added a flaky, duplicate run. The scheduled and manual dispatch triggers are unchanged.