### PR TITLE
Fix review findings on morphMany serialization docs

### DIFF
--- a/docusaurus/docs/cms/api/document-service/populate.md
+++ b/docusaurus/docs/cms/api/document-service/populate.md
@@ -26,11 +26,11 @@ Use the `populate` parameter with the Document Service API to explicitly load re
 By default the [Document Service API](/cms/api/document-service) does not populate any relations, media fields, components, or dynamic zones. This page describes how to use the `populate` parameter to populate specific fields.
 
 :::tip
-You can also use the `select` parameter to return only specific fields with the query results (see the [`select` parameter](/cms/api/document-service/fields) documentation).
+You can also use the `fields` parameter to return only specific fields with the query results (see the [`fields` parameter](/cms/api/document-service/fields) documentation).
 :::
 
 :::caution
-If the Users & Permissions plugin is installed, the `find` permission must be enabled for the content-types that are being populated. If a role doesn't have access to a content-type it will not be populated.
+If the Users & Permissions feature is enabled, the `find` permission must be enabled for the content-types that are being populated. If a role doesn't have access to a content-type it will not be populated.
 :::
 
 <!-- TODO: add link to populate guides (even if REST API, the same logic still applies) -->

--- a/docusaurus/docs/cms/api/document-service/populate.md
+++ b/docusaurus/docs/cms/api/document-service/populate.md
@@ -449,8 +449,8 @@ Same behavior applies with `unpublish()` and `discardDraft()`.
       status: 200,
       statusText: "OK",
       body: `{
-  "id": "cjld2cjxh0000qzrmn831i7rn",
-  "versions": [
+  "documentId": "cjld2cjxh0000qzrmn831i7rn",
+  "entries": [
     {
       "id": "cjld2cjxh0001qzrm1q1i7rn",
       "locale": "en",

--- a/docusaurus/docs/cms/api/rest/populate-select.md
+++ b/docusaurus/docs/cms/api/rest/populate-select.md
@@ -79,7 +79,7 @@ const query = qs.stringify(
   }
 );
 
-await request(`/api/users?${query}`);
+await request(`/api/restaurants?${query}`);
 ```
 
 </TabItem>

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/morph-many-serialization.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/morph-many-serialization.md
@@ -19,7 +19,7 @@ import MigrationIntro from '/docs/snippets/breaking-change-page-migration-intro.
 
 <Tldr>
 
-In Strapi 5, populating an empty `morphMany` relation -- including `type: 'media', multiple: true` fields such as a gallery -- returns `[]` instead of `null`. Update client code that checks `field === null` to treat `[]` as the empty state.
+In Strapi 5, populating an empty `morphMany` relation (including `type: 'media', multiple: true` fields such as a gallery) returns `[]` instead of `null`. Update client code that checks `field === null` to treat `[]` as the empty state.
 
 </Tldr>
 


### PR DESCRIPTION
This PR applies review fixes on top of the morphMany empty-array serialization docs (PR #3349).
- Replaces double hyphens with parentheses in the breaking-change Tldr
- Aligns the JS field-selection example endpoint with its cURL tab and response in populate-select
- Corrects the `fields` parameter name and the Users & Permissions feature wording in the Document Service populate page
- Fixes the `publish()` example response to use `documentId` and `entries`

Direct preview link 👉 [here](https://documentation-git-cms-morphmany-review-fixes-strapijs.vercel.app/cms/migration/v4-to-v5/breaking-changes/morph-many-serialization)