### PR TITLE
Document the status parameter on REST create and update requests

### DIFF
--- a/docusaurus/docs/cms/api/rest.md
+++ b/docusaurus/docs/cms/api/rest.md
@@ -306,7 +306,7 @@ const data = await response.json();
 
 ### Create a document {#create}
 
-If the [Internationalization (i18n) plugin](/cms/features/internationalization) is installed, it's possible to use POST requests to the REST API to [create localized documents](/cms/api/rest/locale#rest-delete).
+If the [Internationalization (i18n) plugin](/cms/features/internationalization) is installed, it's possible to use POST requests to the REST API to [create localized documents](/cms/api/rest/locale#rest-create).
 
 :::note
 While creating a document, you can define its relations and their order (see [Managing relations through the REST API](/cms/api/rest/relations.md) for more details).
@@ -385,7 +385,7 @@ const data = await response.json();
 </Tabs>
 
 <Responses>
-<ResponseTab status={200} statusText="OK">
+<ResponseTab status={201} statusText="Created">
 
 ```json
 {

--- a/docusaurus/docs/cms/api/rest.md
+++ b/docusaurus/docs/cms/api/rest.md
@@ -306,10 +306,10 @@ const data = await response.json();
 
 ### Create a document {#create}
 
-If the [Internationalization (i18n) plugin](/cms/features/internationalization) is installed, it's possible to use POST requests to the REST API to [create localized documents](/cms/api/rest/locale#rest-create).
+If the [Internationalization (i18n) feature](/cms/features/internationalization) is installed, it's possible to use POST requests to the REST API to [create localized documents](/cms/api/rest/locale#rest-create).
 
 :::note
-While creating a document, you can define its relations and their order (see [Managing relations through the REST API](/cms/api/rest/relations.md) for more details).
+While creating a document, you can define its relations and their order (see [Managing relations through the REST API](/cms/api/rest/relations) for more details).
 :::
 
 :::caution Draft & Publish
@@ -317,7 +317,7 @@ With [Draft & Publish](/cms/features/draft-and-publish) enabled, a POST request 
 :::
 
 :::info Dynamic zones
-When you POST a document, each object inside a dynamic zone array must include `__component` with that variant's UID (for example `shared.slider`). Put `__component` on the object that represents one row in the dynamic zone. Nested fields inside that object should mirror the JSON you get back when the same document is fetched with `populate` so you do not place `__component` on inner objects unless the schema treats that level as another discriminated structure.
+Each entry you send for a [dynamic zone](/cms/backend-customization/models#dynamic-zones) must include `__component` with the target component's UID (for example `shared.media`). Strapi uses that field to pick the component schema when you create or update items in the zone; without it, writes can fail validation or return success without changing data. Use the UID shown in the Content-Type Builder for each component in the zone.
 :::
 
 <Endpoint
@@ -415,7 +415,7 @@ const data = await response.json();
 ### Update a document {#update}
 
 :::note NOTES
-* Even with the [Internationalization (i18n) plugin](/cms/features/internationalization) installed, it's currently not possible to [update the locale of a document](/cms/api/rest/locale#rest-update).
+* Even with the [Internationalization (i18n) feature](/cms/features/internationalization) installed, it's currently not possible to [update the locale of a document](/cms/api/rest/locale#rest-update).
 * While updating a document, you can define its relations and their order (see [Managing relations through the REST API](/cms/api/rest/relations) for more details).
 :::
 

--- a/docusaurus/docs/cms/api/rest.md
+++ b/docusaurus/docs/cms/api/rest.md
@@ -312,6 +312,10 @@ If the [Internationalization (i18n) plugin](/cms/features/internationalization) 
 While creating a document, you can define its relations and their order (see [Managing relations through the REST API](/cms/api/rest/relations.md) for more details).
 :::
 
+:::caution Draft & Publish
+With [Draft & Publish](/cms/features/draft-and-publish) enabled, a POST request without a `status` parameter creates the document and publishes it immediately. Pass `?status=draft` to create it as a draft (see [REST API: `status`](/cms/api/rest/status#create-update)).
+:::
+
 :::info Dynamic zones
 When you POST a document, each object inside a dynamic zone array must include `__component` with that variant's UID (for example `shared.slider`). Put `__component` on the object that represents one row in the dynamic zone. Nested fields inside that object should mirror the JSON you get back when the same document is fetched with `populate` so you do not place `__component` on inner objects unless the schema treats that level as another discriminated structure.
 :::
@@ -322,9 +326,10 @@ When you POST a document, each object inside a dynamic zone array must include `
   path="/api/:pluralApiId"
   title="Create a document"
   description="Creates a new document and returns it. Send field values inside a data object in the request body."
-  paramTitle="Body Parameters"
+  paramTitle="Parameters"
   params={[
-    { name: 'data', type: 'object', required: true, description: 'Object containing the field values for the new document' },
+    { name: 'data', type: 'object', required: true, description: 'Body parameter: object containing the field values for the new document' },
+    { name: 'status', type: 'string', required: false, description: 'Query parameter: <code>draft</code> to create the document as a draft, or <code>published</code> to publish it immediately. Default: <code>published</code>. See <a href="/cms/api/rest/status#create-update">status</a>.' },
   ]}>
 
 <Tabs>
