### PR TITLE
Clarify that private attributes are writable in GraphQL mutation inputs

### DIFF
--- a/docusaurus/docs/cms/api/graphql.md
+++ b/docusaurus/docs/cms/api/graphql.md
@@ -492,7 +492,7 @@ For instance, for a "Restaurant" content-type, the following mutations are gener
 | Delete an existing "Restaurant" restaurant  | `deleteRestaurant`  |
 
 :::note Private attributes in mutation inputs
-Attributes marked `private: true` in a content-type schema are **included** in the generated mutation input types (e.g., `RestaurantInput!`) so they can be set via create and update mutations. Private attributes remain hidden from GraphQL query response types and filter inputs — they are write-only from a GraphQL perspective.
+Attributes marked `private: true` in a content-type schema are **included** in the generated mutation input types (e.g., `RestaurantInput!`) so they can be set via create and update mutations. Private attributes remain hidden from GraphQL query response types and filter inputs, as they are write-only from a GraphQL perspective.
 :::
 
 ### Create a new document

--- a/docusaurus/docs/cms/api/graphql.md
+++ b/docusaurus/docs/cms/api/graphql.md
@@ -491,6 +491,10 @@ For instance, for a "Restaurant" content-type, the following mutations are gener
 | Update an existing "Restaurant" restaurant  | `updateRestaurant`  |
 | Delete an existing "Restaurant" restaurant  | `deleteRestaurant`  |
 
+:::note Private attributes in mutation inputs
+Attributes marked `private: true` in a content-type schema are **included** in the generated mutation input types (e.g., `RestaurantInput!`) so they can be set via create and update mutations. Private attributes remain hidden from GraphQL query response types and filter inputs — they are write-only from a GraphQL perspective.
+:::
+
 ### Create a new document
 
 When creating new documents, the `data` argument will have an associated input type that is specific to your content-type.


### PR DESCRIPTION
This PR updates documentation based on https://github.com/strapi/strapi/pull/26489.

## Changes

- **`cms/api/graphql.md`** — added a note to the Mutations section clarifying that attributes marked `private: true` are now included in generated GraphQL mutation input types (e.g., `RestaurantInput!`) so they can be set via create and update mutations, while remaining hidden from response types and filter inputs.

Generated automatically by the docs self-healing workflow.
Review before merging.