### PR TITLE
Clarify repeatable component update workarounds

### DIFF
--- a/docusaurus/docs/cms/api/document-service.md
+++ b/docusaurus/docs/cms/api/document-service.md
@@ -373,7 +373,7 @@ To update a document and publish the new version right away, you can:
 :::
 
 :::caution
-It's not recommended to update repeatable components with the Document Service API (see the related [breaking change entry](/cms/migration/v4-to-v5/breaking-changes/do-not-update-repeatable-components-with-document-service-api.md) for more details).
+It's not recommended to update repeatable components by reusing **published** component `id`s (see the related [breaking change entry](/cms/migration/v4-to-v5/breaking-changes/do-not-update-repeatable-components-with-document-service-api.md) for details and workarounds). Prefer replacing the full component array without `id`s, or updating against **draft** component ids.
 :::
 
 </Endpoint>

--- a/docusaurus/docs/cms/api/document-service.md
+++ b/docusaurus/docs/cms/api/document-service.md
@@ -373,7 +373,7 @@ To update a document and publish the new version right away, you can:
 :::
 
 :::caution
-It's not recommended to update repeatable components by reusing **published** component `id`s (see the related [breaking change entry](/cms/migration/v4-to-v5/breaking-changes/do-not-update-repeatable-components-with-document-service-api.md) for details and workarounds). Prefer replacing the full component array without `id`s, or updating against **draft** component ids.
+It's not recommended to update repeatable components by reusing published component `id`s (see the related [breaking change entry](/cms/migration/v4-to-v5/breaking-changes/do-not-update-repeatable-components-with-document-service-api.md) for details and workarounds). Prefer replacing the full component array without `id`s, or updating against draft component ids.
 :::
 
 </Endpoint>

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/do-not-update-repeatable-components-with-document-service-api.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/do-not-update-repeatable-components-with-document-service-api.md
@@ -1,29 +1,29 @@
 ---
-title: defaultIndex removed
-description: In Strapi 5, it's not recommended to update repeatable components with the Document Service API
-sidebar_label: defaultIndex removed
+title: Updating repeatable components with the Document Service API
+description: In Strapi 5, updating repeatable components by published component id is not recommended; prefer full-array replace or draft ids until a durable component key exists.
+sidebar_label: Updating repeatable components
 displayed_sidebar: cmsSidebar
 tags:
- - breaking changes
- - middlewares
- - upgrade to Strapi 5
+  - breaking changes
+  - Document Service API
+  - components
+  - upgrade to Strapi 5
 ---
 
 import Intro from '/docs/snippets/breaking-change-page-intro.md'
 import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.md'
 
-#  Updating repeatable components with the Document Service API is not recommended
+# Updating repeatable components with the Document Service API is not recommended
 
 <Tldr>
 
-In Strapi 5, updating repeatable components with the Document Service API is not recommended because draft and published components have different IDs, preventing successful updates using `documentId`.
+In Strapi 5, draft and published versions of a document use **different numeric component `id`s**. Reusing an `id` from a published response to update the draft usually fails. Prefer replacing the full component array (or editing against draft ids) until a durable component identity ships.
 
 </Tldr>
 
+In Strapi 5, it's not recommended to update repeatable components by reusing component `id`s from published API responses, because of how Draft & Publish interacts with the Document Service API.
 
-In Strapi 5, it's not recommended to update repeatable components with the API, due to some limitations of the new Document Service API.
-
- <Intro />
+<Intro />
 
 <BreakingChangeIdCard
   plugins
@@ -37,7 +37,7 @@ In Strapi 5, it's not recommended to update repeatable components with the API, 
 
 **In Strapi v4**
 
-You could update a repeatable component with its `id`.
+You could partially update a repeatable component by passing its numeric `id`.
 
 </SideBySideColumn>
 
@@ -45,7 +45,7 @@ You could update a repeatable component with its `id`.
 
 **In Strapi 5**
 
-Strapi 5 uses `documentId` due to the introduction of the [Document Service API](/cms/api/document-service), and you can't update a repeatable component by its `documentId` due to the way the [Draft & Publish](/cms/features/draft-and-publish) feature works with the new API.
+Documents use a stable [`documentId`](/cms/api/document-service), but **nested components still use status-local numeric `id`s**. Publishing creates new component rows, so the draft and published versions of the “same” block have different `id`s. You cannot treat a published component `id` like a document-level identifier.
 
 </SideBySideColumn>
 
