### PR TITLE
Add proxy IP header configuration options to server config documentation

### DIFF
--- a/docusaurus/docs/cms/configurations/server.md
+++ b/docusaurus/docs/cms/configurations/server.md
@@ -37,6 +37,8 @@ The `/config/server.js` file can include the following parameters:
 | `host`<br/><br/>❗️ _Mandatory_     | Host name                                                                                                                                                                                                                                                                                                                                                                   | string                                                                                            | `localhost`         |
 | `port`<br/><br/>❗️ _Mandatory_     | Port on which the server should be running.                                                                                                                                                                                                                                                                                                                                 | integer                                                                                           | `1337`              |
 | `app.keys`<br/><br/>❗️ _Mandatory_ | Declare session keys (based on <ExternalLink to="https://github.com/koajs/session/blob/master/Readme.md" text="Koa session"/>), which is used by the `session` middleware for the Users & Permissions plugin and the Documentation plugin.                                                                                                                                                           | array of strings                                                                                  | `undefined`         |
+| `app.proxyIpHeader`                 | Proxy IP header name to trust when identifying the client's real IP address. Set when behind a reverse proxy (e.g., Nginx, Apache, load balancer). For security, always pair with `app.maxIpsCount` to prevent header spoofing. Example: `'X-Forwarded-For'`, `'CF-Connecting-IP'`.                                                                                        | string                                                                                            | `'X-Forwarded-For'` |
+| `app.maxIpsCount`                   | Maximum number of IP addresses to read from the proxy IP header. Must be set when using a reverse proxy to prevent IP spoofing attacks. Set to `1` for a single proxy, `2` for proxy chains, etc. Setting to `0` (Koa default) means unlimited, which is insecure behind a proxy.                                                                                             | integer                                                                                           | `0`                 |
 | `socket`                            | Listens on a socket. Host and port are cosmetic when this option is provided and likewise use `url` to generate proper urls when using this option. This option is useful for running a server without exposing a port and using proxy servers on the same machine (e.g <ExternalLink to="https://github.com/heroku/heroku-buildpack-nginx#requirements-proxy-mode" text="Heroku nginx buildpack"/>) | string \| integer                                                                                 | `/tmp/nginx.socket` |
 | `emitErrors`                        | Enable errors to be emitted to `koa` when they happen in order to attach custom logic or use error reporting services.                                                                                                                                                                                                                                                      | boolean                                                                                           | `false`             |
 | `url`                               | Public url of the server. Required for many different features (ex: reset password, third login providers etc.). Also enables proxy support such as Apache or Nginx, example: `https://mywebsite.com/api`. The url can be relative, if so, it is used with `http://${host}:${port}` as the base url. An absolute url is however recommended.                                | string                                                                                            | `''`                |
@@ -146,6 +148,8 @@ module.exports = ({ env }) => ({
   port: env.int('PORT', 1337),
   app: {
     keys: env.array('APP_KEYS'),
+    proxyIpHeader: env('PROXY_IP_HEADER', 'X-Forwarded-For'),
+    maxIpsCount: env.int('MAX_IPS_COUNT', 1),
   },
   socket: '/tmp/nginx.socket', // only use if absolutely required
   emitErrors: false,
@@ -190,6 +194,8 @@ export default ({ env }) => ({
   port: env.int('PORT', 1337),
   app: {
     keys: env.array('APP_KEYS'),
+    proxyIpHeader: env('PROXY_IP_HEADER', 'X-Forwarded-For'),
+    maxIpsCount: env.int('MAX_IPS_COUNT', 1),
   },
   socket: '/tmp/nginx.socket', // only use if absolutely required
   emitErrors: false,


### PR DESCRIPTION
This PR updates documentation based on https://github.com/strapi/strapi/pull/26409.

Documents the new `app.proxyIpHeader` and `app.maxIpsCount` configuration options for secure reverse proxy setup.

Generated automatically by the docs self-healing workflow (micro-edit, Haiku).
Review before merging.