### PR TITLE
Document the component preview field for the dynamic zone picker

### DIFF
--- a/docusaurus/docs/cms/api/entity-service/components-dynamic-zones.md
+++ b/docusaurus/docs/cms/api/entity-service/components-dynamic-zones.md
@@ -89,37 +89,3 @@ strapi.entityService.update('api::article.article', 1, {
   },
 });
 ```
-
-## Component screenshots in the Dynamic Zone picker
-
-<!-- unverified: placement on this page — this feature relates to component schema configuration and Content Manager UI (strapi/strapi#26863). Consider moving to cms/backend-customization/models.md or a Content Manager page. -->
-
-You can add an optional `screenshot` field to a component's `info` object in its `schema.json` file. When set, the Dynamic Zone component picker in the Content Manager displays a thumbnail preview for that component instead of the default icon.
-
-<!-- source: PR #26863 (https://github.com/strapi/strapi/pull/26863) — SchemaInfo type in @strapi/types -->
-
-The `screenshot` field accepts:
-- A root-relative path served by Strapi's built-in static middleware (for example, `/_component-screenshots/hero.png`), with the image placed in the project's `public/` directory.
-- An absolute URL pointing to a CDN or external image host.
-
-### Adding a screenshot to a component
-
-1. Open the component's `schema.json` file and add a `screenshot` field to the `info` object:
-
-<!-- source: PR #26863 (https://github.com/strapi/strapi/pull/26863) — example from PR description -->
-
-   ```json
-   {
-     "info": {
-       "displayName": "Hero Section",
-       "icon": "layout",
-       "screenshot": "/_component-screenshots/hero-section.png"
-     }
-   }
-   ```
-
-2. If using a root-relative path, place the image file in the project's `public` directory at the specified path (for example, `public/_component-screenshots/hero-section.png`).
-3. Start or restart Strapi.
-4. Open a content type that contains a Dynamic Zone in the Content Manager, then click **Add a component** and expand a component category.
-
-The picker displays the screenshot as a thumbnail for that component. Hovering over the thumbnail shows an enlarged preview. Components without a `screenshot` continue to display the default icon.

--- a/docusaurus/docs/cms/api/entity-service/components-dynamic-zones.md
+++ b/docusaurus/docs/cms/api/entity-service/components-dynamic-zones.md
@@ -89,3 +89,37 @@ strapi.entityService.update('api::article.article', 1, {
   },
 });
 ```
