### PR TITLE
Tags UI improvements

### DIFF
--- a/docusaurus/src/scss/__index.scss
+++ b/docusaurus/src/scss/__index.scss
@@ -56,6 +56,7 @@
 @use 'sidebar.scss';
 @use 'table.scss';
 @use 'tabs.scss';
+@use 'tags.scss';
 @use 'table-of-contents.scss';
 @use 'tldr.scss';
 @use 'typography.scss';

--- a/docusaurus/src/scss/tags.scss
+++ b/docusaurus/src/scss/tags.scss
@@ -1,0 +1,20 @@
+/** Component: Doc footer tags */
+@use './mixins' as *;
+
+article a[class*="tag_"] {
+  --custom-tag-bg: var(--strapi-primary-100);
+  --docusaurus-tag-list-border: var(--custom-tag-bg);
+  background: var(--custom-tag-bg);
+  transition: border var(--ifm-transition-fast), background var(--ifm-transition-fast);
+}
+
+article a[class*="tag_"]:hover {
+  --custom-tag-bg: var(--strapi-primary-200);
+  --docusaurus-tag-list-border: var(--custom-tag-bg);
+}
+
+@include dark {
+  article a[class*="tag_"]:hover {
+    --custom-tag-bg: var(--strapi-neutral-150);
+  }
+}


### PR DESCRIPTION
Only the tags were modified.

Before
<img width="3264" height="2184" alt="CleanShot 2026-07-03 at 16 33 40@2x" src="https://github.com/user-attachments/assets/c7a25969-8f2a-42c5-9beb-a2c4db66243b" />

After
<img width="3264" height="2184" alt="CleanShot 2026-07-03 at 16 33 47@2x" src="https://github.com/user-attachments/assets/0075e983-6883-4422-ba1e-52be0f52d3cd" />
