### PR TITLE
Fix Document Service API examples not rendering with the redesigned Endpoint

### DIFF
--- a/docusaurus/docs/cms/api/document-service.md
+++ b/docusaurus/docs/cms/api/document-service.md
@@ -113,27 +113,36 @@ Syntax: `findOne(parameters: Params) => Document`
     { name: 'fields', type: 'Object', required: false, description: '<a href="/cms/api/document-service/fields#findone">Select fields</a> to return. Defaults to all fields (except those not populated by default).' },
     { name: 'populate', type: 'Object', required: false, description: '<a href="/cms/api/document-service/populate">Populate</a> results with additional fields. Default: <code>null</code>.' },
   ]}
-  codeTabs={[
-    {
-      label: 'Request',
-      code: `await strapi.documents('api::restaurant.restaurant').findOne({
+>
+
+<Tabs>
+<TabItem value="request" label="Request">
+
+```js
+await strapi.documents('api::restaurant.restaurant').findOne({
   documentId: 'a1b2c3d4e5f6g7h8i9j0klmn'
-})`,
-    },
-  ]}
-  responses={[
-    {
-      status: 200,
-      statusText: 'OK',
-      body: JSON.stringify({
-        documentId: "a1b2c3d4e5f6g7h8i9j0klmn",
-        name: "Biscotte Restaurant",
-        publishedAt: null,
-        locale: "en",
-      }, null, 2),
-    },
-  ]}
-/>
+})
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+{
+  "documentId": "a1b2c3d4e5f6g7h8i9j0klmn",
+  "name": "Biscotte Restaurant",
+  "publishedAt": null,
+  "locale": "en"
+}
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>
 
 ### `findFirst()`
 
@@ -153,14 +162,20 @@ Syntax:  `findFirst(parameters: Params) => Document`
     { name: 'fields', type: 'Object', required: false, description: '<a href="/cms/api/document-service/fields#findfirst">Select fields</a> to return. Defaults to all fields (except those not populated by default).' },
     { name: 'populate', type: 'Object', required: false, description: '<a href="/cms/api/document-service/populate">Populate</a> results with additional fields. Default: <code>null</code>.' },
   ]}
-  codeTabs={[
-    {
-      label: 'Generic example',
-      code: `await strapi.documents('api::restaurant.restaurant').findFirst()`,
-    },
-    {
-      label: 'With filters',
-      code: `await strapi.documents('api::restaurant.restaurant').findFirst(
+>
+
+<Tabs>
+<TabItem value="generic-example" label="Generic example">
+
+```js
+await strapi.documents('api::restaurant.restaurant').findFirst()
+```
+
+</TabItem>
+<TabItem value="with-filters" label="With filters">
+
+```js
+await strapi.documents('api::restaurant.restaurant').findFirst(
   {
     filters: {
       name: {
@@ -168,32 +183,38 @@ Syntax:  `findFirst(parameters: Params) => Document`
       }
     }
   }
-)`,
-    },
-  ]}
-  responses={[
-    {
-      status: 200,
-      statusText: 'Generic',
-      body: JSON.stringify({
-        documentId: "a1b2c3d4e5f6g7h8i9j0klmn",
-        name: "Restaurant Biscotte",
-        publishedAt: null,
-        locale: "en",
-      }, null, 2),
-    },
-    {
-      status: 200,
-      statusText: 'With filters',
-      body: JSON.stringify({
-        documentId: "j9k8l7m6n5o4p3q2r1s0tuvw",
-        name: "Pizzeria Arrivederci",
-        publishedAt: null,
-        locale: "en",
-      }, null, 2),
-    },
-  ]}
->
+)
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="Generic">
+
+```json
+{
+  "documentId": "a1b2c3d4e5f6g7h8i9j0klmn",
+  "name": "Restaurant Biscotte",
+  "publishedAt": null,
+  "locale": "en"
+}
+```
+
+</ResponseTab>
+<ResponseTab status={200} statusText="With filters">
+
+```json
+{
+  "documentId": "j9k8l7m6n5o4p3q2r1s0tuvw",
+  "name": "Pizzeria Arrivederci",
+  "publishedAt": null,
+  "locale": "en"
+}
+```
+
+</ResponseTab>
+</Responses>
 
 If no `locale` or `status` parameters are passed, results return the draft version for the default locale.
 
@@ -219,14 +240,20 @@ Syntax: `findMany(parameters: Params) => Document[]`
     { name: 'pagination', type: 'Object', required: false, description: '<a href="/cms/api/document-service/sort-pagination#pagination">Paginate</a> results.' },
     { name: 'sort', type: 'Object', required: false, description: '<a href="/cms/api/document-service/sort-pagination#sort">Sort</a> results.' },
   ]}
-  codeTabs={[
-    {
-      label: 'Generic example',
-      code: `await strapi.documents('api::restaurant.restaurant').findMany()`,
-    },
-    {
-      label: 'With filters',
-      code: `await strapi.documents('api::restaurant.restaurant').findMany(
+>
+
+<Tabs>
+<TabItem value="generic-example" label="Generic example">
+
+```js
+await strapi.documents('api::restaurant.restaurant').findMany()
+```
+
+</TabItem>
+<TabItem value="with-filters" label="With filters">
+
+```js
+await strapi.documents('api::restaurant.restaurant').findMany(
   {
     filters: {
       name: {
@@ -234,42 +261,48 @@ Syntax: `findMany(parameters: Params) => Document[]`
       }
     }
   }
-)`,
-    },
-  ]}
-  responses={[
-    {
-      status: 200,
-      statusText: 'Generic',
-      body: JSON.stringify([
-        {
-          documentId: "a1b2c3d4e5f6g7h8i9j0klmn",
-          name: "Biscotte Restaurant",
-          publishedAt: null,
-          locale: "en",
-        },
-        {
-          documentId: "j9k8l7m6n5o4p3q2r1s0tuvw",
-          name: "Pizzeria Arrivederci",
-          publishedAt: null,
-          locale: "en",
-        },
-      ], null, 2),
-    },
-    {
-      status: 200,
-      statusText: 'With filters',
-      body: JSON.stringify([
-        {
-          documentId: "j9k8l7m6n5o4p3q2r1s0tuvw",
-          name: "Pizzeria Arrivederci",
-          locale: "en",
-          publishedAt: null,
-        },
-      ], null, 2),
-    },
-  ]}
->
+)
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="Generic">
+
+```json
+[
+  {
+    "documentId": "a1b2c3d4e5f6g7h8i9j0klmn",
+    "name": "Biscotte Restaurant",
+    "publishedAt": null,
+    "locale": "en"
+  },
+  {
+    "documentId": "j9k8l7m6n5o4p3q2r1s0tuvw",
+    "name": "Pizzeria Arrivederci",
+    "publishedAt": null,
+    "locale": "en"
+  }
+]
+```
+
+</ResponseTab>
+<ResponseTab status={200} statusText="With filters">
+
+```json
+[
+  {
+    "documentId": "j9k8l7m6n5o4p3q2r1s0tuvw",
+    "name": "Pizzeria Arrivederci",
+    "locale": "en",
+    "publishedAt": null
+  }
+]
+```
+
+</ResponseTab>
+</Responses>
 
 Available filters are detailed in the [filters](/cms/api/document-service/filters) page of the Document Service API reference.
 
@@ -293,29 +326,36 @@ Syntax: `create(parameters: Params) => Document`
     { name: 'status', type: "'published'", required: false, description: 'If <a href="/cms/features/draft-and-publish">Draft & Publish</a> is enabled: can be set to <code>published</code> to automatically publish the draft version of a document while creating it. <a href="/cms/api/document-service/status#create">See status docs</a>.' },
     { name: 'populate', type: 'Object', required: false, description: '<a href="/cms/api/document-service/populate">Populate</a> results with additional fields. Default: <code>null</code>.' },
   ]}
-  codeTabs={[
-    {
-      label: 'Request',
-      code: `await strapi.documents('api::restaurant.restaurant').create({
+>
+
+<Tabs>
+<TabItem value="request" label="Request">
+
+```js
+await strapi.documents('api::restaurant.restaurant').create({
   data: {
     name: 'Restaurant B'
   }
-})`,
-    },
-  ]}
-  responses={[
-    {
-      status: 200,
-      statusText: 'OK',
-      body: JSON.stringify({
-        documentId: "a1b2c3d4e5f6g7h8i9j0klmn",
-        name: "Restaurant B",
-        publishedAt: null,
-        locale: "en",
-      }, null, 2),
-    },
-  ]}
->
+})
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+{
+  "documentId": "a1b2c3d4e5f6g7h8i9j0klmn",
+  "name": "Restaurant B",
+  "publishedAt": null,
+  "locale": "en"
+}
+```
+
+</ResponseTab>
+</Responses>
 
 :::tip
 If the [Draft & Publish](/cms/features/draft-and-publish) feature is enabled on the content-type, you can automatically publish a document while creating it (see [`status` documentation](/cms/api/document-service/status#create)).
@@ -341,28 +381,35 @@ Syntax: `update(parameters: Params) => Promise<Document>`
     { name: 'status', type: "'published'", required: false, description: 'If <a href="/cms/features/draft-and-publish">Draft & Publish</a> is enabled: can be set to <code>published</code> to automatically publish the draft version of a document while updating it. <a href="/cms/api/document-service/status#update">See status docs</a>.' },
     { name: 'populate', type: 'Object', required: false, description: '<a href="/cms/api/document-service/populate">Populate</a> results with additional fields. Default: <code>null</code>.' },
   ]}
-  codeTabs={[
-    {
-      label: 'Request',
-      code: `await strapi.documents('api::restaurant.restaurant').update({
+>
+
+<Tabs>
+<TabItem value="request" label="Request">
+
+```js
+await strapi.documents('api::restaurant.restaurant').update({
     documentId: 'a1b2c3d4e5f6g7h8i9j0klmn',
     data: { name: "New restaurant name" }
-})`,
-    },
-  ]}
-  responses={[
-    {
-      status: 200,
-      statusText: 'OK',
-      body: JSON.stringify({
-        documentId: "a1b2c3d4e5f6g7h8i9j0klmn",
-        name: "New restaurant name",
-        locale: "en",
-        publishedAt: null,
-      }, null, 2),
-    },
-  ]}
->
+})
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+{
+  "documentId": "a1b2c3d4e5f6g7h8i9j0klmn",
+  "name": "New restaurant name",
+  "locale": "en",
+  "publishedAt": null
+}
+```
+
+</ResponseTab>
+</Responses>
 
 :::tip
 Published versions are read-only, so you can not technically update the published version of a document.
@@ -395,32 +442,41 @@ Syntax: `delete(parameters: Params): Promise<{ documentId: ID, entries: Number }
     { name: 'fields', type: 'Object', required: false, description: '<a href="/cms/api/document-service/fields#delete">Select fields</a> to return. Defaults to all fields (except those not populated by default).' },
     { name: 'populate', type: 'Object', required: false, description: '<a href="/cms/api/document-service/populate">Populate</a> results with additional fields. Default: <code>null</code>.' },
   ]}
