### PR TITLE
Remove outdated free Cloud hosting mention in CLI installation page

### DIFF
--- a/docusaurus/docs/cms/installation/cli.md
+++ b/docusaurus/docs/cms/installation/cli.md
@@ -147,7 +147,7 @@ You will be able to purchase a CMS license later by checking out our <ExternalLi
 You can deploy a project to [Strapi Cloud](/cloud/intro). To host it online, you can choose to:
 
 - host it yourself by pushing the project's code to a repository (e.g., on GitHub) before following the [deployment guide](/cms/deployment),
-- or use the [Cloud CLI](/cloud/cli/cloud-cli) commands to log in to Strapi Cloud, link your local project to an existing Strapi Cloud project, and deploy it there for free.
+- or use the [Cloud CLI](/cloud/cli/cloud-cli) commands to log in to Strapi Cloud, link your local project to an existing Strapi Cloud project, and deploy it there.
 
 If you want to host your project yourself and are not already familiar with GitHub, the following togglable content should get you started👇.
 


### PR DESCRIPTION
This PR removes the leftover "for free" wording from the Cloud CLI bullet in the "Hosting your project" section of the CMS CLI installation page. Strapi Cloud no longer has a Free plan since #3307 introduced the Essential, Pro, and Scale plans: that PR updated the section's intro sentence but left the mention in the bullet just below it.

Fixes CMS-1670

Direct preview link 👉 [here](https://documentation-git-cms-remove-free-cloud-hosting-cbdcd8-strapijs.vercel.app/cms/installation/cli)