### PR TITLE
Automate docs issue triage into PR creation, Slack ping, or redirect

### DIFF
--- a/.github/prompts/issue-to-pr-triage.md
+++ b/.github/prompts/issue-to-pr-triage.md
@@ -1,0 +1,229 @@
+# Issue Triage & PR Creation (Sonnet)
+
+You triage a single documentation issue and act on it in one pass: you classify it,
+then you carry out the action for that classification.
+
+## Environment
+
+- `$DOC_REPO` — local checkout of `strapi/documentation` (you are already in it)
+- `$ISSUE_NUMBER` — the issue number
+- `$ISSUE_TITLE` — the issue title
+- `$ISSUE_BODY_FILE` — path to a file containing the cleaned issue body
+- `$KAPA_ANSWER_FILE` — path to a file containing the answer Kapa already posted
+  as a comment on the issue
+- `$KAPA_SOURCES_FILE` — path to a JSON file with the documentation pages Kapa
+  found relevant (`[{title, url}, ...]`). On a manual re-run this may be an empty
+  array; in that case the relevant links are still listed inside
+  `$KAPA_ANSWER_FILE`, under "Relevant documentation".
+- `$FORCE_DECISION` — either `auto` (you decide) or one of the three decision
+  keywords, in which case you skip classification and go straight to that action
+- `GH_TOKEN` — authenticated `gh` CLI
+
+## Step 1 — Read the context
+
+1. Read `$ISSUE_BODY_FILE`, `$KAPA_ANSWER_FILE` and `$KAPA_SOURCES_FILE`.
+2. Read `$DOC_REPO/claude-plugins/inki/references/git-rules.md` — binding for any
+   branch, commit, PR title or PR description you produce.
+3. Kapa's answer is your main routing signal: it already contains a technical
+   analysis and the pages it considered relevant. Trust it as a starting point,
+   but verify against the actual files — Kapa can cite a page that does not cover
+   what the issue is really about.
+
+## Step 2 — Check idempotence (always, before anything else)
+
+```bash
+gh pr list --repo strapi/documentation --state open --limit 200 \
+  --json number,body --jq '[.[] | select(.body | test("Fixes #'"$ISSUE_NUMBER"'\\b"))] | length'
+```
+
+If the count is greater than 0, an open PR already handles this issue. Write the
+result file with `"decision": "already-handled"` and stop. Do not comment, label,
+or open anything.
+
+## Step 3 — Classify
+
+If `$FORCE_DECISION` is not `auto`, use it as your decision and skip to Step 4.
+
+Otherwise choose exactly one:
+
+**`create-pr`** — the documentation is wrong, outdated or incomplete, and the fix
+is small and localized. A missing note, a broken code sample, an incorrect
+instruction, a missing parameter in a table. You can name the target file and the
+change fits comfortably in a few lines.
+
+**`needs-writing`** — a real documentation gap that needs authoring: a missing
+section, a missing page, or a restructuring. Typically `[Request]: Document X`
+issues. Also use this whenever `create-pr` would be a stretch (see the fallback
+rule in Step 4).
+
+**`not-docs`** — not a documentation problem. A product bug in Strapi itself, a
+feature request, a usage question already answered by Kapa's comment, or spam.
+
+Judgment guidance:
+
+- A bug report *about product behavior* is `not-docs` even when the reporter
+  frames it as a docs issue. A bug report about **behavior that is real and
+  correct but undocumented or documented wrongly** is `create-pr` or
+  `needs-writing`. Issue #3384 is a good example of the latter: the cookie-path
+  behavior is intended, but the page failed to mention it.
+- If Kapa's answer says "this is intended behavior" **and** points at a page that
+  should have said so, that is a documentation fix, not `not-docs`.
+- When genuinely torn between `create-pr` and `needs-writing`, choose
+  `needs-writing`. A human writing something small is cheap; a wrong PR opened in
+  the maintainer's name is not.
+- When genuinely torn between `not-docs` and either other branch, do **not**
+  choose `not-docs`. It starts a 7-day auto-close clock, so a false positive there
+  is the most costly mistake you can make.
+
+## Step 4 — Act
+
+### If `create-pr`
+
+First, confirm the fix really is obvious. **Fall back to `needs-writing`** (do not
+open a PR; continue at the `needs-writing` section) if any of these holds:
+
+- You cannot identify a clear target file.
+- The change would touch more than **3 files**.
+- The change would exceed roughly **50 changed lines**.
+- You would need to invent product behavior you cannot verify in the docs or in
+  Kapa's answer.
+
+Never modify these generated files:
+`docusaurus/static/llms.txt`, `docusaurus/static/llms-full.txt`,
+`docusaurus/static/llms-code.txt`.
+
+Then edit the documentation files under `$DOC_REPO/docusaurus/docs/`, and:
+
+```bash
+cd $DOC_REPO
+BRANCH_NAME="<cms|cloud|repo>/<short-kebab-description>"
+git checkout -b "$BRANCH_NAME"
+git add <the files you edited>     # never `git add .` — never stage generated files
+git commit -m "<imperative, <=80 chars, no conventional prefix>"
+git push -u origin "$BRANCH_NAME"
+
+CONFIG=".github/workflows/config.json"
+ASSIGNEE=$(jq -r '.["issue-to-pr"].assignee' "$CONFIG")
+LABEL=$(jq -r '.["issue-to-pr"].labels[0]' "$CONFIG")
+
+gh pr create \
+  --repo strapi/documentation \
+  --title "<action verb or specific noun phrase, capitalized, <=80 chars>" \
+  --body "This PR <what changed and why, 1-3 sentences, flat text>.
+
+Reported in #$ISSUE_NUMBER.
+
+Fixes #$ISSUE_NUMBER" \
+  --draft \
+  --label "$LABEL" \
+  --assignee "$ASSIGNEE"
+```
+
+Branch prefix: `cms/` if you only touched `docusaurus/docs/cms/`, `cloud/` if only
+`docusaurus/docs/cloud/`, `repo/` otherwise or if both.
+
+PR title rules (from `git-rules.md`): action verb or specific noun phrase,
+capitalized, ≤ 80 characters. **No** `feat:` / `chore:` / `fix:` prefix, no emoji,
+no issue reference in the title.
+
+PR description rules: starts with "This PR", flat text, no `##` headings, no test
+plan, no checklist, 1–3 sentences. `Fixes #<issue>` on the last line — this is
+what closes the issue when the PR is merged, so it must be present and spelled
+exactly that way.
+
+`git-rules.md` says "Open PRs only when explicitly requested". This workflow is
+that standing authorization — do not self-block on that rule here.
+
+Then comment on the issue with the PR link:
+
+```bash
+gh issue comment "$ISSUE_NUMBER" --repo strapi/documentation --body "$(cat <<'BODY'
+Thanks for reporting this! A documentation fix is on the way: <PR_URL>
+
+This issue will be closed automatically once that pull request is merged.
+BODY
+)"
+```
+
+Finally, return to a clean state so the run does not leak into other steps:
+
+```bash
+git checkout main && git clean -fd && git reset --hard origin/main
+```
+
+### If `needs-writing`
+
+Write nothing. Create no branch, no PR, no comment, no label. The Slack
+notification is the whole point of this branch.
+
+Fill `suggested_pages` in the result file with the 1–3 documentation paths where
+the content should most likely go, and make `reason` specific enough to be useful
+without opening the issue — say what is missing and where, not just "needs work".
+
+### If `not-docs`
+
+Post the redirect comment and add the label. Do **not** close the issue — a
+separate scheduled workflow closes it after 7 days, which leaves a veto window.
+
+```bash
+gh issue comment "$ISSUE_NUMBER" --repo strapi/documentation --body "$(cat <<'BODY'
+Thanks for taking the time to report this!
+
+This looks like it concerns Strapi itself rather than the documentation, so the
+team who can help is in a different repository. Could you open it at
+https://github.com/strapi/strapi/issues — that way it reaches the right people.
+
+If you think this really is a documentation problem and it landed here correctly,
+just say so in a comment and a maintainer will take another look.
+BODY
+)"
+
+gh issue edit "$ISSUE_NUMBER" --repo strapi/documentation --add-label "issue: not docs"
+```
+
+Adapt the middle paragraph when the issue is a feature request (point to
+https://feedback.strapi.io instead) or a usage question already answered by Kapa's
+comment (point to https://discord.strapi.io).
+
+## Step 5 — Write the result file
+
+Always write `/tmp/issue-triage-result.json`, whatever the decision, using a bash
+heredoc. Do **not** use the `Write` tool — it may be denied.
+
+```bash
+cat <<'EOF' > /tmp/issue-triage-result.json
+{
+  "issue_number": 3384,
+  "issue_title": "[Bug]: Admin panel customization: changing admin.url…",
+  "decision": "create-pr",
+  "reason": "Missing mention of auth.cookie.path on the host-port-path page",
+  "files": ["cms/admin-panel-customization/host-port-path.md"],
+  "suggested_pages": [],
+  "pr_url": "https://github.com/strapi/documentation/pull/3401",
+  "pr_title": "Document auth.cookie.path requirement when customizing admin.url"
+}
+EOF
+```
+
+Field rules:
+
+- `decision` — one of `create-pr`, `needs-writing`, `not-docs`, `already-handled`.
+  Never `auto`: that input means "you decide", not a decision.
+- `reason` — one sentence, specific. This is what the maintainer reads in Slack.
+- `files` — populated for `create-pr` only; paths relative to `docusaurus/docs/`.
+- `suggested_pages` — populated for `needs-writing` only.
+- `pr_url`, `pr_title` — `create-pr` only; empty strings otherwise.
+
+If you fell back from `create-pr` to `needs-writing`, record `needs-writing` and
+say why in `reason` (for example: "fix would span 6 files — needs a human").
+
+## Rules
+
+- **One issue per run.** Never touch any other issue or PR.
+- **Never push to `main`.** Never force-push. Never delete a branch.
+- **Never close an issue.** `create-pr` closes via `Fixes #`; `not-docs` closes via
+  the scheduled workflow.
+- **Read-only on every repository other than `strapi/documentation`.**
+- **Never stage generated files** (`llms.txt`, `llms-full.txt`, `llms-code.txt`).
+- **Always write the result file**, even on failure — an absent file is reported as
+  a pipeline error.

--- a/.github/workflows/auto-respond-issues.yml
+++ b/.github/workflows/auto-respond-issues.yml
@@ -9,10 +9,22 @@ on:
         description: 'Number of issue to handle'
         required: true
         type: string
+      force_branch:
+        description: 'Force a triage decision instead of letting the model decide'
+        required: false
+        type: choice
+        default: 'auto'
+        options:
+          - auto
+          - create-pr
+          - needs-writing
+          - not-docs
 
 permissions:
   issues: write
-  contents: read
+  contents: write
+  pull-requests: write
+  id-token: write
 
 jobs:
   auto-respond:
@@ -20,6 +32,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          # PAT so the triage stage can push a branch and open a PR attributed
+          # to the maintainer (same approach as docs-self-healing.yml).
+          token: ${{ secrets.PAT_TOKEN_PIWI }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -62,16 +78,51 @@ jobs:
             }
             
             console.log(`Processing issue #${issueNumber}: ${issueTitle}`);
-            
+
             // Skip if issue is from a maintainer/collaborator
-            const collaborators = ['pwizla']; 
+            const collaborators = ['pwizla'];
             const isTesting = issueTitle.includes('[TEST]') || issueBody.includes('testing-auto-response');
-      
+
             if (collaborators.includes(issueAuthor) && !isTesting) {
               console.log('Issue from maintainer, skipping auto-response');
               return;
             }
-            
+
+            // On a manual re-run, reuse the Kapa answer already posted instead of
+            // posting a duplicate comment. Lets a dispatch (optionally with
+            // force_branch) re-trigger only the triage stage. Placed after the
+            // maintainer check so a maintainer-authored issue is still skipped.
+            const isManual = Boolean(context.payload.inputs?.issue_number);
+            if (isManual) {
+              const { data: existing } = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                per_page: 100
+              });
+              const kapaComment = existing.find(c =>
+                c.user.login === 'github-actions[bot]' &&
+                c.body.includes("I've analyzed your question")
+              );
+              if (kapaComment) {
+                console.log('Existing Kapa comment found, reusing it (no new comment posted)');
+                const fs = require('fs');
+                const cleaned = (issueBody || '')
+                  .replace(/<!--[\s\S]*?-->/g, '')
+                  .replace(/\n_No response_\s*$/gm, '')
+                  .replace(/\n{3,}/g, '\n\n')
+                  .trim();
+                fs.writeFileSync('/tmp/issue-body.txt', cleaned);
+                fs.writeFileSync('/tmp/kapa-answer.txt', kapaComment.body);
+                fs.writeFileSync('/tmp/kapa-sources.json', '[]');
+                core.setOutput('kapa_succeeded', 'true');
+                core.setOutput('issue_number', String(issueNumber));
+                core.setOutput('issue_title', issueTitle);
+                return;
+              }
+              console.log('No existing Kapa comment, calling Kapa normally');
+            }
+
             // Prepare the enhanced query for Kapa AI
             const cleanedBody = issueBody
               .replace(/<!--[\s\S]*?-->/g, '') // Remove HTML comments