-  codeTabs={[
-    {
-      label: 'Request',
-      code: `await strapi.documents('api::restaurant.restaurant').delete({
+>
+
+<Tabs>
+<TabItem value="request" label="Request">
+
+```js
+await strapi.documents('api::restaurant.restaurant').delete({
   documentId: 'a1b2c3d4e5f6g7h8i9j0klmn',
-})`,
-    },
-  ]}
-  responses={[
+})
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+{
+  "documentId": "a1b2c3d4e5f6g7h8i9j0klmn",
+  "entries": [
     {
-      status: 200,
-      statusText: 'OK',
-      body: JSON.stringify({
-        documentId: "a1b2c3d4e5f6g7h8i9j0klmn",
-        entries: [
-          {
-            documentId: "a1b2c3d4e5f6g7h8i9j0klmn",
-            name: "Biscotte Restaurant",
-            publishedAt: "2024-03-14T18:30:48.870Z",
-            locale: "en",
-          }
-        ]
-      }, null, 2),
-    },
-  ]}
-/>
+      "documentId": "a1b2c3d4e5f6g7h8i9j0klmn",
+      "name": "Biscotte Restaurant",
+      "publishedAt": "2024-03-14T18:30:48.870Z",
+      "locale": "en"
+    }
+  ]
+}
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>
 
 ### `deleteMany()`
 
@@ -438,10 +494,13 @@ Syntax: `deleteMany(parameters: Params): Promise<{ documentId: ID, entries: Numb
     { name: 'fields', type: 'Object', required: false, description: '<a href="/cms/api/document-service/fields#delete">Select fields</a> to return. Defaults to all fields (except those not populated by default).' },
     { name: 'populate', type: 'Object', required: false, description: '<a href="/cms/api/document-service/populate">Populate</a> results with additional fields. Default: <code>null</code>.' },
   ]}
-  codeTabs={[
-    {
-      label: 'Request',
-      code: `await strapi.documents('api::restaurant.restaurant').deleteMany({
+>
+
+<Tabs>
+<TabItem value="request" label="Request">
+
+```js
+await strapi.documents('api::restaurant.restaurant').deleteMany({
   filters: {
     city: {
       name: {
@@ -449,20 +508,26 @@ Syntax: `deleteMany(parameters: Params): Promise<{ documentId: ID, entries: Numb
       }
     }
   }
-});`,
-    },
-  ]}
-  responses={[
-    {
-      status: 200,
-      statusText: 'OK',
-      body: JSON.stringify({
-        documentId: "multiple_documents",
-        entries: 3
-      }, null, 2),
-    },
-  ]}
-/>
+});
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+{
+  "documentId": "multiple_documents",
+  "entries": 3
+}
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>
 
 ### `publish()`
 
@@ -481,32 +546,41 @@ Syntax: `publish(parameters: Params): Promise<{ documentId: ID, entries: Number 
     { name: 'fields', type: 'Object', required: false, description: '<a href="/cms/api/document-service/fields#publish">Select fields</a> to return. Defaults to all fields (except those not populated by default).' },
     { name: 'populate', type: 'Object', required: false, description: '<a href="/cms/api/document-service/populate">Populate</a> results with additional fields. Default: <code>null</code>.' },
   ]}
-  codeTabs={[
-    {
-      label: 'Request',
-      code: `await strapi.documents('api::restaurant.restaurant').publish({
+>
+
+<Tabs>
+<TabItem value="request" label="Request">
+
+```js
+await strapi.documents('api::restaurant.restaurant').publish({
   documentId: 'a1b2c3d4e5f6g7h8i9j0klmn',
-});`,
-    },
-  ]}
-  responses={[
+});
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+{
+  "documentId": "a1b2c3d4e5f6g7h8i9j0klmn",
+  "entries": [
     {
-      status: 200,
-      statusText: 'OK',
-      body: JSON.stringify({
-        documentId: "a1b2c3d4e5f6g7h8i9j0klmn",
-        entries: [
-          {
-            documentId: "a1b2c3d4e5f6g7h8i9j0klmn",
-            name: "Biscotte Restaurant",
-            publishedAt: "2024-03-14T18:30:48.870Z",
-            locale: "en",
-          }
-        ]
-      }, null, 2),
-    },
-  ]}
-/>
+      "documentId": "a1b2c3d4e5f6g7h8i9j0klmn",
+      "name": "Biscotte Restaurant",
+      "publishedAt": "2024-03-14T18:30:48.870Z",
+      "locale": "en"
+    }
+  ]
+}
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>
 
 ### `unpublish()`
 
@@ -525,32 +599,41 @@ Syntax: `unpublish(parameters: Params): Promise<{ documentId: ID, entries: Numbe
     { name: 'fields', type: 'Object', required: false, description: '<a href="/cms/api/document-service/fields#unpublish">Select fields</a> to return. Defaults to all fields (except those not populated by default).' },
     { name: 'populate', type: 'Object', required: false, description: '<a href="/cms/api/document-service/populate">Populate</a> results with additional fields. Default: <code>null</code>.' },
   ]}
-  codeTabs={[
-    {
-      label: 'Request',
-      code: `await strapi.documents('api::restaurant.restaurant').unpublish({
+>
+
+<Tabs>
+<TabItem value="request" label="Request">
+
+```js
+await strapi.documents('api::restaurant.restaurant').unpublish({
   documentId: 'a1b2c3d4e5f6g7h8i9j0klmn'
-});`,
-    },
-  ]}
-  responses={[
+});
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+{
+  "documentId": "a1b2c3d4e5f6g7h8i9j0klmn",
+  "entries": [
     {
-      status: 200,
-      statusText: 'OK',
-      body: JSON.stringify({
-        documentId: "a1b2c3d4e5f6g7h8i9j0klmn",
-        entries: [
-          {
-            documentId: "a1b2c3d4e5f6g7h8i9j0klmn",
-            name: "Biscotte Restaurant",
-            publishedAt: null,
-            locale: "en",
-          }
-        ]
-      }, null, 2),
-    },
-  ]}
-/>
+      "documentId": "a1b2c3d4e5f6g7h8i9j0klmn",
+      "name": "Biscotte Restaurant",
+      "publishedAt": null,
+      "locale": "en"
+    }
+  ]
+}
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>
 
 ### `discardDraft()`
 
@@ -569,32 +652,41 @@ Syntax: `discardDraft(parameters: Params): Promise<{ documentId: ID, entries: Nu
     { name: 'fields', type: 'Object', required: false, description: '<a href="/cms/api/document-service/fields#discarddraft">Select fields</a> to return. Defaults to all fields (except those not populated by default).' },
     { name: 'populate', type: 'Object', required: false, description: '<a href="/cms/api/document-service/populate">Populate</a> results with additional fields. Default: <code>null</code>.' },
   ]}
-  codeTabs={[
-    {
-      label: 'Request',
-      code: `strapi.documents('api::restaurant.restaurant').discardDraft({
+>
+
+<Tabs>
+<TabItem value="request" label="Request">
+
+```js
+strapi.documents('api::restaurant.restaurant').discardDraft({
   documentId: 'a1b2c3d4e5f6g7h8i9j0klmn',
-});`,
-    },
-  ]}
-  responses={[
+});
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+{
+  "documentId": "a1b2c3d4e5f6g7h8i9j0klmn",
+  "entries": [
     {
-      status: 200,
-      statusText: 'OK',
-      body: JSON.stringify({
-        documentId: "a1b2c3d4e5f6g7h8i9j0klmn",
-        entries: [
-          {
-            documentId: "a1b2c3d4e5f6g7h8i9j0klmn",
-            name: "Biscotte Restaurant",
-            publishedAt: null,
-            locale: "en",
-          }
-        ]
-      }, null, 2),
-    },
-  ]}
-/>
+      "documentId": "a1b2c3d4e5f6g7h8i9j0klmn",
+      "name": "Biscotte Restaurant",
+      "publishedAt": null,
+      "locale": "en"
+    }
+  ]
+}
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>
 
 ### `count()`
 
@@ -612,27 +704,37 @@ Syntax: `count(parameters: Params) => number`
     { name: 'publicationFilter', type: 'String', required: false, description: 'If <a href="/cms/features/draft-and-publish">Draft & Publish</a> is enabled: select documents by how their draft and published versions relate, before applying <code>status</code>. <a href="/cms/api/document-service/publication-filter">See publicationFilter docs</a>.' },
     { name: 'filters', type: 'Object', required: false, description: '<a href="/cms/api/document-service/filters">Filters</a> to use. Default: <code>null</code>.' },
   ]}
-  codeTabs={[
-    {
-      label: 'Generic example',
-      code: `await strapi.documents('api::restaurant.restaurant').count()`,
-    },
-    {
-      label: 'Count published',
-      code: `strapi.documents('api::restaurant.restaurant').count({ status: 'published' })`,
-    },
-    {
-      label: 'With filters',
-      code: `/**
+  isLast={true}
+>
+
+<Tabs>
+<TabItem value="generic-example" label="Generic example">
+
+```js
+await strapi.documents('api::restaurant.restaurant').count()
+```
+
+</TabItem>
+<TabItem value="count-published" label="Count published">
+
+```js
+strapi.documents('api::restaurant.restaurant').count({ status: 'published' })
+```
+
+</TabItem>
+<TabItem value="with-filters" label="With filters">
+
+```js
+/**
  * Count number of draft documents (default if status is omitted)
  * in English (default locale)
  * whose name starts with 'Pizzeria'
  */
-strapi.documents('api::restaurant.restaurant').count({ filters: { name: { $startsWith: "Pizzeria" }}})`,
-    },
-  ]}
-  isLast={true}
->
+strapi.documents('api::restaurant.restaurant').count({ filters: { name: { $startsWith: "Pizzeria" }}})
+```
+
+</TabItem>
+</Tabs>
 
 :::note
 Since published documents necessarily also have a draft counterpart, a published document is still counted as having a draft version.

--- a/docusaurus/docs/cms/api/document-service/fields.md
+++ b/docusaurus/docs/cms/api/document-service/fields.md
@@ -43,28 +43,36 @@ You can also use the `populate` parameter to populate relations, media fields, c
   kind="js"
   path='strapi.documents("api::restaurant.restaurant").findOne()'
   title="Select fields with findOne()"
-  description="Select specific fields to return when finding a document by documentId."
-  codeTabs={[
-    {
-      label: "JavaScript",
-      code: `const document = await strapi.documents("api::restaurant.restaurant").findOne({
+  description="Select specific fields to return when finding a document by documentId.">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+const document = await strapi.documents("api::restaurant.restaurant").findOne({
   documentId: 'a1b2c3d4e5f6g7h8i9j0klm',
   fields: ["name", "description"],
-});`
-    }
-  ]}
-  responses={[
-    {
-      status: 200,
-      statusText: "OK",
-      body: `{
+});
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+{
   documentId: "a1b2c3d4e5f6g7h8i9j0klm",
   name: "Biscotte Restaurant",
   description: "Welcome to Biscotte restaurant! …"
-}`
-    }
-  ]}
-/>
+}
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>
 
 ## Select fields with `findFirst()` queries {#findfirst}
 
@@ -72,27 +80,35 @@ You can also use the `populate` parameter to populate relations, media fields, c
   kind="js"
   path='strapi.documents("api::restaurant.restaurant").findFirst()'
   title="Select fields with findFirst()"
-  description="Select specific fields to return when finding the first matching document."
-  codeTabs={[
-    {
-      label: "JavaScript",
-      code: `const document = await strapi.documents("api::restaurant.restaurant").findFirst({
+  description="Select specific fields to return when finding the first matching document.">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+const document = await strapi.documents("api::restaurant.restaurant").findFirst({
   fields: ["name", "description"],
-});`
-    }
-  ]}
-  responses={[
-    {
-      status: 200,
-      statusText: "OK",
-      body: `{
+});
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+{
   documentId: "a1b2c3d4e5f6g7h8i9j0klm",
   name: "Biscotte Restaurant",
   description: "Welcome to Biscotte restaurant! …"
-}`
-    }
-  ]}
-/>
+}
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>
 
 ## Select fields with `findMany()` queries {#findmany}
 
@@ -100,30 +116,38 @@ You can also use the `populate` parameter to populate relations, media fields, c
   kind="js"
   path='strapi.documents("api::restaurant.restaurant").findMany()'
   title="Select fields with findMany()"
-  description="Select specific fields to return when finding multiple documents."
-  codeTabs={[
-    {
-      label: "JavaScript",
-      code: `const documents = await strapi.documents("api::restaurant.restaurant").findMany({
+  description="Select specific fields to return when finding multiple documents.">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+const documents = await strapi.documents("api::restaurant.restaurant").findMany({
   fields: ["name", "description"],
-});`
-    }
-  ]}
-  responses={[
-    {
-      status: 200,
-      statusText: "OK",
-      body: `[
+});
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+[
   {
     documentId: "a1b2c3d4e5f6g7h8i9j0klm",
     name: "Biscotte Restaurant",
     description: "Welcome to Biscotte restaurant! …"
   }
   // ...
-]`
-    }
-  ]}
-/>
+]
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>
 
 ## Select fields with `create()` queries {#create}
 
@@ -131,32 +155,40 @@ You can also use the `populate` parameter to populate relations, media fields, c
   kind="js"
   path='strapi.documents("api::restaurant.restaurant").create()'
   title="Select fields with create()"
-  description="Select specific fields to return when creating a new document."
-  codeTabs={[
-    {
-      label: "JavaScript",
-      code: `const document = await strapi.documents("api::restaurant.restaurant").create({
+  description="Select specific fields to return when creating a new document.">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+const document = await strapi.documents("api::restaurant.restaurant").create({
   data: {
     name: "Restaurant B",
     description: "Description for the restaurant",
   },
   fields: ["name", "description"],
-});`
-    }
-  ]}
-  responses={[
-    {
-      status: 200,
-      statusText: "OK",
-      body: `{
+});
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+{
   id: 4,
   documentId: 'fmtr6d7ktzpgrijqaqgr6vxs',
   name: 'Restaurant B',
   description: 'Description for the restaurant'
-}`
-    }
-  ]}
-/>
+}
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>
 
 ## Select fields with `update()` queries {#update}
 
@@ -164,30 +196,38 @@ You can also use the `populate` parameter to populate relations, media fields, c
   kind="js"
   path='strapi.documents("api::restaurant.restaurant").update()'
   title="Select fields with update()"
