### PR TITLE
Wrap single-status API responses in one bordered content box

### DIFF
--- a/docusaurus/src/components/ApiReference/Responses.jsx
+++ b/docusaurus/src/components/ApiReference/Responses.jsx
@@ -48,9 +48,17 @@ export default function Responses({ children }) {
     (c) => isValidElement(c) && c.type === ResponseTab,
   );
 
-  // Single response: no tabs needed, just render it.
+  // Single response: no tabs needed. Wrap the status header + code in a bordered
+  // box that mirrors the multi-status <Tabs> container (same border, radius and
+  // insets), minus the tab bar — so a lone 200 response reads as the same
+  // "content" block as a multi-status one. See `.responses--single` in
+  // api-reference.module.scss.
   if (items.length <= 1) {
-    return <div className={styles.responses}>{items}</div>;
+    return (
+      <div className={clsx(styles.responses, styles['responses--single'])}>
+        {items}
+      </div>
+    );
   }
 
   return (

--- a/docusaurus/src/components/ApiReference/api-reference.module.scss
+++ b/docusaurus/src/components/ApiReference/api-reference.module.scss
@@ -731,6 +731,50 @@
   margin-top: 4px;
 }
 
+// Single-status response: no <Tabs>, so there's no container border around the
+// block. Draw ONE bordered box around the status header + code — the "● 200 OK"
+// and the JSON share a single outer border, and the inner CodeBlock's own border
+// is stripped so it blends into the box (no nested double border). Border
+// color/radius mirror `.tabs-container` in api-endpoint blocks (tabs.scss); the
+// inner padding mirrors that container's tabpanel: 21px top/bottom and a 38px
+// left inset so the header and the JSON `{` line up like the tabbed case.
+.responses--single {
+  border: solid 1px var(--custom-code-block-border-color);
+  border-radius: var(--strapi-radius-md, 10px);
+  padding: 21px 20px 21px 38px;
+  // Neutralize the flush single-status inset from the `.responses >
+  // .responseHeader` rule above: inside the box the header aligns via this
+  // container's own 38px left padding. Compound `&.responses--single` so this
+  // wins on specificity over that equal-specificity sibling rule regardless of
+  // source order.
+  &.responses > .responseHeader {
+    padding-left: 0;
+  }
+
+  // Strip the inner CodeBlock's own border, radius and hover-border so it melts
+  // into the single outer box instead of stacking a second nested border.
+  // `:global` because .theme-code-block is a Docusaurus (non-module) class name.
+  :global(.theme-code-block) {
+    border: none !important;
+    border-radius: 0 !important;
+    // Drop the code block's own bottom margin: it stacked on top of the box's
+    // 21px bottom padding, leaving a double gap below the code.
+    margin-bottom: 0 !important;
+
+    &:hover {
+      border-color: transparent !important;
+    }
+  }
+
+  // The inner CodeBlock carries its own 24px padding (code-block.scss). Zero its
+  // LEFT padding so the JSON `{` inherits the box's 38px inset and lines up with
+  // the "● 200 OK" header — same neutralization the tabbed case does in
+  // tabs.scss. `:global` because these are Docusaurus (non-module) class names.
+  :global([class*='codeBlockContainer']):not(:has(:global([class*='codeBlockTitle']))) {
+    padding-left: 0 !important;
+  }
+}
+
 .responseHeader {
   display: flex;
   align-items: center;

--- a/docusaurus/src/scss/tabs.scss
+++ b/docusaurus/src/scss/tabs.scss
@@ -61,10 +61,6 @@
     .margin-top--md {
       margin-top: 24px !important;
     }
-    
-    .tabs + .margin-top--md {
-      margin-top: 0 !important; // Simplified, removed redundant line
-    }
 
     // Inner padding on the tab panel so content is not flush against the
     // container border (top, bottom, left, right).


### PR DESCRIPTION
This PR gives single-status API response blocks (e.g. a lone 200 OK on the REST API reference page) the same bordered content box that multi-status responses already have, minus the status tabs. The status header and the code now share one outer border, the inner code block's own border and bottom margin are stripped so it blends into the box without a double border or double gap, and the copy button still copies only the code.