@@ -414,6 +419,10 @@ const data = await response.json();
 * While updating a document, you can define its relations and their order (see [Managing relations through the REST API](/cms/api/rest/relations) for more details).
 :::
 
+:::caution Draft & Publish
+With [Draft & Publish](/cms/features/draft-and-publish) enabled, a PUT request without a `status` parameter publishes the changes immediately. Pass `?status=draft` to update the draft only (see [REST API: `status`](/cms/api/rest/status#create-update)).
+:::
+
 :::info Dynamic zones
 Each entry you send for a [dynamic zone](/cms/backend-customization/models#dynamic-zones) must include `__component` with the target component's UID (for example `shared.media`). Strapi uses that field to pick the component schema when you create or update items in the zone; without it, writes can fail validation or return success without changing data. Use the UID shown in the Content-Type Builder for each component in the zone.
 :::
@@ -424,9 +433,10 @@ Each entry you send for a [dynamic zone](/cms/backend-customization/models#dynam
   path="/api/:pluralApiId/:documentId"
   title="Update a document"
   description="Partially updates a document by documentId and returns its value. Send a null value to clear fields."
-  paramTitle="Body Parameters"
+  paramTitle="Parameters"
   params={[
-    { name: 'data', type: 'object', required: true, description: 'Object containing the field values to update' },
+    { name: 'data', type: 'object', required: true, description: 'Body parameter: object containing the field values to update' },
+    { name: 'status', type: 'string', required: false, description: 'Query parameter: <code>draft</code> to update the draft only, or <code>published</code> to publish the changes immediately. Default: <code>published</code>. See <a href="/cms/api/rest/status#create-update">status</a>.' },
   ]}>
 
 <Tabs>

--- a/docusaurus/docs/cms/api/rest.md
+++ b/docusaurus/docs/cms/api/rest.md
@@ -420,7 +420,7 @@ const data = await response.json();
 :::
 
 :::note Draft & Publish
-With [Draft & Publish](/cms/features/draft-and-publish) enabled, a PUT request without a `status` parameter publishes the changes immediately. Pass `?status=draft` to update the draft only (see [REST API: `status`](/cms/api/rest/status#create-update)).
+With [Draft & Publish](/cms/features/draft-and-publish) enabled, a PUT request without a `status` parameter publishes the changes immediately. Pass `?status=draft` to update the draft only (see [REST API: `status`](/cms/api/rest/status#create-update)). This also applies to single types, where `PUT /api/:singularApiId` publishes the changes unless you pass `?status=draft`.
 :::
 
 :::info Dynamic zones

--- a/docusaurus/docs/cms/api/rest.md
+++ b/docusaurus/docs/cms/api/rest.md
@@ -294,7 +294,8 @@ const data = await response.json();
   "error": {
     "status": 404,
     "name": "NotFoundError",
-    "message": "Not Found"
+    "message": "Not Found",
+    "details": {}
   }
 }
 ```

--- a/docusaurus/docs/cms/api/rest.md
+++ b/docusaurus/docs/cms/api/rest.md
@@ -294,7 +294,7 @@ const data = await response.json();
   "error": {
     "status": 404,
     "name": "NotFoundError",
-    "message": "Document not found"
+    "message": "Not Found"
   }
 }
 ```

--- a/docusaurus/docs/cms/api/rest.md
+++ b/docusaurus/docs/cms/api/rest.md
@@ -312,7 +312,7 @@ If the [Internationalization (i18n) feature](/cms/features/internationalization)
 While creating a document, you can define its relations and their order (see [Managing relations through the REST API](/cms/api/rest/relations) for more details).
 :::
 
-:::caution Draft & Publish
+:::note Draft & Publish
 With [Draft & Publish](/cms/features/draft-and-publish) enabled, a POST request without a `status` parameter creates the document and publishes it immediately. Pass `?status=draft` to create it as a draft (see [REST API: `status`](/cms/api/rest/status#create-update)).
 :::
 
@@ -414,12 +414,12 @@ const data = await response.json();
 
 ### Update a document {#update}
 
-:::note NOTES
+:::note
 * Even with the [Internationalization (i18n) feature](/cms/features/internationalization) installed, it's currently not possible to [update the locale of a document](/cms/api/rest/locale#rest-update).
 * While updating a document, you can define its relations and their order (see [Managing relations through the REST API](/cms/api/rest/relations) for more details).
 :::
 
-:::caution Draft & Publish
+:::note Draft & Publish
 With [Draft & Publish](/cms/features/draft-and-publish) enabled, a PUT request without a `status` parameter publishes the changes immediately. Pass `?status=draft` to update the draft only (see [REST API: `status`](/cms/api/rest/status#create-update)).
 :::
 

--- a/docusaurus/docs/cms/api/rest.md
+++ b/docusaurus/docs/cms/api/rest.md
@@ -33,10 +33,6 @@ All content types are private by default and need to be either made public or qu
 By default, the REST API responses only include top-level fields and does not populate any relations, media fields, components, or dynamic zones. Use the [`populate` parameter](/cms/api/rest/populate-select) to populate specific fields. Ensure that the find permission is given to the field(s) for the relation(s) you populate.
 :::
 
-:::tip Performance best practices
-For production applications, be intentional about data fetching: use explicit population, limit population depth, and centralize population logic in route middlewares. See <ExternalLink to="https://strapi.io/blog/building-high-performance-strapi-applications-common-pitfalls-and-best-practices" text="Building High-Performance Strapi Applications" /> on the Strapi blog for a comprehensive guide.
-:::
-
 :::strapi Strapi Client
 The [Strapi Client](/cms/api/client) library simplifies interactions with your Strapi back end, providing a way to fetch, create, update, and delete content.
 :::
@@ -99,7 +95,7 @@ The Upload package (which powers the [Media Library feature](/cms/features/media
 [Components](/cms/backend-customization/models#components-json) don't have API endpoints.
 :::
 
-## Requests
+## Requests and responses {#requests}
 
 :::strapi Strapi 5 vs. Strapi v4
 Strapi 5's Content API includes 2 major differences with Strapi v4:
@@ -127,6 +123,8 @@ Requests return a response as an object which usually includes the following key
 Some plugins (including Users & Permissions and Upload) may not follow this response format.
 :::
 
+The following sections detail each generated endpoint.
+
 ### Get documents {#get-all}
 
 :::tip Tip: Strapi 5 vs. Strapi 4
@@ -148,7 +146,7 @@ You can pass an optional header while you're migrating to Strapi 5 (see the [rel
     { name: 'populate', type: 'string | object', required: false, description: 'Relations and components to include. Use <code>*</code> for all. See <a href="/cms/api/rest/populate-select">populate</a>.' },
     { name: 'fields', type: 'string[]', required: false, description: 'Select specific fields to return. See <a href="/cms/api/rest/populate-select#field-selection">field selection</a>.' },
     { name: 'pagination[page]', type: 'integer', required: false, description: 'Page number. Default: <code>1</code>' },
-    { name: 'pagination[pageSize]', type: 'integer', required: false, description: 'Items per page. Default <code>25</code>, max <code>100</code>' },
+    { name: 'pagination[pageSize]', type: 'integer', required: false, description: 'Items per page. Default: <code>25</code>. The maximum is set by <code>api.rest.maxLimit</code> (see <a href="/cms/api/rest/sort-pagination#pagination-by-page">pagination</a>).' },
     { name: 'locale', type: 'string', required: false, description: 'Locale of the documents to fetch. See <a href="/cms/api/rest/locale">locale</a>.' },
     { name: 'status', type: 'string', required: false, description: '<code>published</code> or <code>draft</code>. See <a href="/cms/api/rest/status">status</a>.' },
     { name: 'publicationFilter', type: 'string', required: false, description: 'Query documents by the relationship between their draft and published versions. See <a href="/cms/api/rest/publication-filter">publicationFilter</a>.' },
@@ -562,4 +560,16 @@ const response = await fetch(
 </TabItem>
 </Tabs>
 
+<Responses>
+<ResponseTab status={204} statusText="No Content">
+
+`DELETE` requests only send a `204` HTTP status code on success and do not return any data in the response body.
+
+</ResponseTab>
+</Responses>
+
 </Endpoint>
+
+:::tip Performance best practices
+For production applications, be intentional about data fetching: use explicit population, limit population depth, and centralize population logic in route middlewares. See <ExternalLink to="https://strapi.io/blog/building-high-performance-strapi-applications-common-pitfalls-and-best-practices" text="Building High-Performance Strapi Applications" /> on the Strapi blog for a comprehensive guide.
+:::

--- a/docusaurus/docs/cms/api/rest/locale.md
+++ b/docusaurus/docs/cms/api/rest/locale.md
@@ -263,7 +263,7 @@ curl -X POST \
 ```
 
 <Responses>
-<ResponseTab status={200} statusText="OK">
+<ResponseTab status={201} statusText="Created">
 
 ```json
 {
@@ -310,7 +310,7 @@ curl -X POST \
 ```
 
 <Responses>
-<ResponseTab status={200} statusText="OK">
+<ResponseTab status={201} statusText="Created">
 
 ```json
 {

--- a/docusaurus/docs/cms/api/rest/status.md
+++ b/docusaurus/docs/cms/api/rest/status.md
@@ -148,7 +148,7 @@ The `status` parameter also applies to `POST` and `PUT` requests, where it deter
 | [`PUT /api/:pluralApiId/:documentId?status=draft`](#update-draft) | Updates the draft without publishing the changes |
 | [`PUT /api/:pluralApiId/:documentId`](#publish-later) | Updates the draft and publishes it |
 
-:::caution
+:::note
 With [Draft & Publish](/cms/features/draft-and-publish) enabled, the REST API defaults to `status=published`, so a `POST` or `PUT` request that does not include the `status` parameter publishes the document immediately. Pass `status=draft` explicitly to create or update content without publishing it.
 :::
 

--- a/docusaurus/docs/cms/api/rest/status.md
+++ b/docusaurus/docs/cms/api/rest/status.md
@@ -65,7 +65,7 @@ Since published versions are returned by default, passing no status parameter is
 <Endpoint
   id="get-draft-versions"
   method="GET"
-  path="/api/articles?status=draft"
+  path="/api/restaurants?status=draft"
   title="Get draft versions of restaurants"
   description="Returns draft versions of documents by passing the status=draft query parameter.">
 
@@ -73,7 +73,7 @@ Since published versions are returned by default, passing no status parameter is
 <TabItem value="curl" label="cURL">
 
 ```bash
-curl 'http://localhost:1337/api/articles?status=draft' \
+curl 'http://localhost:1337/api/restaurants?status=draft' \
   -H 'Authorization: Bearer <token>'
 ```
 
@@ -88,7 +88,7 @@ const query = qs.stringify({
     encodeValuesOnly: true, // prettify URL
 });
 
-await request(`/api/articles?${query}`);
+await request(`/api/restaurants?${query}`);
 ```
 
 </TabItem>
@@ -126,7 +126,7 @@ await request(`/api/articles?${query}`);
       "page": 1,
       "pageSize": 25,
       "pageCount": 1,
-      "total": 4
+      "total": 1
     }
   }
 }
@@ -143,10 +143,10 @@ The `status` parameter also applies to `POST` and `PUT` requests, where it deter
 
 | Request | Result |
 |---------|--------|
-| [`POST /api/content-type-plural-name?status=draft`](#create-draft) | Creates a draft document |
-| [`POST /api/content-type-plural-name`](#create-published) | Creates a document and publishes it immediately |
-| [`PUT /api/content-type-plural-name/document-id?status=draft`](#update-draft) | Updates the draft without publishing the changes |
-| [`PUT /api/content-type-plural-name/document-id`](#publish-later) | Publishes the existing draft |
+| [`POST /api/:pluralApiId?status=draft`](#create-draft) | Creates a draft document |
+| [`POST /api/:pluralApiId`](#create-published) | Creates a document and publishes it immediately |
+| [`PUT /api/:pluralApiId/:documentId?status=draft`](#update-draft) | Updates the draft without publishing the changes |
+| [`PUT /api/:pluralApiId/:documentId`](#publish-later) | Publishes the existing draft |
 
 :::caution
 Since the REST API defaults to `status=published`, a `POST` or `PUT` request that does not include the `status` parameter publishes the document immediately. Pass `status=draft` explicitly to create or update content without publishing it.
@@ -161,13 +161,13 @@ Published documents always keep a draft counterpart. Creating or updating a docu
 <Endpoint
   id="create-draft-endpoint"
   method="POST"
-  path="/api/articles?status=draft"
+  path="/api/restaurants?status=draft"
   title="Create a draft document"
   description="Creates a new document and leaves it as a draft by passing the status=draft query parameter.">
 
 ```bash
 curl -X POST \
-  'http://localhost:1337/api/articles?status=draft' \
+  'http://localhost:1337/api/restaurants?status=draft' \
   -H 'Authorization: Bearer <token>' \
   -H 'Content-Type: application/json' \
   -d '{
@@ -209,13 +209,13 @@ Omitting the `status` parameter, or passing `status=published`, creates the docu
 <Endpoint
   id="create-published-endpoint"
   method="POST"
-  path="/api/articles"
+  path="/api/restaurants"
   title="Create and publish a document"
   description="Creates a new document and publishes it immediately, which is the default behavior of the REST API.">
 
 ```bash
 curl -X POST \
-  'http://localhost:1337/api/articles' \
+  'http://localhost:1337/api/restaurants' \
   -H 'Authorization: Bearer <token>' \
   -H 'Content-Type: application/json' \
   -d '{
@@ -257,13 +257,13 @@ Pass `status=draft` to a `PUT` request to modify the draft version and leave the
 <Endpoint
   id="update-draft-endpoint"
   method="PUT"
-  path="/api/articles/:documentId?status=draft"
+  path="/api/restaurants/:documentId?status=draft"
   title="Update a draft entry"
   description="Updates the draft version of a document without publishing the changes.">
 
 ```bash
 curl -X PUT \
-  'http://localhost:1337/api/articles/jae8klabhuucbkgfe2xxc5dj?status=draft' \
+  'http://localhost:1337/api/restaurants/jae8klabhuucbkgfe2xxc5dj?status=draft' \
   -H 'Authorization: Bearer <token>' \
   -H 'Content-Type: application/json' \
   -d '{
@@ -303,13 +303,13 @@ To publish a draft created earlier, send a `PUT` request without the `status` pa
 <Endpoint
   id="publish-later-endpoint"
   method="PUT"
-  path="/api/articles/:documentId"
+  path="/api/restaurants/:documentId"
   title="Publish an existing draft"
   description="Publishes the draft version of a document, which is the default behavior of PUT requests.">
 
 ```bash
 curl -X PUT \
-  'http://localhost:1337/api/articles/jae8klabhuucbkgfe2xxc5dj' \
+  'http://localhost:1337/api/restaurants/jae8klabhuucbkgfe2xxc5dj' \
   -H 'Authorization: Bearer <token>' \
   -H 'Content-Type: application/json' \
   -d '{

--- a/docusaurus/docs/cms/api/rest/status.md
+++ b/docusaurus/docs/cms/api/rest/status.md
@@ -1,6 +1,6 @@
 ---
 title: Status
-description: Use Strapi's REST API to work with draft or published versions of your documents.
+description: Use Strapi's REST API to read, create, and update the draft or published versions of your documents.
 sidebarDepth: 3
 sidebar_label:  Status
 next: ./publication-filter.md
@@ -8,11 +8,14 @@ displayed_sidebar: cmsSidebar
 tags:
 - API
 - Content API
+- create
+- Draft & Publish
 - find
 - interactive query builder
 - REST API
 - qs library
 - status
+- update
 ---
 
 import QsIntroFull from '/docs/snippets/qs-intro-full.md'
@@ -23,21 +26,31 @@ import QsForQueryTitle from '/docs/snippets/qs-for-query-title.md'
 
 <Tldr>
 
-The REST API's `status` parameter filters documents by their publication state, returning either published versions (default) or drafts by passing `status=draft`.
+The REST API's `status` parameter returns either published versions (default) or drafts by passing `status=draft`.
+
+It also applies to write requests: a `POST` or `PUT` request publishes immediately unless you pass `status=draft`.
 
 </Tldr>
 
 
-The [REST API](/cms/api/rest) offers the ability to filter results based on their status, draft or published.
+The [REST API](/cms/api/rest) offers the ability to work with the draft or the published version of documents through the `status` parameter:
+
+- `published`: targets the published version of documents (default)
+- `draft`: targets the draft version of documents
 
 :::prerequisites
 The [Draft & Publish](/cms/features/draft-and-publish) feature should be enabled.
 :::
 
-Queries can accept a `status` parameter to fetch documents based on their status:
+:::note
+The REST API defaults to `published` for every request, including `POST` and `PUT` requests. This differs from the [Document Service API](/cms/api/document-service/status), which defaults to `draft`.
+:::
 
-- `published`: returns only the published version of documents (default)
-- `draft`: returns only the draft version of documents
+To select documents by how their draft and published versions relate (never-published, modified, and others), see [REST API: `publicationFilter`](/cms/api/rest/publication-filter).
+
+## Read draft or published versions {#read}
+
+Add the `status` parameter to a `GET` request to choose which version is returned.
 
 :::tip
 In the response data, the `publishedAt` field is `null` for drafts.
@@ -46,8 +59,6 @@ In the response data, the `publishedAt` field is `null` for drafts.
 :::note
 Since published versions are returned by default, passing no status parameter is equivalent to passing `status=published`.
 :::
-
-To select documents by how their draft and published versions relate (never-published, modified, and others), see [REST API: `publicationFilter`](/cms/api/rest/publication-filter).
 
 <br /><br />
 
@@ -125,3 +136,212 @@ await request(`/api/articles?${query}`);
 </Responses>
 
 </Endpoint>
+
+## Create or update as a draft or as published {#create-update}
+
+The `status` parameter also applies to `POST` and `PUT` requests, where it determines whether the document is left as a draft or published right away:
+
+| Request | Result |
+|---------|--------|
+| [`POST /api/content-type-plural-name?status=draft`](#create-draft) | Creates a draft document |
+| [`POST /api/content-type-plural-name`](#create-published) | Creates a document and publishes it immediately |
+| [`PUT /api/content-type-plural-name/document-id?status=draft`](#update-draft) | Updates the draft without publishing the changes |
+| [`PUT /api/content-type-plural-name/document-id`](#publish-later) | Publishes the existing draft |
+
+:::caution
+Since the REST API defaults to `status=published`, a `POST` or `PUT` request that does not include the `status` parameter publishes the document immediately. Pass `status=draft` explicitly to create or update content without publishing it.
+:::
+
+:::note
+Published documents always keep a draft counterpart. Creating or updating a document with `status=published` writes the draft first, then publishes it, so both versions hold the same data.
+:::
+
+### Create a draft {#create-draft}
+
+<Endpoint
+  id="create-draft-endpoint"
+  method="POST"
+  path="/api/articles?status=draft"
+  title="Create a draft document"
+  description="Creates a new document and leaves it as a draft by passing the status=draft query parameter.">
+
+```bash
+curl -X POST \
+  'http://localhost:1337/api/articles?status=draft' \
+  -H 'Authorization: Bearer <token>' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "data": {
+      "Name": "Biscotte Restaurant"
+    }
+  }'
+```
+
+<Responses>
+<ResponseTab status={201} statusText="Created">
+
+```json
+{
+  "data": {
+    "id": 13,
+    "documentId": "jae8klabhuucbkgfe2xxc5dj",
+    "Name": "Biscotte Restaurant",
+    "createdAt": "2024-03-06T22:19:54.646Z",
+    "updatedAt": "2024-03-06T22:19:54.646Z",
+    "publishedAt": null,
+    "locale": "en"
+  },
+  "meta": {}
+}
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>
+
+The `publishedAt` field is `null`, which confirms the document was created as a draft.
+
+### Create and publish immediately {#create-published}
+
+Omitting the `status` parameter, or passing `status=published`, creates the document and publishes it in a single request:
+
+<Endpoint
+  id="create-published-endpoint"
+  method="POST"
+  path="/api/articles"
+  title="Create and publish a document"
+  description="Creates a new document and publishes it immediately, which is the default behavior of the REST API.">
+
+```bash
+curl -X POST \
+  'http://localhost:1337/api/articles' \
+  -H 'Authorization: Bearer <token>' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "data": {
+      "Name": "Biscotte Restaurant"
+    }
+  }'
+```
+
+<Responses>
+<ResponseTab status={201} statusText="Created">
+
+```json
+{
+  "data": {
+    "id": 13,
+    "documentId": "jae8klabhuucbkgfe2xxc5dj",
+    "Name": "Biscotte Restaurant",
+    "createdAt": "2024-03-06T22:19:54.646Z",
+    "updatedAt": "2024-03-06T22:19:54.646Z",
+    "publishedAt": "2024-03-06T22:19:54.649Z",
+    "locale": "en"
+  },
+  "meta": {}
+}
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>
+
+Here `publishedAt` holds a timestamp instead of `null`, which confirms the document was published.
+
+### Update a draft without publishing it {#update-draft}
+
+Pass `status=draft` to a `PUT` request to modify the draft version and leave the published version untouched:
+
+<Endpoint
+  id="update-draft-endpoint"
+  method="PUT"
+  path="/api/articles/:documentId?status=draft"
+  title="Update a draft entry"
+  description="Updates the draft version of a document without publishing the changes.">
+
+```bash
+curl -X PUT \
+  'http://localhost:1337/api/articles/jae8klabhuucbkgfe2xxc5dj?status=draft' \
+  -H 'Authorization: Bearer <token>' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "data": {
+      "Name": "Biscotte Restaurant (closed)"
+    }
+  }'
+```
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+{
+  "data": {
+    "id": 13,
+    "documentId": "jae8klabhuucbkgfe2xxc5dj",
+    "Name": "Biscotte Restaurant (closed)",
+    "createdAt": "2024-03-06T22:19:54.646Z",
+    "updatedAt": "2024-03-06T22:24:12.145Z",
+    "publishedAt": null,
+    "locale": "en"
+  },
+  "meta": {}
+}
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>
+
+### Publish an existing draft {#publish-later}
+
+To publish a draft created earlier, send a `PUT` request without the `status` parameter, or with `status=published`:
+
+<Endpoint
+  id="publish-later-endpoint"
+  method="PUT"
+  path="/api/articles/:documentId"
+  title="Publish an existing draft"
+  description="Publishes the draft version of a document, which is the default behavior of PUT requests.">
+
+```bash
+curl -X PUT \
+  'http://localhost:1337/api/articles/jae8klabhuucbkgfe2xxc5dj' \
+  -H 'Authorization: Bearer <token>' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "data": {
+      "Name": "Biscotte Restaurant (closed)"
+    }
+  }'
+```
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+{
+  "data": {
+    "id": 13,
+    "documentId": "jae8klabhuucbkgfe2xxc5dj",
+    "Name": "Biscotte Restaurant (closed)",
+    "createdAt": "2024-03-06T22:19:54.646Z",
+    "updatedAt": "2024-03-06T22:26:38.902Z",
+    "publishedAt": "2024-03-06T22:26:38.905Z",
+    "locale": "en"
+  },
+  "meta": {}
+}
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>
+
+:::note
+A `PUT` request requires a `data` object in the body, so it updates and publishes in a single operation. To publish a document without changing its content, pass an empty `data` object.
+:::

--- a/docusaurus/docs/cms/api/rest/status.md
+++ b/docusaurus/docs/cms/api/rest/status.md
@@ -147,6 +147,9 @@ The `status` parameter also applies to `POST` and `PUT` requests, where it deter
 | [`POST /api/:pluralApiId`](#create-published) | Creates a document and publishes it immediately |
 | [`PUT /api/:pluralApiId/:documentId?status=draft`](#update-draft) | Updates the draft without publishing the changes |
 | [`PUT /api/:pluralApiId/:documentId`](#publish-later) | Updates the draft and publishes it |
+| [`PUT /api/:pluralApiId/:documentId` with an empty `data` object](#publish-unchanged) | Publishes the draft as-is, without changing its content |
+
+The same applies to single types, where the `status` parameter can be passed to `PUT /api/:singularApiId`.
 
 :::note
 With [Draft & Publish](/cms/features/draft-and-publish) enabled, the REST API defaults to `status=published`, so a `POST` or `PUT` request that does not include the `status` parameter publishes the document immediately. Pass `status=draft` explicitly to create or update content without publishing it.
@@ -454,7 +457,11 @@ const data = await response.json();
 
 </Endpoint>
 
-A `PUT` request requires a `data` object in the body, so the request above updates and publishes in a single operation. To publish a document without changing its content, pass an empty `data` object:
+A `PUT` request requires a `data` object in the body, so the request above updates and publishes in a single operation.
+
+### Publish a draft without changing its content {#publish-unchanged}
+
+To publish a draft as-is, send a `PUT` request with an empty `data` object:
 
 <Endpoint
   id="publish-unchanged-endpoint"

--- a/docusaurus/docs/cms/api/rest/status.md
+++ b/docusaurus/docs/cms/api/rest/status.md
@@ -51,7 +51,7 @@ To select documents by how their draft and published versions relate (never-publ
 Add the `status` parameter to a `GET` request to choose which version is returned.
 
 :::tip
-In the response data, the `publishedAt` field is `null` for drafts.
+In the response data, the `publishedAt` field is `null` in the returned draft, even when a published version exists.
 :::
 
 :::note
@@ -317,7 +317,7 @@ Pass `status=draft` to a `PUT` request to modify the draft version and leave the
   id="update-draft-endpoint"
   method="PUT"
   path="/api/restaurants/:documentId?status=draft"
-  title="Update a draft entry"
+  title="Update a draft document"
   description="Updates the draft version of a document without publishing the changes.">
 
 <Tabs>

--- a/docusaurus/docs/cms/api/rest/status.md
+++ b/docusaurus/docs/cms/api/rest/status.md
@@ -18,9 +18,7 @@ tags:
 - update
 ---
 
-import QsIntroFull from '/docs/snippets/qs-intro-full.md'
 import QsForQueryBody from '/docs/snippets/qs-for-query-body.md'
-import QsForQueryTitle from '/docs/snippets/qs-for-query-title.md'
 
 # REST API: `status`
 
@@ -137,6 +135,8 @@ await request(`/api/restaurants?${query}`);
 
 </Endpoint>
 
+<QsForQueryBody />
+
 ## Create or update as a draft or as published {#create-update}
 
 The `status` parameter also applies to `POST` and `PUT` requests, where it determines whether the document is left as a draft or published right away:
@@ -165,6 +165,9 @@ Published documents always keep a draft counterpart. Creating or updating a docu
   title="Create a draft document"
   description="Creates a new document and leaves it as a draft by passing the status=draft query parameter.">
 
+<Tabs>
+<TabItem value="curl" label="cURL">
+
 ```bash
 curl -X POST \
   'http://localhost:1337/api/restaurants?status=draft' \
@@ -176,6 +179,31 @@ curl -X POST \
     }
   }'
 ```
+
+</TabItem>
+<TabItem value="js" label="JavaScript">
+
+```js
+const response = await fetch(
+  'http://localhost:1337/api/restaurants?status=draft',
+  {
+    method: 'POST',
+    headers: {
+      Authorization: 'Bearer <token>',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      data: {
+        Name: 'Biscotte Restaurant',
+      },
+    }),
+  }
+);
+const data = await response.json();
+```
+
+</TabItem>
+</Tabs>
 
 <Responses>
 <ResponseTab status={201} statusText="Created">
@@ -213,6 +241,9 @@ Omitting the `status` parameter, or passing `status=published`, creates the docu
   title="Create and publish a document"
   description="Creates a new document and publishes it immediately, which is the default behavior of the REST API.">
 
+<Tabs>
+<TabItem value="curl" label="cURL">
+
 ```bash
 curl -X POST \
   'http://localhost:1337/api/restaurants' \
@@ -224,6 +255,31 @@ curl -X POST \
     }
   }'
 ```
+
+</TabItem>
+<TabItem value="js" label="JavaScript">
+
+```js
+const response = await fetch(
+  'http://localhost:1337/api/restaurants',
+  {
+    method: 'POST',
+    headers: {
+      Authorization: 'Bearer <token>',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      data: {
+        Name: 'Biscotte Restaurant',
+      },
+    }),
+  }
+);
+const data = await response.json();
+```
+
+</TabItem>
+</Tabs>
 
 <Responses>
 <ResponseTab status={201} statusText="Created">
@@ -261,6 +317,9 @@ Pass `status=draft` to a `PUT` request to modify the draft version and leave the
   title="Update a draft entry"
   description="Updates the draft version of a document without publishing the changes.">
 
+<Tabs>
+<TabItem value="curl" label="cURL">
+
 ```bash
 curl -X PUT \
   'http://localhost:1337/api/restaurants/jae8klabhuucbkgfe2xxc5dj?status=draft' \
@@ -272,6 +331,31 @@ curl -X PUT \
     }
   }'
 ```
+
+</TabItem>
+<TabItem value="js" label="JavaScript">
+
+```js
+const response = await fetch(
+  'http://localhost:1337/api/restaurants/jae8klabhuucbkgfe2xxc5dj?status=draft',
+  {
+    method: 'PUT',
+    headers: {
+      Authorization: 'Bearer <token>',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      data: {
+        Name: 'Biscotte Restaurant (closed)',
+      },
+    }),
+  }
+);
+const data = await response.json();
+```
+
+</TabItem>
+</Tabs>
 
 <Responses>
 <ResponseTab status={200} statusText="OK">
@@ -307,6 +391,9 @@ To publish a draft created earlier, send a `PUT` request without the `status` pa
   title="Publish an existing draft"
   description="Publishes the draft version of a document, which is the default behavior of PUT requests.">
 
+<Tabs>
+<TabItem value="curl" label="cURL">
+
 ```bash
 curl -X PUT \
   'http://localhost:1337/api/restaurants/jae8klabhuucbkgfe2xxc5dj' \
@@ -318,6 +405,31 @@ curl -X PUT \
     }
   }'
 ```
+
+</TabItem>
+<TabItem value="js" label="JavaScript">
+
+```js
+const response = await fetch(
+  'http://localhost:1337/api/restaurants/jae8klabhuucbkgfe2xxc5dj',
+  {
+    method: 'PUT',
+    headers: {
+      Authorization: 'Bearer <token>',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      data: {
+        Name: 'Biscotte Restaurant (closed)',
+      },
+    }),
+  }
+);
+const data = await response.json();
+```
+
+</TabItem>
+</Tabs>
 
 <Responses>
 <ResponseTab status={200} statusText="OK">
@@ -342,6 +454,74 @@ curl -X PUT \
 
 </Endpoint>
 
+A `PUT` request requires a `data` object in the body, so the request above updates and publishes in a single operation. To publish a document without changing its content, pass an empty `data` object:
+
+<Endpoint
+  id="publish-unchanged-endpoint"
+  method="PUT"
+  path="/api/restaurants/:documentId"
+  title="Publish a draft without changing its content"
+  description="Publishes the draft version of a document as-is by sending an empty data object.">
+
+<Tabs>
+<TabItem value="curl" label="cURL">
+
+```bash
+curl -X PUT \
+  'http://localhost:1337/api/restaurants/jae8klabhuucbkgfe2xxc5dj' \
+  -H 'Authorization: Bearer <token>' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "data": {}
+  }'
+```
+
+</TabItem>
+<TabItem value="js" label="JavaScript">
+
+```js
+const response = await fetch(
+  'http://localhost:1337/api/restaurants/jae8klabhuucbkgfe2xxc5dj',
+  {
+    method: 'PUT',
+    headers: {
+      Authorization: 'Bearer <token>',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      data: {},
+    }),
+  }
+);
+const data = await response.json();
+```
+
+</TabItem>
+</Tabs>
+
+<Responses>
+<ResponseTab status={200} statusText="OK">
+
+```json
+{
+  "data": {
+    "id": 13,
+    "documentId": "jae8klabhuucbkgfe2xxc5dj",
+    "Name": "Biscotte Restaurant (closed)",
+    "createdAt": "2024-03-06T22:19:54.646Z",
+    "updatedAt": "2024-03-06T22:26:38.902Z",
+    "publishedAt": "2024-03-06T22:31:14.207Z",
+    "locale": "en"
+  },
+  "meta": {}
+}
+```
+
+</ResponseTab>
+</Responses>
+
+</Endpoint>
+
 :::note
-A `PUT` request requires a `data` object in the body, so it updates and publishes in a single operation. To publish a document without changing its content, pass an empty `data` object.
+Omitting the `data` key entirely returns a `400` error, so send `"data": {}` rather than an empty body.
 :::

--- a/docusaurus/docs/cms/api/rest/status.md
+++ b/docusaurus/docs/cms/api/rest/status.md
@@ -146,10 +146,10 @@ The `status` parameter also applies to `POST` and `PUT` requests, where it deter
 | [`POST /api/:pluralApiId?status=draft`](#create-draft) | Creates a draft document |
 | [`POST /api/:pluralApiId`](#create-published) | Creates a document and publishes it immediately |
 | [`PUT /api/:pluralApiId/:documentId?status=draft`](#update-draft) | Updates the draft without publishing the changes |
-| [`PUT /api/:pluralApiId/:documentId`](#publish-later) | Publishes the existing draft |
+| [`PUT /api/:pluralApiId/:documentId`](#publish-later) | Updates the draft and publishes it |
 
 :::caution
-Since the REST API defaults to `status=published`, a `POST` or `PUT` request that does not include the `status` parameter publishes the document immediately. Pass `status=draft` explicitly to create or update content without publishing it.
+With [Draft & Publish](/cms/features/draft-and-publish) enabled, the REST API defaults to `status=published`, so a `POST` or `PUT` request that does not include the `status` parameter publishes the document immediately. Pass `status=draft` explicitly to create or update content without publishing it.
 :::
 
 :::note


### PR DESCRIPTION
This PR documents that the REST API applies the status parameter to POST and PUT requests, not only to GET requests. The REST API defaults to status=published on every action, so a POST or PUT without the parameter publishes content immediately, which was previously undocumented and led users to discover ?status=draft by trial and error. Adds a "Create or update as a draft or as published" section to the REST status page with examples for creating a draft, creating and publishing, updating a draft, and publishing an existing draft, and adds Draft & Publish cautions plus the status query parameter to the create and update endpoints on the REST API page.

Direct preview link 👉 [here](https://documentation-git-cms-rest-status-create-update-strapijs.vercel.app/cms/api/rest/status)

Assesses the following user's feedback:

> I was wiring the draft & publish on my frontend app when I noticed that all items were created as publish. Somehow I figure out that making a POST request and passing a param ?status=draft would work. It's not clear by the docs and even the AI couldn't tell me this.