### PR TITLE
Add callout to mention the beta Media Library

### DIFF
--- a/docusaurus/docs/cms/features/media-library.md
+++ b/docusaurus/docs/cms/features/media-library.md
@@ -31,6 +31,21 @@ The <Icon name="images" /> Media Library is the Strapi feature that displays all
 
 <Guideflow lightId="mk6z26zaqp" darkId="9r2m74otok"/>
 
+:::strapi New Media Library available in <BetaBadge/>
+Strapi has completely reworked the Media Library UI, which is now available as a beta feature for the next few weeks before it replaces the current UI. You can try the beta by adding the following to `config/features.ts|js`:
+
+```tsx
+export default () => ({
+  future: {
+    betaMediaLibrary: true,
+  },
+});
+```
+
+<br/>
+The current page still describes the stable version of the Media Library. Over the next few weeks, the documentation will be updated to reflect the new features. In the meantime, you can <ExternalLink text="read more about it here" to="https://strapi.notion.site/Media-Library-Beta-Release-3c78f3598074810dbad6f2addfa25b6f" />.
+:::
+
 ## Configuration
 
 Some configuration options for the Media Library are available in the admin panel, and some are handled via your Strapi project's code.

--- a/docusaurus/static/llms-code.txt
+++ b/docusaurus/static/llms-code.txt
@@ -25553,6 +25553,22 @@ export default {
 # Media Library
 Source: https://docs.strapi.io/cms/features/media-library
 
+## Media Library
+Description: :::strapi New Media Library available in beta Strapi has completely reworked the Media Library UI, which is now available as a beta feature for a few weeks before replacing the current UI.
+(Source: https://docs.strapi.io/cms/features/media-library#media-library)
+
+Language: TypeScript
+File path: /features.ts
+
+```ts
+export default () => ({
+  future: {
+    betaMediaLibrary: true,
+  },
+});
+```
+
+
 ## Example custom configuration
 Description: The following is an example of a custom configuration for the Upload plugin when using the default upload provider:
 (Source: https://docs.strapi.io/cms/features/media-library#example-custom-configuration)

--- a/docusaurus/static/llms-full.txt
+++ b/docusaurus/static/llms-full.txt
@@ -34438,6 +34438,20 @@ Available and activated by default
 
 Available in both Development & Production environment
 
+:::strapi New Media Library available in beta 
+Strapi has completely reworked the Media Library UI, which is now available as a beta feature for a few weeks before replacing the current UI. You can try the beta by adding this to `config/features.ts|js`:
+
+```tsx
+
+  future: {
+    betaMediaLibrary: true,
+  },
+});
+```
+
+The current page is still describing the stable version of the Media Library. Over the next weeks, the documentation will be updated to reflect the new features. In the meantime, you can .
+:::
+
 ## Configuration
 
 Some configuration options for the Media Library are available in the admin panel, and some are handled via your Strapi project's code.


### PR DESCRIPTION
This PR adds a callout to mention how to enable the new Media Library, currently in beta, and adds a link to the Notion one-pager while the new UI is being documented.