@@ -212,7 +263,23 @@ jobs:
                 issue_number: issueNumber,
                 body: responseBody
               });
-              
+
+              // Export context for the triage stage. Kapa succeeded, so the
+              // triage stage has both a technical analysis and the pages Kapa
+              // considered relevant — its main routing signal.
+              const fs = require('fs');
+              fs.writeFileSync('/tmp/issue-body.txt', finalBody);
+              fs.writeFileSync('/tmp/kapa-answer.txt', aiResponse);
+              fs.writeFileSync('/tmp/kapa-sources.json', JSON.stringify(
+                sources
+                  .filter(s => s.source_url && s.source_url.startsWith('http'))
+                  .map(s => ({ title: s.title || 'Documentation', url: s.source_url })),
+                null, 2
+              ));
+              core.setOutput('kapa_succeeded', 'true');
+              core.setOutput('issue_number', String(issueNumber));
+              core.setOutput('issue_title', issueTitle);
+
               // Add labels based on enhanced content analysis
               const labels = [];
               const titleLower = issueTitle.toLowerCase();
@@ -307,3 +374,173 @@ jobs:
         env:
           KAPA_API_TOKEN: ${{ secrets.KAPA_API_TOKEN }}
           KAPA_PROJECT_ID: ${{ secrets.KAPA_PROJECT_ID }}
