### PR TITLE
View mode switcher improvements

### DIFF
--- a/docusaurus/src/components/ViewMode/ViewModeSwitcher.js
+++ b/docusaurus/src/components/ViewMode/ViewModeSwitcher.js
@@ -1,8 +1,8 @@
-import React, { useState, useEffect, useCallback, useRef } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { useViewMode } from './ViewModeContext';
+import WidthToggle from '@site/src/components/WidthToggle/WidthToggle';
 import styles from './viewModeSwitcher.module.scss';
 
-const SCROLL_THRESHOLD = 50;
 const MODES = [
   { value: 'elegant', label: 'Elegant Mode', icon: 'sparkle' },
   { value: 'markdown', label: 'Markdown Mode', icon: 'code' },
@@ -11,8 +11,6 @@ const MODES = [
 
 export default function ViewModeSwitcher() {
   const { viewMode, setViewMode } = useViewMode();
-  const [visible, setVisible] = useState(true);
-  const lastScrollY = useRef(0);
 
   // The active-tab highlight is decided client-side only. The component is
   // server-rendered with viewMode='elegant', and React keeps that SSR markup on
@@ -22,23 +20,6 @@ export default function ViewModeSwitcher() {
   // viewMode after hydration.
   const [mounted, setMounted] = useState(false);
   useEffect(() => { setMounted(true); }, []);
-
-  // Auto-hide on scroll down, show on scroll up
-  useEffect(() => {
-    const handleScroll = () => {
-      const currentY = window.scrollY;
-      if (currentY < SCROLL_THRESHOLD) {
-        setVisible(true);
-      } else if (currentY > lastScrollY.current) {
-        setVisible(false);
-      } else {
-        setVisible(true);
-      }
-      lastScrollY.current = currentY;
-    };
-    window.addEventListener('scroll', handleScroll, { passive: true });
-    return () => window.removeEventListener('scroll', handleScroll);
-  }, []);
 
   const handleKeyDown = useCallback((e) => {
     const currentIndex = MODES.findIndex((m) => m.value === viewMode);
@@ -56,29 +37,32 @@ export default function ViewModeSwitcher() {
   }, [viewMode, setViewMode]);
 
   return (
-    <div
-      className={`${styles.switcher} ${visible ? '' : styles.hidden}`}
-      role="radiogroup"
-      aria-label="View mode"
-      onKeyDown={handleKeyDown}
-    >
-      {MODES.map((m) => {
-        const isActive = mounted && viewMode === m.value;
-        return (
-          <button
-            key={m.value}
-            className={`${styles.button} ${isActive ? styles.active : ''}`}
-            role="radio"
-            aria-checked={isActive}
-            aria-label={m.label}
-            tabIndex={isActive ? 0 : -1}
-            onClick={() => setViewMode(m.value)}
-          >
-            <i className={`ph-bold ph-${m.icon}`} />
-            {m.label}
-          </button>
-        );
-      })}
+    <div className={styles.switcher}>
+      <div
+        className={styles.modes}
+        role="radiogroup"
+        aria-label="View mode"
+        onKeyDown={handleKeyDown}
+      >
+        {MODES.map((m) => {
+          const isActive = mounted && viewMode === m.value;
+          return (
+            <button
+              key={m.value}
+              className={`${styles.button} ${isActive ? styles.active : ''}`}
+              role="radio"
+              aria-checked={isActive}
+              aria-label={m.label}
+              tabIndex={isActive ? 0 : -1}
+              onClick={() => setViewMode(m.value)}
+            >
+              <i className={`ph-bold ph-${m.icon}`} />
+              {m.label}
+            </button>
+          );
+        })}
+      </div>
+      <WidthToggle />
     </div>
   );
 }

--- a/docusaurus/src/components/ViewMode/viewModeSwitcher.module.scss
+++ b/docusaurus/src/components/ViewMode/viewModeSwitcher.module.scss
@@ -3,39 +3,52 @@
 .switcher {
   display: flex;
   align-items: center;
-  gap: 4px;
+  // Mode tabs on the left, width toggle on the right.
+  justify-content: space-between;
+  gap: 8px;
+  // Pinned right below the sticky navbar, always visible — no scroll-driven
+  // show/hide. The top padding gives it breathing room under the navbar.
   position: sticky;
-  // Vertically aligned with the NAVIGATION / ON THIS PAGE sidebar labels and
-  // the content-width toggle. Lower offset than the toggle because this block
-  // sits in the article flow with its own top padding, which pushes it down.
-  top: calc(var(--ifm-navbar-height, 3.75rem) + 9px);
+  top: var(--ifm-navbar-height, 3.75rem);
   z-index: 10;
-  // The switcher sits at the very top of the article flow, which starts ~13px
-  // lower than the sidebar labels and the width toggle. Pull it up so the top
-  // of all four (NAVIGATION, switcher, width toggle, ON THIS PAGE) line up.
-  margin-top: -13px;
-  margin-bottom: 8px;
-  padding: 6px 0;
-  transition: opacity 0.3s ease, transform 0.3s ease;
-  flex-wrap: wrap;
-  // Opaque background so it doesn't blend with content when scrolling.
+  padding-top: 40px;
+  // Height of the fade-out band below the bar; the bottom margin matches it
+  // so the page title starts below the gradient instead of under it.
+  --fade-height: 40px;
+  margin-bottom: var(--fade-height);
+  // Opaque background + side bleed so content doesn't show through or peek
+  // around the edges while scrolling underneath.
   background: var(--strapi-surface-1);
-  // Ensure background covers full width and hides content scrolling underneath
-  margin-left: -16px;
-  margin-right: -16px;
-  padding-left: 16px;
-  padding-right: 16px;
+
+  // Fade-out below the bar, so content scrolling underneath dissolves into
+  // the background instead of being cut on a hard edge.
+  &::after {
+    content: '';
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    height: var(--fade-height);
+    background: linear-gradient(to bottom, var(--strapi-surface-1), transparent);
+    pointer-events: none;
+  }
 
   @include small-down {
     position: static;
     background: transparent;
+    margin-bottom: 0;
+
+    &::after {
+      display: none;
+    }
   }
 }
 
-.hidden {
-  opacity: 0;
-  pointer-events: none;
-  transform: translateY(-10px);
+.modes {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-wrap: wrap;
 }
 
 .button {
@@ -43,13 +56,6 @@
   align-items: center;
   gap: 4px;
   padding: 4px 10px;
-
-  // The switcher row is inset (button padding) so the first tab sat to the
-  // right of the H1. Pull the first button left so its content lines up with
-  // the H1 (and the page body).
-  &:first-child {
-    margin-left: -16px;
-  }
   border: none;
   border-radius: 6px;
   background: transparent;
@@ -93,7 +99,6 @@
 }
 
 @include dark {
-  // .switcher background comes from surface-1 (set above), which already adapts.
   .button {
     color: var(--strapi-neutral-400);
 

--- a/docusaurus/src/components/ViewMode/viewModeSwitcher.module.scss
+++ b/docusaurus/src/components/ViewMode/viewModeSwitcher.module.scss
@@ -10,7 +10,9 @@
   // show/hide. The top padding gives it breathing room under the navbar.
   position: sticky;
   top: var(--ifm-navbar-height, 3.75rem);
-  z-index: 10;
+  // Above in-content overlays (annotations use 20–22), below the fixed
+  // chrome (AI panel 100, navbar and step-progress widget 200).
+  z-index: 50;
   padding-top: 40px;
   // Height of the fade-out band below the bar; the bottom margin matches it
   // so the page title starts below the gradient instead of under it.

--- a/docusaurus/src/components/WidthToggle/WidthToggle.js
+++ b/docusaurus/src/components/WidthToggle/WidthToggle.js
@@ -1,8 +1,7 @@
-import React, { useState, useEffect, useCallback, useRef } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import styles from './widthToggle.module.scss';
 
 const STORAGE_KEY = 'strapi-content-width';
-const SCROLL_THRESHOLD = 50;
 const WIDTHS = [
   { value: 'default', label: 'Default width', icon: 'arrows-in-line-horizontal' },
   { value: 'wide', label: 'Wide width', icon: 'arrows-out-line-horizontal' },
@@ -35,8 +34,6 @@ function getDomWidth() {
 export default function WidthToggle() {
   // SSR renders 'default'; the real value is synced from the DOM after mount.
   const [width, setWidth] = useState('default');
-  const [visible, setVisible] = useState(true);
-  const lastScrollY = useRef(0);
 
   // On mount: apply the stored width to the DOM (if not already set), then keep
   // this instance's state in sync with the DOM attribute. A MutationObserver
@@ -57,23 +54,6 @@ export default function WidthToggle() {
       attributeFilter: ['data-content-width'],
     });
     return () => observer.disconnect();
-  }, []);
-
-  // Auto-hide on scroll down, show on scroll up
-  useEffect(() => {
-    const handleScroll = () => {
-      const currentY = window.scrollY;
-      if (currentY < SCROLL_THRESHOLD) {
-        setVisible(true);
-      } else if (currentY > lastScrollY.current) {
-        setVisible(false);
-      } else {
-        setVisible(true);
-      }
-      lastScrollY.current = currentY;
-    };
-    window.addEventListener('scroll', handleScroll, { passive: true });
-    return () => window.removeEventListener('scroll', handleScroll);
   }, []);
 
   const handleChange = useCallback((value) => {
@@ -112,7 +92,7 @@ export default function WidthToggle() {
 
   return (
     <div
-      className={`${styles.widthToggle} ${visible ? '' : styles.hidden}`}
+      className={styles.widthToggle}
       role="radiogroup"
       aria-label="Content width"
       onKeyDown={handleKeyDown}

--- a/docusaurus/src/components/WidthToggle/widthToggle.module.scss
+++ b/docusaurus/src/components/WidthToggle/widthToggle.module.scss
@@ -1,5 +1,7 @@
 @use '../../scss/mixins' as *;
 
+// Rendered inside the ViewModeSwitcher sticky bar (right side); it carries no
+// positioning of its own.
 .widthToggle {
   display: none;
 
@@ -7,22 +9,7 @@
     display: inline-flex;
     align-items: center;
     gap: 2px;
-    padding: 0;
-    border-radius: 6px;
-    background: transparent;
-    position: sticky;
-    // Vertically aligned with the NAVIGATION / ON THIS PAGE sidebar labels and
-    // the mode switcher (top of all four kept in line).
-    top: calc(var(--ifm-navbar-height, 3.75rem) + 22px);
-    z-index: 1;
-    float: right;
-    transition: opacity 0.3s ease;
   }
-}
-
-.hidden {
-  opacity: 0;
-  pointer-events: none;
 }
 
 .button {

--- a/docusaurus/src/scss/_base.scss
+++ b/docusaurus/src/scss/_base.scss
@@ -66,7 +66,7 @@ main {
 .markdown :is(h1, h2, h3, h4, h5, h6)[id],
 .api-endpoint-block[id],
 .api-call[id] {
-  scroll-margin-top: 120px;
+  scroll-margin-top: 150px;
 }
 
   [class*="docRoot"]:not(:has(main)) {

--- a/docusaurus/src/scss/_base.scss
+++ b/docusaurus/src/scss/_base.scss
@@ -56,17 +56,17 @@ main {
  * Anchor scroll offset.
  *
  * The navbar (64px) is sticky, and on doc pages the view-mode switcher toolbar
- * (~34px) is sticky right below it. Jumping to a #hash (e.g. from the homepage
+ * (~44px) is sticky right below it. Jumping to a #hash (e.g. from the homepage
  * API Explorer "Read the docs" link) landed the target heading flush under the
  * navbar, hidden behind the toolbar. Give heading anchor targets a scroll
- * margin so they come to rest just below both bars, fully visible. ~110px =
- * navbar + toolbar + a little breathing room. (Only scroll-margin-top here, not
- * scroll-padding-top on the root, or the two offsets would stack.)
+ * margin so they come to rest just below both bars, fully visible. ~120px =
+ * navbar + toolbar + a little breathing room. (Only scroll-margin-top here,
+ * not scroll-padding-top on the root, or the two offsets would stack.)
  */
 .markdown :is(h1, h2, h3, h4, h5, h6)[id],
 .api-endpoint-block[id],
 .api-call[id] {
-  scroll-margin-top: 110px;
+  scroll-margin-top: 120px;
 }
 
   [class*="docRoot"]:not(:has(main)) {

--- a/docusaurus/src/scss/breadcrumbs.scss
+++ b/docusaurus/src/scss/breadcrumbs.scss
@@ -9,6 +9,13 @@
   display: none !important;
 }
 
+// The margin actually sits on the wrapping <nav> (.theme-doc-breadcrumbs),
+// which stays in the DOM with the theme's own margin-bottom (0.8rem) even
+// though the list inside is hidden. Zero it out too.
+.theme-doc-breadcrumbs {
+  margin-bottom: 0 !important;
+}
+
 /* Original styles kept below for reference, but overridden by display:none above */
 .breadcrumbs--original {
   --ifm-breadcrumb-item-background-active: transparent;

--- a/docusaurus/src/scss/view-modes.scss
+++ b/docusaurus/src/scss/view-modes.scss
@@ -60,25 +60,6 @@
     max-width: calc(100% + 24px);
   }
 
-  // Mode switcher: the markdown "tighten everything" rules zero its negative
-  // top margin, which dropped the toolbar ~13px lower than in elegant mode.
-  // Re-apply it so the toolbar stays at a fixed height below the navbar in
-  // both modes.
-  [class*="switcher"] {
-    margin-top: -13px !important;
-  }
-
-  // On mobile the negative margin above is calibrated for desktop, where the
-  // switcher follows the breadcrumb. On mobile the collapsible "On this page"
-  // TOC sits right above it (and markdown zeroes that TOC's bottom spacing), so
-  // -13px pulled the switcher flush against the TOC. Restore a small positive
-  // gap there so the mode bar isn't glued to the TOC.
-  @include medium-down {
-    [class*="switcher"] {
-      margin-top: 8px !important;
-    }
-  }
-
   // Flatten card grids into simple list (article only)
   article [class*="docCardList"],
   article [class*="customDocCardsWrapper"],
@@ -801,9 +782,17 @@
     display: none !important;
   }
 
-  // Prevent sticky switcher from overlapping h1
+  // AI mode's split layout breaks sticky positioning and made the switcher
+  // overlap the h1. Keep it in the normal flow there, without the fade-out
+  // gradient (it only makes sense under a pinned bar) — and without the
+  // matching bottom margin that reserves space for it.
   article [class*="switcher"] {
     position: static;
+    margin-bottom: 8px;
+
+    &::after {
+      display: none;
+    }
   }
 
   // Sidebar in AI mode: start collapsed, show content when expanded

--- a/docusaurus/src/theme/DocCategoryGeneratedIndexPage/index.js
+++ b/docusaurus/src/theme/DocCategoryGeneratedIndexPage/index.js
@@ -56,7 +56,9 @@ function DocCategoryGeneratedIndexPageContent({ categoryGeneratedIndex }) {
     <div className={styles.generatedIndexPage}>
       {/* Content-width selector, so these pages can be widened/narrowed like
           regular doc pages (they follow --doc-content-max-width). */}
-      <WidthToggle />
+      <div className={styles.widthToggleRow}>
+        <WidthToggle />
+      </div>
       <DocVersionBanner />
       <DocBreadcrumbs />
       <DocVersionBadge />

--- a/docusaurus/src/theme/DocCategoryGeneratedIndexPage/styles.module.css
+++ b/docusaurus/src/theme/DocCategoryGeneratedIndexPage/styles.module.css
@@ -41,3 +41,16 @@
 .list article:last-child {
   margin-bottom: 0 !important;
 }
+
+/* The WidthToggle carries no positioning of its own (on doc pages it lives in
+   the sticky view-mode bar). These pages have no view-mode bar, so give the
+   standalone toggle its own right-aligned sticky row below the navbar. */
+.widthToggleRow {
+  display: flex;
+  justify-content: flex-end;
+  position: sticky;
+  top: var(--ifm-navbar-height, 3.75rem);
+  z-index: 10;
+  padding-top: 8px;
+  padding-bottom: 8px;
+}

--- a/docusaurus/src/theme/DocItem/Layout/index.js
+++ b/docusaurus/src/theme/DocItem/Layout/index.js
@@ -1,8 +1,8 @@
 /**
- * Swizzled DocItem/Layout — adds WidthToggle inside the article container.
+ * Swizzled DocItem/Layout — adds the view-mode switcher bar (mode tabs +
+ * WidthToggle) at the top of the article element.
  *
- * Based on the original Docusaurus DocItemLayout, with WidthToggle
- * inserted at the top of the article element.
+ * Based on the original Docusaurus DocItemLayout.
  */
 import React from 'react';
 import clsx from 'clsx';
@@ -17,7 +17,6 @@ import DocItemTOCDesktop from '@theme/DocItem/TOC/Desktop';
 import DocItemContent from '@theme/DocItem/Content';
 import DocBreadcrumbs from '@theme/DocBreadcrumbs';
 import ContentVisibility from '@theme/ContentVisibility';
-import WidthToggle from '@site/src/components/WidthToggle/WidthToggle';
 import ViewModeSwitcher from '@site/src/components/ViewMode/ViewModeSwitcher';
 import AiPanel from '@site/src/components/ViewMode/AiPanel';
 import styles from '@docusaurus/theme-classic/lib/theme/DocItem/Layout/styles.module.css';
@@ -46,15 +45,14 @@ export default function DocItemLayout({children}) {
     <>
       <div className="row">
         <div className={clsx('col', !docTOC.hidden && styles.docItemCol)}>
-          <WidthToggle />
           <ContentVisibility metadata={metadata} />
           <DocVersionBanner />
           <div className={styles.docItemContainer}>
             <article>
+              <ViewModeSwitcher />
               <DocBreadcrumbs />
               <DocVersionBadge />
               {docTOC.mobile}
-              <ViewModeSwitcher />
               <DocItemContent>{children}</DocItemContent>
               <DocItemFooter />
             </article>


### PR DESCRIPTION
Small UI improvements for the mode switcher.
- prevent switcher to disappear on scroll
- improve spacings
- add gradient below for a smooth transition between the content and the switcher
- moved the layout switcher inside of the mode switcher container for better alignement
- use padding rather that top so the content isn't visible above the switcher

Before
<img width="3264" height="2184" alt="CleanShot 2026-07-03 at 15 08 33@2x" src="https://github.com/user-attachments/assets/f295f3a3-e6de-4f8b-8db5-d35656fefdc9" />

After
<img width="3264" height="2184" alt="CleanShot 2026-07-03 at 15 08 19@2x" src="https://github.com/user-attachments/assets/fec2ff25-01dc-49b3-84ef-6d3a5ccf84c4" />
