### PR TITLE
Fix duplicate screenshot number on Cloud projects overview page

### DIFF
--- a/docusaurus/docs/cloud/projects/overview.md
+++ b/docusaurus/docs/cloud/projects/overview.md
@@ -66,8 +66,8 @@ From the dashboard header of a chosen project, you can:
 - trigger a new deployment (see [Deployments management](/cloud/projects/deploys)) and visit your application <ScreenshotNumberReference number="5" />.
 
 Your project dashboard also displays:
-- the list of all the deployments of your environment (see [Deployments history](/cloud/projects/deploys-history)) <ScreenshotNumberReference number="5" />,
-- the project and environment details in a box on the right of the interface <ScreenshotNumberReference number="6" />, including:
+- the list of all the deployments of your environment (see [Deployments history](/cloud/projects/deploys-history)) <ScreenshotNumberReference number="6" />,
+- the project and environment details in a box on the right of the interface <ScreenshotNumberReference number="7" />, including:
   - a summary of API, bandwidth, and storage consumption (see [Project observability](/cloud/projects/observability) for the full breakdown),
   - the name of the branch and a **Manage** button to be redirect to the branch settings (see [Modifying git repository & branch](/cloud/projects/settings#modifying-git-repository--branch)),
   - the name of the base directory,


### PR DESCRIPTION
This PR fixes the numbered callouts on the Cloud projects overview page. The dashboard screenshot has 7 numbered zones, but the prose reused number 5 and stopped at 6, leaving the 7th callout (the project and environment details box) undescribed. The second list is renumbered to 6 and 7 so all seven callouts are documented.

Direct preview link 👉 [here](https://documentation-git-cloud-overview-screenshot-7-callouts-strapijs.vercel.app/cloud/projects/overview)