-  description="Select specific fields to return when updating a document."
-  codeTabs={[
-    {
-      label: "JavaScript",
-      code: `const document = await strapi.documents("api::restaurant.restaurant").update({
+  description="Select specific fields to return when updating a document.">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+const document = await strapi.documents("api::restaurant.restaurant").update({
   documentId: "fmtr6d7ktzpgrijqaqgr6vxs",
   data: {
     name: "Restaurant C",
   },
   fields: ["name"],
-});`
-    }
-  ]}
-  responses={[
-    {
-      status: 200,
-      statusText: "OK",
-      body: `{
+});
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+{
   documentId: 'fmtr6d7ktzpgrijqaqgr6vxs',
   name: 'Restaurant C'
-}`
-    }
-  ]}
-/>
+}
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>
 
 ## Select fields with `delete()` queries {#delete}
 
@@ -195,21 +235,26 @@ You can also use the `populate` parameter to populate relations, media fields, c
   kind="js"
   path='strapi.documents("api::restaurant.restaurant").delete()'
   title="Select fields with delete()"
-  description="Select specific fields to return when deleting a document."
-  codeTabs={[
-    {
-      label: "JavaScript",
-      code: `const document = await strapi.documents("api::restaurant.restaurant").delete({
+  description="Select specific fields to return when deleting a document.">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+const document = await strapi.documents("api::restaurant.restaurant").delete({
   documentId: "fmtr6d7ktzpgrijqaqgr6vxs",
   fields: ["name"],
-});`
-    }
-  ]}
-  responses={[
-    {
-      status: 200,
-      statusText: "OK",
-      body: `  documentId: 'fmtr6d7ktzpgrijqaqgr6vxs',
+});
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+  documentId: 'fmtr6d7ktzpgrijqaqgr6vxs',
   // All of the deleted document's versions are returned
   entries: [
     {
@@ -219,10 +264,13 @@ You can also use the `populate` parameter to populate relations, media fields, c
       // …
     }
   ]
-}`
-    }
-  ]}
-/>
+}
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>
 
 ## Select fields with `publish()` queries {#publish}
 
@@ -230,21 +278,26 @@ You can also use the `populate` parameter to populate relations, media fields, c
   kind="js"
   path='strapi.documents("api::restaurant.restaurant").publish()'
   title="Select fields with publish()"
-  description="Select specific fields to return when publishing a document."
-  codeTabs={[
-    {
-      label: "JavaScript",
-      code: `const document = await strapi.documents("api::restaurant.restaurant").publish({
+  description="Select specific fields to return when publishing a document.">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+const document = await strapi.documents("api::restaurant.restaurant").publish({
   documentId: "fmtr6d7ktzpgrijqaqgr6vxs",
   fields: ["name"],
-});`
-    }
-  ]}
-  responses={[
-    {
-      status: 200,
-      statusText: "OK",
-      body: `{
+});
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+{
   documentId: 'fmtr6d7ktzpgrijqaqgr6vxs',
   // All of the published locale entries are returned
   entries: [
@@ -253,10 +306,13 @@ You can also use the `populate` parameter to populate relations, media fields, c
       name: 'Restaurant B'
     }
   ]
-}`
-    }
-  ]}
-/>
+}
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>
 
 ## Select fields with `unpublish()` queries {#unpublish}
 
@@ -264,21 +320,26 @@ You can also use the `populate` parameter to populate relations, media fields, c
   kind="js"
   path='strapi.documents("api::restaurant.restaurant").unpublish()'
   title="Select fields with unpublish()"
-  description="Select specific fields to return when unpublishing a document."
-  codeTabs={[
-    {
-      label: "JavaScript",
-      code: `const document = await strapi.documents("api::restaurant.restaurant").unpublish({
+  description="Select specific fields to return when unpublishing a document.">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+const document = await strapi.documents("api::restaurant.restaurant").unpublish({
   documentId: "cjld2cjxh0000qzrmn831i7rn",
   fields: ["name"],
-});`
-    }
-  ]}
-  responses={[
-    {
-      status: 200,
-      statusText: "OK",
-      body: `{
+});
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+{
   documentId: 'fmtr6d7ktzpgrijqaqgr6vxs',
   // All of the published locale entries are returned
   entries: [
@@ -287,10 +348,13 @@ You can also use the `populate` parameter to populate relations, media fields, c
       name: 'Restaurant B'
     }
   ]
-}`
-    }
-  ]}
-/>
+}
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>
 
 ## Select fields with `discardDraft()` queries {#discarddraft}
 
@@ -299,20 +363,26 @@ You can also use the `populate` parameter to populate relations, media fields, c
   path='strapi.documents("api::restaurant.restaurant").discardDraft()'
   title="Select fields with discardDraft()"
   description="Select specific fields to return when discarding a draft document."
-  codeTabs={[
-    {
-      label: "JavaScript",
-      code: `const document = await strapi.documents("api::restaurant.restaurant").discardDraft({
+  isLast>
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+const document = await strapi.documents("api::restaurant.restaurant").discardDraft({
   documentId: "fmtr6d7ktzpgrijqaqgr6vxs",
   fields: ["name"],
-});`
-    }
-  ]}
-  responses={[
-    {
-      status: 200,
-      statusText: "OK",
-      body: `{
+});
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+{
   documentId: "fmtr6d7ktzpgrijqaqgr6vxs",
   // All of the discarded draft entries are returned
   entries: [
@@ -320,8 +390,10 @@ You can also use the `populate` parameter to populate relations, media fields, c
       "name": "Restaurant B"
     }
   ]
-}`
-    }
-  ]}
-  isLast
-/>
+}
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>

--- a/docusaurus/docs/cms/api/document-service/filters.md
+++ b/docusaurus/docs/cms/api/document-service/filters.md
@@ -64,11 +64,13 @@ The following operators are available:
   kind="js"
   path="strapi.documents().findMany()"
   title="$not"
-  description="Negates the nested condition(s)."
-  codeTabs={[
-    {
-      label: 'JavaScript',
-      code: `const entries = await strapi.documents('api::article.article').findMany({
+  description="Negates the nested condition(s).">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+const entries = await strapi.documents('api::article.article').findMany({
   filters: {
     title: {
       $not: {
@@ -76,448 +78,562 @@ The following operators are available:
       },
     },
   },
-});`
-    }
-  ]}
-/>
+});
+```
+
+</TabItem>
+</Tabs>
+
+</Endpoint>
 
 <Endpoint
   id="eq"
   kind="js"
   path="strapi.documents().findMany()"
   title="$eq"
-  description="Attribute equals input value."
-  codeTabs={[
-    {
-      label: 'JavaScript',
-      code: `const entries = await strapi.documents('api::article.article').findMany({
+  description="Attribute equals input value.">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+const entries = await strapi.documents('api::article.article').findMany({
   filters: {
     title: {
       $eq: 'Hello World',
     },
   },
-});`
-    },
-    {
-      label: 'Shorthand',
-      code: `// $eq can be omitted:
+});
+```
+
+</TabItem>
+<TabItem value="shorthand" label="Shorthand">
+
+```js
+// $eq can be omitted:
 const entries = await strapi.documents('api::article.article').findMany({
   filters: {
     title: 'Hello World',
   },
-});`
-    }
-  ]}
-/>
+});
+```
+
+</TabItem>
+</Tabs>
+
+</Endpoint>
 
 <Endpoint
   id="eqi"
   kind="js"
   path="strapi.documents().findMany()"
   title="$eqi"
-  description="Attribute equals input value (case-insensitive)."
-  codeTabs={[
-    {
-      label: 'JavaScript',
-      code: `const entries = await strapi.documents('api::article.article').findMany({
+  description="Attribute equals input value (case-insensitive).">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+const entries = await strapi.documents('api::article.article').findMany({
   filters: {
     title: {
       $eqi: 'HELLO World',
     },
   },
-});`
-    }
-  ]}
-/>
+});
+```
+
+</TabItem>
+</Tabs>
+
+</Endpoint>
 
 <Endpoint
   id="ne"
   kind="js"
   path="strapi.documents().findMany()"
   title="$ne"
-  description="Attribute does not equal input value."
-  codeTabs={[
-    {
-      label: 'JavaScript',
-      code: `const entries = await strapi.documents('api::article.article').findMany({
+  description="Attribute does not equal input value.">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+const entries = await strapi.documents('api::article.article').findMany({
   filters: {
     title: {
       $ne: 'ABCD',
     },
   },
-});`
-    }
-  ]}
-/>
+});
+```
+
+</TabItem>
+</Tabs>
+
+</Endpoint>
 
 <Endpoint
   id="nei"
   kind="js"
   path="strapi.documents().findMany()"
   title="$nei"
-  description="Attribute does not equal input value (case-insensitive)."
-  codeTabs={[
-    {
-      label: 'JavaScript',
-      code: `const entries = await strapi.documents('api::article.article').findMany({
+  description="Attribute does not equal input value (case-insensitive).">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+const entries = await strapi.documents('api::article.article').findMany({
   filters: {
     title: {
       $nei: 'abcd',
     },
   },
-});`
-    }
-  ]}
-/>
+});
+```
+
+</TabItem>
+</Tabs>
+
+</Endpoint>
 
 <Endpoint
   id="in"
   kind="js"
   path="strapi.documents().findMany()"
   title="$in"
-  description="Attribute is contained in the input list."
-  codeTabs={[
-    {
-      label: 'JavaScript',
-      code: `const entries = await strapi.documents('api::article.article').findMany({
+  description="Attribute is contained in the input list.">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+const entries = await strapi.documents('api::article.article').findMany({
   filters: {
     title: {
       $in: ['Hello', 'Hola', 'Bonjour'],
     },
   },
-});`
-    },
-    {
-      label: 'Shorthand',
-      code: `// $in can be omitted when passing an array of values:
+});
+```
+
+</TabItem>
+<TabItem value="shorthand" label="Shorthand">
+
+```js
+// $in can be omitted when passing an array of values:
 const entries = await strapi.documents('api::article.article').findMany({
   filters: {
     title: ['Hello', 'Hola', 'Bonjour'],
   },
-});`
-    }
-  ]}
-/>
+});
+```
+
+</TabItem>
+</Tabs>
+
+</Endpoint>
 
 <Endpoint
   id="notin"
   kind="js"
   path="strapi.documents().findMany()"
   title="$notIn"