@@ -53,36 +53,114 @@ Strapi 5 uses `documentId` due to the introduction of the [Document Service API]
 
 ## Migration
 
-<br/>
+<MigrationIntro />
 
 ### Notes
 
-In Strapi 5, draft components and published components have different ids, and you could fetch data like follows:
+With Draft & Publish enabled, a typical Content API flow looks like this:
 
 ```js
-// Request
-GET /articles // -> returns published article
+// Request — Content API returns the published version by default
+GET /api/articles
 
-// Response
+// Response (published)
 {
-   documentId …
-   component: [
-     { id: 2, name: 'component-1'  },
-     { id: 4, name: 'component-2'  },
-   ]
+  data: {
+    documentId: '…',
+    components: [
+      { id: 2, name: 'component-1' },
+      { id: 4, name: 'component-2' },
+    ],
+  },
 }
 ```
 
-You can then try to do the following:
+Updating with those published `id`s writes the **draft**, which has different component row ids:
 
 ```js
-PUT /articles/{documentId} // <== Update draft article
+PUT /api/articles/{documentId}
 {
-   documentId …
-   component: [
-     { id: 2, name: 'component-1-updated'  }, // <== Update component 1
-   ]
+  data: {
+    components: [
+      { id: 2, name: 'component-1-updated' }, // published id — usually wrong for draft
+    ],
+  },
 }
 ```
 
-However, this would fail because the component id of the draft article is different from the published one. Therefore, it's not recommended to try to update repeatable components with the Document Service API.
+This often fails with an error such as `Some of the provided components in components are not related to the entity`, because `id: 2` is not linked to the draft entry.
+
+The [Document Service](/cms/api/document-service) defaults to the **draft** on read/update, so in-place updates by `id` can work there (and in the Content Manager) when you use draft component ids. The trap is mixing **published** ids with **draft** writes.
+
+### Recommended workarounds
+
+Until a durable nested identity is available, use one of the following.
+
+#### 1. Replace the full component array (preferred for Content API)
+
+Omit component `id`s and send the complete desired list. Strapi recreates the components on the draft. This is the supported, non-fragile approach for REST/GraphQL clients that only see published data:
+
+```js
+// Document Service
+await strapi.documents('api::article.article').update({
+  documentId,
+  data: {
+    components: [
+      { name: 'component-1-updated' },
+      { name: 'component-2' },
+    ],
+  },
+});
+```
+
+```js
+// REST Content API
+PUT /api/articles/{documentId}
+{
+  "data": {
+    "components": [
+      { "name": "component-1-updated" },
+      { "name": "component-2" }
+    ]
+  }
+}
+```
+
+:::tip
+Include every component you want to keep. Entries omitted from the array are removed from the draft.
+:::
+
+#### 2. Edit against draft component ids (Document Service / admin-style)
+
+If you control the backend (custom routes, scripts, Document Service), load the **draft**, then update using those ids:
+
+```js
+const draft = await strapi.documents('api::article.article').findOne({
+  documentId,
+  status: 'draft',
+  populate: ['components'],
+});
+
+await strapi.documents('api::article.article').update({
+  documentId,
+  data: {
+    components: draft.components.map((component) =>
+      component.id === targetDraftId
+        ? { id: component.id, name: 'component-1-updated' }
+        : { id: component.id, name: component.name }
+    ),
+  },
+});
+```
+
+Do **not** reuse ids from a default Content API `GET` (published) for this pattern.
+
+#### 3. Draft & Publish disabled
+
+If Draft & Publish is disabled on the content-type, there is only one component row set, so id-based updates are less problematic. Prefer the full-array replace pattern anyway for simpler client code.
+
+### Related
+
+- [Components and dynamic zones do not return an id](/cms/migration/v4-to-v5/breaking-changes/components-and-dynamic-zones-do-not-return-id) (REST response shape)
+- [Document Service API](/cms/api/document-service)
+- [Draft & Publish](/cms/features/draft-and-publish)

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/do-not-update-repeatable-components-with-document-service-api.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/do-not-update-repeatable-components-with-document-service-api.md
@@ -17,7 +17,7 @@ import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.
 
 <Tldr>
 
-In Strapi 5, draft and published versions of a document use **different numeric component `id`s**. Reusing an `id` from a published response to update the draft usually fails. Prefer replacing the full component array (or editing against draft ids) until a durable component identity ships.
+In Strapi 5, draft and published versions of a document use different numeric component `id`s. Reusing an `id` from a published response to update the draft usually fails. Prefer replacing the full component array (or editing against draft ids) until a durable component identity ships.
 
 </Tldr>
 