+
+      # ── Triage & act (Sonnet) ──
+      # Only runs when Kapa succeeded: its answer and relevant_sources are the
+      # routing signal. On Kapa failure the fallback comment above is the whole
+      # response and the issue falls back to the manual path.
+      - name: Load triage prompt
+        if: steps.process-issue.outputs.kapa_succeeded == 'true'
+        id: load-triage-prompt
+        run: |
+          echo "prompt<<PROMPT_EOF" >> $GITHUB_OUTPUT
+          cat .github/prompts/issue-to-pr-triage.md >> $GITHUB_OUTPUT
+          echo "PROMPT_EOF" >> $GITHUB_OUTPUT
+
+      - name: Run triage and act (Sonnet)
+        if: steps.process-issue.outputs.kapa_succeeded == 'true'
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_SELF_HEALING_DOCS_API_KEY }}
+          github_token: ${{ secrets.PAT_TOKEN_PIWI }}
+          prompt: ${{ steps.load-triage-prompt.outputs.prompt }}
+          claude_args: '--model claude-sonnet-4-6 --max-turns 50 --allowedTools "Bash,Read,Write,Edit,Glob,Grep"'
+          show_full_output: true
+        env:
+          DOC_REPO: ${{ github.workspace }}
+          GH_TOKEN: ${{ secrets.PAT_TOKEN_PIWI }}
+          ISSUE_NUMBER: ${{ steps.process-issue.outputs.issue_number }}
+          ISSUE_TITLE: ${{ steps.process-issue.outputs.issue_title }}
+          ISSUE_BODY_FILE: /tmp/issue-body.txt
+          KAPA_ANSWER_FILE: /tmp/kapa-answer.txt
+          KAPA_SOURCES_FILE: /tmp/kapa-sources.json
+          FORCE_DECISION: ${{ inputs.force_branch || 'auto' }}
+
+      - name: Report triage result
+        if: always() && steps.process-issue.outputs.kapa_succeeded == 'true'
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL: ${{ secrets.SLACK_DOCUMENTATION_OPS_CHANNEL_ID }}
+          ISSUE_NUMBER: ${{ steps.process-issue.outputs.issue_number }}
+          ISSUE_TITLE: ${{ steps.process-issue.outputs.issue_title }}
+        run: |
+          # Join arguments with real newlines. Avoids indented multi-line string
+          # literals, which would leak leading spaces into the Slack message.
+          # $(...) strips the trailing newline, so no extra trimming is needed.
+          slack_lines() { printf '%s\n' "$@" ; }
+
+          RESULT_FILE="/tmp/issue-triage-result.json"
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          DATE=$(date -u '+%Y-%m-%d %H:%M UTC')
+          ISSUE_URL="${{ github.server_url }}/${{ github.repository }}/issues/${ISSUE_NUMBER}"
+
+          # Truncate the title for Slack readability
+          SHORT_TITLE=$(printf '%s' "$ISSUE_TITLE" | cut -c1-70)
+          if [ "${#ISSUE_TITLE}" -gt 70 ]; then SHORT_TITLE="${SHORT_TITLE}…"; fi
+          ISSUE_LINK="<${ISSUE_URL}|#${ISSUE_NUMBER} — ${SHORT_TITLE}>"
+
+          echo "## Issue triage" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          if [ ! -f "$RESULT_FILE" ]; then
+            DECISION="error"
+            REASON="Triage produced no result file (check the run for max-turns, API or SDK errors)"
+          elif ! jq -e . "$RESULT_FILE" > /dev/null 2>&1; then
+            DECISION="error"
+            REASON="Triage wrote a result file that is not valid JSON"
+          else
+            DECISION=$(jq -r '.decision // "error"' "$RESULT_FILE")
+            REASON=$(jq -r '.reason // "no reason given"' "$RESULT_FILE")
+          fi
+
+          case "$DECISION" in
+            create-pr)
+              PR_URL=$(jq -r '.pr_url // ""' "$RESULT_FILE")
+              PR_TITLE=$(jq -r '.pr_title // ""' "$RESULT_FILE")
+              FILES=$(jq -r '(.files // []) | join(", ")' "$RESULT_FILE")
+              PR_NUMBER=$(printf '%s' "$PR_URL" | sed -n 's#.*/pull/\([0-9]*\).*#\1#p')
+              if [ -z "$PR_URL" ]; then
+                # Claimed create-pr but recorded no PR URL: the PR creation
+                # failed. Report an error rather than a broken Slack link.
+                MSG=$(slack_lines \
+                  ":pepe_alarm: *Docs issue triage FAILED* (${DATE})" \
+                  "Issue: ${ISSUE_LINK}" \
+                  "Decided \`create-pr\` but recorded no PR URL — the PR was probably not created." \
+                  "<${RUN_URL}|View run>")
+                {
+                  echo "**Decision:** \`create-pr\`, but no PR URL was recorded"
+                  echo ""
+                  echo "- Issue: [#${ISSUE_NUMBER}](${ISSUE_URL})"
+                  echo "- Reason: ${REASON}"
+                } >> $GITHUB_STEP_SUMMARY
+              else
+                MSG=$(slack_lines \
+                  ":noted: *Docs issue → PR* (${DATE})" \
+                  "Issue: ${ISSUE_LINK}" \
+                  "PR created: <${PR_URL}|#${PR_NUMBER} — ${PR_TITLE}>" \
+                  "Files: ${FILES}" \
+                  "<${RUN_URL}|View run>")
+                {
+                  echo "**Decision:** \`create-pr\`"
+                  echo ""
+                  echo "- Issue: [#${ISSUE_NUMBER}](${ISSUE_URL})"
+                  echo "- PR: [${PR_TITLE}](${PR_URL})"
+                  echo "- Files: ${FILES}"
+                  echo "- Reason: ${REASON}"
+                } >> $GITHUB_STEP_SUMMARY
+              fi
+              ;;
+            needs-writing)
+              PAGES=$(jq -r '(.suggested_pages // []) | join(", ")' "$RESULT_FILE")
+              MSG=$(slack_lines \
+                ":frog_detective: *Docs issue needs human writing* (${DATE})" \
+                "Issue: ${ISSUE_LINK}" \
+                "Reason: ${REASON}" \
+                "Suggested pages: ${PAGES:-none identified}" \
+                "<${RUN_URL}|View run>")
+              {
+                echo "**Decision:** \`needs-writing\`"
+                echo ""
+                echo "- Issue: [#${ISSUE_NUMBER}](${ISSUE_URL})"
+                echo "- Reason: ${REASON}"
+                echo "- Suggested pages: ${PAGES:-none identified}"
+              } >> $GITHUB_STEP_SUMMARY
+              ;;
+            not-docs)
+              CLOSE_DATE=$(date -u -d '+7 days' '+%Y-%m-%d' 2>/dev/null || date -u -v+7d '+%Y-%m-%d')
+              MSG=$(slack_lines \
+                ":frog_shrug: *Docs issue classified as not-docs* (${DATE})" \
+                "Issue: ${ISSUE_LINK}" \
+                "Reason: ${REASON}" \
+                "Redirected to strapi/strapi. Auto-closing on ${CLOSE_DATE} unless the \`issue: not docs\` label is removed." \
+                "<${RUN_URL}|View run>")
+              {
+                echo "**Decision:** \`not-docs\`"
+                echo ""
+                echo "- Issue: [#${ISSUE_NUMBER}](${ISSUE_URL})"
+                echo "- Reason: ${REASON}"
+                echo "- Auto-closing on ${CLOSE_DATE} unless the label is removed"
+              } >> $GITHUB_STEP_SUMMARY
+              ;;
+            already-handled)
+              echo "Issue #${ISSUE_NUMBER} already has an open PR — no action, no notification."
+              {
+                echo "**Decision:** \`already-handled\` — an open PR already references this issue."
+              } >> $GITHUB_STEP_SUMMARY
+              exit 0
+              ;;
+            *)
+              MSG=$(slack_lines \
+                ":pepe_alarm: *Docs issue triage FAILED* (${DATE})" \
+                "Issue: ${ISSUE_LINK}" \
+                "${REASON}" \
+                "<${RUN_URL}|View run>")
+              {
+                echo "**Decision:** failed"
+                echo ""
+                echo "- Issue: [#${ISSUE_NUMBER}](${ISSUE_URL})"
+                echo "- ${REASON}"
+              } >> $GITHUB_STEP_SUMMARY
+              ;;
+          esac
+
+          if [ -z "$SLACK_BOT_TOKEN" ] || [ -z "$SLACK_CHANNEL" ]; then
+            echo "Slack not configured, skipping notification"
+            exit 0
+          fi
+
+          curl -s -X POST "https://slack.com/api/chat.postMessage" \
+            -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+            -H "Content-type: application/json; charset=utf-8" \
+            -d "$(jq -n --arg channel "$SLACK_CHANNEL" --arg text "$MSG" '{channel: $channel, text: $text}')" \
+            > /dev/null || echo "Slack notification failed (non-blocking)"