-  description="Attribute is not contained in the input list."
-  codeTabs={[
-    {
-      label: 'JavaScript',
-      code: `const entries = await strapi.documents('api::article.article').findMany({
+  description="Attribute is not contained in the input list.">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+const entries = await strapi.documents('api::article.article').findMany({
   filters: {
     title: {
       $notIn: ['Hello', 'Hola', 'Bonjour'],
     },
   },
-});`
-    }
-  ]}
-/>
+});
+```
+
+</TabItem>
+</Tabs>
+
+</Endpoint>
 
 <Endpoint
   id="lt"
   kind="js"
   path="strapi.documents().findMany()"
   title="$lt"
-  description="Attribute is less than the input value."
-  codeTabs={[
-    {
-      label: 'JavaScript',
-      code: `const entries = await strapi.documents('api::article.article').findMany({
+  description="Attribute is less than the input value.">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+const entries = await strapi.documents('api::article.article').findMany({
   filters: {
     rating: {
       $lt: 10,
     },
   },
-});`
-    }
-  ]}
-/>
+});
+```
+
+</TabItem>
+</Tabs>
+
+</Endpoint>
 
 <Endpoint
   id="lte"
   kind="js"
   path="strapi.documents().findMany()"
   title="$lte"
-  description="Attribute is less than or equal to the input value."
-  codeTabs={[
-    {
-      label: 'JavaScript',
-      code: `const entries = await strapi.documents('api::article.article').findMany({
+  description="Attribute is less than or equal to the input value.">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+const entries = await strapi.documents('api::article.article').findMany({
   filters: {
     rating: {
       $lte: 10,
     },
   },
-});`
-    }
-  ]}
-/>
+});
+```
+
+</TabItem>
+</Tabs>
+
+</Endpoint>
 
 <Endpoint
   id="gt"
   kind="js"
   path="strapi.documents().findMany()"
   title="$gt"
-  description="Attribute is greater than the input value."
-  codeTabs={[
-    {
-      label: 'JavaScript',
-      code: `const entries = await strapi.documents('api::article.article').findMany({
+  description="Attribute is greater than the input value.">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+const entries = await strapi.documents('api::article.article').findMany({
   filters: {
     rating: {
       $gt: 5,
     },
   },
-});`
-    }
-  ]}
-/>
+});
+```
+
+</TabItem>
+</Tabs>
+
+</Endpoint>
 
 <Endpoint
   id="gte"
   kind="js"
   path="strapi.documents().findMany()"
   title="$gte"
-  description="Attribute is greater than or equal to the input value."
-  codeTabs={[
-    {
-      label: 'JavaScript',
-      code: `const entries = await strapi.documents('api::article.article').findMany({
+  description="Attribute is greater than or equal to the input value.">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+const entries = await strapi.documents('api::article.article').findMany({
   filters: {
     rating: {
       $gte: 5,
     },
   },
-});`
-    }
-  ]}
-/>
+});
+```
+
+</TabItem>
+</Tabs>
+
+</Endpoint>
 
 <Endpoint
   id="between"
   kind="js"
   path="strapi.documents().findMany()"
   title="$between"
-  description={<>Attribute is between the 2 input values, boundaries included (e.g., <code>$between[1, 3]</code> will also return <code>1</code> and <code>3</code>).</>}
-  codeTabs={[
-    {
-      label: 'JavaScript',
-      code: `const entries = await strapi.documents('api::article.article').findMany({
+  description={<>Attribute is between the 2 input values, boundaries included (e.g., <code>$between[1, 3]</code> will also return <code>1</code> and <code>3</code>).</>}>
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+const entries = await strapi.documents('api::article.article').findMany({
   filters: {
     rating: {
       $between: [1, 20],
     },
   },
-});`
-    }
-  ]}
-/>
+});
+```
+
+</TabItem>
+</Tabs>
+
+</Endpoint>
 
 <Endpoint
   id="contains"
   kind="js"
   path="strapi.documents().findMany()"
   title="$contains"
-  description="Attribute contains the input value (case-sensitive)."
-  codeTabs={[
-    {
-      label: 'JavaScript',
-      code: `const entries = await strapi.documents('api::article.article').findMany({
+  description="Attribute contains the input value (case-sensitive).">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+const entries = await strapi.documents('api::article.article').findMany({
   filters: {
     title: {
       $contains: 'Hello',
     },
   },
-});`
-    }
-  ]}
-/>
+});
+```
+
+</TabItem>
+</Tabs>
+
+</Endpoint>
 
 <Endpoint
   id="notcontains"
   kind="js"
   path="strapi.documents().findMany()"
   title="$notContains"
-  description="Attribute does not contain the input value (case-sensitive)."
-  codeTabs={[
-    {
-      label: 'JavaScript',
-      code: `const entries = await strapi.documents('api::article.article').findMany({
+  description="Attribute does not contain the input value (case-sensitive).">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+const entries = await strapi.documents('api::article.article').findMany({
   filters: {
     title: {
       $notContains: 'Hello',
     },
   },
-});`
-    }
-  ]}
-/>
+});
+```
+
+</TabItem>
+</Tabs>
+
+</Endpoint>
 
 <Endpoint
   id="containsi"
   kind="js"
   path="strapi.documents().findMany()"
   title="$containsi"
-  description={<><code>$containsi</code> is not case-sensitive, while <a href="#contains">$contains</a> is.</>}
-  codeTabs={[
-    {
-      label: 'JavaScript',
-      code: `const entries = await strapi.documents('api::article.article').findMany({
+  description={<><code>$containsi</code> is not case-sensitive, while <a href="#contains">$contains</a> is.</>}>
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+const entries = await strapi.documents('api::article.article').findMany({
   filters: {
     title: {
       $containsi: 'hello',
     },
   },
-});`
-    }
-  ]}
-/>
+});
+```
+
+</TabItem>
+</Tabs>
+
+</Endpoint>
 
 <Endpoint
   id="notcontainsi"
   kind="js"
   path="strapi.documents().findMany()"
   title="$notContainsi"
-  description={<><code>$notContainsi</code> is not case-sensitive, while <a href="#notcontains">$notContains</a> is.</>}
-  codeTabs={[
-    {
-      label: 'JavaScript',
-      code: `const entries = await strapi.documents('api::article.article').findMany({
+  description={<><code>$notContainsi</code> is not case-sensitive, while <a href="#notcontains">$notContains</a> is.</>}>
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+const entries = await strapi.documents('api::article.article').findMany({
   filters: {
     title: {
       $notContainsi: 'hello',
     },
   },
-});`
-    }
-  ]}
-/>
+});
+```
+
+</TabItem>
+</Tabs>
+
+</Endpoint>
 
 <Endpoint
   id="startswith"
   kind="js"
   path="strapi.documents().findMany()"
   title="$startsWith"
-  description="Attribute starts with input value (case-sensitive)."
-  codeTabs={[
-    {
-      label: 'JavaScript',
-      code: `const entries = await strapi.documents('api::article.article').findMany({
+  description="Attribute starts with input value (case-sensitive).">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+const entries = await strapi.documents('api::article.article').findMany({
   filters: {
     title: {
       $startsWith: 'ABCD',
     },
   },
-});`
-    }
-  ]}
-/>
+});
+```
+
+</TabItem>
+</Tabs>
+
+</Endpoint>
 
 <Endpoint
   id="startswithi"
   kind="js"
   path="strapi.documents().findMany()"
   title="$startsWithi"
-  description="Attribute starts with input value (case-insensitive)."
-  codeTabs={[
-    {
-      label: 'JavaScript',
-      code: `const entries = await strapi.documents('api::article.article').findMany({
+  description="Attribute starts with input value (case-insensitive).">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+const entries = await strapi.documents('api::article.article').findMany({
   filters: {
     title: {
       $startsWithi: 'ABCD', // will return the same as filtering with 'abcd'
     },
   },
-});`
-    }
-  ]}
-/>
+});
+```
+
+</TabItem>
+</Tabs>
+
+</Endpoint>
 
 <Endpoint
   id="endswith"
   kind="js"
   path="strapi.documents().findMany()"
   title="$endsWith"
-  description="Attribute ends with input value (case-sensitive)."
-  codeTabs={[
-    {
-      label: 'JavaScript',
-      code: `const entries = await strapi.documents('api::article.article').findMany({
+  description="Attribute ends with input value (case-sensitive).">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+const entries = await strapi.documents('api::article.article').findMany({
   filters: {
     title: {
       $endsWith: 'ABCD',
     },
   },
-});`
-    }
-  ]}
-/>
+});
+```
+
+</TabItem>
+</Tabs>
+
+</Endpoint>
 
 <Endpoint
   id="endswithi"
   kind="js"
   path="strapi.documents().findMany()"
   title="$endsWithi"
-  description="Attribute ends with input value (case-insensitive)."
-  codeTabs={[
-    {
-      label: 'JavaScript',
-      code: `const entries = await strapi.documents('api::article.article').findMany({
+  description="Attribute ends with input value (case-insensitive).">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+const entries = await strapi.documents('api::article.article').findMany({
   filters: {
     title: {
       $endsWith: 'ABCD', // will return the same as filtering with 'abcd'
     },
   },
-});`
-    }
-  ]}
-/>
+});
+```
+
+</TabItem>
+</Tabs>
+
+</Endpoint>
 
 <Endpoint
   id="null"
   kind="js"
   path="strapi.documents().findMany()"
   title="$null"
-  description={<>Attribute is <code>null</code>.</>}
-  codeTabs={[
-    {
-      label: 'JavaScript',
-      code: `const entries = await strapi.documents('api::article.article').findMany({
+  description={<>Attribute is <code>null</code>.</>}>
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+const entries = await strapi.documents('api::article.article').findMany({
   filters: {
     title: {
       $null: true,
     },
   },
-});`
-    }
-  ]}
-/>
+});
+```
+
+</TabItem>
+</Tabs>
+
+</Endpoint>
 
 <Endpoint
   id="notnull"
   kind="js"
   path="strapi.documents().findMany()"
   title="$notNull"
-  description={<>Attribute is not <code>null</code>.</>}
-  codeTabs={[
-    {
-      label: 'JavaScript',
-      code: `const entries = await strapi.documents('api::article.article').findMany({
+  description={<>Attribute is not <code>null</code>.</>}>
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+const entries = await strapi.documents('api::article.article').findMany({
   filters: {
     title: {
       $notNull: true,
     },
   },
-});`
-    }
-  ]}
-/>
+});
+```
+
+</TabItem>
+</Tabs>
+
+</Endpoint>
 
 ## Logical operators
 
@@ -526,11 +642,13 @@ const entries = await strapi.documents('api::article.article').findMany({
   kind="js"
   path="strapi.documents().findMany()"
   title="$and"
-  description={<>All nested conditions must be <code>true</code>.</>}
-  codeTabs={[
-    {
-      label: 'JavaScript',
-      code: `const entries = await strapi.documents('api::article.article').findMany({
+  description={<>All nested conditions must be <code>true</code>.</>}>
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+const entries = await strapi.documents('api::article.article').findMany({
   filters: {
     $and: [
       {
@@ -541,31 +659,39 @@ const entries = await strapi.documents('api::article.article').findMany({
       },
     ],
   },
-});`
-    },
-    {
-      label: 'Implicit $and',
-      code: `// $and will be used implicitly when passing an object with nested conditions:
+});
+```
+
+</TabItem>
+<TabItem value="implicit-and" label="Implicit $and">
+
+```js
+// $and will be used implicitly when passing an object with nested conditions:
 const entries = await strapi.documents('api::article.article').findMany({
   filters: {
     title: 'Hello World',
     createdAt: { $gt: '2021-11-17T14:28:25.843Z' },
   },
-});`
-    }
-  ]}
-/>
+});
+```
+
+</TabItem>
+</Tabs>
+
+</Endpoint>
 
 <Endpoint
   id="or"
   kind="js"
   path="strapi.documents().findMany()"
   title="$or"
-  description={<>One or many nested conditions must be <code>true</code>.</>}
-  codeTabs={[
-    {
-      label: 'JavaScript',
-      code: `const entries = await strapi.documents('api::article.article').findMany({
+  description={<>One or many nested conditions must be <code>true</code>.</>}>
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+const entries = await strapi.documents('api::article.article').findMany({
   filters: {
     $or: [
       {
@@ -576,30 +702,38 @@ const entries = await strapi.documents('api::article.article').findMany({
       },
     ],
   },
-});`
-    }
-  ]}
-/>
+});
+```
+
+</TabItem>
+</Tabs>
+
+</Endpoint>
 
 <Endpoint
   id="not-logical"
   kind="js"
   path="strapi.documents().findMany()"
   title="$not"
-  description="Negates the nested conditions."
-  codeTabs={[
-    {
-      label: 'JavaScript',
-      code: `const entries = await strapi.documents('api::article.article').findMany({
+  description="Negates the nested conditions.">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+const entries = await strapi.documents('api::article.article').findMany({
   filters: {
     $not: {
       title: 'Hello World',
     },
   },
-});`
-    }
-  ]}
-/>
+});
+```
+
+</TabItem>
+</Tabs>
+
+</Endpoint>
 
 :::note
 `$not` can be used as:

--- a/docusaurus/docs/cms/api/document-service/locale.md
+++ b/docusaurus/docs/cms/api/document-service/locale.md
@@ -37,30 +37,38 @@ By default the [Document Service API](/cms/api/document-service) returns the def
   kind="js"
   path="strapi.documents().findOne()"
   title="Get a locale version with findOne()"
-  description="Pass a locale to findOne() to get the version of the document for that locale."
-  codeTabs={[
-    {
-      label: 'JavaScript',
-      code: `await strapi.documents('api::restaurant.restaurant').findOne({
+  description="Pass a locale to findOne() to get the version of the document for that locale.">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+await strapi.documents('api::restaurant.restaurant').findOne({
   documentId: 'a1b2c3d4e5f6g7h8i9j0klm',
   locale: 'fr',
-});`
-    }
-  ]}
-  responses={[
-    {
-      status: 200,
-      statusText: 'OK',
-      body: `{
+});
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+{
   documentId: "a1b2c3d4e5f6g7h8i9j0klm",
   name: "Biscotte Restaurant",
   publishedAt: null, // draft version (default)
   locale: "fr", // as asked from the parameters
   // …
-}`
-    }
-  ]}
-/>
+}
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>
 
 If no `status` parameter is passed, the `draft` version is returned by default.
 
@@ -70,27 +78,35 @@ If no `status` parameter is passed, the `draft` version is returned by default.
   kind="js"
   path="strapi.documents().findFirst()"
   title="Get a locale version with findFirst()"
-  description="Pass a locale to findFirst() to return documents matching that locale."
-  codeTabs={[
-    {
-      label: 'JavaScript',
-      code: `const document = await strapi.documents('api::article.article').findFirst({
+  description="Pass a locale to findFirst() to return documents matching that locale.">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+const document = await strapi.documents('api::article.article').findFirst({
   locale: 'fr',
-});`
-    }
-  ]}
-  responses={[
-    {
-      status: 200,
-      statusText: 'OK',
-      body: `{
+});
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+{
   "documentId": "cjld2cjxh0000qzrmn831i7rn",
   "title": "Test Article"
   // …
-}`
-    }
-  ]}
-/>
+}
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>
 
 If no `status` parameter is passed, the `draft` version is returned by default.
 
@@ -102,19 +118,24 @@ If no `status` parameter is passed, the `draft` versions are returned by default
   kind="js"
   path="strapi.documents().findMany()"
   title="Get locale versions with findMany()"
-  description="Pass a locale to findMany() to return all documents that have this locale available."
-  codeTabs={[
-    {
-      label: 'JavaScript',
-      code: `// Defaults to status: draft
-await strapi.documents('api::restaurant.restaurant').findMany({ locale: 'fr' });`
-    }
-  ]}
-  responses={[
-    {
-      status: 200,
-      statusText: 'OK',
-      body: `[
+  description="Pass a locale to findMany() to return all documents that have this locale available.">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+// Defaults to status: draft
+await strapi.documents('api::restaurant.restaurant').findMany({ locale: 'fr' });
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+[
   {
     documentId: 'a1b2c3d4e5f6g7h8i9j0klm',
     name: 'Restaurant Biscotte',
@@ -123,10 +144,13 @@ await strapi.documents('api::restaurant.restaurant').findMany({ locale: 'fr' });
     // …
   },
   // …
-]`
-    }
-  ]}
-/>
+]
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>
 
 <details>
 <summary>Explanation:</summary>
@@ -156,30 +180,38 @@ Given the following 4 documents that have various locales:
   kind="js"
   path="strapi.documents().create()"
   title="Create a document for a locale"
-  description="Pass a locale to create() to create the document for that specific locale."
-  codeTabs={[
-    {
-      label: 'JavaScript',
-      code: `await strapi.documents('api::restaurant.restaurant').create({
+  description="Pass a locale to create() to create the document for that specific locale.">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+await strapi.documents('api::restaurant.restaurant').create({
   locale: 'es' // if not passed, the draft is created for the default locale
   data: { name: 'Restaurante B' }
-})`
-    }
-  ]}
-  responses={[
-    {
-      status: 200,
-      statusText: 'OK',
-      body: `{
+})
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+{
   documentId: "pw2s0nh5ub1zmnk0d80vgqrh",
   name: "Restaurante B",
   publishedAt: null,
   locale: "es"
   // …
-}`
-    }
-  ]}
-/>
+}
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>
 
 ## `update()` a locale version {#update}
 
@@ -187,31 +219,39 @@ Given the following 4 documents that have various locales:
   kind="js"
   path="strapi.documents().update()"
   title="Update a locale version"
-  description="Pass a locale to update() to update only that specific locale version of a document."
-  codeTabs={[
-    {
-      label: 'JavaScript',
-      code: `await strapi.documents('api::restaurant.restaurant').update({
+  description="Pass a locale to update() to update only that specific locale version of a document.">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+await strapi.documents('api::restaurant.restaurant').update({
   documentId: 'a1b2c3d4e5f6g7h8i9j0klm',
   locale: 'es',
   data: { name: 'Nuevo nombre del restaurante' },
-});`
-    }
-  ]}
-  responses={[
-    {
-      status: 200,
-      statusText: 'OK',
-      body: `{
+});
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+{
   documentId: "a1b2c3d4e5f6g7h8i9j0klm",
   name: "Nuevo nombre del restaurante",
   locale: "es",
   publishedAt: null,
   // …
-}`
-    }
-  ]}
-/>
+}
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>
 
 ## `delete()` locale versions {#delete}
 
@@ -224,17 +264,22 @@ Use the `locale` parameter with the [`delete()` method](/cms/api/document-servic
   kind="js"
   path="strapi.documents().delete()"
   title="Delete a locale version"
-  description="Pass a locale to delete() to delete only that specific locale version of a document."
-  codeTabs={[
-    {
-      label: 'JavaScript',
-      code: `await strapi.documents('api::restaurant.restaurant').delete({
+  description="Pass a locale to delete() to delete only that specific locale version of a document.">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+await strapi.documents('api::restaurant.restaurant').delete({
   documentId: 'a1b2c3d4e5f6g7h8i9j0klm', // documentId,
   locale: 'es',
-});`
-    }
-  ]}
-/>
+});
+```
+
+</TabItem>
+</Tabs>
+
+</Endpoint>
 
 ### Delete all locale versions
 
@@ -243,21 +288,26 @@ Use the `locale` parameter with the [`delete()` method](/cms/api/document-servic
   kind="js"
   path="strapi.documents().delete()"
   title="Delete all locale versions"
-  description="Use the * wildcard with the locale parameter to delete all locale versions of a document."
-  codeTabs={[
-    {
-      label: 'JavaScript',
-      code: `await strapi.documents('api::restaurant.restaurant').delete({
+  description="Use the * wildcard with the locale parameter to delete all locale versions of a document.">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+await strapi.documents('api::restaurant.restaurant').delete({
   documentId: 'a1b2c3d4e5f6g7h8i9j0klm', // documentId,
   locale: '*',
-}); // for all existing locales`
-    }
-  ]}
-  responses={[
-    {
-      status: 200,
-      statusText: 'OK',
-      body: `{
+}); // for all existing locales
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+{
   "documentId": "a1b2c3d4e5f6g7h8i9j0klm",
   // All of the deleted locale versions are returned
   "versions": [
@@ -265,10 +315,13 @@ Use the `locale` parameter with the [`delete()` method](/cms/api/document-servic
       "title": "Test Article"
     }
   ]
-}`
-    }
-  ]}
-/>
+}
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>
 
 ## `publish()` locale versions {#publish}
 
@@ -281,21 +334,26 @@ To publish only specific locale versions of a document with the [`publish()` met
   kind="js"
   path="strapi.documents().publish()"
   title="Publish a locale version"
-  description="Pass a locale to publish() to publish only that specific locale version of a document."
-  codeTabs={[
-    {
-      label: 'JavaScript',
-      code: `await strapi.documents('api::restaurant.restaurant').publish({
+  description="Pass a locale to publish() to publish only that specific locale version of a document.">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+await strapi.documents('api::restaurant.restaurant').publish({
   documentId: 'a1b2c3d4e5f6g7h8i9j0klm',
   locale: 'fr',
-});`
-    }
-  ]}
-  responses={[
-    {
-      status: 200,
-      statusText: 'OK',
-      body: `{
+});
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+{
   versions: [
     {
       documentId: 'a1b2c3d4e5f6g7h8i9j0klm',
@@ -305,10 +363,13 @@ To publish only specific locale versions of a document with the [`publish()` met
       // …
     },
   ]
-}`
-    }
-  ]}
-/>
+}
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>
 
 ### Publish all locale versions
 
@@ -317,20 +378,25 @@ To publish only specific locale versions of a document with the [`publish()` met
   kind="js"
   path="strapi.documents().publish()"
   title="Publish all locale versions"
-  description="Use the * wildcard with the locale parameter to publish all locale versions of a document."
-  codeTabs={[
-    {
-      label: 'JavaScript',
-      code: `await strapi
+  description="Use the * wildcard with the locale parameter to publish all locale versions of a document.">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+await strapi
   .documents('api::restaurant.restaurant')
-  .publish({ documentId: 'a1b2c3d4e5f6g7h8i9j0klm', locale: '*' });`
-    }
-  ]}
-  responses={[
-    {
-      status: 200,
-      statusText: 'OK',
-      body: `{
+  .publish({ documentId: 'a1b2c3d4e5f6g7h8i9j0klm', locale: '*' });
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+{
   "versions": [
     {
       "documentId": "a1b2c3d4e5f6g7h8i9j0klm",
@@ -351,10 +417,13 @@ To publish only specific locale versions of a document with the [`publish()` met
       // …
     }
   ]
-}`
-    }
-  ]}
-/>
+}
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>
 
 ## `unpublish()` locale versions {#unpublish}
 
@@ -367,25 +436,33 @@ To publish only specific locale versions of a document with the [`unpublish()` m
   kind="js"
   path="strapi.documents().unpublish()"
   title="Unpublish a locale version"
-  description="Pass a locale to unpublish() to unpublish only that specific locale version of a document."
-  codeTabs={[
-    {
-      label: 'JavaScript',
-      code: `await strapi
+  description="Pass a locale to unpublish() to unpublish only that specific locale version of a document.">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+await strapi
   .documents('api::restaurant.restaurant')
-  .unpublish({ documentId: 'a1b2c3d4e5f6g7h8i9j0klm', locale: 'fr' });`
-    }
-  ]}
-  responses={[
-    {
-      status: 200,
-      statusText: 'OK',
-      body: `{
+  .unpublish({ documentId: 'a1b2c3d4e5f6g7h8i9j0klm', locale: 'fr' });
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+{
   versions: 1
-}`
-    }
-  ]}
-/>
+}
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>
 
 ### Unpublish all locale versions
 
@@ -394,46 +471,59 @@ To publish only specific locale versions of a document with the [`unpublish()` m
   kind="js"
   path="strapi.documents().unpublish()"
   title="Unpublish all locale versions"
-  description="Use the * wildcard with the locale parameter to unpublish all locale versions of a document."
-  codeTabs={[
-    {
-      label: 'JavaScript',
-      code: `await strapi
+  description="Use the * wildcard with the locale parameter to unpublish all locale versions of a document.">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+await strapi
   .documents('api::restaurant.restaurant')
-  .unpublish({ documentId: 'a1b2c3d4e5f6g7h8i9j0klm', locale: '*' });`
-    }
-  ]}
-  responses={[
-    {
-      status: 200,
-      statusText: 'OK',
-      body: `{
+  .unpublish({ documentId: 'a1b2c3d4e5f6g7h8i9j0klm', locale: '*' });
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+{
   versions: 3
-}`
-    }
-  ]}
-/>
+}
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>
 
 <Endpoint
   id="unpublish-with-fields"
   kind="js"
   path="strapi.documents().unpublish()"
   title="Unpublish with fields selection"
-  description="Unpublish a document while selecting specific fields to return."
-  codeTabs={[
-    {
-      label: 'JavaScript',
-      code: `const document = await strapi.documents('api::article.article').unpublish({
+  description="Unpublish a document while selecting specific fields to return.">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+const document = await strapi.documents('api::article.article').unpublish({
   documentId: 'cjld2cjxh0000qzrmn831i7rn',
   fields: ['title'],
-});`
-    }
-  ]}
-  responses={[
-    {
-      status: 200,
-      statusText: 'OK',
-      body: `{
+});
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+{
   "documentId": "cjld2cjxh0000qzrmn831i7rn",
   // All of the unpublished locale versions are returned
   "versions": [
@@ -441,10 +531,13 @@ To publish only specific locale versions of a document with the [`unpublish()` m
       "title": "Test Article"
     }
   ]
-}`
-    }
-  ]}
-/>
+}
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>
 
 ## `discardDraft()` for locale versions {#discard-draft}
 
@@ -457,20 +550,25 @@ To discard draft data only for some locales versions of a document with the [`di
   kind="js"
   path="strapi.documents().discardDraft()"
   title="Discard draft for a locale version"
-  description="Pass a locale to discardDraft() to discard draft data for that specific locale version."
-  codeTabs={[
-    {
-      label: 'JavaScript',
-      code: `await strapi
+  description="Pass a locale to discardDraft() to discard draft data for that specific locale version.">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+await strapi
   .documents('api::restaurant.restaurant')
-  .discardDraft({ documentId: 'a1b2c3d4e5f6g7h8i9j0klm', locale: 'fr' });`
-    }
-  ]}
-  responses={[
-    {
-      status: 200,
-      statusText: 'OK',
-      body: `{
+  .discardDraft({ documentId: 'a1b2c3d4e5f6g7h8i9j0klm', locale: 'fr' });
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+{
   versions: [
     {
       documentId: 'a1b2c3d4e5f6g7h8i9j0klm',
@@ -480,10 +578,13 @@ To discard draft data only for some locales versions of a document with the [`di
       // …
     },
   ]
-}`
-    }
-  ]}
-/>
+}
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>
 
 ### Discard drafts for all locale versions
 
@@ -492,20 +593,25 @@ To discard draft data only for some locales versions of a document with the [`di
   kind="js"
   path="strapi.documents().discardDraft()"
   title="Discard drafts for all locale versions"
-  description="Use the * wildcard with the locale parameter to discard drafts for all locale versions of a document."
-  codeTabs={[
-    {
-      label: 'JavaScript',
-      code: `await strapi
+  description="Use the * wildcard with the locale parameter to discard drafts for all locale versions of a document.">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+await strapi
   .documents('api::restaurant.restaurant')
-  .discardDraft({ documentId: 'a1b2c3d4e5f6g7h8i9j0klm', locale: '*' });`
-    }
-  ]}
-  responses={[
-    {
-      status: 200,
-      statusText: 'OK',
-      body: `{
+  .discardDraft({ documentId: 'a1b2c3d4e5f6g7h8i9j0klm', locale: '*' });
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+{
   versions: [
     {
       documentId: 'a1b2c3d4e5f6g7h8i9j0klm',
@@ -529,10 +635,13 @@ To discard draft data only for some locales versions of a document with the [`di
       // …
     },
   ]
-}`
-    }
-  ]}
-/>
+}
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>
 
 ## `count()` documents for a locale {#count}
 

--- a/docusaurus/docs/cms/api/document-service/populate.md
+++ b/docusaurus/docs/cms/api/document-service/populate.md
@@ -46,20 +46,25 @@ Queries can accept a `populate` parameter to explicitly define which fields to p
   path='strapi.documents("api::article.article").findMany()'
   title="Populate 1 level for all relations"
   description="Populate one-level deep for all relations using the wildcard."
-  id="populate-1-level-all"
-  codeTabs={[
-    {
-      label: "JavaScript",
-      code: `const documents = await strapi.documents("api::article.article").findMany({
+  id="populate-1-level-all">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+const documents = await strapi.documents("api::article.article").findMany({
   populate: "*",
-});`
-    }
-  ]}
-  responses={[
-    {
-      status: 200,
-      statusText: "OK",
-      body: `{
+});
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+{
   [
     {
       "id": "cjld2cjxh0000qzrmn831i7rn",
@@ -89,10 +94,13 @@ Queries can accept a `populate` parameter to explicitly define which fields to p
     }
     // ...
   ]
-}`
-    }
-  ]}
-/>
+}
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>
 
 ### Populate 1 level for specific relations
 
@@ -101,20 +109,25 @@ Queries can accept a `populate` parameter to explicitly define which fields to p
   path='strapi.documents("api::article.article").findMany()'
   title="Populate 1 level for specific relations"
   description="Populate specific relations one-level deep using an array."
-  id="populate-1-level-specific"
-  codeTabs={[
-    {
-      label: "JavaScript",
-      code: `const documents = await strapi.documents("api::article.article").findMany({
+  id="populate-1-level-specific">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+const documents = await strapi.documents("api::article.article").findMany({
   populate: ["headerImage"],
-});`
-    }
-  ]}
-  responses={[
-    {
-      status: 200,
-      statusText: "OK",
-      body: `[
+});
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+[
   {
     "id": "cjld2cjxh0000qzrmn831i7rn",
     "title": "Test Article",
@@ -128,10 +141,13 @@ Queries can accept a `populate` parameter to explicitly define which fields to p
     }
   }
   // ...
-]`
-    }
-  ]}
-/>
+]
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>
 
 ### Populate several levels deep for specific relations
 
@@ -140,24 +156,29 @@ Queries can accept a `populate` parameter to explicitly define which fields to p
   path='strapi.documents("api::article.article").findMany()'
   title="Populate several levels deep for specific relations"
   description="Populate specific relations several levels deep using nested populate."
-  id="populate-several-levels-deep"
-  codeTabs={[
-    {
-      label: "JavaScript",
-      code: `const documents = await strapi.documents("api::article.article").findMany({
+  id="populate-several-levels-deep">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+const documents = await strapi.documents("api::article.article").findMany({
   populate: {
     categories: {
       populate: ["articles"],
     },
   },
-});`
-    }
-  ]}
-  responses={[
-    {
-      status: 200,
-      statusText: "OK",
-      body: `[
+});
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+[
   {
     "id": "cjld2cjxh0000qzrmn831i7rn",
     "title": "Test Article",
@@ -183,10 +204,13 @@ Queries can accept a `populate` parameter to explicitly define which fields to p
     }
   }
   // ...
-]`
-    }
-  ]}
-/>
+]
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>
 
 ### Sort populated relations
 
@@ -199,24 +223,29 @@ Use the `sort` parameter inside a `populate` object to order related entries by 
   path='strapi.documents("api::article.article").findMany()'
   title="Sort populated relations"
   description="Order related entries by an attribute using the sort parameter inside a populate object."
-  id="populate-sort-relations"
-  codeTabs={[
-    {
-      label: "JavaScript",
-      code: `const documents = await strapi.documents("api::article.article").findMany({
+  id="populate-sort-relations">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+const documents = await strapi.documents("api::article.article").findMany({
   populate: {
     categories: {
       sort: 'name:asc',
     },
   },
-});`
-    }
-  ]}
-  responses={[
-    {
-      status: 200,
-      statusText: "OK",
-      body: `[
+});
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+[
   {
     "id": "cjld2cjxh0000qzrmn831i7rn",
     "title": "Test Article",
@@ -235,10 +264,13 @@ Use the `sort` parameter inside a `populate` object to order related entries by 
     ]
   }
   // ...
-]`
-    }
-  ]}
-/>
+]
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>
 
 :::note
 Omit `sort` from a `populate` object to preserve the default connect order (the order in which entries were associated).
@@ -253,20 +285,25 @@ Components are populated the same way as relations:
   path='strapi.documents("api::article.article").findMany()'
   title="Populate components"
   description="Populate components using the same syntax as relations."
-  id="populate-components"
-  codeTabs={[
-    {
-      label: "JavaScript",
-      code: `const documents = await strapi.documents("api::article.article").findMany({
+  id="populate-components">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+const documents = await strapi.documents("api::article.article").findMany({
   populate: ["testComp"],
-});`
-    }
-  ]}
-  responses={[
-    {
-      status: 200,
-      statusText: "OK",
-      body: `[
+});
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+[
   {
     "id": "cjld2cjxh0000qzrmn831i7rn",
     "title": "Test Article",
@@ -280,10 +317,13 @@ Components are populated the same way as relations:
     }
   }
   // ...
-]`
-    }
-  ]}
-/>
+]
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>
 
 Dynamic zones are highly dynamic content structures by essence. Standard populate queries (like `populate: '*'` or `populate: ['testDZ']`) will only retrieve the default, non-relational scalar fields (e.g., strings, numbers) of components within a dynamic zone. They will **not** automatically fetch nested relations, media fields, or nested components.
 
@@ -294,11 +334,13 @@ To populate component-specific nested relations, media fields, or components wit
   path='strapi.documents("api::article.article").findMany()'
   title="Populate dynamic zones"
   description="Populate dynamic zones using per-component queries with the on property."
-  id="populate-dynamic-zones"
-  codeTabs={[
-    {
-      label: "JavaScript",
-      code: `const documents = await strapi.documents("api::article.article").findMany({
+  id="populate-dynamic-zones">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+const documents = await strapi.documents("api::article.article").findMany({
   populate: {
     testDZ: {
       on: {
@@ -309,14 +351,17 @@ To populate component-specific nested relations, media fields, or components wit
       },
     },
   },
-});`
-    }
-  ]}
-  responses={[
-    {
-      status: 200,
-      statusText: "OK",
-      body: `[
+});
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+[
   {
     "id": "cjld2cjxh0000qzrmn831i7rn",
     "title": "Test Article",
@@ -336,10 +381,13 @@ To populate component-specific nested relations, media fields, or components wit
     ]
   }
   // ...
-]`
-    }
-  ]}
-/>
+]
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>
 
 ## Populating with `create()`
 
@@ -348,11 +396,13 @@ To populate component-specific nested relations, media fields, or components wit
   path='strapi.documents("api::article.article").create()'
   title="Populate with create"
   description="Populate relations in the response when creating a document."
-  id="populate-with-create"
-  codeTabs={[
-    {
-      label: "JavaScript",
-      code: `strapi.documents("api::article.article").create({
+  id="populate-with-create">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+strapi.documents("api::article.article").create({
   data: {
     title: "Test Article",
     slug: "test-article",
@@ -360,14 +410,17 @@ To populate component-specific nested relations, media fields, or components wit
     headerImage: 2,
   },
   populate: ["headerImage"],
-});`
-    }
-  ]}
-  responses={[
-    {
-      status: 200,
-      statusText: "OK",
-      body: `{
+});
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+{
   "id": "cjld2cjxh0000qzrmn831i7rn",
   "title": "Test Article",
   "slug": "test-article",
@@ -377,10 +430,13 @@ To populate component-specific nested relations, media fields, or components wit
     "name": "17520.jpg"
     // ...
   }
-}`
-    }
-  ]}
-/>
+}
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>
 
 ## Populating with `update()`
 
@@ -389,24 +445,29 @@ To populate component-specific nested relations, media fields, or components wit
   path='strapi.documents("api::article.article").update()'
   title="Populate with update"
   description="Populate relations in the response when updating a document."
-  id="populate-with-update"
-  codeTabs={[
-    {
-      label: "JavaScript",
-      code: `strapi.documents("api::article.article").update({
+  id="populate-with-update">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+strapi.documents("api::article.article").update({
   documentId: "cjld2cjxh0000qzrmn831i7rn",
   data: {
     title: "Test Article Update",
   },
   populate: ["headerImage"],
-});`
-    }
-  ]}
-  responses={[
-    {
-      status: 200,
-      statusText: "OK",
-      body: `{
+});
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+{
   "id": "cjld2cjxh0000qzrmn831i7rn",
   "title": "Test Article Update",
   "slug": "test-article",
@@ -416,10 +477,13 @@ To populate component-specific nested relations, media fields, or components wit
     "name": "17520.jpg"
     // ...
   }
-}`
-    }
-  ]}
-/>
+}
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>
 
 ## Populating with `publish()`
 
@@ -430,21 +494,26 @@ Same behavior applies with `unpublish()` and `discardDraft()`.
   path='strapi.documents("api::article.article").publish()'
   title="Populate with publish"
   description="Populate relations in the response when publishing a document."
-  id="populate-with-publish"
-  codeTabs={[
-    {
-      label: "JavaScript",
-      code: `strapi.documents("api::article.article").publish({
+  id="populate-with-publish">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+strapi.documents("api::article.article").publish({
   documentId: "cjld2cjxh0000qzrmn831i7rn",
   populate: ["headerImage"],
-});`
-    }
-  ]}
-  responses={[
-    {
-      status: 200,
-      statusText: "OK",
-      body: `{
+});
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+{
   "id": "cjld2cjxh0000qzrmn831i7rn",
   "versions": [
     {
@@ -458,10 +527,13 @@ Same behavior applies with `unpublish()` and `discardDraft()`.
       }
     }
   ]
-}`
-    }
-  ]}
-/>
+}
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>
 
 ## Populating with `delete()`
 
@@ -472,21 +544,26 @@ To populate while deleting documents:
   path='strapi.documents("api::article.article").delete()'
   title="Populate with delete"
   description="Populate relations in the response when deleting a document."
-  id="populate-with-delete"
-  codeTabs={[
-    {
-      label: "JavaScript",
-      code: `strapi.documents("api::article.article").delete({
+  id="populate-with-delete">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+strapi.documents("api::article.article").delete({
   documentId: "cjld2cjxh0000qzrmn831i7rn",
   populate: ["headerImage"],
-});`
-    }
-  ]}
-  responses={[
-    {
-      status: 200,
-      statusText: "OK",
-      body: `{
+});
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+{
   "documentId": "cjld2cjxh0000qzrmn831i7rn",
   "entries": [
     {
@@ -502,7 +579,10 @@ To populate while deleting documents:
       // ...
     }
   ]
-}`
-    }
-  ]}
-/>
+}
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>

--- a/docusaurus/docs/cms/api/document-service/publication-filter.md
+++ b/docusaurus/docs/cms/api/document-service/publication-filter.md
@@ -91,21 +91,26 @@ This parameter combination works only on a given locale; to find these documents
   kind="js"
   path="strapi.documents().findMany()"
   title="findMany() with publicationFilter: 'never-published'"
-  description="Return the drafts that have never been published for their locale."
-  codeTabs={[
-    {
-      label: 'JavaScript',
-      code: `await strapi.documents('api::restaurant.restaurant').findMany({
+  description="Return the drafts that have never been published for their locale.">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+await strapi.documents('api::restaurant.restaurant').findMany({
     status: 'draft',
     publicationFilter: 'never-published',
-});`
-    }
-  ]}
-  responses={[
-    {
-      status: 200,
-      statusText: 'OK',
-      body: `[
+});
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+[
     {
       documentId: "a1b2c3d4e5f6g7h8i9j0klm",
       name: "New Restaurant",
@@ -114,10 +119,13 @@ This parameter combination works only on a given locale; to find these documents
       // …
     }
   // …
-]`
-    }
-  ]}
-/>
+]
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>
 
 ### Find drafts never published in any locale {#never-published-document}
 
@@ -129,21 +137,26 @@ A document counts as published as soon as one of its locales is published: the d
   kind="js"
   path="strapi.documents().findMany()"
   title="findMany() with publicationFilter: 'never-published-document'"
-  description="Return the drafts of documents never published in any locale."
-  codeTabs={[
-    {
-      label: 'JavaScript',
-      code: `await strapi.documents('api::restaurant.restaurant').findMany({
+  description="Return the drafts of documents never published in any locale.">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+await strapi.documents('api::restaurant.restaurant').findMany({
     status: 'draft',
     publicationFilter: 'never-published-document',
-});`
-    }
-  ]}
-  responses={[
-    {
-      status: 200,
-      statusText: 'OK',
-      body: `[
+});
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+[
     {
       documentId: "d41r46wac4xix5vpba7561at",
       name: "New Restaurant",
@@ -152,10 +165,13 @@ A document counts as published as soon as one of its locales is published: the d
       // …
     }
   // …
-]`
-    }
-  ]}
-/>
+]
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>
 
 ### Find modified documents {#modified}
 
@@ -167,21 +183,26 @@ For instance, with `status: 'draft'`, the query returns the draft versions:
   kind="js"
   path="strapi.documents().findMany()"
   title="findMany() with publicationFilter: 'modified' and status: 'draft'"
-  description="Return the draft versions of documents with unpublished changes."
-  codeTabs={[
-    {
-      label: 'JavaScript',
-      code: `await strapi.documents('api::restaurant.restaurant').findMany({
+  description="Return the draft versions of documents with unpublished changes.">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+await strapi.documents('api::restaurant.restaurant').findMany({
     status: 'draft',
     publicationFilter: 'modified',
-});`
-    }
-  ]}
-  responses={[
-    {
-      status: 200,
-      statusText: 'OK',
-      body: `[
+});
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+[
     {
       documentId: "a1b2c3d4e5f6g7h8i9j0klm",
       name: "Biscotte Restaurant (updated)",
@@ -190,10 +211,13 @@ For instance, with `status: 'draft'`, the query returns the draft versions:
       // …
     }
   // …
-]`
-    }
-  ]}
-/>
+]
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>
 
 <br/>
 With `status: 'published'`, the same query returns the currently live version of those documents instead:
@@ -202,21 +226,26 @@ With `status: 'published'`, the same query returns the currently live version of
   kind="js"
   path="strapi.documents().findMany()"
   title="findMany() with publicationFilter: 'modified' and status: 'published'"
-  description="Return the currently live versions of documents with unpublished changes."
-  codeTabs={[
-    {
-      label: 'JavaScript',
-      code: `await strapi.documents('api::restaurant.restaurant').findMany({
+  description="Return the currently live versions of documents with unpublished changes.">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+await strapi.documents('api::restaurant.restaurant').findMany({
     status: 'published',
     publicationFilter: 'modified',
-});`
-    }
-  ]}
-  responses={[
-    {
-      status: 200,
-      statusText: 'OK',
-      body: `[
+});
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+[
     {
       documentId: "a1b2c3d4e5f6g7h8i9j0klm",
       name: "Biscotte Restaurant",
@@ -225,10 +254,13 @@ With `status: 'published'`, the same query returns the currently live version of
       // …
     }
   // …
-]`
-    }
-  ]}
-/>
+]
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>
 
 ### Find unmodified documents {#unmodified}
 
