### PR TITLE
Compute release state during self-healing dry runs too

### DIFF
--- a/.github/workflows/docs-self-healing.yml
+++ b/.github/workflows/docs-self-healing.yml
@@ -336,7 +336,14 @@ jobs:
       #
       # `unflag-released-prs.yml` removes the label later, using the same script.
       - name: Resolve release state for each candidate PR
-        if: steps.check-triage.outputs.has_candidates == 'true'
+        # Runs on a normal run (after Triage) and on a dry run (where Triage is
+        # skipped). Release state is pure bash and costs no tokens, so a dry run
+        # can exercise it and report what it would label.
+        #
+        # Note: a dry run forces has_prs=false to gate every AI step, so this
+        # condition cannot test it. The step guards on the candidate file itself
+        # instead, and exits cleanly when there is none.
+        if: success() && (steps.check-triage.outputs.has_candidates == 'true' || inputs.dry_run == true)
         id: release-state
         # Labelling must never break drafting. If this step fails, /tmp/pr-labels.json
         # is absent or partial and both prompts fall back to config.json — the run
@@ -353,6 +360,19 @@ jobs:
           BASE_LABEL=$(jq -r '.["docs-self-healing"].labels[0]' .github/workflows/config.json)
           PENDING_LABEL="flag: merge pending release"
           OUT="/tmp/pr-labels.json"
+
+          # On a normal run, Triage has narrowed the list. On a dry run Triage is
+          # skipped, so fall back to the bash pre-filter output.
+          if [ -s /tmp/triaged-prs.json ]; then
+            CANDIDATES="/tmp/triaged-prs.json"
+          elif [ -s /tmp/new-prs.json ]; then
+            CANDIDATES="/tmp/new-prs.json"
+          else
+            echo "No candidate list found, nothing to resolve"
+            exit 0
+          fi
+
+          echo "Candidates from: $CANDIDATES"
 
           # Resolve the reference tag once so every PR in this run is judged
           # against the same release.
@@ -403,7 +423,7 @@ jobs:
 
             jq --arg k "$PR_NUMBER" --arg v "$LABELS" '. + {($k): $v}' "$OUT" > "$OUT.tmp"
             mv "$OUT.tmp" "$OUT"
-          done < <(jq -r '.[].number // empty' /tmp/triaged-prs.json)
+          done < <(jq -r '.[].number // empty' "$CANDIDATES")
 
           echo ""
           echo "Released: $RELEASED | pending release: $PENDING"
@@ -416,6 +436,12 @@ jobs:
             echo "- Already released: $RELEASED"
             echo "- Will be flagged \`$PENDING_LABEL\`: $PENDING"
             echo ""
+            if [ -s "$OUT" ]; then
+              echo "| strapi/strapi PR | Labels the doc PR will get |"
+              echo "| --- | --- |"
+              jq -r 'to_entries[] | "| [#\(.key)](https://github.com/strapi/strapi/pull/\(.key)) | `\(.value | gsub(",";"`, `"))` |"' "$OUT"
+              echo ""
+            fi
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Load Router prompt


### PR DESCRIPTION
This PR makes the release-state step testable without spending tokens. A dry run of the self-healing workflow stops after bash pre-filtering, and it forces has_prs=false to gate every AI step. The labelling step added in #3399 sits after Triage, so a dry run skipped it entirely and there was no way to check what it would do short of a full nightly run.

The step now runs in both modes. On a normal run it reads the triaged list as before; on a dry run, where Triage never produced one, it falls back to the bash pre-filter output. If neither file exists it exits cleanly rather than failing. The run summary gains a table listing each source PR and the labels its doc PR would receive, which is the part worth seeing before trusting the automation.

The condition deliberately tests inputs.dry_run rather than has_prs, because a dry run forces that output to false as its way of blocking the AI. The four steps that invoke a model or create PRs (Pre-fetch, Triage, Router, Drafter) keep their original conditions, so a dry run still consumes no tokens and creates nothing.

Follows #3399