--- a/.github/workflows/close-stale-not-docs.yml
+++ b/.github/workflows/close-stale-not-docs.yml
@@ -1,0 +1,112 @@
+name: Close stale not-docs issues
+
+# Companion to the triage stage of auto-respond-issues.yml.
+#
+# When an issue is classified `not-docs`, the triage stage posts a redirect
+# comment and adds the `issue: not docs` label but does NOT close the issue.
+# This workflow closes it 7 days later, which leaves a veto window: removing
+# the label (or closing/relabelling by hand) cancels the automatic close.
+#
+# A misclassification is publicly visible and unwelcoming to a contributor, so
+# no issue is ever closed in the same run that classified it.
+
+on:
+  schedule:
+    - cron: '0 6 * * *' # 06:00 UTC daily
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'List what would be closed without closing anything'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  issues: write
+
+env:
+  STALE_LABEL: 'issue: not docs'
+  GRACE_DAYS: 7
+
+jobs:
+  close-stale:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close issues labeled not-docs for more than the grace period
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+
+          CUTOFF=$(date -u -d "${GRACE_DAYS} days ago" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \
+                || date -u -v-"${GRACE_DAYS}"d '+%Y-%m-%dT%H:%M:%SZ')
+          echo "Closing issues labeled '${STALE_LABEL}' on or before ${CUTOFF}"
+
+          echo "## Stale not-docs issues" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          NUMBERS=$(gh issue list --repo "$REPO" --state open \
+            --label "$STALE_LABEL" --limit 100 --json number --jq '.[].number')
+
+          if [ -z "$NUMBERS" ]; then
+            echo "No open issues carry the label."
+            echo "No open issues carry the \`${STALE_LABEL}\` label." >> $GITHUB_STEP_SUMMARY
+            exit 0
+          fi
+
+          CLOSED=0
+          WAITING=0
+
+          for N in $NUMBERS; do
+            # Use the timeline's most recent `labeled` event for this label, not
+            # the issue's updated_at: later comments must not reset the clock.
+            # --slurp combines the pages into one array before filtering.
+            # Without it, `gh --paginate --jq` applies the filter per page and
+            # would emit one `max` per page (a multi-line value). --slurp and
+            # --jq are mutually exclusive, hence the pipe to standalone jq.
+            # `|| true` so a transient API error on one issue does not abort the
+            # loop and silently skip every remaining issue (set -e is active).
+            LABELED_AT=$(gh api "repos/${REPO}/issues/${N}/timeline?per_page=100" \
+              --paginate --slurp -H "Accept: application/vnd.github+json" \
+              | jq -r --arg label "$STALE_LABEL" \
+                '[.[][] | select(.event == "labeled" and .label.name == $label) | .created_at] | max // empty' \
+              || true)
+
+            if [ -z "$LABELED_AT" ]; then
+              echo "#${N}: label present but no labeled event found, skipping"
+              continue
+            fi
+
+            if [[ "$LABELED_AT" > "$CUTOFF" ]]; then
+              echo "#${N}: labeled ${LABELED_AT}, still within grace period"
+              WAITING=$((WAITING + 1))
+              continue
+            fi
+
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "#${N}: would be closed (labeled ${LABELED_AT})"
+              echo "- Would close [#${N}](https://github.com/${REPO}/issues/${N}) — labeled ${LABELED_AT}" >> $GITHUB_STEP_SUMMARY
+              CLOSED=$((CLOSED + 1))
+              continue
+            fi
+
+            if gh issue close "$N" --repo "$REPO" --reason "not planned" \
+              --comment "Closing automatically: this was identified as not being a documentation issue ${GRACE_DAYS} days ago and no one objected. If that was a mistake, comment here and a maintainer will reopen it."
+            then
+              echo "#${N}: closed (labeled ${LABELED_AT})"
+              echo "- Closed [#${N}](https://github.com/${REPO}/issues/${N}) — labeled ${LABELED_AT}" >> $GITHUB_STEP_SUMMARY
+              CLOSED=$((CLOSED + 1))
+            else
+              echo "#${N}: close failed, will retry on the next run"
+              echo "- ⚠️ Failed to close [#${N}](https://github.com/${REPO}/issues/${N})" >> $GITHUB_STEP_SUMMARY
+            fi
+          done
+
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "**Dry run** — ${CLOSED} issue(s) would be closed, ${WAITING} still in the grace period." >> $GITHUB_STEP_SUMMARY
+          else
+            echo "${CLOSED} issue(s) closed, ${WAITING} still in the grace period." >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/config.json
+++ b/.github/workflows/config.json
@@ -8,5 +8,10 @@
     "assignee": "pwizla",
     "labels": ["auto-doc-healing"],
     "title_prefix": ""
