### PR TITLE
Remove incorrect private-provider section from custom email providers doc

### DIFF
--- a/docusaurus/docs/cms/configurations/email-custom-providers.md
+++ b/docusaurus/docs/cms/configurations/email-custom-providers.md
@@ -86,15 +86,3 @@ To use a custom provider without publishing it to npm:
 
 4. Update `/config/plugins.js|ts` to [configure the provider](/cms/features/email#configuring-providers).
 5. Run `yarn` or `npm install` to link the local package.
-
-## Private providers
-
-A provider can be marked as **private**, meaning every asset URL will be signed for secure access rather than exposed as a plain URL.
-
-To enable this, implement the `isPrivate()` method and return `true` in your provider module.
-
-When a provider is private, Strapi uses a `getSignedUrl(file)` method — also implemented in the provider — to generate a signed URL for each asset. The signed URL contains an encrypted signature that grants access for a limited time and with specific restrictions, depending on your implementation.
-
-:::note
-For security reasons, the Content API does not return signed URLs. Developers consuming the API must sign URLs themselves using the provider's signing logic.
-:::

--- a/docusaurus/docs/cms/features/email.md
+++ b/docusaurus/docs/cms/features/email.md
@@ -296,7 +296,7 @@ If your provider gives you a single URL instead of host and port values, pass th
 To build your own provider, publish it to npm, or use it locally in your project, see the dedicated documentation:
 
 <CustomDocCardsWrapper>
-<CustomDocCard icon="wrench" title="Creating custom email providers" description="Implement the provider interface, use a local provider, or set up signed URLs for private assets." link="/cms/configurations/email-custom-providers"/>
+<CustomDocCard icon="wrench" title="Creating custom email providers" description="Implement the provider interface, then publish it to npm or use it locally in your project." link="/cms/configurations/email-custom-providers"/>
 </CustomDocCardsWrapper>
 
 ## Usage


### PR DESCRIPTION
This PR removes the "Private providers" section from the custom email providers page and fixes the matching doc card on the Email feature page.

Signed URLs and the isPrivate() / getSignedUrl() methods are Upload (Media Library) provider features, not email provider features. The maintained email providers (email-nodemailer, email-sendgrid, etc.) only implement init() returning a send() function, while isPrivate() and getSignedUrl() are defined in the upload providers (for example upload-aws-s3). This same signed-URL guidance is already correctly documented on the Media Library providers page, so the email page was describing behavior that does not exist for email providers.