### PR TITLE
Fix sidebar labels for many Cloud pages

### DIFF
--- a/docusaurus/docs/cloud/account/account-settings.md
+++ b/docusaurus/docs/cloud/account/account-settings.md
@@ -1,6 +1,7 @@
 ---
 title: Cloud profile settings
 displayed_sidebar: cloudSidebar
+sidebar_label: Profile settings
 description: Manage Strapi Cloud account settings.
 canonicalUrl: https://docs.strapi.io/cloud/account/account-settings.html
 tags:

--- a/docusaurus/docs/cloud/projects/collaboration.md
+++ b/docusaurus/docs/cloud/projects/collaboration.md
@@ -1,6 +1,7 @@
 ---
 title: Cloud project collaboration
 displayed_sidebar: cloudSidebar
+sidebar_label: Collaboration
 description: Share your projects on Strapi Cloud to collaborate with others.
 canonicalUrl: https://docs.strapi.io/cloud/projects/collaboration.md
 sidebar_position: 1

--- a/docusaurus/docs/cloud/projects/deploys-history.md
+++ b/docusaurus/docs/cloud/projects/deploys-history.md
@@ -1,6 +1,7 @@
 ---
 title: Cloud deployment history & logs
 displayed_sidebar: cloudSidebar
+sidebar_label: Deployment history & logs
 description: View projects' deployment history and logs.
 canonicalUrl: https://docs.strapi.io/cloud/deploys-history.html
 sidebar_position: 1

--- a/docusaurus/docs/cloud/projects/deploys.md
+++ b/docusaurus/docs/cloud/projects/deploys.md
@@ -1,6 +1,7 @@
 ---
 title: Cloud deployments management
 displayed_sidebar: cloudSidebar
+sidebar_label: Deployment management
 description: Manage your projects's deployments.
 canonicalUrl: https://docs.strapi.io/cloud/projects/deploys.html
 sidebar_position: 1

--- a/docusaurus/docs/cloud/projects/logs.md
+++ b/docusaurus/docs/cloud/projects/logs.md
@@ -1,7 +1,7 @@
 ---
 title: Cloud project logs
 displayed_sidebar: cloudSidebar
-sidebar_label: Logs
+sidebar_label: Project logs
 description: View logs for a Strapi Cloud project.
 canonicalUrl: https://docs.strapi.io/cloud/projects/logs.html
 sidebar_position: 1

--- a/docusaurus/docs/cloud/projects/logs.md
+++ b/docusaurus/docs/cloud/projects/logs.md
@@ -1,6 +1,7 @@
 ---
 title: Cloud project logs
 displayed_sidebar: cloudSidebar
+sidebar_label: Logs
 description: View logs for a Strapi Cloud project.
 canonicalUrl: https://docs.strapi.io/cloud/projects/logs.html
 sidebar_position: 1

--- a/docusaurus/docs/cloud/projects/observability.md
+++ b/docusaurus/docs/cloud/projects/observability.md
@@ -1,6 +1,7 @@
 ---
 title: Cloud project observability
 displayed_sidebar: cloudSidebar
+sidebar_label: Observability
 description: Monitor API requests, bandwidth, asset storage, and CPU and Memory usage directly from your Strapi Cloud project dashboard.
 canonicalUrl: https://docs.strapi.io/cloud/projects/observability.html
 tags:

--- a/docusaurus/docs/cloud/projects/overview.md
+++ b/docusaurus/docs/cloud/projects/overview.md
@@ -1,6 +1,7 @@
 ---
 title: Cloud projects overview
 displayed_sidebar: cloudSidebar
+sidebar_label: Overview
 description: View and manage your projects on Strapi Cloud.
 canonicalUrl: https://docs.strapi.io/cloud/projects/overview.html
 sidebar_position: 1

--- a/docusaurus/docs/cloud/projects/settings.md
+++ b/docusaurus/docs/cloud/projects/settings.md
@@ -1,7 +1,7 @@
 ---
 title: Cloud project settings
 displayed_sidebar: cloudSidebar
-sidebar_label: Settings
+sidebar_label: Project settings
 description: View and manage your projects settings on Strapi Cloud.
 canonicalUrl: https://docs.strapi.io/cloud/projects/settings.html
 sidebar_position: 2

--- a/docusaurus/docs/cloud/projects/settings.md
+++ b/docusaurus/docs/cloud/projects/settings.md
@@ -1,6 +1,7 @@
 ---
 title: Cloud project settings
 displayed_sidebar: cloudSidebar
+sidebar_label: Settings
 description: View and manage your projects settings on Strapi Cloud.
 canonicalUrl: https://docs.strapi.io/cloud/projects/settings.html
 sidebar_position: 2


### PR DESCRIPTION
This PR makes the sidebar labels for cloud pages consistent while explicitly preserving longer titles in other places.