### PR TITLE
Mention that local plugin server entry must be JavaScript without SDK

### DIFF
--- a/docusaurus/docs/cms/plugins-development/create-a-plugin.md
+++ b/docusaurus/docs/cms/plugins-development/create-a-plugin.md
@@ -223,6 +223,10 @@ module.exports = () => {
 
 Here, you export a function that returns your plugin's core components such as controllers, routes, and configuration. For more details, please refer to the [Server API reference](/cms/plugins-development/server-api).
 
+:::caution
+Without the Plugin SDK, Strapi loads a local plugin's server entry point directly through Node.js, which only resolves `.js` and `.json` files. A `strapi-server.ts` entry point is not transpiled at load time and resolves to an empty plugin, so the server entry point of a local plugin configured this way must be JavaScript. The admin entry point can still use TypeScript because the admin panel build compiles it.
+:::
+
 ### Admin entry point
 
 The admin entry point file sets up your plugin within the Strapi admin panel. The expected structure for `strapi-admin.js` (or its TypeScript variant) is:


### PR DESCRIPTION
### Description

The `Setting a local plugin in a monorepo environment without the Plugin SDK` section lists `strapi-server.js|ts` as the server entry point, which implies a TypeScript server entry works for this setup. It does not when the plugin is loaded directly without the SDK build or watch step.

Strapi loads a local plugin's server entry point through the Node-side config loader (`packages/core/core/src/utils/load-config-file.ts`), which only resolves `.js` and `.json` files and returns an empty object for any other extension. The plugin loader defaults the server entry to `./strapi-server.js`, so a `strapi-server.ts` entry is not transpiled at load time and the plugin's server code silently does not load. The admin entry point can stay TypeScript because the admin panel build compiles it.

I added a `:::caution` admonition to the Server entry point subsection to document this current behavior, which matches what several people ran into in the linked issue.

### Related issue(s)/PR(s)

Relates to #3025