### PR TITLE
Clarify that a release publishes the latest draft, not a snapshot

### DIFF
--- a/docusaurus/docs/cms/features/releases.md
+++ b/docusaurus/docs/cms/features/releases.md
@@ -104,6 +104,10 @@ Since publishing an entry with a release means turning a draft entry into a publ
 - Adding content to a release requires the appropriate permissions for the Content-Releases plugin (see [configuring administrator roles](/cms/features/users-permissions)).
 :::
 
+:::caution
+A release stores a reference to an entry, not a copy of its content. If the draft is edited after being added to a release, the release will publish the latest saved version of the draft, not the version that existed when the entry was added. A release cannot be pinned to a specific version of an entry. To publish an earlier version, restore it as the draft using [Content History](/cms/features/content-history) before the release is published.
+:::
+
 #### One entry at a time
 
 **Path:** Edit view of the <Icon name="feather" /> Content Manager


### PR DESCRIPTION
### Description

Adds a caution admonition to the Releases page clarifying what a release actually captures when an entry is added to it.

A release action stores only a reference to an entry (content type, document ID, locale, and action type), not a copy of its content. When the release is published, each entry's current draft is resolved at that moment. This means editing a draft after adding it to a release changes what gets published, and a release cannot be pinned to a specific version of an entry.

This behaviour was not documented anywhere on the Releases page. It is a recurring point of confusion for content managers using scheduled releases, where the gap between adding an entry and the release firing can be days.

Placed under "Including content in a release", right after the prerequisites block, so it covers both the single-entry and bulk-add flows and appears where the reader forms their mental model of what a release holds.

Supporting references in `strapi/strapi`, pinned to commit `e64ce632af`:

- [`release-action/schema.ts#L22-L46`](https://github.com/strapi/strapi/blob/e64ce632af/packages/core/content-releases/server/src/content-types/release-action/schema.ts#L22-L46) shows the release action schema has no content payload field
- [`release.ts#L31-L75`](https://github.com/strapi/strapi/blob/e64ce632af/packages/core/content-releases/server/src/services/release.ts#L31-L75) reduces each action to `{ documentId, locale }` at publish time
- [`repository.ts#L541-L621`](https://github.com/strapi/strapi/blob/e64ce632af/packages/core/core/src/services/document-service/repository.ts#L541-L621) resolves the draft via `publishedAt: null`, i.e. whatever the draft is at that instant

The closing sentence points at Content History as the way to publish an earlier version. Tiering lines up: Releases is Growth+ and Content History is Growth+/Enterprise, so anyone who can use Releases can use History.

Not labelled `flag: merge pending release`, since this documents existing behaviour rather than an upcoming product change. Happy to add it if the Docs team disagrees.

### Related issue(s)/PR(s)

None. Prompted by a support question asking whether a scheduled release publishes the version of the draft from when it was added, or the latest one.