### PR TITLE
Document auth.cookie.path requirement when customizing admin.url

### DIFF
--- a/docusaurus/docs/cms/admin-panel-customization/host-port-path.md
+++ b/docusaurus/docs/cms/admin-panel-customization/host-port-path.md
@@ -10,6 +10,8 @@ tags:
 
 ---
 
+import AdminUrlCookiePath from '/docs/snippets/admin-url-cookie-path.md'
+
 # Admin panel customization: Host, port, and path configuration
 
 <Tldr>
@@ -37,22 +39,7 @@ module.exports = ({ env }) => ({
 });
 ```
 
-:::caution Cookie path must match
-When you change `url`, you must also update [`auth.cookie.path`](/cms/configurations/admin-panel#cookie-configuration) to the same value. The cookie path defaults to `'/admin'` regardless of `url`, so if they differ, the browser will not send the authentication cookie to the new path and logins will silently fail.
-
-```js title="/config/admin.js"
-module.exports = ({ env }) => ({
-  url: "/dashboard",
-  auth: {
-    cookie: {
-      path: "/dashboard", // must match url
-    },
-  },
-});
-```
-
-After changing `auth.cookie.path`, rebuild the admin panel before starting Strapi, as this value is inlined into the admin bundle at build time.
-:::
+<AdminUrlCookiePath />
 
 Since by default the back-end server and the admin panel server run on the same host and port, only updating the `config/admin.[ts|js]` file should work if you left the `host` and `port` property values untouched in the [server configuration](/cms/configurations/server) file, which should be as follows:
 

--- a/docusaurus/docs/cms/admin-panel-customization/host-port-path.md
+++ b/docusaurus/docs/cms/admin-panel-customization/host-port-path.md
@@ -37,6 +37,23 @@ module.exports = ({ env }) => ({
 });
 ```
 
+:::caution Cookie path must match
+When you change `url`, you must also update [`auth.cookie.path`](/cms/configurations/admin-panel#cookie-configuration) to the same value. The cookie path defaults to `'/admin'` regardless of `url`, so if they differ, the browser will not send the authentication cookie to the new path and logins will silently fail.
+
+```js title="/config/admin.js"
+module.exports = ({ env }) => ({
+  url: "/dashboard",
+  auth: {
+    cookie: {
+      path: "/dashboard", // must match url
+    },
+  },
+});
+```
+
+After changing `auth.cookie.path`, rebuild the admin panel before starting Strapi, as this value is inlined into the admin bundle at build time.
+:::
+
 Since by default the back-end server and the admin panel server run on the same host and port, only updating the `config/admin.[ts|js]` file should work if you left the `host` and `port` property values untouched in the [server configuration](/cms/configurations/server) file, which should be as follows:
 
 <Tabs groupId="js-ts">

--- a/docusaurus/docs/cms/configurations/admin-panel.md
+++ b/docusaurus/docs/cms/configurations/admin-panel.md
@@ -85,6 +85,23 @@ module.exports = ({ env }) => ({
 });
 ```
 
+:::caution Cookie path must match
+When you change `url`, you must also update [`auth.cookie.path`](#cookie-configuration) to the same value. The cookie path defaults to `'/admin'` regardless of `url`, so if they differ, the browser will not send the authentication cookie to the new path and logins will silently fail.
+
+```js title="/config/admin.js"
+module.exports = ({ env }) => ({
+  url: "/dashboard",
+  auth: {
+    cookie: {
+      path: "/dashboard", // must match url
+    },
+  },
+});
+```
+
+After changing `auth.cookie.path`, rebuild the admin panel before starting Strapi, as this value is inlined into the admin bundle at build time.
+:::
+
 Since by default the back-end server and the admin panel server run on the same host and port, only updating the `config/admin` file should work if you left the `host` and `port` property values untouched in the back-end [server configuration](/cms/configurations/server) file.
 
 ### Update the admin panel's host and port

--- a/docusaurus/docs/cms/configurations/admin-panel.md
+++ b/docusaurus/docs/cms/configurations/admin-panel.md
@@ -14,6 +14,8 @@ tags:
 - password
 ---
 
+import AdminUrlCookiePath from '/docs/snippets/admin-url-cookie-path.md'
+
 # Admin panel configuration
 
 <Tldr>
@@ -85,22 +87,7 @@ module.exports = ({ env }) => ({
 });
 ```
 
-:::caution Cookie path must match
-When you change `url`, you must also update [`auth.cookie.path`](#cookie-configuration) to the same value. The cookie path defaults to `'/admin'` regardless of `url`, so if they differ, the browser will not send the authentication cookie to the new path and logins will silently fail.
-
-```js title="/config/admin.js"
-module.exports = ({ env }) => ({
-  url: "/dashboard",
-  auth: {
-    cookie: {
-      path: "/dashboard", // must match url
-    },
-  },
-});
-```
-
-After changing `auth.cookie.path`, rebuild the admin panel before starting Strapi, as this value is inlined into the admin bundle at build time.
-:::
+<AdminUrlCookiePath />
 
 Since by default the back-end server and the admin panel server run on the same host and port, only updating the `config/admin` file should work if you left the `host` and `port` property values untouched in the back-end [server configuration](/cms/configurations/server) file.
 

--- a/docusaurus/docs/snippets/admin-url-cookie-path.md
+++ b/docusaurus/docs/snippets/admin-url-cookie-path.md
@@ -1,0 +1,16 @@
+:::caution Cookie path must match
+When you change `url`, you must also update [`auth.cookie.path`](/cms/configurations/admin-panel#cookie-configuration) to the same value. The cookie path defaults to `'/admin'` regardless of `url`, so if they differ, the browser will not send the authentication cookie to the new path and logins will silently fail.
+
+```js title="/config/admin.js"
+module.exports = ({ env }) => ({
+  url: "/dashboard",
+  auth: {
+    cookie: {
+      path: "/dashboard", // must match url
+    },
+  },
+});
+```
+
+After changing `auth.cookie.path`, rebuild the admin panel before starting Strapi, as this value is inlined into the admin bundle at build time.
+:::


### PR DESCRIPTION
This PR documents that `auth.cookie.path` must be updated to match `admin.url` when the admin panel path is changed from its default, otherwise authentication silently fails because the browser does not send the cookie to the new path.

The caution is shared between the host/port/path customization page and the admin panel configuration reference through a new `admin-url-cookie-path` snippet, so the guidance stays in sync in both places.

Reported in #3384.

Fixes #3384