### PR TITLE
Rework OpenAPI HTTP endpoint config for the new access setting

### DIFF
--- a/docusaurus/docs/cms/api/openapi.md
+++ b/docusaurus/docs/cms/api/openapi.md
@@ -218,6 +218,14 @@ export default {
 Setting `content-api.access` to `authenticated` or `admin.access` to `public` throws an error at startup.
 :::
 
+:::note
+Role-based access control for OpenAPI endpoints is not supported yet. The admin endpoint uses the `admin::isAuthenticatedAdmin` policy and does not filter by admin role or permission: any authenticated admin user can read the specification.
+:::
+
+:::tip
+A public Content API specification describes your entire Content API surface, including content types that are not publicly readable, to anyone who can reach the endpoint. If you do not want to expose the specification without authentication, leave `content-api.access` at `'disabled'` and use the CLI to generate a static file instead.
+:::
+
 ### Endpoint options
 
 Besides `access`, each endpoint (`content-api` and `admin`) accepts the following options:

--- a/docusaurus/docs/cms/api/openapi.md
+++ b/docusaurus/docs/cms/api/openapi.md
@@ -161,50 +161,37 @@ The generated OpenAPI specification includes all available API endpoints in your
 - File upload endpoints for media handling
 - Plugin endpoints from installed plugins
 
-## Serving the specification over HTTP
+## Configuration
 
-Strapi can serve the generated OpenAPI specification as a live HTTP endpoint. Serving specifications over HTTP removes the need to regenerate a static file after each content-type change. Both the Content API and Admin API specifications can be served independently.
+By default, Strapi does not expose HTTP endpoints for the generated OpenAPI specification. To opt in, add an `openapi` key to the `/config/server` file.
 
-Both endpoints use `access: 'disabled'` by default and are not registered. Set `access` on 1 or both endpoints in the [server configuration](/cms/configurations/server) file to expose them.
+### HTTP endpoint access
 
-### Configuration
+The `openapi` configuration accepts 2 sub-keys, `content-api` and `admin`, each with an `access` property:
 
-Add an `openapi` key to the `server` configuration:
+| Sub-key | Endpoint | `access` value | Default | Behavior |
+|---------|----------|----------------|---------|----------|
+| `content-api` | `GET /api/openapi.json` | `disabled` | Yes | Endpoint not registered. |
+| `content-api` | `GET /api/openapi.json` | `public` | No | Endpoint accessible without authentication. |
+| `admin` | `GET /admin/openapi.json` | `disabled` | Yes | Endpoint not registered. |
+| `admin` | `GET /admin/openapi.json` | `authenticated` | No | Endpoint requires an authenticated admin user. |
+
+The following example exposes both endpoints:
 
 <Tabs groupId="js-ts">
 <TabItem value="js" label="JavaScript">
 
 ```js title="/config/server.js"
-module.exports = ({ env }) => ({
-  host: env('HOST', '0.0.0.0'),
-  port: env.int('PORT', 1337),
-  // highlight-start
+module.exports = {
   openapi: {
     'content-api': {
       access: 'public',
-      route: {
-        path: '/openapi.json',
-      },
-      cache: {
-        enabled: true,
-        maxAgeMs: 60000,
-        filePath: '.strapi/openapi/content-api.json',
-      },
     },
     admin: {
       access: 'authenticated',
-      route: {
-        path: '/openapi.json',
-      },
-      cache: {
-        enabled: true,
-        maxAgeMs: 60000,
-        filePath: '.strapi/openapi/admin.json',
-      },
     },
   },
-  // highlight-end
-});
+};
 ```
 
 </TabItem>
@@ -212,89 +199,46 @@ module.exports = ({ env }) => ({
 <TabItem value="ts" label="TypeScript">
 
 ```ts title="/config/server.ts"
-export default ({ env }) => ({
-  host: env('HOST', '0.0.0.0'),
-  port: env.int('PORT', 1337),
-  // highlight-start
+export default {
   openapi: {
     'content-api': {
       access: 'public',
-      route: {
-        path: '/openapi.json',
-      },
-      cache: {
-        enabled: true,
-        maxAgeMs: 60000,
-        filePath: '.strapi/openapi/content-api.json',
-      },
     },
     admin: {
       access: 'authenticated',
-      route: {
-        path: '/openapi.json',
-      },
-      cache: {
-        enabled: true,
-        maxAgeMs: 60000,
-        filePath: '.strapi/openapi/admin.json',
-      },
     },
   },
-  // highlight-end
-});
+};
 ```
 
 </TabItem>
 </Tabs>
 
-The `content-api` endpoint is served under the REST API prefix (`/api` by default). The full URL is `http://localhost:1337/api/openapi.json`. The `admin` endpoint is served under the admin path (`/admin` by default). The full URL is `http://localhost:1337/admin/openapi.json`.
+:::caution
+Setting `content-api.access` to `authenticated` or `admin.access` to `public` throws an error at startup.
+:::
+
+### Endpoint options
+
+Besides `access`, each endpoint (`content-api` and `admin`) accepts the following options:
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `route.path` | String | `'/openapi.json'` | Subpath where the specification is served. Resolved under `/api` for `content-api` and under `/admin` for `admin`. |
+| `cache.enabled` | Boolean | `true` | Enables file-based caching of the generated specification. |
+| `cache.maxAgeMs` | Number | `60000` | Maximum age of the cache file, in milliseconds, before the specification is regenerated. |
+| `cache.filePath` | String | `.strapi/openapi/<type>.json` | Path of the cache file. Relative paths are resolved from the application root. |
+
+With the default `route.path`, the full URLs are `http://localhost:1337/api/openapi.json` for the Content API endpoint and `http://localhost:1337/admin/openapi.json` for the Admin endpoint.
 
 :::caution
 Both endpoints must resolve to different full paths. If the `content-api` and `admin` endpoints resolve to the same URL, Strapi throws an error at startup.
 :::
 
-### Available options
-
-Each endpoint (`content-api` and `admin`) accepts the following options:
-
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `access` | String | `'disabled'` | Controls whether the endpoint is registered and how it is protected. See [Access control](#access-control) for accepted values per endpoint. |
-| `route.path` | String | `'/openapi.json'` | Path where the specification is served. Appended to the endpoint prefix (`/api` for `content-api`, `/admin` for `admin`). |
-| `cache.enabled` | Boolean | `true` | Enables file-based caching of the generated specification. |
-| `cache.maxAgeMs` | Number | `60000` | Maximum age of the cache file in milliseconds before regeneration. |
-| `cache.filePath` | String | `'.strapi/openapi/<type>.json'` | File path for the cache file. Relative paths are resolved from the application root. |
-
-### Access control
-
-The `access` option controls whether each endpoint is registered and how it is protected. Each endpoint supports different values:
-
-**Content API** (`content-api`):
-
-| Value | Behavior |
-|-------|----------|
-| `'disabled'` (default) | The endpoint is not registered. |
-| `'public'` | The endpoint is registered without authentication. Anyone can fetch the specification. |
-
-**Admin** (`admin`):
-
-| Value | Behavior |
-|-------|----------|
-| `'disabled'` (default) | The endpoint is not registered. |
-| `'authenticated'` | The endpoint requires an authenticated admin session. Any authenticated admin user can access the specification. |
-
-:::note
-Role-based access control for OpenAPI endpoints is not supported yet. The admin endpoint uses the `admin::isAuthenticatedAdmin` policy and does not filter by admin role or permission.
-:::
-
-:::tip
-The Content API endpoint is always public when `access` is `'public'`. If you do not want to expose the specification without authentication, leave `content-api.access` at `'disabled'` and use the CLI to generate a static file instead.
-:::
-
 ## Integrating with Swagger UI
 
 :::tip
-If you [registered an HTTP endpoint](#serving-the-specification-over-http), you can point Swagger UI directly at the live URL (e.g., `http://localhost:1337/api/openapi.json`) instead of generating a static file. Skip step 1 below and use the endpoint URL as the `url` value in step 3.
+If you [exposed an HTTP endpoint](#http-endpoint-access), you can point Swagger UI directly at the live URL (e.g., `http://localhost:1337/api/openapi.json`) instead of generating a static file. Skip step 1 below and use the endpoint URL as the `url` value in step 3.
 :::
 
 With the following steps you can quickly generate a [Swagger UI](https://swagger.io/)-compatible page:

--- a/docusaurus/docs/cms/api/openapi.md
+++ b/docusaurus/docs/cms/api/openapi.md
@@ -161,7 +161,7 @@ The generated OpenAPI specification includes all available API endpoints in your
 - File upload endpoints for media handling
 - Plugin endpoints from installed plugins
 
-## Configuration
+## Configuring 
 
 By default, Strapi does not expose HTTP endpoints for the generated OpenAPI specification. To opt in, add an `openapi` key to the `/config/server` file.
 


### PR DESCRIPTION
This PR reworks the OpenAPI HTTP endpoint documentation to reflect the new single `access` setting per endpoint (`content-api`: disabled/public, `admin`: disabled/authenticated, both disabled by default), replacing the earlier `enabled` + `access.mode`/`access.roles` model, while keeping the still-supported `route.path` and `cache.*` options.

Documents [#26574](https://github.com/strapi/strapi/pull/26574)

Direct preview link 👉 [here](https://documentation-git-cms-add-openapi-access-config-strapijs.vercel.app/cms/api/openapi)