### PR TITLE
Improve the REST API reference structure and fix response inaccuracies

### DIFF
--- a/docusaurus/docs/cms/api/rest.md
+++ b/docusaurus/docs/cms/api/rest.md
@@ -25,20 +25,14 @@ The REST API allows accessing the [content-types](/cms/backend-customization/mod
 
 This section of the documentation is for the REST API reference for content-types. We also have [guides](/cms/api/rest/guides/intro) available for specific use cases.
 
+This page documents the [generated endpoints](#endpoints), the [request and response format](#requests), and one section per operation. Query parameters such as filtering, sorting, population, locale, and status are documented in [API parameters](/cms/api/rest/parameters). If you prefer a typed client over raw HTTP requests, see the [Strapi Client](/cms/api/client).
+
 :::prerequisites
 All content types are private by default and need to be either made public or queries need to be authenticated with the proper permissions. See the [Quick Start Guide](/cms/quick-start#step-10-set-roles--permissions), the user guide for the [Users & Permissions feature](/cms/features/users-permissions#roles), and [API tokens configuration documentation](/cms/features/api-tokens) for more details.
 :::
 
 :::note
 By default, the REST API responses only include top-level fields and does not populate any relations, media fields, components, or dynamic zones. Use the [`populate` parameter](/cms/api/rest/populate-select) to populate specific fields. Ensure that the find permission is given to the field(s) for the relation(s) you populate.
-:::
-
-:::tip Performance best practices
-For production applications, be intentional about data fetching: use explicit population, limit population depth, and centralize population logic in route middlewares. See <ExternalLink to="https://strapi.io/blog/building-high-performance-strapi-applications-common-pitfalls-and-best-practices" text="Building High-Performance Strapi Applications" /> on the Strapi blog for a comprehensive guide.
-:::
-
-:::strapi Strapi Client
-The [Strapi Client](/cms/api/client) library simplifies interactions with your Strapi back end, providing a way to fetch, create, update, and delete content.
 :::
 
 ## Endpoints

--- a/docusaurus/docs/cms/api/rest.md
+++ b/docusaurus/docs/cms/api/rest.md
@@ -93,12 +93,12 @@ The Upload package (which powers the [Media Library feature](/cms/features/media
 [Components](/cms/backend-customization/models#components-json) don't have API endpoints.
 :::
 
-## Requests
+## Requests and responses {#requests}
 
 :::strapi Strapi 5 vs. Strapi v4
 Strapi 5's Content API includes 2 major differences with Strapi v4:
 
-- The response format has been flattened, which means attributes are no longer nested in a `data.attributes` object and are directly accessible at the first level of the `data` object (e.g., a content-type's "title" attribute is accessed with `data.title`).
+- The response format has been flattened, which means attributes are no longer nested in a `data.attributes` object and are directly accessible at the first level of the `data` object (e.g., a content-type's "title" attribute is accessed with `data.title`). While migrating, you can pass an optional header to keep the v4 format (see the [related breaking change](/cms/migration/v4-to-v5/breaking-changes/new-response-format)).
 - Strapi 5 now uses **documents** <DocumentDefinition/> and documents are accessed by their `documentId` (see [breaking change entry](/cms/migration/v4-to-v5/breaking-changes/use-document-id) for details)
 :::
 
@@ -121,13 +121,9 @@ Requests return a response as an object which usually includes the following key
 Some plugins (including Users & Permissions and Upload) may not follow this response format.
 :::
 
+The following sections detail each generated endpoint.
+
 ### Get documents {#get-all}
-
-:::tip Tip: Strapi 5 vs. Strapi 4
-In Strapi 5 the response format has been flattened, and attributes are directly accessible from the `data` object instead of being nested in `data.attributes`.
-
-You can pass an optional header while you're migrating to Strapi 5 (see the [related breaking change](/cms/migration/v4-to-v5/breaking-changes/new-response-format)).
-:::
 
 <Endpoint
   id="get-all-endpoint"
@@ -556,4 +552,22 @@ const response = await fetch(
 </TabItem>
 </Tabs>
 
+<Responses>
+<ResponseTab status={204} statusText="No Content">
+
+`DELETE` requests only send a `204` HTTP status code on success and do not return any data in the response body.
+
+</ResponseTab>
+</Responses>
+
 </Endpoint>
+
+:::tip Performance best practices
+For production applications, be intentional about data fetching: use explicit population, limit population depth, and centralize population logic in route middlewares. See <ExternalLink to="https://strapi.io/blog/building-high-performance-strapi-applications-common-pitfalls-and-best-practices" text="Building High-Performance Strapi Applications" /> on the Strapi blog for a comprehensive guide.
+:::
+
+## What's next?
+
+- Refine your queries with [API parameters](/cms/api/rest/parameters): [filters](/cms/api/rest/filters), [sorting and pagination](/cms/api/rest/sort-pagination), [populate and select](/cms/api/rest/populate-select), [locale](/cms/api/rest/locale), and [status](/cms/api/rest/status).
+- Manage relations through the API with [Managing relations](/cms/api/rest/relations).
+- Follow a use-case-driven walkthrough with the [REST API guides](/cms/api/rest/guides/intro).

--- a/docusaurus/docs/cms/api/rest.md
+++ b/docusaurus/docs/cms/api/rest.md
@@ -148,7 +148,7 @@ You can pass an optional header while you're migrating to Strapi 5 (see the [rel
     { name: 'populate', type: 'string | object', required: false, description: 'Relations and components to include. Use <code>*</code> for all. See <a href="/cms/api/rest/populate-select">populate</a>.' },
     { name: 'fields', type: 'string[]', required: false, description: 'Select specific fields to return. See <a href="/cms/api/rest/populate-select#field-selection">field selection</a>.' },
     { name: 'pagination[page]', type: 'integer', required: false, description: 'Page number. Default: <code>1</code>' },
-    { name: 'pagination[pageSize]', type: 'integer', required: false, description: 'Items per page. Default <code>25</code>, max <code>100</code>' },
+    { name: 'pagination[pageSize]', type: 'integer', required: false, description: 'Items per page. Default: <code>25</code>. The maximum is set by <code>api.rest.maxLimit</code> (see <a href="/cms/api/rest/sort-pagination#pagination-by-page">pagination</a>).' },
     { name: 'locale', type: 'string', required: false, description: 'Locale of the documents to fetch. See <a href="/cms/api/rest/locale">locale</a>.' },
     { name: 'status', type: 'string', required: false, description: '<code>published</code> or <code>draft</code>. See <a href="/cms/api/rest/status">status</a>.' },
     { name: 'publicationFilter', type: 'string', required: false, description: 'Query documents by the relationship between their draft and published versions. See <a href="/cms/api/rest/publication-filter">publicationFilter</a>.' },

--- a/docusaurus/docs/cms/api/rest.md
+++ b/docusaurus/docs/cms/api/rest.md
@@ -25,14 +25,16 @@ The REST API allows accessing the [content-types](/cms/backend-customization/mod
 
 This section of the documentation is for the REST API reference for content-types. We also have [guides](/cms/api/rest/guides/intro) available for specific use cases.
 
-This page documents the [generated endpoints](#endpoints), the [request and response format](#requests), and one section per operation. Filtering, sorting, population, locale, and status each have their own page under API parameters. If you prefer a typed client over raw HTTP requests, the [Strapi Client](/cms/api/client) library can fetch, create, update, and delete content for you.
-
 :::prerequisites
 All content types are private by default and need to be either made public or queries need to be authenticated with the proper permissions. See the [Quick Start Guide](/cms/quick-start#step-10-set-roles--permissions), the user guide for the [Users & Permissions feature](/cms/features/users-permissions#roles), and [API tokens configuration documentation](/cms/features/api-tokens) for more details.
 :::
 
 :::note
 By default, the REST API responses only include top-level fields and does not populate any relations, media fields, components, or dynamic zones. Use the [`populate` parameter](/cms/api/rest/populate-select) to populate specific fields. Ensure that the find permission is given to the field(s) for the relation(s) you populate.
+:::
+
+:::strapi Strapi Client
+The [Strapi Client](/cms/api/client) library simplifies interactions with your Strapi back end, providing a way to fetch, create, update, and delete content.
 :::
 
 ## Endpoints

--- a/docusaurus/docs/cms/api/rest.md
+++ b/docusaurus/docs/cms/api/rest.md
@@ -25,7 +25,7 @@ The REST API allows accessing the [content-types](/cms/backend-customization/mod
 
 This section of the documentation is for the REST API reference for content-types. We also have [guides](/cms/api/rest/guides/intro) available for specific use cases.
 
-This page documents the [generated endpoints](#endpoints), the [request and response format](#requests), and one section per operation. Query parameters such as filtering, sorting, population, locale, and status are documented in [API parameters](/cms/api/rest/parameters). If you prefer a typed client over raw HTTP requests, see the [Strapi Client](/cms/api/client).
+This page documents the [generated endpoints](#endpoints), the [request and response format](#requests), and one section per operation. Filtering, sorting, population, locale, and status each have their own page under API parameters. If you prefer a typed client over raw HTTP requests, the [Strapi Client](/cms/api/client) library can fetch, create, update, and delete content for you.
 
 :::prerequisites
 All content types are private by default and need to be either made public or queries need to be authenticated with the proper permissions. See the [Quick Start Guide](/cms/quick-start#step-10-set-roles--permissions), the user guide for the [Users & Permissions feature](/cms/features/users-permissions#roles), and [API tokens configuration documentation](/cms/features/api-tokens) for more details.

--- a/docusaurus/docs/cms/api/rest.md
+++ b/docusaurus/docs/cms/api/rest.md
@@ -100,7 +100,7 @@ The Upload package (which powers the [Media Library feature](/cms/features/media
 :::strapi Strapi 5 vs. Strapi v4
 Strapi 5's Content API includes 2 major differences with Strapi v4:
 
-- The response format has been flattened, which means attributes are no longer nested in a `data.attributes` object and are directly accessible at the first level of the `data` object (e.g., a content-type's "title" attribute is accessed with `data.title`). While migrating, you can pass an optional header to keep the v4 format (see the [related breaking change](/cms/migration/v4-to-v5/breaking-changes/new-response-format)).
+- The response format has been flattened, which means attributes are no longer nested in a `data.attributes` object and are directly accessible at the first level of the `data` object (e.g., a content-type's "title" attribute is accessed with `data.title`).
 - Strapi 5 now uses **documents** <DocumentDefinition/> and documents are accessed by their `documentId` (see [breaking change entry](/cms/migration/v4-to-v5/breaking-changes/use-document-id) for details)
 :::
 
@@ -126,6 +126,12 @@ Some plugins (including Users & Permissions and Upload) may not follow this resp
 The following sections detail each generated endpoint.
 
 ### Get documents {#get-all}
+
+:::tip Tip: Strapi 5 vs. Strapi 4
+In Strapi 5 the response format has been flattened, and attributes are directly accessible from the `data` object instead of being nested in `data.attributes`.
+
+You can pass an optional header while you're migrating to Strapi 5 (see the [related breaking change](/cms/migration/v4-to-v5/breaking-changes/new-response-format)).
+:::
 
 <Endpoint
   id="get-all-endpoint"

--- a/docusaurus/docs/cms/api/rest.md
+++ b/docusaurus/docs/cms/api/rest.md
@@ -565,9 +565,3 @@ const response = await fetch(
 :::tip Performance best practices
 For production applications, be intentional about data fetching: use explicit population, limit population depth, and centralize population logic in route middlewares. See <ExternalLink to="https://strapi.io/blog/building-high-performance-strapi-applications-common-pitfalls-and-best-practices" text="Building High-Performance Strapi Applications" /> on the Strapi blog for a comprehensive guide.
 :::
-
-## What's next?
-
-- Refine your queries with [API parameters](/cms/api/rest/parameters): [filters](/cms/api/rest/filters), [sorting and pagination](/cms/api/rest/sort-pagination), [populate and select](/cms/api/rest/populate-select), [locale](/cms/api/rest/locale), and [status](/cms/api/rest/status).
-- Manage relations through the API with [Managing relations](/cms/api/rest/relations).
-- Follow a use-case-driven walkthrough with the [REST API guides](/cms/api/rest/guides/intro).

--- a/docusaurus/docs/cms/api/rest/locale.md
+++ b/docusaurus/docs/cms/api/rest/locale.md
@@ -263,7 +263,7 @@ curl -X POST \
 ```
 
 <Responses>
-<ResponseTab status={200} statusText="OK">
+<ResponseTab status={201} statusText="Created">
 
 ```json
 {
@@ -310,7 +310,7 @@ curl -X POST \
 ```
 
 <Responses>
-<ResponseTab status={200} statusText="OK">
+<ResponseTab status={201} statusText="Created">
 
 ```json
 {


### PR DESCRIPTION
This PR applies the structural and factual findings from the review of #3382 that were out of that PR's scope. Replaces the five-admonition intro with a reading guide, renames Requests to Requests and responses while keeping the #requests anchor, removes the duplicated Strapi 5 vs. v4 callout, documents the DELETE 204 response, and closes the page with a next-steps section. Also fixes the POST response code on the locale page to 201 Created and attributes the pageSize maximum to the api.rest.maxLimit setting instead of a hardcoded 100.

Based on #3382, so it should be merged after it.

Direct preview link 👉 [here](https://documentation-git-cms-rest-reference-structure-strapijs.vercel.app/cms/api/rest)