+
+## Component screenshots in the Dynamic Zone picker
+
+<!-- unverified: placement on this page — this feature relates to component schema configuration and Content Manager UI (strapi/strapi#26863). Consider moving to cms/backend-customization/models.md or a Content Manager page. -->
+
+You can add an optional `screenshot` field to a component's `info` object in its `schema.json` file. When set, the Dynamic Zone component picker in the Content Manager displays a thumbnail preview for that component instead of the default icon.
+
+<!-- source: PR #26863 (https://github.com/strapi/strapi/pull/26863) — SchemaInfo type in @strapi/types -->
+
+The `screenshot` field accepts:
+- A root-relative path served by Strapi's built-in static middleware (for example, `/_component-screenshots/hero.png`), with the image placed in the project's `public/` directory.
+- An absolute URL pointing to a CDN or external image host.
+
+### Adding a screenshot to a component
+
+1. Open the component's `schema.json` file and add a `screenshot` field to the `info` object:
+
+<!-- source: PR #26863 (https://github.com/strapi/strapi/pull/26863) — example from PR description -->
+
+   ```json
+   {
+     "info": {
+       "displayName": "Hero Section",
+       "icon": "layout",
+       "screenshot": "/_component-screenshots/hero-section.png"
+     }
+   }
+   ```
+
+2. If using a root-relative path, place the image file in the project's `public` directory at the specified path (for example, `public/_component-screenshots/hero-section.png`).
+3. Start or restart Strapi.
+4. Open a content type that contains a Dynamic Zone in the Content Manager, then click **Add a component** and expand a component category.
+
+The picker displays the screenshot as a thumbnail for that component. Hovering over the thumbnail shows an enlarged preview. Components without a `screenshot` continue to display the default icon.

--- a/docusaurus/docs/cms/backend-customization/models.md
+++ b/docusaurus/docs/cms/backend-customization/models.md
@@ -120,8 +120,12 @@ Components accept an optional `preview` parameter in their `info` object. It poi
 
 The `preview` parameter accepts:
 
-- A root-relative path to an image placed in the project's `public` directory, for instance `/_component-screenshots/hero-section.png`. The image is then served by the [`public` middleware](/cms/configurations/middlewares#public), which does not serve paths starting with `/uploads/`.
+- A root-relative path to an image placed in the project's `public` directory, for instance `/_component-screenshots/hero-section.png`. The image is served by the [`public` middleware](/cms/configurations/middlewares#public), which does not serve paths starting with `/uploads/`.
 - An absolute URL pointing to an external image host.
+
+:::caution
+[Media Library](/cms/features/media-library) images are served from `/uploads/`, so they cannot be used as preview images. Commit the file to `public` instead.
+:::
 
 ```json title="./src/components/sections/hero-section.json"
 {

--- a/docusaurus/docs/cms/backend-customization/models.md
+++ b/docusaurus/docs/cms/backend-customization/models.md
@@ -96,6 +96,8 @@ The `info` key in the model's schema describes information used to display the m
 | `singularName` | String | Singular form of the content-type name.<br />Used to generate the API routes and databases/tables collection.<br /><br />Should be kebab-case. |
 | `pluralName`   | String | Plural form of the content-type name.<br />Used to generate the API routes and databases/tables collection.<br /><br />Should be kebab-case.    |
 | `description`  | String | Description of the model                                                                                                                   |
+| `icon`         | String | Name of the [Strapi icon](https://github.com/strapi/design-system) used to represent the model in the admin panel                          |
+| `preview`      | String | Path or URL of an image used to represent a component in the admin panel.<br /><br />Components only. See [Component preview images](#component-preview-images). |
 
 ```json title="./src/api/[api-name]/content-types/restaurant/schema.json"
 
@@ -106,6 +108,31 @@ The `info` key in the model's schema describes information used to display the m
     "description": ""
   },
 ```
+
+#### Component preview images
+
+Components accept an optional `preview` parameter in their `info` object. It points to an image representing the component in the [dynamic zone picker](/cms/features/content-manager#dynamic-zones).
+
+The `preview` parameter accepts:
+
+- A root-relative path to an image placed in the project's `public` directory, for instance `/_component-screenshots/hero-section.png`. The image is then served by the [`public` middleware](/cms/configurations/middlewares#public), which does not serve paths starting with `/uploads/`.
+- An absolute URL pointing to an external image host.
+
+```json title="./src/components/sections/hero-section.json"
+{
+  "info": {
+    "displayName": "Hero Section",
+    "icon": "layout",
+    "preview": "/_component-screenshots/hero-section.png"
+  }
+}
+```
+
+When `preview` is omitted, or when the image fails to load, the admin panel falls back to the component's `icon`.
+
+:::note
+The `preview` parameter must be set manually in the component's schema file. The Content-type Builder cannot upload a preview image yet.
+:::
 
 ### Model attributes
 

--- a/docusaurus/docs/cms/backend-customization/models.md
+++ b/docusaurus/docs/cms/backend-customization/models.md
@@ -57,6 +57,9 @@ Component models can't be created with CLI tools. Use the [Content-type Builder]
 
 Components models are stored in the `./src/components` folder. Every component has to be inside a subfolder, named after the category the component belongs to (see [project structure](/cms/project-structure)).
 
+Components also accept an optional preview image, displayed in the dynamic zone picker
+instead of their icon (see [Component preview images](#component-preview-images)).
+
 ## Model schema
 
 The `schema.json` file of a model consists of:
@@ -607,6 +610,10 @@ Component fields create a relation between a content-type and a component struct
   }
 }
 ```
