### PR TITLE
Add shared Claude Code settings to auto-offer the Inki plugin

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,13 @@
+{
+  "extraKnownMarketplaces": {
+    "strapi-documentation": {
+      "source": {
+        "source": "github",
+        "repo": "strapi/documentation"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "inki@strapi-documentation": true
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
-.claude/
+# Keep Claude Code local files ignored, but track the shared project settings
+# (.claude/settings.json) so the Inki plugin marketplace is offered to everyone.
+**/.claude/*
+!/.claude/settings.json
 
 # Local artifacts from Anthropic superpowers skill plugin (brainstorm, plans, specs).
 # These are working notes from individual contributors and should never be tracked.


### PR DESCRIPTION
This PR tracks .claude/settings.json so that anyone who clones and trusts the repo in Claude Code is automatically offered the in-repo strapi-documentation plugin marketplace with the Inki plugin enabled. The .gitignore rule is narrowed so all other .claude/ files (local settings, lock files) stay ignored at any depth.