@@ -240,21 +272,26 @@ For instance, with `status: 'draft'`, the query returns the draft versions:
   kind="js"
   path="strapi.documents().findMany()"
   title="findMany() with publicationFilter: 'unmodified' and status: 'draft'"
-  description="Return the draft versions of documents unchanged since their last publication."
-  codeTabs={[
-    {
-      label: 'JavaScript',
-      code: `await strapi.documents('api::restaurant.restaurant').findMany({
+  description="Return the draft versions of documents unchanged since their last publication.">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+await strapi.documents('api::restaurant.restaurant').findMany({
     status: 'draft',
     publicationFilter: 'unmodified',
-});`
-    }
-  ]}
-  responses={[
-    {
-      status: 200,
-      statusText: 'OK',
-      body: `[
+});
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+[
     {
       documentId: "a1b2c3d4e5f6g7h8i9j0klm",
       name: "Biscotte Restaurant",
@@ -263,10 +300,13 @@ For instance, with `status: 'draft'`, the query returns the draft versions:
       // …
     }
   // …
-]`
-    }
-  ]}
-/>
+]
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>
 
 <br/>
 With `status: 'published'`, the same query returns the currently live version of those documents instead:
@@ -275,21 +315,26 @@ With `status: 'published'`, the same query returns the currently live version of
   kind="js"
   path="strapi.documents().findMany()"
   title="findMany() with publicationFilter: 'unmodified' and status: 'published'"
