### PR TITLE
Restore Cloud qualifier in Cloud page titles and guard frontmatter edits

### DIFF
--- a/claude-plugins/inki/references/authoring/AGENTS.cloud.md
+++ b/claude-plugins/inki/references/authoring/AGENTS.cloud.md
@@ -7,6 +7,10 @@ Technical writing rules
 - Follow CONTRIBUTING.md and STYLE_GUIDE.pdf.
 - 12 Rules of Technical Writing: ../../12-rules-of-technical-writing.md
 
+Frontmatter and structure
+- Never modify an existing page's frontmatter properties (`title`, `description`, `displayed_sidebar`, `sidebar_label`, `tags`, `canonicalUrl`, etc.) as a side effect of another edit. Changing these silently breaks page titles, SEO, and canonical URLs. Only touch a frontmatter value when the user explicitly asks for it, and confirm the exact before/after change with the user first.
+- Cloud page `title` values keep the `Cloud` qualifier (e.g., `Cloud project collaboration`, `Cloud project logs`, `Cloud project settings`). This keeps the "Cloud" notion in the browser tab title and search results. Do not shorten these to drop `Cloud`.
+
 Content specifics
 - Emphasize deployment, security, IAM, and operational runbooks.
 - For provider steps (e.g., AWS), keep screenshots current and add troubleshooting.

--- a/claude-plugins/inki/references/authoring/AGENTS.cms.md
+++ b/claude-plugins/inki/references/authoring/AGENTS.cms.md
@@ -12,6 +12,7 @@ Technical writing rules
 Frontmatter and structure
 - Always provide `title`, optional `description`, and meaningful headings (H2/H3).
 - Include a <Tldr> section at the top summarizing the page.
+- Never modify an existing page's frontmatter properties (`title`, `description`, `displayed_sidebar`, `sidebar_label`, `tags`, `canonicalUrl`, etc.) as a side effect of another edit. Changing these silently breaks page titles, SEO, and canonical URLs. Only touch a frontmatter value when the user explicitly asks for it, and confirm the exact before/after change with the user first.
 
 Templates
 - CMS authoring templates live in `claude-plugins/inki/references/templates/` (guide, API, configuration, feature, migration, plugin). Start from a template to ensure structure and frontmatter are correct.

--- a/claude-plugins/inki/references/prompts/drafter.md
+++ b/claude-plugins/inki/references/prompts/drafter.md
@@ -243,6 +243,8 @@ Analyze `source_material` + `target.notes` to determine what needs to change. Fo
 - When `target.notes` says something like "add X to the Y table", that maps directly to an `add_row` instruction. Follow the Router's guidance literally.
 - When the source material shows a code change (PR diff), trace it to the documentation impact: new parameter → `add_row` to the parameters table; changed behavior → `replace` the outdated description; new feature → `add_text` with a new paragraph or callout.
 
+**Never modify existing YAML frontmatter properties.** Do not change, rename, or remove any value already present in a page's frontmatter block (`title`, `description`, `displayed_sidebar`, `sidebar_label`, `tags`, `pagination_*`, `canonicalUrl`, etc.) as a side effect of a patch. These properties control the browser tab title, SEO metadata, sidebar labels, and canonical URLs; silently rewriting one (for example, shortening a `title` from `Cloud project collaboration` to `Project collaboration`) breaks the rendered page title and search results. If — and only if — the user's request is explicitly about a frontmatter property, propose the exact before/after change and get **explicit human confirmation** before applying it. When adding a brand-new section or page, set frontmatter from `outline.frontmatter` as usual; this rule concerns *existing* values on *existing* pages.
+
 ### Step 5: Apply edits and write the output
 
 Choose the output format based on complexity:
@@ -258,6 +260,7 @@ After producing the output, verify:
 - Edited text is consistent with the rest of the page (no contradictions introduced).
 - Table columns match the existing table structure.
 - New content references use the same terminology as the rest of the page.
+- Existing YAML frontmatter is byte-for-byte unchanged (unless the user explicitly asked to change a frontmatter property and confirmed the exact edit).
 
 ---
 

--- a/docusaurus/docs/cloud/projects/collaboration.md
+++ b/docusaurus/docs/cloud/projects/collaboration.md
@@ -1,5 +1,5 @@
 ---
-title: Project collaboration
+title: Cloud project collaboration
 displayed_sidebar: cloudSidebar
 description: Share your projects on Strapi Cloud to collaborate with others.
 canonicalUrl: https://docs.strapi.io/cloud/projects/collaboration.md

--- a/docusaurus/docs/cloud/projects/logs.md
+++ b/docusaurus/docs/cloud/projects/logs.md
@@ -1,5 +1,5 @@
 ---
-title: Project logs
+title: Cloud project logs
 displayed_sidebar: cloudSidebar
 description: View logs for a Strapi Cloud project.
 canonicalUrl: https://docs.strapi.io/cloud/projects/logs.html

--- a/docusaurus/docs/cloud/projects/observability.md
+++ b/docusaurus/docs/cloud/projects/observability.md
@@ -1,5 +1,5 @@
 ---
-title: Project observability
+title: Cloud project observability
 displayed_sidebar: cloudSidebar
 description: Monitor API requests, bandwidth, asset storage, and CPU and Memory usage directly from your Strapi Cloud project dashboard.
 canonicalUrl: https://docs.strapi.io/cloud/projects/observability.html

--- a/docusaurus/docs/cloud/projects/overview.md
+++ b/docusaurus/docs/cloud/projects/overview.md
@@ -1,5 +1,5 @@
 ---
-title: Project overview
+title: Cloud projects overview
 displayed_sidebar: cloudSidebar
 description: View and manage your projects on Strapi Cloud.
 canonicalUrl: https://docs.strapi.io/cloud/projects/overview.html


### PR DESCRIPTION
This PR restores the "Cloud" qualifier in the frontmatter title of several Cloud project pages that PR #3323 had inadvertently shortened (for example "Cloud project collaboration" became "Project collaboration"), which dropped the Cloud notion from the browser tab title and search results. It also adds a guardrail to the Inki agent prompts and CMS/Cloud authoring guides so agents never modify existing frontmatter properties without explicit user confirmation.

Direct preview link 👉 [here](https://documentation-git-repo-restore-cloud-page-titles-strapijs.vercel.app/cloud/projects/collaboration)