@@ -45,7 +45,7 @@ You could partially update a repeatable component by passing its numeric `id`.
 
 **In Strapi 5**
 
-Documents use a stable [`documentId`](/cms/api/document-service), but **nested components still use status-local numeric `id`s**. Publishing creates new component rows, so the draft and published versions of the “same” block have different `id`s. You cannot treat a published component `id` like a document-level identifier.
+Documents use a stable [`documentId`](/cms/api/document-service), but nested components still use status-local numeric `id`s. Publishing creates new component rows, so the draft and published versions of the same block have different `id`s. You cannot treat a published component `id` like a document-level identifier.
 
 </SideBySideColumn>
 
@@ -60,7 +60,7 @@ Documents use a stable [`documentId`](/cms/api/document-service), but **nested c
 With Draft & Publish enabled, a typical Content API flow looks like this:
 
 ```js
-// Request — Content API returns the published version by default
+// Request: Content API returns the published version by default
 GET /api/articles
 
 // Response (published)
@@ -75,22 +75,22 @@ GET /api/articles
 }
 ```
 
-Updating with those published `id`s writes the **draft**, which has different component row ids:
+Updating with those published `id`s writes the draft, which has different component row ids:
 
 ```js
 PUT /api/articles/{documentId}
 {
   data: {
     components: [
-      { id: 2, name: 'component-1-updated' }, // published id — usually wrong for draft
+      { id: 2, name: 'component-1-updated' }, // published id, usually wrong for draft
     ],
   },
 }
 ```
 
-This often fails with an error such as `Some of the provided components in components are not related to the entity`, because `id: 2` is not linked to the draft entry.
+This often fails with an error such as `Some of the provided components in components are not related to the entity`, because `id: 2` is not linked to the draft entry. This is related to the fact that [components and dynamic zones do not return an `id`](/cms/migration/v4-to-v5/breaking-changes/components-and-dynamic-zones-do-not-return-id) in REST API responses.
 
-The [Document Service](/cms/api/document-service) defaults to the **draft** on read/update, so in-place updates by `id` can work there (and in the Content Manager) when you use draft component ids. The trap is mixing **published** ids with **draft** writes.
+The [Document Service](/cms/api/document-service) defaults to the draft on read/update, so in-place updates by `id` can work there (and in the Content Manager) when you use draft component ids. The trap is mixing published ids with draft writes.
 
 ### Recommended workarounds
 
@@ -132,7 +132,7 @@ Include every component you want to keep. Entries omitted from the array are rem
 
 #### 2. Edit against draft component ids (Document Service / admin-style)
 
-If you control the backend (custom routes, scripts, Document Service), load the **draft**, then update using those ids:
+If you control the backend (custom routes, scripts, Document Service), load the draft, then update using those ids:
 
 ```js
 const draft = await strapi.documents('api::article.article').findOne({
@@ -153,14 +153,8 @@ await strapi.documents('api::article.article').update({
 });
 ```
 
-Do **not** reuse ids from a default Content API `GET` (published) for this pattern.
+Do not reuse ids from a default Content API `GET` (published) for this pattern.
 
 #### 3. Draft & Publish disabled
 
 If Draft & Publish is disabled on the content-type, there is only one component row set, so id-based updates are less problematic. Prefer the full-array replace pattern anyway for simpler client code.
-
-### Related
-
-- [Components and dynamic zones do not return an id](/cms/migration/v4-to-v5/breaking-changes/components-and-dynamic-zones-do-not-return-id) (REST response shape)
-- [Document Service API](/cms/api/document-service)
-- [Draft & Publish](/cms/features/draft-and-publish)


### PR DESCRIPTION
## Summary

- Fixes incorrect frontmatter on the repeatable-components breaking-change page (was copy-pasted as `defaultIndex removed`).
- Clarifies why published component `id`s cannot update drafts.
- Documents interim workarounds until durable nested identity (`componentKey`) ships:
  1. Full-array replace without `id`s (preferred for Content API)
  2. Edit against draft ids via Document Service
  3. Note for D&P-disabled types
- Tweaks the Document Service tip to point at those workarounds.

Companion feature draft: https://github.com/strapi/strapi/pull/27077

## Test plan

- [ ] Preview the breaking-change page locally / on Vercel
- [ ] Confirm links to Document Service + Draft & Publish resolve
- [ ] Confirm sidebar label reads “Updating repeatable components”