### PR TITLE
General design improvements

### DIFF
--- a/docusaurus/docs/cms/quick-start.md
+++ b/docusaurus/docs/cms/quick-start.md
@@ -46,7 +46,7 @@ There are 3 options to discover Strapi. Choose what best suits you:
 You will also need to <ExternalLink to="https://github.com/git-guides/install-git" text="install git"/> and to have a <ExternalLink to="https://github.com" text="GitHub"/> account to deploy your project to Strapi Cloud.
 :::
 
-## <Icon name="rocket-launch"/> Part A: Create a new project with Strapi
+## Part A: Create a new project with Strapi
 
 We will first create a new Strapi project on your machine by running a command in the terminal, and then register our first local administrator user.
 
@@ -126,7 +126,7 @@ sources={{
 You have just created a new Strapi project! You can start playing with Strapi and discover the [Content Manager](/cms/features/content-manager) by yourself, or proceed to part B below.
 :::
 
-## <Icon name="wrench" /> Part B: Build your content structure with the Content-type Builder
+## Part B: Build your content structure with the Content-type Builder
 
 The installation script has just created an empty project. We will now guide you through creating a small restaurants directory.
 
@@ -204,7 +204,7 @@ You have just created a basic content structure for your Strapi project! You can
 While we showed here how to manually create a content structure, there are other options you can explore: you can import a Figma prototype, import some files from your computer, or even start prompting [Strapi AI](/cms/features/content-type-builder#strapi-ai) <GrowthBadge /> in natural language to let it create things for you. Feel free to try them out!
 :::
 
-## <Icon name="cloud" />️ Part C: Deploy to Strapi Cloud
+## Part C: Deploy to Strapi Cloud
 
 Now that your beautiful first Strapi project is working locally, it's time for the world to see it live! The most straightforward way to host your project is to use Strapi Cloud.
 
@@ -252,7 +252,7 @@ Now your project is hosted on Strapi Cloud and accessible online. You can learn 
 Feel free to play with the Content-Type Builder even further and add more fields to your content-types or create new content-types. Anytime you make such changes, push them to GitHub to trigger a new deployment on Strapi Cloud (if you enabled **Deploy on push** during project creation), or trigger a deployment manually from the [Cloud dashboard](/cloud/projects/deploys). You can also deploy from your terminal with the [Cloud CLI](/cloud/getting-started/deployment-cli).
 :::
 
-## <Icon name="note-pencil" /> Part D: Add content to your Strapi Cloud project with the Content Manager
+## Part D: Add content to your Strapi Cloud project with the Content Manager
 
 Now that we have created a basic content structure with 2 collection types, "Restaurant" and "Category", and deployed your project to Strapi Cloud, let's use the Cloud to actually add content by creating new entries.
 

--- a/docusaurus/src/components/NextSteps/next-steps.module.scss
+++ b/docusaurus/src/components/NextSteps/next-steps.module.scss
@@ -38,7 +38,7 @@
   }
 
   &:hover .step {
-    background: var(--strapi-surface-2, #F4F4F5);
+    outline: 1px solid var(--strapi-border, rgba(0, 0, 0, 0.06));
   }
 
   &:hover .stepArrow {
@@ -122,6 +122,6 @@
   }
 
   .stepLink:hover .step {
-    background: var(--strapi-surface-2, #18181B);
+    outline: 1px solid var(--strapi-border, rgba(255, 255, 255, 0.1));
   }
 }

--- a/docusaurus/src/scss/_tokens-overrides.scss
+++ b/docusaurus/src/scss/_tokens-overrides.scss
@@ -31,6 +31,7 @@
 
   --ifm-link-color: var(--strapi-primary-600);
   --ifm-link-decoration: none;
+  --ifm-link-hover-decoration: none;
 
   --ifm-font-family-base: var(--strapi-font-family-body);
   --ifm-heading-font-family: var(--strapi-font-family-display);

--- a/docusaurus/src/scss/_tokens.scss
+++ b/docusaurus/src/scss/_tokens.scss
@@ -43,6 +43,11 @@
   --strapi-line-height-xxl: 2.25rem;  // 36px
   --strapi-line-height-xxxl: 2.5rem;  // 40px
 
+  /** Letter-spacing applied to all-caps labels set in the monospace font
+   *  (JetBrains Mono). Kept at `normal` on purpose — change it here once to
+   *  adjust every mono uppercase label (badges, title bars, footer, etc.). */
+  --custom-strapi-monospace-letter-spacing: normal;
+
   /** Color: Neutral */
   --strapi-neutral-1000: #181826;
   --strapi-neutral-900: #212134;

--- a/docusaurus/src/scss/_tokens.scss
+++ b/docusaurus/src/scss/_tokens.scss
@@ -150,7 +150,7 @@
   /** V3: Border radius */
   --strapi-radius-xs: 4px;
   --strapi-radius-sm: 6px;
-  --strapi-radius-md: 10px;
+  --strapi-radius-md: 8px;
   --strapi-radius-lg: 16px;
   --strapi-radius-xl: 24px;
   --strapi-radius-full: 9999px;

--- a/docusaurus/src/scss/admonition.scss
+++ b/docusaurus/src/scss/admonition.scss
@@ -117,7 +117,7 @@
     --custom-admonition-background-color: var(--strapi-success-100);
     --custom-admonition-border-color: var(--strapi-success-500);
     --custom-admonition-code-background-color: var(--strapi-success-200);
-    --custom-admonition-code-color: var(--strapi-success-600);
+    --custom-admonition-code-color: var(--strapi-success-700);
     --custom-admonition-heading-color: var(--strapi-success-600);
 
     // Links use a darker success shade than the heading so they stand out as
@@ -129,6 +129,16 @@
     --custom-selection-background-color: var(--strapi-success-700);
     --custom-selection-color: var(--strapi-success-100);
     border-color: var(--strapi-success-200);
+
+    // Inline code uses the darker success-700 (via the code-color var) instead
+    // of the heading color that the base rule wires up, so it reads clearly
+    // against the green tint. Matches the base `h1..table code` selector's
+    // specificity so this override actually wins.
+    h1, h2, h3, li, p, table {
+      code {
+        --custom-code-color: var(--custom-admonition-code-color);
+      }
+    }
   }
 
   &--caution {

--- a/docusaurus/src/scss/admonition.scss
+++ b/docusaurus/src/scss/admonition.scss
@@ -9,10 +9,10 @@
   --custom-admonition-heading-color: var(--strapi-fg-1);
   --custom-admonition-heading-mb: var(--strapi-spacing-2);
   --custom-admonition-mb: var(--strapi-spacing-4);
-  --custom-admonition-px: 1.375rem;
-  --custom-admonition-py: 1.5rem;
-  --custom-prerequisites-px: 40px;
-  --custom-prerequisites-py: 46px;
+  --custom-admonition-px: 24px;
+  --custom-admonition-py: 24px;
+  --custom-prerequisites-px: 24px;
+  --custom-prerequisites-py: 24px;
   --custom-admonition-my: var(--strapi-spacing-7);
 
   --ifm-link-decoration: none;

--- a/docusaurus/src/scss/admonition.scss
+++ b/docusaurus/src/scss/admonition.scss
@@ -120,6 +120,12 @@
     --custom-admonition-code-color: var(--strapi-success-600);
     --custom-admonition-heading-color: var(--strapi-success-600);
 
+    // Links use a darker success shade than the heading so they stand out as
+    // interactive against the green tint (the base sets link color to the
+    // heading color, which was too light here).
+    --ifm-link-color: var(--strapi-success-800);
+    --ifm-link-hover-color: var(--strapi-success-800);
+
     --custom-selection-background-color: var(--strapi-success-700);
     --custom-selection-color: var(--strapi-success-100);
     border-color: var(--strapi-success-200);

--- a/docusaurus/src/scss/admonition.scss
+++ b/docusaurus/src/scss/admonition.scss
@@ -123,8 +123,8 @@
     // Links use a darker success shade than the heading so they stand out as
     // interactive against the green tint (the base sets link color to the
     // heading color, which was too light here).
-    --ifm-link-color: var(--strapi-success-800);
-    --ifm-link-hover-color: var(--strapi-success-800);
+    --ifm-link-color: var(--strapi-success-700);
+    --ifm-link-hover-color: var(--strapi-success-700);
 
     --custom-selection-background-color: var(--strapi-success-700);
     --custom-selection-color: var(--strapi-success-100);

--- a/docusaurus/src/scss/admonition.scss
+++ b/docusaurus/src/scss/admonition.scss
@@ -4,7 +4,7 @@
 .theme-admonition {
   --custom-admonition-background-color: transparent;
   --custom-admonition-border-color: var(--strapi-neutral-200);
-  --custom-admonition-border-radius: var(--strapi-spacing-1);
+  --custom-admonition-border-radius: var(--strapi-radius-md);
   --custom-admonition-color: var(--strapi-fg-2);
   --custom-admonition-heading-color: var(--strapi-fg-1);
   --custom-admonition-heading-mb: var(--strapi-spacing-2);

--- a/docusaurus/src/scss/api-call.scss
+++ b/docusaurus/src/scss/api-call.scss
@@ -63,7 +63,7 @@
       font-size: var(--custom-api-call-heading-font-size);
       font-weight: var(--custom-api-call-heading-font-weight);
       font-family: var(--strapi-font-family-mono);
-      letter-spacing: 0.02em;
+      letter-spacing: var(--custom-strapi-monospace-letter-spacing);
       text-transform: uppercase;
       padding: var(--custom-api-call-heading-py) var(--custom-api-call-heading-px);
     }

--- a/docusaurus/src/scss/code-block.scss
+++ b/docusaurus/src/scss/code-block.scss
@@ -340,7 +340,7 @@ pre.prism-code {
   // corner radius as admonitions (--strapi-radius-xs) for all terminal blocks.
   position: relative;
   border: solid 1px var(--custom-code-block-border-color);
-  border-radius: var(--strapi-radius-xs);
+  border-radius: var(--strapi-radius-md);
   overflow: hidden;
   transition: border-color var(--strapi-duration-fast) var(--strapi-ease);
   margin-bottom: var(--ifm-leading);

--- a/docusaurus/src/scss/code-block.scss
+++ b/docusaurus/src/scss/code-block.scss
@@ -227,7 +227,7 @@ pre.prism-code {
     background: var(--code-title-bar-lang-bg);
     padding: 3px 8px;
     border-radius: var(--strapi-radius-xs);
-    letter-spacing: 0.05em;
+    letter-spacing: var(--custom-strapi-monospace-letter-spacing);
     text-transform: uppercase;
     line-height: 1;
   }

--- a/docusaurus/src/scss/details.scss
+++ b/docusaurus/src/scss/details.scss
@@ -87,6 +87,7 @@ details.alert {
   // Inside a TabItem the wrapper already has padding:0, so this restores parity.
   > .code-block-enhanced {
     padding: 0;
+    border-radius: var(--strapi-radius-md);
   }
 
   > *:last-child {

--- a/docusaurus/src/scss/footer.scss
+++ b/docusaurus/src/scss/footer.scss
@@ -46,7 +46,7 @@
     font-weight: 600;
     margin-bottom: 12px;
     text-transform: uppercase;
-    letter-spacing: 0.1em;
+    letter-spacing: var(--custom-strapi-monospace-letter-spacing);
     color: var(--strapi-neutral-500);
   }
 

--- a/docusaurus/src/scss/footer.scss
+++ b/docusaurus/src/scss/footer.scss
@@ -29,13 +29,15 @@
   }
 
   a {
-    color: var(--strapi-primary-600);
+    // Match the left sidebar's link look: neutral grey at rest, darkening to
+    // the primary foreground on hover (instead of the previous accent blue).
+    color: var(--strapi-neutral-500);
     font-family: var(--strapi-font-family-body);
     font-size: 13px;
     line-height: 1.5;
 
     &:hover {
-      color: var(--strapi-accent, #4945FF);
+      color: var(--strapi-fg-1);
     }
   }
 

--- a/docusaurus/src/scss/pagination-nav.scss
+++ b/docusaurus/src/scss/pagination-nav.scss
@@ -40,7 +40,7 @@
     color: var(--strapi-fg-4);
     font-weight: 500;
     text-transform: uppercase;
-    letter-spacing: 0.08em;
+    letter-spacing: var(--custom-strapi-monospace-letter-spacing);
     margin-bottom: 8px;
 
     &::before,

--- a/docusaurus/src/scss/typography.scss
+++ b/docusaurus/src/scss/typography.scss
@@ -26,7 +26,7 @@ h1, .markdown h1:first-child {
   font-size: var(--strapi-font-size-display-sm);
   line-height: 1.15;
   letter-spacing: -0.03em;
-  font-weight: 800;
+  font-weight: 600;
 }
 
 h2, .markdown > h2 {
@@ -35,7 +35,7 @@ h2, .markdown > h2 {
   --ifm-heading-line-height: var(--strapi-line-height-xxl);
   line-height: var(--strapi-line-height-xxl);
   padding-top: 32px;
-  font-weight: 700;
+  font-weight: 600;
 }
 
 h2 + p, .markdown > h2 + p {

--- a/docusaurus/src/scss/view-modes.scss
+++ b/docusaurus/src/scss/view-modes.scss
@@ -272,7 +272,7 @@
       font-size: 13px;
       font-weight: 700;
       text-transform: uppercase;
-      letter-spacing: 0.05em;
+      letter-spacing: var(--custom-strapi-monospace-letter-spacing);
       margin-bottom: 4px;
       color: var(--custom-admonition-heading-color);
     }
@@ -719,7 +719,7 @@
       font-size: 13px;
       font-weight: 700;
       text-transform: uppercase;
-      letter-spacing: 0.05em;
+      letter-spacing: var(--custom-strapi-monospace-letter-spacing);
       color: var(--strapi-neutral-500);
       margin-top: var(--strapi-spacing-4);
       margin-bottom: var(--strapi-spacing-2);


### PR DESCRIPTION
- [x] Consistent paddings for prerequisites and admonitions
- [x] No icons in Quick Start Guide headings
- [x] Consistent border radiuses for StepDetails blocks, admonitions, prerequisites, and terminal blocks
- [x] No underline for links
- [x] Link color is success-700 for links in tips
- [x] Decrease h1, h2, h3 font weight to 600
- [x] No letter spacing on any element using the monospace font in all caps
- [x] Footer links should be consistent with left sidebar look
- [x] Inline code in tip admonition should use a darker green (success-700)
- [x] StepDetails blocks with title color neutral-800
- [x] StepLink blocks without gray background and with small outline

