### PR TITLE
Clarify that ForbiddenError custom messages are not included in API responses

### DIFF
--- a/docusaurus/docs/cms/error-handling.md
+++ b/docusaurus/docs/cms/error-handling.md
@@ -414,6 +414,10 @@ The `ForbiddenError` class is a specific error class used when a user either doe
 throw new errors.ForbiddenError('Ah ah ah, you didn\'t say the magic word');
 ```
 
+:::note
+The custom `message` passed to `ForbiddenError` is not included in the API response. Instead, the API returns the default message. If you need to return a custom error message indicating insufficient permissions, use [`PolicyError`](#policies) instead.
+:::
+
 </TabItem>
 
 <TabItem value="Unauthorized" label="Unauthorized">

--- a/docusaurus/static/llms-code.txt
+++ b/docusaurus/static/llms-code.txt
@@ -22366,6 +22366,10 @@ File path: N/A
 
 ```
 
+:::note
+The custom `message` passed to `ForbiddenError` is not included in the API response. Instead, the API returns the default message. If you need to return a custom error message indicating insufficient permissions, use [`PolicyError`](#policies) instead.
+:::
+
 </TabItem>
 
 <TabItem value="Unauthorized" label="Unauthorized">

--- a/docusaurus/static/llms-full.txt
+++ b/docusaurus/static/llms-full.txt
@@ -29697,6 +29697,10 @@ The `ForbiddenError` class is a specific error class used when a user either doe
 throw new errors.ForbiddenError('Ah ah ah, you didn\'t say the magic word');
 ```
 
+:::note
+The custom `message` passed to `ForbiddenError` is not included in the API response. Instead, the API returns the default message. If you need to return a custom error message indicating insufficient permissions, use [`PolicyError`](#policies) instead.
+:::
+
 The `UnauthorizedError` class is a specific error class used when a user doesn't have the proper role or permissions to perform a specific action, but has properly authenticated. It accepts the following parameters:
 
 | Parameter | Type | Description | Default |


### PR DESCRIPTION
### Description

- Added a `note` admonition to the `ForbiddenError` tab in error-handling.md.
- Clarifies that custom messages passed to `ForbiddenError` are not included in the API response.
- Recommends using `PolicyError` if a custom error message indicating insufficient permissions needs to be returned.
- Updated the auto-generated LLM reference files (llms-code.txt and llms-full.txt) to keep them in sync.

See https://github.com/strapi/strapi/blob/e2975f5915e497cee4c1c75314c555a45777f79b/packages/core/core/src/services/server/compose-endpoint.ts#L46-L52.

### Related issue(s)/PR(s)

N/A