### PR TITLE
Unify homepage card styles and typography

### DIFF
--- a/docusaurus/src/pages/home/home.module.scss
+++ b/docusaurus/src/pages/home/home.module.scss
@@ -213,17 +213,15 @@
   align-items: center;
   gap: 24px;
   padding: 28px 32px;
-  border-radius: 16px;
-  border: 1px solid var(--strapi-border);
-  background: var(--strapi-surface-1);
+  border-radius: var(--strapi-radius-lg);
+  border: 1px solid var(--strapi-border-strong);
+  background: transparent;
   text-decoration: none !important;
   color: inherit;
   transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1);
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
 
   &:hover {
     border-color: var(--strapi-accent-light);
-    box-shadow: 0 8px 32px rgba(73, 69, 255, 0.08);
     text-decoration: none !important;
     color: inherit;
     transform: translateY(-2px);
@@ -241,7 +239,7 @@
 .quickstartIcon {
   width: 48px;
   height: 48px;
-  border-radius: 14px;
+  border-radius: 12px;
   background: color-mix(in srgb, var(--strapi-primary-500) 10%, transparent);
   display: grid;
   place-items: center;
@@ -304,7 +302,7 @@
 .exploreGrid {
   display: grid;
   grid-template-columns: 1fr;
-  gap: 8px;
+  gap: 24px;
 }
 
 .exploreCard {
@@ -312,20 +310,17 @@
   align-items: flex-start;
   gap: 14px;
   padding: 16px 20px;
-  border-radius: 12px;
-  border: 1px solid var(--strapi-border);
-  background: var(--strapi-surface-1);
+  border-radius: var(--strapi-radius-lg);
+  border: 1px solid var(--strapi-border-strong);
+  background: transparent;
   text-decoration: none !important;
   color: inherit;
   transition: all 0.25s cubic-bezier(0.16, 1, 0.3, 1);
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.03);
 
   &:hover {
     border-color: var(--strapi-accent-light);
-    background: var(--strapi-surface-2);
     text-decoration: none !important;
     color: inherit;
-    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.06);
     transform: translateY(-2px);
   }
 }
