### PR TITLE
Document Content History retention and version creation scope

### DIFF
--- a/docusaurus/docs/cms/configurations/admin-panel.md
+++ b/docusaurus/docs/cms/configurations/admin-panel.md
@@ -393,10 +393,6 @@ Transfer tokens for the [Data transfer](/cms/features/data-management/transfer) 
 |-----------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|-------------------------------------------------------------------------------------------------------------------------------------|
 | `transfer.token.salt`             | Salt used to generate Transfer tokens.<br/><br/>If no transfer token salt is defined, transfer features will be disabled.               | string        | a random string                                                                                                                       |
 
-:::note Retention days for self-hosted vs. Strapi Cloud users
-For Strapi Cloud customers, the `auditLogs.retentionDays` value stored in the license information is used, unless a _smaller_ `retentionDays` value is defined in the `config/admin.js|ts` configuration file.
-:::
-
 ## Configuration examples
 
 The `/config/admin` file should at least include a minimal configuration with required parameters for [authentication](#authentication) and [API tokens](#api-tokens). Additional parameters can be included for a full configuration.

--- a/docusaurus/docs/cms/configurations/admin-panel.md
+++ b/docusaurus/docs/cms/configurations/admin-panel.md
@@ -327,7 +327,7 @@ To configure HTTP cookies for admin authentication, use the following parameters
 | `auth.cookie.path`                | Cookie path                                                                                                                                                                                        | string        | `'/admin'`                                                                                                                          |
 | `auth.cookie.sameSite`            | <ExternalLink to="https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie#samesitesamesite-value" text="SameSite cookie attribute"/>                                                                                                                                                                          | string        | `'lax'`                                                                                                                             |
 
-## Content history {#content-history}
+## Content history
 
 The [Content History](/cms/features/content-history) feature can be configured with the following parameter:
 

--- a/docusaurus/docs/cms/configurations/admin-panel.md
+++ b/docusaurus/docs/cms/configurations/admin-panel.md
@@ -327,6 +327,18 @@ To configure HTTP cookies for admin authentication, use the following parameters
 | `auth.cookie.path`                | Cookie path                                                                                                                                                                                        | string        | `'/admin'`                                                                                                                          |
 | `auth.cookie.sameSite`            | <ExternalLink to="https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie#samesitesamesite-value" text="SameSite cookie attribute"/>                                                                                                                                                                          | string        | `'lax'`                                                                                                                             |
 
+## Content history {#content-history}
+
+The [Content History](/cms/features/content-history) feature can be configured with the following parameter:
+
+| Parameter                         | Description                                                                                                                                                                                        | Type          | Default                                                                                                                             |
+|-----------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|-------------------------------------------------------------------------------------------------------------------------------------|
+| `history.retentionDays`           | How long history versions are kept, in days.<br /><br />_The value can only shorten the retention period, see the note under the table._                                                            | integer       | 90                                                                                                                                  |
+
+:::note Retention days for Content History
+The `history.retentionDays` value is only taken into account if it is _smaller_ than the value stored in the license information. It cannot be used to keep history versions for longer than the license allows, and versions are never kept for more than 90 days. There is no equivalent setting in the admin panel: the retention period can only be shortened from the `config/admin.js|ts` configuration file.
+:::
+
 ## Feature flags
 
 The feature flags can be configured with the following parameters:
@@ -499,6 +511,9 @@ module.exports = ({ env }) => ({
       sameSite: 'lax',
     },
   },
+  history: { // only accessible with a Growth or Enterprise plan
+    retentionDays: 30,
+  },
   url: env('PUBLIC_ADMIN_URL', '/dashboard'),
   autoOpen: false,
   watchIgnoreFiles: [
@@ -571,6 +586,9 @@ export default ({ env }) => ({
       path: '/admin',
       sameSite: 'lax',
     },
+  },
+  history: { // only accessible with a Growth or Enterprise plan
+    retentionDays: 30,
   },
   url: env('PUBLIC_ADMIN_URL', '/dashboard'),
   autoOpen: false,

--- a/docusaurus/docs/cms/configurations/admin-panel.md
+++ b/docusaurus/docs/cms/configurations/admin-panel.md
@@ -336,7 +336,7 @@ The [Content History](/cms/features/content-history) feature can be configured w
 | `history.retentionDays`           | How long history versions are kept, in days.<br /><br />_The value can only shorten the retention period, see the note under the table._                                                            | integer       | 90                                                                                                                                  |
 
 :::note Retention days for Content History
-The `history.retentionDays` value is only taken into account if it is _smaller_ than the value stored in the license information. It cannot be used to keep history versions for longer than the license allows, and versions are never kept for more than 90 days. There is no equivalent setting in the admin panel: the retention period can only be shortened from the `config/admin.js|ts` configuration file.
+The `history.retentionDays` value is only taken into account if it is _smaller_ than the value stored in the license information. It cannot be used to keep history versions for longer than the license allows, and versions are never kept for more than 90 days.
 :::
 
 ## Feature flags

--- a/docusaurus/docs/cms/features/content-history.md
+++ b/docusaurus/docs/cms/features/content-history.md
@@ -27,6 +27,26 @@ The Content History feature, in the <Icon name="feather" /> Content Manager, giv
 
 <Guideflow lightId="9r2m2y1sok" darkId="er566mli6p"/>
 
+## How versions are created
+
+A history version is only created when a document is modified through the <Icon name="feather" /> Content Manager in the admin panel. Content modified in any other way does not appear in the Content History of the document.
+
+| Content is modified through | Version created |
+|-----------------------------|-----------------|
+| The [Content Manager](/cms/features/content-manager) in the admin panel | Yes |
+| The [REST API](/cms/api/rest) | No |
+| The [GraphQL API](/cms/api/graphql) | No |
+| The [Document Service API](/cms/api/document-service), for instance `strapi.documents()` called from application code | No |
+| [Lifecycle hooks](/cms/backend-customization/models#lifecycle-hooks) | No |
+| [Cron jobs](/cms/configurations/cron) | No |
+| The `strapi import` and `strapi transfer` commands (see [Data management](/cms/features/data-management)) | No |
+
+:::caution
+Content History is not a record of every change made to a document. Documents written programmatically, such as those created by a migration script or an integration calling the REST API, have no corresponding version, and a document can therefore differ from the most recent version listed in its Content History.
+
+To trace the actions performed by users of the admin panel, use [Audit Logs](/cms/features/audit-logs).
+:::
+
 ## Usage
 
 **Path to use the feature:** <Icon name="feather" /> Content Manager <br/> From the edit view of a content type: click <Icon name="dots-three-outline" /> (top right corner) then <Icon name="clock-counter-clockwise" /> **Content History**.
@@ -73,3 +93,11 @@ sources={{
   dark:'/img/assets/content-manager/restoring-content-history_DARK.png',
 }}
 />
+
+## Version retention
+
+Content History is not a permanent archive. Versions are deleted automatically: a job runs once a day, at midnight, and permanently deletes every version older than the retention period. Versions deleted by this job cannot be recovered from the Content History interface.
+
+Regardless of the plan, versions are kept for a maximum of 90 days. This period is counted from the creation date of each version.
+
+The retention period can be shortened, but never extended, with the [`history.retentionDays`](/cms/configurations/admin-panel#content-history) parameter of the `/config/admin` file. When both the license and the configuration file define a value, the lower of the two applies.

--- a/docusaurus/docs/cms/features/content-history.md
+++ b/docusaurus/docs/cms/features/content-history.md
@@ -2,7 +2,6 @@
 title: Content History
 description: Learn how you can use the Content History feature of Strapi 5 to browse and restore previous versions of documents from the Content Manager.
 displayed_sidebar: cmsSidebar
-toc_max_heading_level: 5
 tags:
  - content manager
  - content history
@@ -27,9 +26,7 @@ The Content History feature, in the <Icon name="feather" /> Content Manager, giv
 
 <Guideflow lightId="9r2m2y1sok" darkId="er566mli6p"/>
 
-## How versions are created
-
-A history version is only created when a document is modified through the <Icon name="feather" /> Content Manager in the admin panel. Content modified in any other way does not appear in the Content History of the document.
+A version is only created when a document is modified through the <Icon name="feather" /> Content Manager in the admin panel. Content modified in any other way does not appear in the Content History of the document.
 
 | Content is modified through | Version created |
 |-----------------------------|-----------------|
@@ -46,6 +43,47 @@ Content History is not a record of every change made to a document. Documents wr
 
 To trace the actions performed by users of the admin panel, use [Audit Logs](/cms/features/audit-logs).
 :::
+
+## Configuration
+
+Content History is available by default with the required plan and needs no activation. The only configurable aspect is how long versions are kept before they are deleted.
+
+Content History is not a permanent archive. Versions are deleted automatically: a job runs once a day, at midnight, and permanently deletes every version older than the retention period. Versions deleted by this job cannot be recovered from the Content History interface.
+
+Regardless of the plan, versions are kept for a maximum of 90 days. This period is counted from the creation date of each version.
+
+### Code-based configuration
+
+The retention period can be shortened, but never extended, with the [`history.retentionDays`](/cms/configurations/admin-panel#content-history) parameter of the `/config/admin` file. When both the license and the configuration file define a value, the lower of the 2 applies.
+
+<Tabs groupId="js-ts">
+<TabItem value="js" label="JavaScript">
+
+```js title="/config/admin.js"
+module.exports = ({ env }) => ({
+  // … other configuration properties
+  history: {
+    retentionDays: 30,
+  },
+});
+```
+
+</TabItem>
+<TabItem value="ts" label="TypeScript">
+
+```ts title="/config/admin.ts"
+export default ({ env }) => ({
+  // … other configuration properties
+  history: {
+    retentionDays: 30,
+  },
+});
+```
+
+</TabItem>
+</Tabs>
+
+There is no equivalent setting in the admin panel: the retention period can only be shortened from the `/config/admin` file.
 
 ## Usage
 
@@ -93,11 +131,3 @@ sources={{
   dark:'/img/assets/content-manager/restoring-content-history_DARK.png',
 }}
 />
-
-## Version retention
-
-Content History is not a permanent archive. Versions are deleted automatically: a job runs once a day, at midnight, and permanently deletes every version older than the retention period. Versions deleted by this job cannot be recovered from the Content History interface.
-
-Regardless of the plan, versions are kept for a maximum of 90 days. This period is counted from the creation date of each version.
-
-The retention period can be shortened, but never extended, with the [`history.retentionDays`](/cms/configurations/admin-panel#content-history) parameter of the `/config/admin` file. When both the license and the configuration file define a value, the lower of the two applies.

--- a/docusaurus/docs/cms/features/content-history.md
+++ b/docusaurus/docs/cms/features/content-history.md
@@ -13,7 +13,7 @@ tags:
 <GrowthBadge /> <EnterpriseBadge/> <VersionBadge version="5.0.0" />
 
 <Tldr>
-Content History stores previous document versions so editors can compare and restore earlier states from the Content Manager. This documentation explains how to browse and restore workflows for quick rollback of mistakes.
+Content History stores previous document versions so editors can compare and restore earlier states from the Content Manager. This documentation explains how to browse and restore workflows for quick rollback of mistakes. Versions are only created for content edited in the Content Manager, and are kept for a maximum of 90 days.
 </Tldr>
 
 The Content History feature, in the <Icon name="feather" /> Content Manager, gives you the ability to browse and restore previous versions of documents created with the [Content Manager](/cms/features/content-manager).

--- a/docusaurus/docs/cms/features/content-history.md
+++ b/docusaurus/docs/cms/features/content-history.md
@@ -38,7 +38,7 @@ A version is only created when a document is modified through the <Icon name="fe
 | [Cron jobs](/cms/configurations/cron) | No |
 | The `strapi import` and `strapi transfer` commands (see [Data management](/cms/features/data-management)) | No |
 
-:::caution
+:::note
 Content History is not a record of every change made to a document. Documents written programmatically, such as those created by a migration script or an integration calling the REST API, have no corresponding version, and a document can therefore differ from the most recent version listed in its Content History.
 
 To trace the actions performed by users of the admin panel, use [Audit Logs](/cms/features/audit-logs).
@@ -48,10 +48,10 @@ To trace the actions performed by users of the admin panel, use [Audit Logs](/cm
 
 The only configurable aspect is how long versions are kept before they are deleted.
 
-:::caution
-Content History is not a permanent archive. Versions are deleted automatically: a job runs once a day, at midnight, and permanently deletes every version older than the retention period. Versions deleted by this job cannot be recovered from the Content History interface.
+Content History is not a permanent archive. Versions are deleted automatically: a job runs once a day, at midnight, and deletes every version older than the retention period. Regardless of the plan, versions are kept for a maximum of 90 days, counted from the creation date of each version.
 
-Regardless of the plan, versions are kept for a maximum of 90 days. This period is counted from the creation date of each version.
+:::caution
+Versions deleted by the retention job cannot be recovered from the Content History interface.
 :::
 
 ### Code-based configuration

--- a/docusaurus/docs/cms/features/content-history.md
+++ b/docusaurus/docs/cms/features/content-history.md
@@ -26,17 +26,7 @@ The Content History feature, in the <Icon name="feather" /> Content Manager, giv
 
 <Guideflow lightId="9r2m2y1sok" darkId="er566mli6p"/>
 
-A version is only created when a document is modified through the <Icon name="feather" /> Content Manager in the admin panel. Content modified in any other way does not appear in the Content History of the document.
-
-| Content is modified through | Version created |
-|-----------------------------|-----------------|
-| The [Content Manager](/cms/features/content-manager) in the admin panel | Yes |
-| The [REST API](/cms/api/rest) | No |
-| The [GraphQL API](/cms/api/graphql) | No |
-| The [Document Service API](/cms/api/document-service), for instance `strapi.documents()` called from application code | No |
-| [Lifecycle hooks](/cms/backend-customization/models#lifecycle-hooks) | No |
-| [Cron jobs](/cms/configurations/cron) | No |
-| The `strapi import` and `strapi transfer` commands (see [Data management](/cms/features/data-management)) | No |
+A version is only created when a document is modified through the <Icon name="feather" /> Content Manager in the admin panel. Content modified in any other way does not appear in the Content History of the document: this includes the REST API, the GraphQL API, the Document Service API, lifecycle hooks, cron jobs, and the `strapi import` and `strapi transfer` commands.
 
 :::note
 Content History is not a record of every change made to a document. Documents written programmatically, such as those created by a migration script or an integration calling the REST API, have no corresponding version, and a document can therefore differ from the most recent version listed in its Content History.

--- a/docusaurus/docs/cms/features/content-history.md
+++ b/docusaurus/docs/cms/features/content-history.md
@@ -46,11 +46,13 @@ To trace the actions performed by users of the admin panel, use [Audit Logs](/cm
 
 ## Configuration
 
-Content History is available by default with the required plan and needs no activation. The only configurable aspect is how long versions are kept before they are deleted.
+The only configurable aspect is how long versions are kept before they are deleted.
 
+:::caution
 Content History is not a permanent archive. Versions are deleted automatically: a job runs once a day, at midnight, and permanently deletes every version older than the retention period. Versions deleted by this job cannot be recovered from the Content History interface.
 
 Regardless of the plan, versions are kept for a maximum of 90 days. This period is counted from the creation date of each version.
+:::
 
 ### Code-based configuration
 

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -289,6 +289,11 @@ const sidebars = {
             },
             {
               type: 'link',
+              label: 'Content History',
+              href: '/cms/configurations/admin-panel#content-history',
+            },
+            {
+              type: 'link',
               label: 'Feature flags',
               href: '/cms/configurations/admin-panel#feature-flags',
             },


### PR DESCRIPTION
This PR documents two Content History behaviors that the documentation did not cover at all, both of which support currently has nothing to cite when customers ask.

- Adds a "How versions are created" section stating that versions are only created for content edited through the Content Manager, with a table covering the REST API, the GraphQL API, the Document Service API, lifecycle hooks, cron jobs, and the `strapi import` and `strapi transfer` commands
- Adds a "Version retention" section covering the daily deletion job, the fact that expired versions are permanently deleted and cannot be recovered from the interface, and the 90-day maximum
- Documents the `history.retentionDays` parameter on the admin panel configuration page, mirroring the existing `auditLogs.retentionDays` entry, and adds it to the full configuration examples
- Removes a misplaced copy of the audit logs retention note that sat under the Transfer tokens section, where it referred to an unrelated parameter

Behavior was verified against `packages/core/content-manager/server/src/history` in strapi/strapi.