-  description="Return the currently live versions of documents unchanged since their last publication."
-  codeTabs={[
-    {
-      label: 'JavaScript',
-      code: `await strapi.documents('api::restaurant.restaurant').findMany({
+  description="Return the currently live versions of documents unchanged since their last publication.">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+await strapi.documents('api::restaurant.restaurant').findMany({
     status: 'published',
     publicationFilter: 'unmodified',
-});`
-    }
-  ]}
-  responses={[
-    {
-      status: 200,
-      statusText: 'OK',
-      body: `[
+});
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+[
     {
       documentId: "a1b2c3d4e5f6g7h8i9j0klm",
       name: "Biscotte Restaurant",
@@ -298,10 +343,13 @@ With `status: 'published'`, the same query returns the currently live version of
       // …
     }
   // …
-]`
-    }
-  ]}
-/>
+]
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>
 
 ### Find documents with a published version {#has-published-version}
 
@@ -313,21 +361,26 @@ For instance, with `status: 'draft'`, the query returns the draft versions:
   kind="js"
   path="strapi.documents().findMany()"
   title="findMany() with publicationFilter: 'has-published-version' and status: 'draft'"
-  description="Return the draft versions of documents that also have a published version for the same locale."
-  codeTabs={[
-    {
-      label: 'JavaScript',
-      code: `await strapi.documents('api::restaurant.restaurant').findMany({
+  description="Return the draft versions of documents that also have a published version for the same locale.">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+await strapi.documents('api::restaurant.restaurant').findMany({
     status: 'draft',
     publicationFilter: 'has-published-version',
-});`
-    }
-  ]}
-  responses={[
-    {
-      status: 200,
-      statusText: 'OK',
-      body: `[
+});
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+[
     {
       documentId: "a1b2c3d4e5f6g7h8i9j0klm",
       name: "Biscotte Restaurant",
@@ -336,10 +389,13 @@ For instance, with `status: 'draft'`, the query returns the draft versions:
       // …
     }
   // …
-]`
-    }
-  ]}
-/>
+]
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>
 
 <br/>
 With `status: 'published'`, the same query returns the currently live version of those documents instead:
