### PR TITLE
Clarify sizeLimit applies to file replacement operations

### DIFF
--- a/docusaurus/docs/cms/configurations/media-library-providers/local-upload.md
+++ b/docusaurus/docs/cms/configurations/media-library-providers/local-upload.md
@@ -53,7 +53,7 @@ Providers configuration is defined in [the `/config/plugins` file](/cms/configur
 * `provider` to define the provider name (i.e., `local`)
 * `providerOptions` to define options that are passed down during the construction of the provider.
 
-For the local Upload provider, `providerOptions` accepts only one parameter: `sizeLimit`, which must be a number. The unit is bytes, and the default value is 1000000000 (1 GB). When increasing this limit, also configure the body parser middleware `maxFileSize` so the file can be sent and processed (see [Media Library documentation](/cms/features/media-library#max-file-size) for details).
+For the local Upload provider, `providerOptions` accepts only one parameter: `sizeLimit`, which must be a number. The unit is bytes, and the default value is 1000000000 (1 GB). The `sizeLimit` is enforced for both file uploads and file replacements. When increasing this limit, also configure the body parser middleware `maxFileSize` so the file can be sent and processed (see [Media Library documentation](/cms/features/media-library#max-file-size) for details).
 
 The following is an example configuration:
 


### PR DESCRIPTION
This PR updates documentation based on https://github.com/strapi/strapi/pull/27414.

The sizeLimit parameter now enforces the file size limit for both file uploads and file replacements. Updated the local upload provider documentation to clarify this behavior.

Generated automatically by the docs self-healing workflow (micro-edit).
Review before merging.