### PR TITLE
Correct package manager version handling on Strapi Cloud

### DIFF
--- a/docusaurus/docs/cloud/projects/settings.md
+++ b/docusaurus/docs/cloud/projects/settings.md
@@ -322,8 +322,8 @@ Ensure the Node version configured in your Strapi project matches the Node versi
 :::note Package manager version
 The package manager version is not set in the project settings. During the build, Strapi Cloud detects which package manager to use from your project's lockfile, defaulting to npm.
 
-- For **yarn** and **pnpm**, [Corepack](https://nodejs.org/api/corepack.html) is enabled in the build environment, so the version pinned in your `package.json` `packageManager` field is honored automatically. If no version is pinned, Corepack's bundled default version is used.
-- **npm** is not managed by Corepack: it uses the version bundled with the selected Node.js release.
+- For `yarn` and `pnpm`, [Corepack](https://github.com/nodejs/corepack#readme) is enabled in the build environment, so the version pinned in your `package.json` `packageManager` field is honored automatically. If no version is pinned, Corepack's bundled default version is used.
+- `npm` is not managed by Corepack: it uses the version bundled with the selected Node.js release.
 :::
 
 #### Editing Git branch

--- a/docusaurus/docs/cloud/projects/settings.md
+++ b/docusaurus/docs/cloud/projects/settings.md
@@ -319,6 +319,13 @@ The environment's Node version is based on the one chosen at the creation of the
 Ensure the Node version configured in your Strapi project matches the Node version shown in your project’s dashboard before deploying.
 :::
 
+:::note Package manager version
+The package manager version is not set in the project settings. During the build, Strapi Cloud detects which package manager to use from your project's lockfile, defaulting to npm.
+
+- For **yarn** and **pnpm**, [Corepack](https://nodejs.org/api/corepack.html) is enabled in the build environment, so the version pinned in your `package.json` `packageManager` field is honored automatically. If no version is pinned, Corepack's bundled default version is used.
+- **npm** is not managed by Corepack: it uses the version bundled with the selected Node.js release.
+:::
+
 #### Editing Git branch
 
 

--- a/docusaurus/docs/cms/installation/cli.md
+++ b/docusaurus/docs/cms/installation/cli.md
@@ -67,8 +67,8 @@ Follow the steps below to create a new Strapi project, being sure to use the app
 
     <TabItem value="pnpm" label="pnpm">
 
-    :::caution
-    You might have issues with projects created with pnpm on Strapi Cloud. Strapi Cloud is fixed to pnpm v9, so it's recommended to use npm if you plan to eventually host your project on Strapi Cloud.
+    :::note
+    On Strapi Cloud, the pnpm version is managed by [Corepack](https://github.com/nodejs/corepack#readme): the version pinned in your project's `package.json` `packageManager` field is honored automatically, or Corepack's bundled default is used if none is pinned. For details, see [Package manager version](/cloud/projects/settings#modifying-node-version).
     :::
 
     ```bash

--- a/docusaurus/docs/snippets/installation-prerequisites.md
+++ b/docusaurus/docs/snippets/installation-prerequisites.md
@@ -3,6 +3,6 @@ Before installing Strapi, the following requirements must be installed on your c
 - <ExternalLink to="https://nodejs.org" text="Node.js"/>: Only <ExternalLink to="https://nodejs.org/en/about/previous-releases" text="Active LTS or Maintenance LTS versions"/> are supported (currently `v22`, `v24`, and `v26`). Odd-number releases of Node, known as "current" versions of Node.js, are not supported (e.g. v23, v25).
 - Your preferred Node.js package manager:
     - <ExternalLink to="https://docs.npmjs.com/cli/v6/commands/npm-install" text="npm"/> (`v6` and above)
-    - <ExternalLink to="https://pnpm.io/" text="pnpm" /> (pnpm is fixed to v9 on Strapi Cloud)
+    - <ExternalLink to="https://pnpm.io/" text="pnpm" /> (on Strapi Cloud, <ExternalLink to="https://nodejs.org/api/corepack.html" text="Corepack"/> matches the pnpm version pinned in your project's `package.json` `packageManager` field, or uses Corepack's bundled default if none is pinned)
 - <ExternalLink to="https://www.python.org/downloads/" text="Python"/> (if using a SQLite database)
 - A supported web browser: The Admin panel targets browsers matching the default <ExternalLink to="https://github.com/browserslist/browserslist" text="Browserslist"/> query: `last 3 major versions`, `Firefox ESR`, `last 2 Opera versions`, and `not dead`. See <ExternalLink to="https://browsersl.ist/#q=last+3+major+versions%2C+Firefox+ESR%2C+last+2+Opera+versions%2C+not+dead" text="browsersl.ist"/> for the current coverage matrix. Projects can override these defaults with a Browserslist configuration at the project root.


### PR DESCRIPTION
This PR corrects the documentation on how Strapi Cloud resolves package manager versions. The previous notes wrongly stated that pnpm is fixed to v9 on Strapi Cloud. In reality, Strapi Cloud detects the package manager from the project's lockfile (defaulting to npm), and for yarn and pnpm it enables Corepack so the version pinned in the `package.json` `packageManager` field is honored, falling back to Corepack's bundled default; npm is not managed by Corepack and uses the version bundled with the selected Node.js release. It updates the installation prerequisites snippet, adds a note to the Cloud project settings page next to the Node version documentation, and replaces the outdated "fixed to pnpm v9" caution in the CLI installation page with a note describing the Corepack behavior and linking to the settings page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)