### PR TITLE
Document that MCP actions are recorded in audit logs

### DIFF
--- a/docusaurus/docs/cms/features/audit-logs.md
+++ b/docusaurus/docs/cms/features/audit-logs.md
@@ -8,6 +8,7 @@ tags:
 - audit logs
 - admin panel
 - Enterprise feature
+- MCP
 - payload
 - features
 ---
@@ -53,6 +54,10 @@ The Audit Logs feature logs the following events:
 | Role / Permission | `create`, `update`, `delete` |
 | User | `create`, `update`, `delete` |
 
+<VersionBadge version="5.52.0" />
+
+Logged actions can come from the admin panel or from the [MCP server](/cms/features/strapi-mcp-server). Entry actions performed through the MCP server are logged like their admin panel equivalents. Actions that only read content are not logged.
+
 For each log item, the following information is displayed:
 
 - Action: type of action performed by the user (e.g.`create` or `update`).
@@ -80,6 +85,10 @@ By default, all logs are displayed in reverse chronological order. You can filte
 ### Accessing log details {#log-details}
 
 For any log item, click the <Icon name="eye" /> icon to access a modal with more details about that action. In the modal, the *Payload* section displays the details in an interactive JSON component, enabling you to expand and collapse the JSON object.
+
+<VersionBadge version="5.52.0" />
+
+In the payload, the `origin` key indicates where the action came from: `mcp` for the [MCP server](/cms/features/strapi-mcp-server), or `admin` for the admin panel.
 
 <ThemedImage
   alt="Log details modal"

--- a/docusaurus/docs/cms/features/audit-logs.md
+++ b/docusaurus/docs/cms/features/audit-logs.md
@@ -54,16 +54,14 @@ The Audit Logs feature logs the following events:
 | Role / Permission | `create`, `update`, `delete` |
 | User | `create`, `update`, `delete` |
 
-<VersionBadge version="5.52.0" />
-
-Logged actions can come from the admin panel or from the [MCP server](/cms/features/strapi-mcp-server). Entry actions performed through the MCP server are logged like their admin panel equivalents. Actions that only read content are not logged.
-
 For each log item, the following information is displayed:
 
 - Action: type of action performed by the user (e.g.`create` or `update`).
 - Date: date and time of the action.
 - User: user who performed the action.
 - Details: displays a modal with more details about the action (e.g. the User IP address, the request body, or the response body).
+
+With Strapi <VersionBadge version="5.52.0+" noTooltip />  logged actions can come from the admin panel or from the [MCP server](/cms/features/strapi-mcp-server). Entry actions performed through the MCP server are logged like their admin panel equivalents. Actions that only read content are not logged.
 
 
 ### Filtering logs
@@ -86,10 +84,6 @@ By default, all logs are displayed in reverse chronological order. You can filte
 
 For any log item, click the <Icon name="eye" /> icon to access a modal with more details about that action. In the modal, the *Payload* section displays the details in an interactive JSON component, enabling you to expand and collapse the JSON object.
 
-<VersionBadge version="5.52.0" />
-
-In the payload, the `origin` key indicates where the action came from: `mcp` for the [MCP server](/cms/features/strapi-mcp-server), or `admin` for the admin panel.
-
 <ThemedImage
   alt="Log details modal"
   sources={{
@@ -97,3 +91,5 @@ In the payload, the `origin` key indicates where the action came from: `mcp` for
     dark: '/img/assets/settings/settings_log-details_DARK.png',
   }}
 />
+
+With Strapi <VersionBadge version="5.52.0" noTooltip />, in the payload, the `origin` key indicates where the action came from: `mcp` for the [MCP server](/cms/features/strapi-mcp-server), or `admin` for the admin panel.

--- a/docusaurus/docs/cms/features/strapi-mcp-server.md
+++ b/docusaurus/docs/cms/features/strapi-mcp-server.md
@@ -355,8 +355,6 @@ Create dedicated Admin tokens for each AI client or use case. Use the most restr
 
 Entry actions performed through the MCP server are recorded in the [Audit Logs](/cms/features/audit-logs). Each log payload carries an `origin` key set to `mcp`, which distinguishes actions triggered by an AI client from actions performed in the admin panel. Operations that only read content are not recorded.
 
-Audit Logs requires the CMS Enterprise plan and is not included in the Growth plan.
-
 ### Stateless architecture
 
 The MCP server uses a stateless architecture. Each POST request to the `/mcp` endpoint creates a fresh, ephemeral MCP server instance scoped to the authenticated token's permissions. There is no session persistence between requests: every request is independently authenticated and authorized. Because there is no session state, the AI client does not need to manage session IDs, and permission changes (such as revoking a token or updating its permissions) take effect on the next request.

--- a/docusaurus/docs/cms/features/strapi-mcp-server.md
+++ b/docusaurus/docs/cms/features/strapi-mcp-server.md
@@ -6,6 +6,7 @@ tags:
   - features
   - ai
   - MCP
+  - audit logs
   - content management
 toc_max_heading_level: 4
 ---
@@ -347,6 +348,14 @@ This means you can create tokens with fine-grained access:
 :::tip
 Create dedicated Admin tokens for each AI client or use case. Use the most restrictive permissions that still allow the AI to accomplish its task.
 :::
+
+### Audit logs
+
+<EnterpriseBadge /> <VersionBadge version="5.52.0" />
+
+Entry actions performed through the MCP server are recorded in the [Audit Logs](/cms/features/audit-logs). Each log payload carries an `origin` key set to `mcp`, which distinguishes actions triggered by an AI client from actions performed in the admin panel. Operations that only read content are not recorded.
+
+Audit Logs requires the CMS Enterprise plan and is not included in the Growth plan.
 
 ### Stateless architecture
 


### PR DESCRIPTION
This PR documents that entry actions performed through the MCP server are recorded in the Audit Logs, following strapi/strapi#27151 (Strapi 5.52.0). The Audit Logs page now mentions the MCP server as a possible action origin and documents the `origin` key in the log payload, and the MCP server page gains an Enterprise-gated Audit logs subsection. Read-only operations are not audited, which both pages state explicitly.