@@ -348,21 +404,26 @@ With `status: 'published'`, the same query returns the currently live version of
   kind="js"
   path="strapi.documents().findMany()"
   title="findMany() with publicationFilter: 'has-published-version' and status: 'published'"
-  description="Return the currently live versions of documents that also have a published version for the same locale."
-  codeTabs={[
-    {
-      label: 'JavaScript',
-      code: `await strapi.documents('api::restaurant.restaurant').findMany({
+  description="Return the currently live versions of documents that also have a published version for the same locale.">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+await strapi.documents('api::restaurant.restaurant').findMany({
     status: 'published',
     publicationFilter: 'has-published-version',
-});`
-    }
-  ]}
-  responses={[
-    {
-      status: 200,
-      statusText: 'OK',
-      body: `[
+});
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+[
     {
       documentId: "a1b2c3d4e5f6g7h8i9j0klm",
       name: "Biscotte Restaurant",
@@ -371,10 +432,13 @@ With `status: 'published'`, the same query returns the currently live version of
       // …
     }
   // …
-]`
-    }
-  ]}
-/>
+]
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>
 
 ### Find documents with a published version in at least one locale {#has-published-version-document}
 
@@ -384,21 +448,26 @@ With `status: 'published'`, the same query returns the currently live version of
   kind="js"
   path="strapi.documents().findMany()"
   title="findMany() with publicationFilter: 'has-published-version-document'"
-  description="Return the draft versions of documents published in at least one locale."
-  codeTabs={[
-    {
-      label: 'JavaScript',
-      code: `await strapi.documents('api::restaurant.restaurant').findMany({
+  description="Return the draft versions of documents published in at least one locale.">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+await strapi.documents('api::restaurant.restaurant').findMany({
     status: 'draft',
     publicationFilter: 'has-published-version-document',
-});`
-    }
-  ]}
-  responses={[
-    {
-      status: 200,
-      statusText: 'OK',
-      body: `[
+});
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+[
     {
       documentId: "a1b2c3d4e5f6g7h8i9j0klm",
       name: "Biscotte Restaurant",
@@ -407,10 +476,13 @@ With `status: 'published'`, the same query returns the currently live version of
       // …
     }
   // …
-]`
-    }
-  ]}
-/>
+]
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>
 
 ### Use with `findOne()` and `findFirst()` {#find-one-find-first}
 
@@ -420,25 +492,33 @@ If the requested document (and locale, when applicable) does not match the filte
   kind="js"
   path="strapi.documents().findOne()"
   title="findOne() with publicationFilter: 'never-published'"
-  description="Return the document only if it matches the filter, null otherwise."
-  codeTabs={[
-    {
-      label: 'JavaScript',
-      code: `await strapi.documents('api::restaurant.restaurant').findOne({
+  description="Return the document only if it matches the filter, null otherwise.">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+await strapi.documents('api::restaurant.restaurant').findOne({
     documentId: 'a1b2c3d4e5f6g7h8i9j0klm',
     status: 'draft',
     publicationFilter: 'never-published',
-});`
-    }
-  ]}
-  responses={[
-    {
-      status: 200,
-      statusText: 'OK',
-      body: `null // the documentId exists, but the document does not match never-published`
-    }
-  ]}
-/>
+});
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+null // the documentId exists, but the document does not match never-published
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>
 
 ### Count only matching documents {#count}
 
@@ -448,26 +528,34 @@ Without `publicationFilter`, `count({ status: 'draft' })` counts every draft ver
   kind="js"
   path="strapi.documents().count()"
   title="count() with publicationFilter: 'never-published'"
-  description="Count only the documents that match a given value."
-  codeTabs={[
-    {
-      label: 'JavaScript',
-      code: `const neverPublishedCount = await strapi
+  description="Count only the documents that match a given value.">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+const neverPublishedCount = await strapi
     .documents('api::restaurant.restaurant')
     .count({
       status: 'draft',
       publicationFilter: 'never-published',
-    });`
-    }
-  ]}
-  responses={[
-    {
-      status: 200,
-      statusText: 'OK',
-      body: `12 // the number of never-published drafts`
-    }
-  ]}
-/>
+    });
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+12 // the number of never-published drafts
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>
 
 ## Diagnostic values {#diagnostics}
 
@@ -482,21 +570,26 @@ The `published-without-draft` and `published-with-draft` values are meant for da
   kind="js"
   path="strapi.documents().findMany()"
   title="findMany() with publicationFilter: 'published-without-draft'"
-  description="Return published documents with no matching draft version for the same locale."
-  codeTabs={[
-    {
-      label: 'JavaScript',
-      code: `await strapi.documents('api::restaurant.restaurant').findMany({
+  description="Return published documents with no matching draft version for the same locale.">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+await strapi.documents('api::restaurant.restaurant').findMany({
     status: 'published',
     publicationFilter: 'published-without-draft',
-});`
-    }
-  ]}
-  responses={[
-    {
-      status: 200,
-      statusText: 'OK',
-      body: `[
+});
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+[
   {
     documentId: "j0klm1n2o3p4q5r6s7t8u9v",
     name: "Legacy Restaurant",
@@ -505,10 +598,13 @@ The `published-without-draft` and `published-with-draft` values are meant for da
     // …
   }
   // …
-]`
-    }
-  ]}
-/>
+]
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>
 
 <br/>
 `publicationFilter: published-with-draft` selects published documents that also have a draft, which is every published document in a healthy database:
@@ -517,21 +613,26 @@ The `published-without-draft` and `published-with-draft` values are meant for da
   kind="js"
   path="strapi.documents().findMany()"
   title="findMany() with publicationFilter: 'published-with-draft'"
-  description="Return published documents that also have a matching draft version for the same locale."
-  codeTabs={[
-    {
-      label: 'JavaScript',
-      code: `await strapi.documents('api::restaurant.restaurant').findMany({
+  description="Return published documents that also have a matching draft version for the same locale.">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+await strapi.documents('api::restaurant.restaurant').findMany({
     status: 'published',
     publicationFilter: 'published-with-draft',
-});`
-    }
-  ]}
-  responses={[
-    {
-      status: 200,
-      statusText: 'OK',
-      body: `[
+});
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+[
     {
       documentId: "a1b2c3d4e5f6g7h8i9j0klm",
       name: "Biscotte Restaurant",
@@ -540,10 +641,13 @@ The `published-without-draft` and `published-with-draft` values are meant for da
       // …
     }
   // …
-]`
-    }
-  ]}
-/>
+]
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>
 
 </details>
 

--- a/docusaurus/docs/cms/api/document-service/sort-pagination.md
+++ b/docusaurus/docs/cms/api/document-service/sort-pagination.md
@@ -33,20 +33,25 @@ To sort results returned by the Document Service API, include the `sort` paramet
   kind="js"
   path="strapi.documents().findMany()"
   title="Sort on a single field"
