### PR TITLE
Update Media Library docs for folder rename and asset actions

### DIFF
--- a/docusaurus/docs/cms/configurations/features.md
+++ b/docusaurus/docs/cms/configurations/features.md
@@ -111,5 +111,6 @@ Developers can use the following APIs to interact with future flags:
 
 | Property name | Related feature | Suggested environment variable name |
 | ------------- | --------------- | ---------------------------------- |
+| `betaMediaLibrary` | [Media Library](/cms/features/media-library) — next-generation Media Library | `STRAPI_FUTURE_BETA_MEDIA_LIBRARY` |
 | `experimental_firstPublishedAt` | [Draft & Publish](/cms/features/draft-and-publish#recording-the-first-publication-date) | `STRAPI_FUTURE_EXPERIMENTAL_FIRST_PUBLISHED_AT` |
 

--- a/docusaurus/docs/cms/features/media-library.md
+++ b/docusaurus/docs/cms/features/media-library.md
@@ -690,6 +690,8 @@ The [Media Library settings](#configuring-settings) also allow generating metada
 
 The Media Library allows managing assets, which includes modifying assets' file details and location, downloading and copying the link of the assets file, and deleting assets. Image files can also be cropped.
 
+Assets can be managed from the asset details window (by clicking the edit button) or quickly via the asset actions menu by clicking the "..." button next to an asset in the grid or table view.
+
 #### Editing assets
 
 Click on the edit <Icon name="pencil-simple" /> button of an asset to open up the "Details" window, where all the available asset management options are available.
@@ -820,6 +822,8 @@ Once created, a folder can be renamed, moved or deleted.
 1. In the Folders part of the Media library, hover the folder to be edited and click its edit button <Icon name="pencil-simple" />.
 2. In the window that pops up, update the name and location with the _Name_ field and _Location_ drop-down list, respectively.
 3. Click **Save**.
+
+Folders can also be quickly renamed from the folder actions menu: click the "..." button next to a folder in the grid or table view, then select "Rename folder" from the menu.
 
 #### Deleting folders
 


### PR DESCRIPTION
This PR updates documentation based on the following strapi/strapi PRs:
- https://github.com/strapi/strapi/pull/27279 (folder rename actions)
- https://github.com/strapi/strapi/pull/27263 (asset actions menu)
- https://github.com/strapi/strapi/pull/27278 (betaMediaLibrary flag)

## Changes
- Added mention of folder rename capability via folder actions menu to Media Library feature page
- Added mention of asset actions menu for quick asset management 
- Documented the betaMediaLibrary feature flag in the Features configuration page

Generated automatically by the docs self-healing workflow (micro-edit, Haiku).
Review before merging.