### PR TITLE
Remove unsupported $eqi from RBAC condition operators

### DIFF
--- a/docusaurus/docs/cms/configurations/guides/rbac.md
+++ b/docusaurus/docs/cms/configurations/guides/rbac.md
@@ -49,7 +49,6 @@ Query objects are useful to verify conditions on the entities you read, create, 
 - `$or`
 - `$and`
 - `$eq`
-- `$eqi`
 - `$ne`
 - `$in`
 - `$nin`
@@ -59,6 +58,10 @@ Query objects are useful to verify conditions on the entities you read, create, 
 - `$gte`
 - `$exists`
 - `$elemMatch`
+
+:::caution
+This list is exhaustive. Condition query objects are evaluated in-memory with `sift.js` whenever an administrator creates, updates, deletes, or publishes an entity, and only the operators listed above are registered. Other operators — including filter operators available in the [REST API](/cms/api/rest/filters) and [Query Engine API](/cms/api/query-engine/filtering) such as `$eqi`, `$contains`, `$startsWith`, or `$null` — are not supported here and throw an `Unsupported operation` error when the condition is evaluated.
+:::
 
 The condition `handler` can be a synchronous or asynchronous function that:
 

--- a/docusaurus/docs/cms/configurations/guides/rbac.md
+++ b/docusaurus/docs/cms/configurations/guides/rbac.md
@@ -60,7 +60,7 @@ Query objects are useful to verify conditions on the entities you read, create, 
 - `$elemMatch`
 
 :::caution
-This list is exhaustive. Condition query objects are evaluated in-memory with `sift.js` whenever an administrator creates, updates, deletes, or publishes an entity, and only the operators listed above are registered. Other operators — including filter operators available in the [REST API](/cms/api/rest/filters) and [Query Engine API](/cms/api/query-engine/filtering) such as `$eqi`, `$contains`, `$startsWith`, or `$null` — are not supported here and throw an `Unsupported operation` error when the condition is evaluated.
+This list is exhaustive. Condition query objects are evaluated in-memory with `sift.js` whenever an administrator creates, updates, deletes, or publishes an entity, and only the operators listed above are registered. Other operators, including filter operators available in the [REST API](/cms/api/rest/filters) and [Query Engine API](/cms/api/query-engine/filtering) such as `$eqi`, `$contains`, `$startsWith`, or `$null`, are not supported here and throw an `Unsupported operation` error when the condition is evaluated.
 :::
 
 The condition `handler` can be a synchronous or asynchronous function that:


### PR DESCRIPTION
### Description

The RBAC custom-conditions guide listed `$eqi` as a supported operator for condition query objects, but it is **not** supported.

RBAC condition query objects are matched in-memory by `sift.js` through a restricted operator whitelist defined in `packages/core/permissions/src/engine/abilities/casl-ability.ts`:

```ts
const allowedOperations = [
  '$or', '$and', '$eq', '$ne', '$in', '$nin',
  '$lt', '$lte', '$gt', '$gte', '$exists', '$elemMatch',
] as const;

const operations = pick(allowedOperations, sift);
const conditionsMatcher = (conditions) => sift.createQueryTester(conditions, { operations });
```

`$eqi` is absent from that list. Any operator outside the whitelist (`$eqi`, `$contains`, `$startsWith`, `$null`, …) causes `sift` to throw `Unsupported operation: <op>` when the condition is evaluated on a create/update/delete/publish, so a "read-valid" condition can hard-fail write operations.

This PR:
- Removes `$eqi` from the supported-operators list so it matches the code whitelist.
- Adds a caution clarifying that the list is exhaustive and that filter operators available in the REST/Query Engine APIs (e.g. `$eqi`, `$contains`, `$startsWith`, `$null`) are not usable in RBAC condition query objects and will throw when evaluated.

### Related issue(s)/PR(s)

EE-115
