### PR TITLE
Fix doc card width so cards fill their grid cell

### DIFF
--- a/docusaurus/src/scss/custom-doc-cards.scss
+++ b/docusaurus/src/scss/custom-doc-cards.scss
@@ -36,6 +36,16 @@
     display: flex;
     flex-direction: column;
     justify-content: flex-start;
+    // The `.custom-doc-card` grid cell is a flex ROW (default direction), so its
+    // main axis is horizontal. Without an explicit width the inner `<a>` sizes
+    // to its own text width on that axis, leaving cards with shorter titles or
+    // descriptions visibly narrower than their 312px grid cell (this is why
+    // cards inside `.expandable-cards-wrapper`, which tend to have shorter copy,
+    // looked narrower than standalone cards). `flex: 1` + `width: 100%` makes the
+    // visible card fill its cell horizontally, so every card is exactly as wide
+    // as its grid track regardless of text length.
+    flex: 1;
+    width: 100%;
     // `min-height` (not a fixed `height`) so a card whose title wraps to two
     // lines can grow to fit its clamped description instead of clipping the
     // last line mid-text. `height: 100%` makes the visible card fill its


### PR DESCRIPTION
This PR fixes a layout inconsistency where CustomDocCard items with shorter text rendered narrower than their grid cell, so cards in the same row (and in ExpandableDocCardsWrapper vs CustomDocCardsWrapper) had different widths. It adds flex: 1 and width: 100% to the card container so every card fills its grid track regardless of text length.