### PR TITLE
Apply the merge pending release flag when the source has not shipped

### DIFF
--- a/.github/prompts/docs-self-healing-drafter.md
+++ b/.github/prompts/docs-self-healing-drafter.md
@@ -81,7 +81,21 @@ git push -u origin "$BRANCH_NAME"
 CONFIG=".github/workflows/config.json"
 TITLE_PREFIX=$(jq -r '.["docs-self-healing"].title_prefix' "$CONFIG")
 ASSIGNEE=$(jq -r '.["docs-self-healing"].assignee' "$CONFIG")
-LABEL=$(jq -r '.["docs-self-healing"].labels[0]' "$CONFIG")
+
+# Labels are precomputed by the workflow, keyed by source PR number. Do NOT
+# decide them yourself: the file already accounts for whether the feature has
+# shipped. Fall back to config.json only if the entry is missing.
+#
+# Build one --label flag per label. A single comma-joined value is NOT
+# equivalent and must not be used here.
+LABEL_ARGS=()
+while IFS= read -r L; do
+  [ -n "$L" ] && LABEL_ARGS+=(--label "$L")
+done < <(jq -r --arg n "<NUMBER>" '(.[$n] // "") | split(",")[]' /tmp/pr-labels.json 2>/dev/null)
+
+if [ ${#LABEL_ARGS[@]} -eq 0 ]; then
+  LABEL_ARGS=(--label "$(jq -r '.["docs-self-healing"].labels[0]' "$CONFIG")")
+fi
 
 gh pr create \
   --repo strapi/documentation \
@@ -100,7 +114,7 @@ Review before merging.
 BODY
 )" \
   --draft \
-  --label "$LABEL" \
+  "${LABEL_ARGS[@]}" \
   --assignee "$ASSIGNEE"
 ```
 

--- a/.github/prompts/docs-self-healing-router.md
+++ b/.github/prompts/docs-self-healing-router.md
@@ -96,7 +96,21 @@ git push -u origin "$BRANCH_NAME"
 CONFIG=".github/workflows/config.json"
 TITLE_PREFIX=$(jq -r '.["docs-self-healing"].title_prefix' "$CONFIG")
 ASSIGNEE=$(jq -r '.["docs-self-healing"].assignee' "$CONFIG")
-LABEL=$(jq -r '.["docs-self-healing"].labels[0]' "$CONFIG")
+
+# Labels are precomputed by the workflow, keyed by source PR number. Do NOT
+# decide them yourself: the file already accounts for whether the feature has
+# shipped. Fall back to config.json only if the entry is missing.
+#
+# Build one --label flag per label. A single comma-joined value is NOT
+# equivalent and must not be used here.
+LABEL_ARGS=()
+while IFS= read -r L; do
+  [ -n "$L" ] && LABEL_ARGS+=(--label "$L")
+done < <(jq -r --arg n "<NUMBER>" '(.[$n] // "") | split(",")[]' /tmp/pr-labels.json 2>/dev/null)
+
+if [ ${#LABEL_ARGS[@]} -eq 0 ]; then
+  LABEL_ARGS=(--label "$(jq -r '.["docs-self-healing"].labels[0]' "$CONFIG")")
+fi
 
 gh pr create \
   --repo strapi/documentation \
@@ -109,7 +123,7 @@ Review before merging.
 BODY
 )" \
   --draft \
-  --label "$LABEL" \
+  "${LABEL_ARGS[@]}" \
   --assignee "$ASSIGNEE"
 git checkout main
 git clean -fd

--- a/.github/workflows/docs-self-healing.yml
+++ b/.github/workflows/docs-self-healing.yml
@@ -324,6 +324,100 @@ jobs:
           } >> $GITHUB_OUTPUT
 
       # ── Step A: Haiku Router (only for triage "yes" PRs) ──
+      # ── Release state, computed before any agent runs ──
+      #
+      # A doc PR for a feature that has not shipped yet must carry
+      # `flag: merge pending release`. That label used to be applied by hand,
+      # days after the PR was opened.
+      #
+      # This is a deterministic fact, so it is resolved here in bash rather than
+      # delegated to the Router or the Drafter. Both agents read the resulting
+      # file and apply the labels it lists; neither decides anything.
+      #
+      # `unflag-released-prs.yml` removes the label later, using the same script.
+      - name: Resolve release state for each candidate PR
+        if: steps.check-triage.outputs.has_candidates == 'true'
+        id: release-state
+        # Labelling must never break drafting. If this step fails, /tmp/pr-labels.json
+        # is absent or partial and both prompts fall back to config.json — the run
+        # produces PRs exactly as it did before this step existed.
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.PAT_TOKEN_PIWI }}
+        run: |
+          set -euo pipefail
+
+          SCRIPT=".github/scripts/is-strapi-pr-released.sh"
+          chmod +x "$SCRIPT"
+
+          BASE_LABEL=$(jq -r '.["docs-self-healing"].labels[0]' .github/workflows/config.json)
+          PENDING_LABEL="flag: merge pending release"
+          OUT="/tmp/pr-labels.json"
+
+          # Resolve the reference tag once so every PR in this run is judged
+          # against the same release.
+          TAG=$(gh api "repos/strapi/strapi/releases?per_page=30" \
+            --jq '[.[] | select(.draft == false and .prerelease == false and (.tag_name | startswith("v5.")))]
+                  | sort_by(.published_at) | reverse | .[0].tag_name')
+
+          if [ -z "$TAG" ] || [ "$TAG" = "null" ]; then
+            # Fail open: without a reference tag we cannot tell released from
+            # unreleased. Label everything as pending — a PR wrongly held back
+            # costs a manual unflag, a PR wrongly released costs bad docs.
+            echo "::warning::Could not resolve a v5 release tag — flagging all PRs as pending release"
+            TAG=""
+          else
+            echo "Reference release: $TAG"
+          fi
+
+          echo '{}' > "$OUT"
+          PENDING=0
+          RELEASED=0
+
+          while read -r PR_NUMBER; do
+            [ -z "$PR_NUMBER" ] && continue
+
+            if [ -z "$TAG" ]; then
+              LABELS="$BASE_LABEL,$PENDING_LABEL"
+              PENDING=$((PENDING + 1))
+            else
+              set +e
+              "$SCRIPT" "$PR_NUMBER" "$TAG" > /dev/null 2>&1
+              CODE=$?
+              set -e
+
+              case "$CODE" in
+                0)
+                  LABELS="$BASE_LABEL"
+                  RELEASED=$((RELEASED + 1))
+                  echo "  strapi#$PR_NUMBER — released in $TAG"
+                  ;;
+                *)
+                  # Both "not released" (1) and "cannot tell" (2) flag the PR.
+                  LABELS="$BASE_LABEL,$PENDING_LABEL"
+                  PENDING=$((PENDING + 1))
+                  echo "  strapi#$PR_NUMBER — not in $TAG, will be flagged pending release"
+                  ;;
+              esac
+            fi
+
+            jq --arg k "$PR_NUMBER" --arg v "$LABELS" '. + {($k): $v}' "$OUT" > "$OUT.tmp"
+            mv "$OUT.tmp" "$OUT"
+          done < <(jq -r '.[].number // empty' /tmp/triaged-prs.json)
+
+          echo ""
+          echo "Released: $RELEASED | pending release: $PENDING"
+
+          {
+            echo "### Release state"
+            echo ""
+            echo "Reference release: \`${TAG:-unresolved}\`"
+            echo ""
+            echo "- Already released: $RELEASED"
+            echo "- Will be flagged \`$PENDING_LABEL\`: $PENDING"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Load Router prompt
         if: steps.check-triage.outputs.has_candidates == 'true'
         id: load-router-prompt


### PR DESCRIPTION
This PR completes the automation of the merge pending release label. #3397 removes it once a feature ships; this one applies it in the first place, replacing a step the maintainer does by hand three to fourteen days after a PR is opened. That delay is what blocks auto-merge: with a 24-hour quarantine, roughly one self-healing PR in three would merge before it could be flagged.

A new bash step runs between Triage and Router, resolves the newest published v5 tag once, and writes a label list per source PR to /tmp/pr-labels.json. Both the Router (micro-edits, Haiku) and the Drafter (full drafting, Sonnet) create PRs, so both prompts were updated to read that file instead of config.json. Neither agent decides anything: release state is a verifiable fact, resolved in bash, and handed to them as data.

Three safety properties. The step is continue-on-error, so if it fails both prompts fall back to config.json and the run produces PRs exactly as before. An API error is treated as not-released, because flagging wrongly costs one manual unflag while not flagging publishes documentation for an unshipped feature. Labels are passed as one --label flag each rather than a comma-joined string, since the comma syntax behaved ambiguously when tested.

Verified locally end to end (compute, write, parse) across four cases: a released PR, an unreleased one, an API error, and a PR missing from the file. Spaces in the label name survive the round trip.

Follows #3397