### PR TITLE
Fix ScreenshotNumberReference number centering

### DIFF
--- a/docusaurus/src/components/ScreenshotNumberReference.jsx
+++ b/docusaurus/src/components/ScreenshotNumberReference.jsx
@@ -4,16 +4,17 @@ const ScreenshotNumberReference = ({ number }) => {
   return (
     <span
       style={{
-        display: 'inline-block',
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
         width: '1.5rem',
         height: '1.5rem',
         borderRadius: '50%',
         backgroundColor: '#4743FF',
-        color: '#fff', 
-        textAlign: 'center',
+        color: '#fff',
         fontSize: '.8rem',
         fontWeight: 'bold',
-        padding: '0.1rem',
+        verticalAlign: 'middle',
       }}
     >
       {number}


### PR DESCRIPTION
## Summary

The number badge used `inline-block` with `textAlign`/`padding` to fake centering, which left the digit slightly off-center depending on font metrics.

Switched to flexbox (`inline-flex` + `alignItems`/`justifyContent`) for reliable vertical and horizontal centering.