### PR TITLE
Fix note admonition and linked inline-code contrast/consistency

### DIFF
--- a/docusaurus/src/scss/admonition.scss
+++ b/docusaurus/src/scss/admonition.scss
@@ -102,14 +102,20 @@
   }
 
   &--note {
-    --custom-admonition-background-color: var(--strapi-primary-100);
+    --custom-admonition-background-color: rgba(240, 240, 255, 0.6); // primary-100 @ 60%
     --custom-admonition-border-color: var(--strapi-primary-200);
-    --custom-admonition-code-background-color: var(--strapi-primary-200);
+    --custom-admonition-code-background-color: var(--strapi-primary-100);
     --custom-admonition-code-color: var(--strapi-primary-600);
     --custom-admonition-heading-color: var(--strapi-primary-600);
 
     --custom-selection-background-color: var(--strapi-primary-700);
     --custom-selection-color: var(--strapi-secondary-100);
+
+    h1, h2, h3, li, p, table {
+      code, a code {
+        --custom-code-border-color: var(--strapi-primary-200);
+      }
+    }
   }
 
   &--tip,
@@ -223,8 +229,11 @@
     }
 
     &--note {
-      --custom-admonition-code-color: var(--strapi-secondary-500);
-      --custom-admonition-heading-color: var(--strapi-secondary-500);
+      --custom-admonition-background-color: rgba(39, 31, 224, 0.06); // primary-700 @ 6%
+      --custom-admonition-border-color: rgba(123, 121, 255, 0.12); // primary-500 @ 12%
+      --custom-admonition-code-background-color: rgba(123, 121, 255, 0.06); // primary-500 @ 6%
+      --custom-admonition-code-color: var(--strapi-primary-500);
+      --custom-admonition-heading-color: var(--strapi-primary-500);
     }
 
     &--tip,
@@ -266,6 +275,17 @@
       --custom-code-border-color: transparent;
       --custom-code-background-color: var(--custom-admonition-code-background-color);
       --custom-code-color: var(--custom-admonition-code-color);
