### PR TITLE
Document migration progress heartbeats feature

### DIFF
--- a/docusaurus/docs/cms/database-migrations.md
+++ b/docusaurus/docs/cms/database-migrations.md
@@ -110,7 +110,7 @@ module.exports = {
 
 </details>
 
-## Migration progress heartbeats
+## Using the migration progress heartbeats
 
 For long-running migrations, Strapi provides a progress heartbeat feature that logs periodic status updates without rewriting terminal output. This is useful when migrations process large datasets and need to show activity to the operator.
 

--- a/docusaurus/docs/cms/database-migrations.md
+++ b/docusaurus/docs/cms/database-migrations.md
@@ -110,6 +110,17 @@ module.exports = {
 
 </details>
 
+## Migration progress heartbeats
+
+For long-running migrations, Strapi provides a progress heartbeat feature that logs periodic status updates without rewriting terminal output. This is useful when migrations process large datasets and need to show activity to the operator.
+
+The heartbeat logger is time-throttled (default 60 seconds) and reports progress in a format like:
+```
+… still running (120s) · files 12000/450000
+```
+
+This feature is automatically enabled for migrations that use the heartbeat logging capability, such as data backfill operations. The progress updates are append-only, making them suitable for long-running operations that don't produce frequent log output.
+
 ## Handling migrations with TypeScript code
 
 By default Strapi looks for migration files in the source directory rather than the build directory when using TypeScript. This means that TypeScript migrations won't be found and executed properly unless you configure Strapi to look in the right place.


### PR DESCRIPTION
This PR updates documentation based on https://github.com/strapi/strapi/pull/27325.

Adds a new 'Migration progress heartbeats' section to the database-migrations page, documenting the progress heartbeat feature that logs periodic status updates during long-running migrations.

Generated automatically by the docs self-healing workflow (micro-edit, Haiku).
Review before merging.