-  description="Sort results based on a single field using a string value."
-  codeTabs={[
-    {
-      label: 'JavaScript',
-      code: `const documents = await strapi.documents("api::article.article").findMany({
+  description="Sort results based on a single field using a string value.">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+const documents = await strapi.documents("api::article.article").findMany({
   sort: "title:asc",
-});`,
-    },
-  ]}
-  responses={[
-    {
-      status: 200,
-      statusText: 'OK',
-      body: `[
+});
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+[
   {
     "documentId": "cjld2cjxh0000qzrmn831i7rn",
     "title": "Test Article",
@@ -59,10 +64,13 @@ To sort results returned by the Document Service API, include the `sort` paramet
     "slug": "test-article-2",
     "body": "Test 2"
   }
-]`,
-    },
-  ]}
-/>
+]
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>
 
 ### Sort on multiple fields
 
@@ -71,20 +79,25 @@ To sort results returned by the Document Service API, include the `sort` paramet
   kind="js"
   path="strapi.documents().findMany()"
   title="Sort on multiple fields"
-  description="Sort results on multiple fields by passing an array of sort objects."
-  codeTabs={[
-    {
-      label: 'JavaScript',
-      code: `const documents = await strapi.documents("api::article.article").findMany({
+  description="Sort results on multiple fields by passing an array of sort objects.">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+const documents = await strapi.documents("api::article.article").findMany({
   sort: [{ title: "asc" }, { slug: "desc" }],
-});`,
-    },
-  ]}
-  responses={[
-    {
-      status: 200,
-      statusText: 'OK',
-      body: `[
+});
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+[
   {
     "documentId": "cjld2cjxh0000qzrmn831i7rn",
     "title": "Test Article",
@@ -97,10 +110,13 @@ To sort results returned by the Document Service API, include the `sort` paramet
     "slug": "test-article-2",
     "body": "Test 2"
   }
-]`,
-    },
-  ]}
-/>
+]
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>
 
 ## Pagination
 
@@ -108,21 +124,26 @@ To sort results returned by the Document Service API, include the `sort` paramet
   kind="js"
   path="strapi.documents().findMany()"
   title="Pagination"
-  description="Paginate results using the limit and start parameters."
-  codeTabs={[
-    {
-      label: 'JavaScript',
-      code: `const documents = await strapi.documents("api::article.article").findMany({
+  description="Paginate results using the limit and start parameters.">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+const documents = await strapi.documents("api::article.article").findMany({
   limit: 10,
   start: 0,
-});`,
-    },
-  ]}
-  responses={[
-    {
-      status: 200,
-      statusText: 'OK',
-      body: `[
+});
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+[
   {
     "documentId": "cjld2cjxh0000qzrmn831i7rn",
     "title": "Test Article",
@@ -135,7 +156,10 @@ To sort results returned by the Document Service API, include the `sort` paramet
     "slug": "test-article-2",
     "body": "Test 2"
   }
-]`,
-    },
-  ]}
-/>
+]
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>

--- a/docusaurus/docs/cms/api/document-service/status.md
+++ b/docusaurus/docs/cms/api/document-service/status.md
@@ -44,30 +44,38 @@ To select documents by how their draft and published versions relate (never-publ
   kind="js"
   path="strapi.documents().findOne()"
   title="findOne() with status: 'published'"
-  description="Return the published version of a specific document."
-  codeTabs={[
-    {
-      label: 'JavaScript',
-      code: `await strapi.documents('api::restaurant.restaurant').findOne({
+  description="Return the published version of a specific document.">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+await strapi.documents('api::restaurant.restaurant').findOne({
   documentId: 'a1b2c3d4e5f6g7h8i9j0klm',
   status: 'published'
-});`
-    }
-  ]}
-  responses={[
-    {
-      status: 200,
-      statusText: 'OK',
-      body: `{
+});
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+{
   documentId: "a1b2c3d4e5f6g7h8i9j0klm",
   name: "Biscotte Restaurant",
   publishedAt: "2024-03-14T15:40:45.330Z",
   locale: "en", // default locale
   // …
-}`
-    }
-  ]}
-/>
+}
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>
 
 ## Get the published version with `findFirst()` {#find-first}
 
@@ -75,29 +83,37 @@ To select documents by how their draft and published versions relate (never-publ
   kind="js"
   path="strapi.documents().findFirst()"
   title="findFirst() with status: 'published'"
-  description="Return the published version of the first matching document."
-  codeTabs={[
-    {
-      label: 'JavaScript',
-      code: `const document = await strapi.documents("api::restaurant.restaurant").findFirst({
+  description="Return the published version of the first matching document.">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+const document = await strapi.documents("api::restaurant.restaurant").findFirst({
   status: 'published',
-});`
-    }
-  ]}
-  responses={[
-    {
-      status: 200,
-      statusText: 'OK',
-      body: `{
+});
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+{
   documentId: "a1b2c3d4e5f6g7h8i9j0klm",
   name: "Biscotte Restaurant",
   publishedAt: "2024-03-14T15:40:45.330Z",
   locale: "en", // default locale
   // …
-}`
-    }
-  ]}
-/>
+}
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>
 
 ## Get the published version with `findMany()` {#find-many}
 
@@ -105,20 +121,25 @@ To select documents by how their draft and published versions relate (never-publ
   kind="js"
   path="strapi.documents().findMany()"
   title="findMany() with status: 'published'"
-  description="Return the published versions of all matching documents."
-  codeTabs={[
-    {
-      label: 'JavaScript',
-      code: `const documents = await strapi.documents("api::restaurant.restaurant").findMany({
+  description="Return the published versions of all matching documents.">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+const documents = await strapi.documents("api::restaurant.restaurant").findMany({
   status: 'published'
-});`
-    }
-  ]}
-  responses={[
-    {
-      status: 200,
-      statusText: 'OK',
-      body: `[
+});
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+[
   {
     documentId: "a1b2c3d4e5f6g7h8i9j0klm",
     name: "Biscotte Restaurant",
@@ -127,10 +148,13 @@ To select documents by how their draft and published versions relate (never-publ
     // …
   }
   // …
-]`
-    }
-  ]}
-/>
+]
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>
 
 ## `count()` only draft or published versions {#count}
 
@@ -162,32 +186,40 @@ This means that counting with the `status: 'draft'` parameter still returns the 
   kind="js"
   path="strapi.documents().create()"
   title="create() with status: 'published'"
-  description="Create a new document and immediately publish it."
-  codeTabs={[
-    {
-      label: 'JavaScript',
-      code: `await strapi.documents('api::restaurant.restaurant').create({
+  description="Create a new document and immediately publish it.">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+await strapi.documents('api::restaurant.restaurant').create({
   data: {
     name: "New Restaurant",
   },
   status: 'published',
-})`
-    }
-  ]}
-  responses={[
-    {
-      status: 200,
-      statusText: 'OK',
-      body: `{
+})
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+{
   documentId: "d41r46wac4xix5vpba7561at",
   name: "New Restaurant",
   publishedAt: "2024-03-14T17:29:03.399Z",
   locale: "en" // default locale
   // …
-}`
-    }
-  ]}
-/>
+}
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>
 
 ## Update a draft and publish it {#update}
 
@@ -195,30 +227,38 @@ This means that counting with the `status: 'draft'` parameter still returns the 
   kind="js"
   path="strapi.documents().update()"
   title="update() with status: 'published'"
-  description="Update an existing document and immediately publish it."
-  codeTabs={[
-    {
-      label: 'JavaScript',
-      code: `await strapi.documents('api::restaurant.restaurant').update({
+  description="Update an existing document and immediately publish it.">
+
+<Tabs>
+<TabItem value="javascript" label="JavaScript">
+
+```js
+await strapi.documents('api::restaurant.restaurant').update({
   documentId: 'a1b2c3d4e5f6g7h8i9j0klm',
   data: {
     name: "Biscotte Restaurant (closed)",
   },
   status: 'published',
-})`
-    }
-  ]}
-  responses={[
-    {
-      status: 200,
-      statusText: 'OK',
-      body: `{
+})
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+{
   documentId: "a1b2c3d4e5f6g7h8i9j0klm",
   name: "Biscotte Restaurant (closed)",
   publishedAt: "2024-03-14T17:29:03.399Z",
   locale: "en" // default locale
   // …
-}`
-    }
-  ]}
-/>
+}
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>

--- a/docusaurus/docs/cms/api/rest/guides/understanding-populate.md
+++ b/docusaurus/docs/cms/api/rest/guides/understanding-populate.md
@@ -1303,23 +1303,27 @@ Let's compare and explain the responses returned with `populate[0]=blocks` (only
 When we only populate the `blocks` dynamic zone, we go only 1 level deep, and we can get the following example response. Highlighted lines show the `blocks` dynamic zone and the 2 components it includes:
 
 <Endpoint
-  collapsibleResponse
   method="GET"
   path="/api/articles"
   title="Populating only the dynamic zone"
   description="Populates the blocks dynamic zone 1 level deep."
-  id="populating-only-the-dynamic-zone"
-  codeTabs={[
-    {
-      label: "Request",
-      code: "GET /api/articles?populate[0]=blocks"
-    }
-  ]}
-  responses={[
-    {
-      status: 200,
-      statusText: "OK",
-      body: `{
+  id="populating-only-the-dynamic-zone">
+
+<Tabs>
+<TabItem value="request" label="Request">
+
+```bash
+GET /api/articles?populate[0]=blocks
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK" collapsible>
+
+```json
+{
   "data": [
     {
       "id": 1,
@@ -1369,33 +1373,40 @@ When we only populate the `blocks` dynamic zone, we go only 1 level deep, and we
       "total": 4
     }
   }
-}`
-    }
-  ]}
-/>
+}
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>
 
 ##### Example: Populating the dynamic zone and applying a shared strategy to its components
 
 When we populate the `blocks` dynamic zone and apply a shared population strategy to all its components with `[populate]=*`, we not only include components fields but also their 1st-level relations, as shown in the highlighted lines of the following example response:
 
 <Endpoint
-  collapsibleResponse
   method="GET"
   path="/api/articles"
   title="Populating the dynamic zone with shared strategy"
   description="Populates the blocks dynamic zone and applies a shared population strategy to all its components."
-  id="populating-dynamic-zone-shared-strategy"
-  codeTabs={[
-    {
-      label: "Request",
-      code: "GET /api/articles?populate[blocks][populate]=*"
-    }
-  ]}
-  responses={[
-    {
-      status: 200,
-      statusText: "OK",
-      body: `{
+  id="populating-dynamic-zone-shared-strategy">
+
+<Tabs>
+<TabItem value="request" label="Request">
+
+```bash
+GET /api/articles?populate[blocks][populate]=*
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK" collapsible>
+
+```json
+{
   "data": [
     {
       "id": 1,
@@ -1489,10 +1500,13 @@ When we populate the `blocks` dynamic zone and apply a shared population strateg
       "total": 4
     }
   }
-}`
-    }
-  ]}
-/> -->
+}
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint> -->
 
 Dynamic zones are highly dynamic content structures by essence. When querying dynamic zones, standard populate parameters (such as `populate[0]=dynamic-zone-name` or `populate=*`) will only fetch the default scalar fields (e.g., strings, numbers, booleans) of the components within the dynamic zone. By default, they will **not** populate nested relations, media fields, or nested components inside those components.
 

--- a/docusaurus/src/components/ApiReference/Responses.jsx
+++ b/docusaurus/src/components/ApiReference/Responses.jsx
@@ -58,8 +58,14 @@ export default function Responses({ children }) {
       <Tabs>
         {items.map((item, i) => {
           const status = Number(item.props.status);
+          const statusText = item.props.statusText || '';
+          // The tab value must be unique: several responses can share a status
+          // code (e.g. two 200s distinguished by statusText), so the index keeps
+          // it unique. The label shows the status and, when present, the
+          // statusText, so same-status tabs stay distinguishable.
+          const label = statusText ? `${status} ${statusText}` : String(status);
           return (
-            <TabItem key={i} value={String(status)} label={String(status)}>
+            <TabItem key={i} value={`${status}-${i}`} label={label}>
               {item}
             </TabItem>
           );


### PR DESCRIPTION
This PR fixes the Document Service API reference pages where all request examples and responses had stopped rendering: the redesigned Endpoint component (#3341) only reads code from children, but these pages still used the old codeTabs/responses props, which were silently ignored. It migrates ~92 Endpoint blocks across 8 Document Service API pages and one REST guide to the children-based Tabs/Responses syntax, preserving every example and response verbatim. It also fixes the Responses component, which generated duplicate Docusaurus tab values when two responses shared the same HTTP status code (breaking the build).

Direct preview link 👉 [here](https://documentation-git-repo-fix-endpoint-codetabs-migration-strapijs.vercel.app/cms/api/document-service)