### PR TITLE
Fix vertical centering in homepage Quick start card

### DIFF
--- a/docusaurus/src/pages/home/home.module.scss
+++ b/docusaurus/src/pages/home/home.module.scss
@@ -156,7 +156,7 @@
   color: var(--strapi-fg-3);
   border: 1px solid var(--strapi-border);
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   gap: 8px;
   overflow: hidden;
 }


### PR DESCRIPTION
This PR fixes the vertical alignment in the homepage Quick start card. The command code block used `align-items: flex-start`, which top-aligned the copy button against the single-line command instead of centering it. Switching to `align-items: center` puts the command text and the copy button on the same vertical axis.