+  },
+  "issue-to-pr": {
+    "assignee": "pwizla",
+    "labels": ["auto-doc-healing"],
+    "title_prefix": ""
   }
 }


### PR DESCRIPTION
This PR extends the auto-respond workflow so that, after the Kapa answer is posted, each new documentation issue is routed into one of three branches.

- `create-pr` — the docs are wrong or incomplete and the fix is small and localized: a draft PR is opened and linked from the issue, and `Fixes #<issue>` closes the issue on merge
- `needs-writing` — a real documentation gap needing authoring: nothing is written, Slack is pinged with the suggested target pages
- `not-docs` — not a documentation problem: a redirect comment to strapi/strapi is posted and the `issue: not docs` label is added

Chains on Kapa's answer and relevant_sources as the routing signal, so the stage is skipped entirely when the Kapa call fails. A single Sonnet call both classifies and acts, and falls back to `needs-writing` whenever the fix would span more than 3 files or roughly 50 lines, so "obvious" stays honest.

Non-documentation issues are never closed in the same run that classifies them: a second scheduled workflow closes them 7 days later, so removing the label vetoes the close. Manual dispatch accepts a `force_branch` choice and reuses an existing Kapa comment instead of posting a duplicate.

Note that this widens the workflow permissions to `contents: write` and `pull-requests: write` and switches the checkout to a PAT, both required for branch and PR creation. The new cron becomes active on merge; no open issue currently carries the `issue: not docs` label, so nothing is closed retroactively.