### PR TITLE
Fetch only the release script in the unflag workflow

### DIFF
--- a/.github/workflows/unflag-released-prs.yml
+++ b/.github/workflows/unflag-released-prs.yml
@@ -31,8 +31,24 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
+      # This job needs exactly one file: the release-detection script. A default
+      # checkout of this repository was observed taking minutes (it carries
+      # ~865 MB of history, mostly images under static/).
+      #
+      # Two settings matter, and both are needed:
+      #   sparse-checkout  — limits what is written to the working tree
+      #   filter: blob:none — limits what is transferred at all
+      #
+      # Sparse checkout alone still fetched 417 MB in 21s; adding the blob
+      # filter brings it to 392 KB in ~1s. The script stays a real file in the
+      # repository, so it remains runnable locally.
+      - name: Checkout the release-detection script
         uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+          fetch-depth: 1
+          filter: blob:none
 
       - name: Remove the label from released PRs
         env:


### PR DESCRIPTION
This PR fixes a slow checkout in the unflag-released-prs workflow. The job needs exactly one file, the release-detection script, but the default checkout pulled the whole repository: roughly 865 MB of history, mostly images under static/. A dry run spent close to three minutes in the Checkout step before being cancelled, against about 20 seconds for workflows that genuinely need the tree.

Two settings are needed and neither is sufficient alone: sparse-checkout limits what is written to the working tree, and filter: blob:none limits what is transferred at all. Measured locally against this repository, sparse checkout on its own still fetched 417 MB in 21 seconds, while adding the blob filter brings it to 392 KB in about 1 second, with the script as the only file in the working tree.

The script remains a real file in the repository rather than being inlined into the workflow, so it can still be run locally against any strapi/strapi PR number.

Follows #3397