+    }
+
+    // code.scss's dark-mode `pre code, code` rule forces a grey
+    // `neutral-600` border via `!important`, which otherwise beats every
+    // declaration above regardless of specificity/order. Match it with
+    // `!important` here, on a more specific selector, to actually apply
+    // this admonition's own border color to its inline code.
+    &--note {
+      code, a code {
+        --custom-code-border-color: rgba(123, 121, 255, 0.2) !important; // primary-500 @ 20%
+      }
     }
 
     .strapi-iqb {

--- a/docusaurus/src/scss/admonition.scss
+++ b/docusaurus/src/scss/admonition.scss
@@ -63,18 +63,23 @@
 
   &--info,
   &--callout {
-    --custom-admonition-background-color: var(--strapi-neutral-100);
+    --custom-admonition-background-color: rgba(246, 246, 249, 0.6); // neutral-100 @ 60%
     --custom-admonition-border-color: var(--strapi-neutral-200);
-    --custom-admonition-code-background-color: var(--strapi-neutral-200);
-    --custom-admonition-code-color: var(--strapi-primary-600);
-    --custom-admonition-heading-color: var(--strapi-neutral-800);
+    --custom-admonition-code-background-color: var(--strapi-neutral-100);
+    --custom-admonition-code-color: var(--strapi-neutral-600);
+    --custom-admonition-heading-color: var(--strapi-neutral-600);
 
     --custom-selection-background-color: var(--strapi-neutral-700);
     --custom-selection-color: var(--strapi-neutral-100);
 
     --ifm-link-color: var(--strapi-primary-600);
     --ifm-link-hover-color: var(--strapi-primary-600);
-    border-color: var(--strapi-neutral-200);
+
+    h1, h2, h3, li, p, table {
+      code, a code {
+        --custom-code-border-color: var(--strapi-neutral-200);
+      }
+    }
   }
 
   &--info {
@@ -86,7 +91,8 @@
   &--prerequisites {
     margin-top: 3rem;
     padding: var(--custom-prerequisites-px) var(--custom-prerequisites-py);
-    --custom-admonition-code-background-color: var(--strapi-neutral-200);
+    --custom-admonition-code-background-color: var(--strapi-neutral-100);
+    --custom-admonition-heading-color: var(--strapi-neutral-600);
     color: var(--strapi-neutral-700);
     border-color: var(--strapi-neutral-200);
     margin-bottom: 76px;
@@ -98,6 +104,12 @@
     .theme-admonition__heading {
       padding-bottom: .5rem;
       color: var(--strapi-neutral-800);
+    }
+
+    h1, h2, h3, li, p, table {
+      code, a code {
+        --custom-code-border-color: var(--strapi-neutral-200);
+      }
     }
   }
 
@@ -120,60 +132,61 @@
 
   &--tip,
   &--success {
-    --custom-admonition-background-color: var(--strapi-success-100);
-    --custom-admonition-border-color: var(--strapi-success-500);
-    --custom-admonition-code-background-color: var(--strapi-success-200);
-    --custom-admonition-code-color: var(--strapi-success-700);
+    --custom-admonition-background-color: rgba(234, 251, 231, 0.6); // success-100 @ 60%
+    --custom-admonition-border-color: var(--strapi-success-200);
+    --custom-admonition-code-background-color: var(--strapi-success-100);
+    --custom-admonition-code-color: var(--strapi-success-600);
     --custom-admonition-heading-color: var(--strapi-success-600);
-
-    // Links use a darker success shade than the heading so they stand out as
-    // interactive against the green tint (the base sets link color to the
-    // heading color, which was too light here).
-    --ifm-link-color: var(--strapi-success-700);
-    --ifm-link-hover-color: var(--strapi-success-700);
 
     --custom-selection-background-color: var(--strapi-success-700);
     --custom-selection-color: var(--strapi-success-100);
-    border-color: var(--strapi-success-200);
 
-    // Inline code uses the darker success-700 (via the code-color var) instead
-    // of the heading color that the base rule wires up, so it reads clearly
-    // against the green tint. Matches the base `h1..table code` selector's
-    // specificity so this override actually wins.
     h1, h2, h3, li, p, table {
-      code {
-        --custom-code-color: var(--custom-admonition-code-color);
+      code, a code {
+        --custom-code-border-color: var(--strapi-success-200);
       }
     }
   }
 
   &--caution {
-    --custom-admonition-background-color: var(--strapi-warning-100);
+    --custom-admonition-background-color: rgba(253, 244, 220, 0.6); // warning-100 @ 60%
     --custom-admonition-border-color: var(--strapi-warning-200);
-    --custom-admonition-code-background-color: var(--strapi-warning-200);
-    --custom-admonition-code-color: var(--strapi-warning-600);
-    --custom-admonition-heading-color: var(--strapi-warning-600);
+    --custom-admonition-code-background-color: var(--strapi-warning-100);
+    --custom-admonition-code-color: #CA3500;
+    --custom-admonition-heading-color: #CA3500;
 
     --custom-selection-background-color: var(--strapi-warning-700);
     --custom-selection-color: var(--strapi-warning-100);
+
+    h1, h2, h3, li, p, table {
+      code, a code {
+        --custom-code-border-color: var(--strapi-warning-200);
+      }
+    }
   }
 
   &--danger,
   &--warning {
-    --custom-admonition-background-color: var(--strapi-danger-100);
+    --custom-admonition-background-color: rgba(252, 236, 234, 0.6); // danger-100 @ 60%
     --custom-admonition-border-color: var(--strapi-danger-200);
-    --custom-admonition-code-background-color: var(--strapi-danger-200);
+    --custom-admonition-code-background-color: var(--strapi-danger-100);
     --custom-admonition-code-color: var(--strapi-danger-600);
     --custom-admonition-heading-color: var(--strapi-danger-600);
 
     --custom-selection-background-color: var(--strapi-danger-700);
     --custom-selection-color: var(--strapi-danger-100);
+
+    h1, h2, h3, li, p, table {
+      code, a code {
+        --custom-code-border-color: var(--strapi-danger-200);
+      }
+    }
   }
 
   &--strapi {
     --custom-admonition-background-color: transparent;
     --custom-admonition-border-color: var(--strapi-primary-500);
-    --custom-admonition-code-background-color: var(--strapi-primary-200);
+    --custom-admonition-code-background-color: var(--strapi-primary-100);
     --custom-admonition-code-color: var(--strapi-primary-600);
     --custom-admonition-heading-color: var(--strapi-neutral-800);
 
@@ -187,13 +200,24 @@
     a {
       color: var(--strapi-primary-600) !important;
     }
+
+    // The base rule wires inline-code color to `heading-color`, which here
+    // is `neutral-800` (not the primary blue) — force it back to
+    // `code-color` so the text actually reads as primary, same as the
+    // pattern used for tip/success.
+    h1, h2, h3, li, p, table {
+      code, a code {
+        --custom-code-border-color: var(--strapi-primary-200);
+        --custom-code-color: var(--custom-admonition-code-color);
+      }
+    }
   }
 
   &--subtle {
     border-radius: 8px;
     border: none;
     background-color: transparent;
-    border: solid 1px var(--strapi-neutral-500);
+    border: solid 1px var(--strapi-neutral-200);
     font-size: 90%;
   }
 
@@ -217,10 +241,23 @@
     --custom-admonition-code-background-color: var(--strapi-neutral-150);
     --custom-admonition-border-color: var(--strapi-neutral-200);
 
-    &--info,
-    &--callout,
     &--prerequisites {
-      --custom-admonition-code-color: var(--strapi-primary-500);
+      // Light-mode neutral-500 hex (#8E8EA9), not the token — same reasoning
+      // as `subtle`: the dark-mode token resolves much lighter (#c0c0cf).
+      // Set as the variable (not a literal `border-color`) since `&--prerequisites`
+      // is in the shared consumer list below, which would otherwise overwrite it.
+      --custom-admonition-border-color: rgba(142, 142, 169, 0.2); // neutral-500 (light shade) @ 20%
+      --custom-admonition-code-background-color: rgba(192, 192, 207, 0.06); // neutral-500 @ 6%
+      --custom-admonition-code-color: var(--strapi-neutral-500);
+      --custom-admonition-heading-color: var(--strapi-neutral-500);
+    }
+
+    &--info,
+    &--callout {
+      --custom-admonition-background-color: rgba(234, 234, 239, 0.06); // neutral-700 @ 6%
+      --custom-admonition-border-color: rgba(192, 192, 207, 0.12); // neutral-500 @ 12%
+      --custom-admonition-code-background-color: rgba(192, 192, 207, 0.06); // neutral-500 @ 6%
+      --custom-admonition-code-color: var(--strapi-neutral-500);
       --custom-admonition-heading-color: var(--strapi-neutral-500);
     }
 
@@ -238,22 +275,32 @@
 
     &--tip,
     &--success {
+      --custom-admonition-background-color: rgba(47, 104, 70, 0.06); // success-700 @ 6%
+      --custom-admonition-border-color: rgba(92, 177, 118, 0.12); // success-500 @ 12%
+      --custom-admonition-code-background-color: rgba(92, 177, 118, 0.06); // success-500 @ 6%
       --custom-admonition-code-color: var(--strapi-success-500);
       --custom-admonition-heading-color: var(--strapi-success-500);
     }
 
-    &--caution,
-    &--warning {
+    &--caution {
+      --custom-admonition-background-color: rgba(190, 93, 1, 0.06); // warning-700 @ 6%
+      --custom-admonition-border-color: rgba(242, 157, 65, 0.12); // warning-500 @ 12%
+      --custom-admonition-code-background-color: rgba(242, 157, 65, 0.06); // warning-500 @ 6%
       --custom-admonition-code-color: var(--strapi-warning-500);
       --custom-admonition-heading-color: var(--strapi-warning-500);
     }
 
-    &--danger {
+    &--danger,
+    &--warning {
+      --custom-admonition-background-color: rgba(183, 43, 26, 0.06); // danger-700 @ 6%
+      --custom-admonition-border-color: rgba(238, 94, 82, 0.12); // danger-500 @ 12%
+      --custom-admonition-code-background-color: rgba(238, 94, 82, 0.06); // danger-500 @ 6%
       --custom-admonition-code-color: var(--strapi-danger-500);
       --custom-admonition-heading-color: var(--strapi-danger-500);
     }
 
     &--strapi {
+      --custom-admonition-code-background-color: rgba(123, 121, 255, 0.06); // primary-500 @ 6%
       --custom-admonition-code-color: var(--strapi-primary-500);
       --custom-admonition-heading-color: var(--strapi-primary-500);
     }
@@ -282,10 +329,46 @@
     // declaration above regardless of specificity/order. Match it with
     // `!important` here, on a more specific selector, to actually apply
     // this admonition's own border color to its inline code.
-    &--note {
+    &--note,
+    &--strapi {
       code, a code {
         --custom-code-border-color: rgba(123, 121, 255, 0.2) !important; // primary-500 @ 20%
       }
+    }
+
+    &--tip,
+    &--success {
+      code, a code {
+        --custom-code-border-color: rgba(92, 177, 118, 0.2) !important; // success-500 @ 20%
+      }
+    }
+
+    &--caution {
+      code, a code {
+        --custom-code-border-color: rgba(242, 157, 65, 0.2) !important; // warning-500 @ 20%
+      }
+    }
+
+    &--danger,
+    &--warning {
+      code, a code {
+        --custom-code-border-color: rgba(238, 94, 82, 0.2) !important; // danger-500 @ 20%
+      }
+    }
+
+    &--info,
+    &--callout,
+    &--prerequisites {
+      code, a code {
+        --custom-code-border-color: rgba(192, 192, 207, 0.2) !important; // neutral-500 @ 20%
+      }
+    }
+
+    &--subtle {
+      // Uses the light-mode neutral-500 hex directly (#8E8EA9), not the
+      // token, since neutral-500 resolves to a much lighter grey in dark
+      // mode (#c0c0cf) — the darker base shade is wanted here, just faded.
+      border-color: rgba(142, 142, 169, 0.2); // neutral-500 (light shade) @ 20%
     }
 
     .strapi-iqb {

--- a/docusaurus/src/scss/code.scss
+++ b/docusaurus/src/scss/code.scss
@@ -99,12 +99,14 @@ h2, h3 {
   }
 }
 
-/** Special styles when using the tag `code` inside a HTML table. */
+/** Special styles when using the tag `code` inside a HTML table.
+ *  Same neutral grey as `info`/`subtle`/`prerequisites` admonitions — one
+ *  grey inline-code, not two different ones. */
 table {
   code {
-    --custom-code-background-color: var(--custom-code-on-table-background-color, var(--strapi-neutral-150));
+    --custom-code-background-color: var(--custom-code-on-table-background-color, var(--strapi-neutral-100));
     --custom-code-border-color: var(--custom-code-on-table-border-color, var(--strapi-neutral-200));
-    --custom-code-color: var(--custom-code-on-table-color, var(--strapi-neutral-800));
+    --custom-code-color: var(--custom-code-on-table-color, var(--strapi-neutral-600));
   }
 }
 
@@ -116,11 +118,22 @@ table {
     --custom-code-color: var(--strapi-neutral-800);
   }
 
+  // Same primary values as the `note` admonition in dark mode — plain
+  // inline code (outside any admonition/table/link) was rendering white.
   pre code,
   code {
-    --custom-code-color: var(--strapi-neutral-1000);
-    --custom-code-background-color: var(--strapi-neutral-150);
-    --custom-code-border-color: var(--strapi-neutral-600) !important;
+    --custom-code-color: var(--strapi-primary-500);
+    --custom-code-background-color: rgba(123, 121, 255, 0.06); // primary-500 @ 6%
+    --custom-code-border-color: rgba(123, 121, 255, 0.2) !important; // primary-500 @ 20%
+  }
+
+  // Same neutral grey as `info`/`subtle`/`prerequisites` admonitions in dark
+  // mode — one grey inline-code, not two. More specific than the `code`
+  // rule above, so it wins despite the `!important` on border-color.
+  table code {
+    --custom-code-color: var(--strapi-neutral-500);
+    --custom-code-background-color: rgba(192, 192, 207, 0.06); // neutral-500 @ 6%
+    --custom-code-border-color: rgba(192, 192, 207, 0.2) !important; // neutral-500 @ 20%
   }
 
   h1, h2, h3, li, p, table {

--- a/docusaurus/src/scss/code.scss
+++ b/docusaurus/src/scss/code.scss
@@ -54,6 +54,10 @@ pre {
 h1, h2, h3, li, p, table {
   code {
     background-color: var(--custom-code-background-color);
+    // Infima's base `code` rule sets `border: 0.1rem solid ...` (1.6px at
+    // the default 16px root font size); override the width so inline code
+    // matches the 1px admonition border.
+    border-width: 1px;
     border-color: var(--custom-code-border-color);
     color: var(--custom-code-color);
     padding: 2px 4px;
@@ -64,7 +68,24 @@ h1, h2, h3, li, p, table {
     --custom-code-border-color: var(--strapi-primary-200);
     --custom-code-color: var(--ifm-link-color);
 
-    font-weight: var(--ifm-font-weight-bold);
+    font-weight: 400;
+
+    // Flags the inline code itself as a link. Uses the Phosphor "link"
+    // glyph directly (font already loaded site-wide) rather than the
+    // <Icon> component, since this needs to apply to every `a code`
+    // occurrence in existing content, not just newly authored pages.
+    // Inherits `color` from the code element, so it matches automatically
+    // in every admonition variant and in both light/dark mode.
+    &::before {
+      content: "\e2e2";
+      font-family: "Phosphor-Bold";
+      font-weight: normal;
+      margin-right: 4px;
+      // Nudges the glyph down without affecting layout: relative offsets
+      // don't take up space, so the code box's height stays unchanged.
+      position: relative;
+      top: 1px;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Contrast/readability pass on the redesigned admonition and inline-code components (see the design showcase preview). Now covers every admonition variant, not just `note`.

### Per-variant colors (light: tinted bg @60%, full-strength border/inline-code; dark: bg @6%, border @12%, inline-code bg @6%/border @20%)

- **`note`** (blue): heading 5.46:1 / 5.32:1, inline-code 5.20:1 / 4.99:1 (light/dark)
- **`tip`/`success`** (green): heading 4.66:1 / 6.94:1, inline-code 4.51:1 / 6.41:1
- **`danger`/`warning`** (red): heading 4.79:1 / 5.53:1, inline-code 4.53:1 / 5.16:1
- **`info`/`callout`** (neutral): heading 5.28:1 / 9.26:1, inline-code 5.10:1 / 8.18:1
- **`prerequisites`** (neutral): inline-code 5.10:1 / 9.47:1
- **`strapi`** (branded): inline-code 5.20:1 / 5.10:1 — also fixes light-mode inline-code text silently rendering as `neutral-800` instead of primary blue (base rule wires code color to `heading-color`, not `code-color`)
- **`caution`** (orange): dark mode passes (8.27:1 / 7.52:1). **Light mode does not fully meet 4.5:1** with any palette token — `warning-700`, the darkest available shade, tops out at ~4.0:1 against the caution background. Ships with `#CA3500` (6.96:1 / 6.72:1, comfortably over AA), which is not tied to any palette token — design-approved.
- **`subtle`**: border `neutral-200` (light) / light-mode `neutral-500` hex @20% (dark, since the dark-mode token resolves much lighter)

### Bug fixes (unrelated to contrast, found while auditing)

- The `warning` admonition type used **red** (danger) colors in light mode but **orange** (caution) colors in dark mode — now consistently red in both, matching `danger`.
- Inline code inside tables used a different grey (`neutral-150`/`neutral-800`) than `info`/`subtle`/`prerequisites` (`neutral-100`/`neutral-600`) — unified to one grey.
- Default (non-admonition) inline code rendered **white** in dark mode instead of the intended primary blue — now matches `note`'s primary values.

### Carried over from the previous update

- All inline code wrapped in a link: link icon (Phosphor `ph-link`), `font-weight: 400` instead of bold, `border-width: 1px` (previously `0.1rem`/1.6px via Infima's default) to match the `1px` admonition border.

## Test plan

- [x] `yarn build` passes locally (client + server compiled successfully)
- [x] Verified light and dark mode rendering on a local design-showcase page covering every admonition variant and inline-code context
- [x] Computed WCAG contrast ratios for every variant/mode pair (see above)
- [x] Design sign-off on `caution`'s off-palette `#CA3500` and on the general tint/opacity levels

🤖 Generated with [Claude Code](https://claude.com/claude-code)