@@ -333,7 +328,7 @@
 .exploreCardIcon {
   width: 36px;
   height: 36px;
-  border-radius: 10px;
+  border-radius: 12px;
   background: color-mix(in srgb, var(--strapi-primary-500) 10%, transparent);
   display: grid;
   place-items: center;
@@ -401,7 +396,7 @@
 .featuresGrid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 20px;
+  gap: 24px;
 
   @media (max-width: 768px) {
     grid-template-columns: 1fr;
@@ -413,18 +408,16 @@
   flex-direction: column;
   padding: 28px;
   border-radius: var(--strapi-radius-lg);
-  border: 1px solid var(--strapi-neutral-150);
-  background: var(--strapi-surface-0);
+  border: 1px solid var(--strapi-border-strong);
+  background: transparent;
   text-decoration: none;
   color: var(--strapi-neutral-800);
   transition: transform 0.25s cubic-bezier(0.16, 1, 0.3, 1),
-              box-shadow 0.25s cubic-bezier(0.16, 1, 0.3, 1),
               border-color 0.25s ease;
 
   &:hover {
-    transform: translateY(-4px);
-    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.08);
-    border-color: var(--strapi-primary-500);
+    transform: translateY(-2px);
+    border-color: var(--strapi-accent-light);
     text-decoration: none;
     color: var(--strapi-neutral-800);
   }
@@ -444,6 +437,7 @@
 }
 
 .featureCardTitle {
+  font-family: var(--strapi-font-family-display);
   font-size: 20px;
   font-weight: 700;
   margin-bottom: 8px;
@@ -484,27 +478,25 @@
 .showcaseGrid {
   display: grid;
   grid-template-columns: 1fr;
-  gap: 16px;
+  gap: 24px;
 
   /* Equal height cards via inner stretch */
   > div { display: flex; }
 }
 
 .showcaseCard {
-  border-radius: 16px;
-  border: 1px solid var(--strapi-border);
-  background: var(--strapi-surface-1);
+  border-radius: var(--strapi-radius-lg);
+  border: 1px solid var(--strapi-border-strong);
+  background: transparent;
   padding: 32px;
   text-decoration: none !important;
   color: inherit;
   display: flex;
   flex-direction: column;
   transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1);
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
 
   &:hover {
     border-color: var(--strapi-accent-light);
-    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.06);
     text-decoration: none !important;
     color: inherit;
     transform: translateY(-2px);
@@ -514,7 +506,7 @@
 .showcaseCardIcon {
   width: 48px;
   height: 48px;
-  border-radius: 14px;
+  border-radius: 12px;
   background: color-mix(in srgb, var(--strapi-primary-500) 10%, transparent);
   display: grid;
   place-items: center;
@@ -614,17 +606,15 @@
   align-items: center;
   gap: 24px;
   padding: 28px 32px;
-  border-radius: 16px;
-  border: 1px solid var(--strapi-border);
-  background: var(--strapi-surface-1);
+  border-radius: var(--strapi-radius-lg);
+  border: 1px solid var(--strapi-border-strong);
+  background: transparent;
   text-decoration: none !important;
   color: inherit;
   transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1);
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
 
   &:hover {
     border-color: var(--strapi-accent-light);
-    box-shadow: 0 8px 32px rgba(73, 69, 255, 0.08);
     text-decoration: none !important;
     color: inherit;
     transform: translateY(-2px);
@@ -642,7 +632,7 @@
 .deployIcon {
   width: 48px;
   height: 48px;
-  border-radius: 14px;
+  border-radius: 12px;
   background: color-mix(in srgb, var(--strapi-primary-500) 10%, transparent);
   display: grid;
   place-items: center;
@@ -719,43 +709,12 @@
     color: rgba(255, 255, 255, 0.5);
   }
 
-  .quickstartCard {
-    background: #1a1a2e;
-    border-color: rgba(255, 255, 255, 0.08);
-
-    &:hover {
-      border-color: rgba(73, 69, 255, 0.4);
-      box-shadow: 0 8px 32px rgba(73, 69, 255, 0.15);
-    }
-  }
-
   .quickstartIcon {
-    background: rgba(73, 69, 255, 0.2);
-  }
-
-  .exploreCard {
-    background: #1a1a2e;
-    border-color: rgba(255, 255, 255, 0.08);
-
-    &:hover {
-      background: #222240;
-      border-color: rgba(73, 69, 255, 0.4);
-      box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
-    }
+    background: rgba(73, 69, 255, 0.15);
   }
 
   .exploreCardIcon {
     background: rgba(73, 69, 255, 0.15);
-  }
-
-  .showcaseCard {
-    background: #1a1a2e;
-    border-color: rgba(255, 255, 255, 0.08);
-
-    &:hover {
-      border-color: rgba(73, 69, 255, 0.4);
-      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
-    }
   }
 
   .showcaseCardIcon {
@@ -767,18 +726,8 @@
     border-color: rgba(255, 255, 255, 0.06);
   }
 
-  .deployCard {
-    background: #1a1a2e;
-    border-color: rgba(255, 255, 255, 0.08);
-
-    &:hover {
-      border-color: rgba(73, 69, 255, 0.4);
-      box-shadow: 0 8px 32px rgba(73, 69, 255, 0.15);
-    }
-  }
-
   .deployIcon {
-    background: rgba(73, 69, 255, 0.2);
+    background: rgba(73, 69, 255, 0.15);
   }
 
   .codeBlock {
@@ -804,17 +753,6 @@
 
     &::after {
       background: rgba(255, 255, 255, 0.08);
-    }
-  }
-
-  .featureCard {
-    background: #1a1a2e;
-    border-color: rgba(255, 255, 255, 0.08);
-
-    &:hover {
-      background: #222240;
-      border-color: rgba(73, 69, 255, 0.4);
-      box-shadow: 0 12px 40px rgba(0, 0, 0, 0.4);
     }
   }
 

--- a/docusaurus/src/pages/home/home.module.scss
+++ b/docusaurus/src/pages/home/home.module.scss
@@ -219,6 +219,7 @@
   text-decoration: none !important;
   color: inherit;
   transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+  box-shadow: var(--strapi-shadow-xs);
 
   &:hover {
     border-color: var(--strapi-accent-light);
@@ -254,7 +255,7 @@
 .quickstartTitle {
   font-family: var(--strapi-font-family-display);
   font-size: 18px;
-  font-weight: 700;
+  font-weight: 600;
   letter-spacing: -0.02em;
   color: var(--strapi-fg-1);
   margin-bottom: 4px;
@@ -316,6 +317,7 @@
   text-decoration: none !important;
   color: inherit;
   transition: all 0.25s cubic-bezier(0.16, 1, 0.3, 1);
+  box-shadow: var(--strapi-shadow-xs);
 
   &:hover {
     border-color: var(--strapi-accent-light);
@@ -413,7 +415,9 @@
   text-decoration: none;
   color: var(--strapi-neutral-800);
   transition: transform 0.25s cubic-bezier(0.16, 1, 0.3, 1),
+              box-shadow 0.25s cubic-bezier(0.16, 1, 0.3, 1),
               border-color 0.25s ease;
+  box-shadow: var(--strapi-shadow-xs);
 
   &:hover {
     transform: translateY(-2px);
@@ -439,9 +443,9 @@
 .featureCardTitle {
   font-family: var(--strapi-font-family-display);
   font-size: 20px;
-  font-weight: 700;
+  font-weight: 600;
   margin-bottom: 8px;
-  color: var(--strapi-neutral-800);
+  color: var(--strapi-fg-1);
 }
 
 .featureCardDesc {
@@ -494,6 +498,7 @@
   display: flex;
   flex-direction: column;
   transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+  box-shadow: var(--strapi-shadow-xs);
 
   &:hover {
     border-color: var(--strapi-accent-light);
@@ -545,7 +550,7 @@
 .showcaseCardTitle {
   font-family: var(--strapi-font-family-display);
   font-size: 24px;
-  font-weight: 700;
+  font-weight: 600;
   letter-spacing: -0.02em;
   color: var(--strapi-fg-1);
   margin-bottom: 12px;
@@ -612,6 +617,7 @@
   text-decoration: none !important;
   color: inherit;
   transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+  box-shadow: var(--strapi-shadow-xs);
 
   &:hover {
     border-color: var(--strapi-accent-light);
@@ -647,7 +653,7 @@
 .deployTitle {
   font-family: var(--strapi-font-family-display);
   font-size: 18px;
-  font-weight: 700;
+  font-weight: 600;
   letter-spacing: -0.02em;
   color: var(--strapi-fg-1);
   margin-bottom: 4px;
@@ -754,10 +760,6 @@
     &::after {
       background: rgba(255, 255, 255, 0.08);
     }
-  }
-
-  .featureCardTitle {
-    color: rgba(255, 255, 255, 0.95);
   }
 
   .featureCardDesc {


### PR DESCRIPTION
This PR unifies the styling of the cards on the documentation homepage, which previously looked inconsistent because some cards read as filled while others visually blended into the page background. All five card types (quick start, explore, features, showcase, and deploy) now share the same outline treatment: a transparent background, a `--strapi-border-strong` border, a 16px radius (`--strapi-radius-lg`), a subtle `--strapi-shadow-xs` shadow to lift them off the page, and identical hover behaviour (an `--strapi-accent-light` border plus a 2px lift).

Card headings are also unified. They now all use the Poppins display font (`--strapi-font-family-display`), the `--strapi-fg-1` text color, and a 600 font weight, which fixes the "Powerful features" titles that previously used a different font, color, and weight from every other section. Icon tile radii are normalised to 12px and all three card grids now use a 24px gap.

In dark mode, the hard-coded `#1a1a2e` card fills and redundant hover overrides were removed so cards stay transparent and rely on the border, which flips automatically via the token. Icon tile backgrounds in dark mode are unified to a single value.

Only `docusaurus/src/pages/home/home.module.scss` was changed and `yarn build` passes without errors.