+
+These parameters are set on the attribute of the content-type using the component.
+Parameters set on the component itself, such as its preview image, belong to its own
+`info` object (see [Component preview images](#component-preview-images)).
 
 #### Dynamic zones
 

--- a/docusaurus/docs/cms/backend-customization/models.md
+++ b/docusaurus/docs/cms/backend-customization/models.md
@@ -99,6 +99,11 @@ The `info` key in the model's schema describes information used to display the m
 | `icon`         | String | Name of the [Strapi icon](https://github.com/strapi/design-system) used to represent the model in the admin panel                          |
 | `preview`      | String | Path or URL of an image used to represent a component in the admin panel.<br /><br />Components only. See [Component preview images](#component-preview-images). |
 
+:::note
+This `preview` parameter is unrelated to the [Preview feature](/cms/features/preview).
+That feature previews front-end content, and uses the `preview` object of `config/admin`.
+:::
+
 ```json title="./src/api/[api-name]/content-types/restaurant/schema.json"
 
   "info": {

--- a/docusaurus/docs/cms/features/content-manager.md
+++ b/docusaurus/docs/cms/features/content-manager.md
@@ -426,11 +426,13 @@ Dynamic zones are a combination of components, which themselves are composed of 
   }}
 />
 
+In the component picker, each component displays an icon.
+A component whose schema defines a preview image displays that image as a thumbnail instead, and hovering over it shows an enlarged version.
+Developers set this image in the [component schema](/cms/backend-customization/models#component-preview-images).
+
 1. Click on the <Icon name="plus-circle" /> **Add a component to [dynamic zone name]** button.
 2. Choose a component available for the dynamic zone.
 3. Fill in the fields of the component.
-
-Components display an icon in the picker. A component that defines a [preview image](/cms/backend-customization/models#component-preview-images) displays it as a thumbnail instead. Hovering over the thumbnail shows an enlarged preview.
 
 Dynamic zones' components can also be reordered or deleted directly in the edit view, using buttons displayed in the top right corner of the component area.
 

--- a/docusaurus/docs/cms/features/content-manager.md
+++ b/docusaurus/docs/cms/features/content-manager.md
@@ -430,6 +430,8 @@ Dynamic zones are a combination of components, which themselves are composed of 
 2. Choose a component available for the dynamic zone.
 3. Fill in the fields of the component.
 
+Components display an icon in the picker. A component that defines a [preview image](/cms/backend-customization/models#component-preview-images) displays it as a thumbnail instead. Hovering over the thumbnail shows an enlarged preview.
+
 Dynamic zones' components can also be reordered or deleted directly in the edit view, using buttons displayed in the top right corner of the component area.
 
 - Use the drag & drop button <Icon name="dots-six-vertical" classes="ph-bold" /> to reorder components in your dynamic zone.


### PR DESCRIPTION
This PR documents the optional preview field that components accept in their info object, which displays a thumbnail for the component in the dynamic zone picker instead of the default icon. The field is documented in the model information reference and the Content Manager dynamic zones section. Note that the field is named preview, not screenshot as the upstream pull request title suggests: it was renamed during review before https://github.com/strapi/strapi/pull/26863 merged.

The model information table also gains a row for the icon parameter, which was already supported but undocumented.

A note distinguishes this preview parameter from the Preview feature, which previews front-end content and uses the preview object of config/admin. A caution warns that Media Library images are served from /uploads/ and therefore cannot be used as preview images, since the public middleware does not serve that path. Both Components sections of the models page now cross-reference the new Component preview images section, so the information is reachable from either entry point.

Direct preview link 👉 [here](https://documentation-git-cms-document-component-screen-402286-strapijs.vercel.app/cms/backend-customization/models)
