### PR TITLE
Remove labels via the REST API so the unflag job survives one failure

### DIFF
--- a/.github/workflows/unflag-released-prs.yml
+++ b/.github/workflows/unflag-released-prs.yml
@@ -102,6 +102,12 @@ jobs:
 
           # Read the source PR number from the doc PR body. Same pattern the
           # self-healing dedup already relies on.
+          # One PR must never take down the run. `set -e` is deliberately
+          # relaxed inside the loop: on 2026-08-26 a single failed label removal
+          # aborted the job before the other ten PRs were even looked at. Every
+          # step below reports its own failure and moves on.
+          set +e
+
           while read -r DOC_PR; do
             TITLE=$(jq -r --argjson n "$DOC_PR" '.[] | select(.number == $n) | .title' /tmp/flagged.json)
 
@@ -132,10 +138,8 @@ jobs:
               continue
             fi
 
-            set +e
             RESULT=$("$SCRIPT" "$SOURCE" "$TAG" 2>&1)
             CODE=$?
-            set -e
 
             case "$CODE" in
               0)
@@ -143,7 +147,24 @@ jobs:
                 if [ "$DRY_RUN" = "true" ]; then
                   echo "     (dry run, no change)"
                 else
-                  gh pr edit "$DOC_PR" --repo strapi/documentation --remove-label "$LABEL"
+                  # Use the REST labels endpoint, not `gh pr edit`.
+                  #
+                  # `gh pr edit` issues a GraphQL mutation that also reads
+                  # organisation fields (login, name, slug), so it demands the
+                  # `read:org` scope. PAT_TOKEN_PIWI only carries `repo`, and the
+                  # 2026-08-26 run failed on the first PR with:
+                  #   "The 'login' field requires one of the following scopes:
+                  #    ['read:org'], but your token has only been granted: ['repo']"
+                  #
+                  # DELETE /issues/{n}/labels/{label} needs `repo` alone.
+                  ENCODED=$(jq -rn --arg l "$LABEL" '$l|@uri')
+                  if ! gh api --method DELETE \
+                    "repos/strapi/documentation/issues/$DOC_PR/labels/$ENCODED" \
+                    --silent 2>/tmp/unflag-error; then
+                    echo "::warning::#$DOC_PR — could not remove the label: $(cat /tmp/unflag-error | head -1)"
+                    SKIPPED=$((SKIPPED + 1))
+                    continue
+                  fi
                 fi
                 UNFLAGGED=$((UNFLAGGED + 1))
                 SUMMARY="${SUMMARY}- [#${DOC_PR}](https://github.com/strapi/documentation/pull/${DOC_PR}) — ${TITLE}\n"
@@ -160,6 +181,8 @@ jobs:
                 ;;
             esac
           done < <(jq -r '.[].number' /tmp/flagged.json)
+
+          set -e
 
           echo ""
           echo "Unflagged: $UNFLAGGED | still waiting: $STILL_WAITING | held: $HELD | skipped: $SKIPPED"

--- a/docusaurus/docs/cms/features/media-library.md
+++ b/docusaurus/docs/cms/features/media-library.md
@@ -60,7 +60,7 @@ export default () => ({
 </TabItem>
 </Tabs>
 
-Set the property to `false` to use the current stable version again.
+Restart your Strapi application after the configuration change. Set the property to `false` and restart Strapi to use the current stable version again.
 
 The current page still describes the stable version of the Media Library. Over the next few weeks, the documentation will be updated to reflect the new features. In the meantime, you can <ExternalLink text="read more about it here" to="https://strapi.notion.site/Media-Library-Beta-Release-3c78f3598074810dbad6f2addfa25b6f" />.
 :::


### PR DESCRIPTION
This PR fixes two problems the first real run of unflag-released-prs exposed on 2026-08-26, when v5.52.2 shipped. The release detection itself worked: the job resolved v5.52.2, identified #3388 as released, and tried to unflag it. Everything after that failed.

The first problem is a token scope. gh pr edit issues a GraphQL mutation that also reads organisation fields (login, name, slug), so it demands read:org, and the token only carries repo. The DELETE /issues/{n}/labels/{label} endpoint does the same job with repo alone, verified locally, so the job now calls that instead.

The second problem matters more. The step runs under set -euo pipefail, so the failed label removal aborted the whole job on the very first PR and the other ten were never examined. A single unreachable PR should never cost a run. The loop now runs with set -e relaxed, reports each failure as a warning, increments the skipped counter and moves on.

Simulated against the nine PRs still flagged: the loop walks all of them without stopping, two would be unflagged (#3378, #3377), one still waits on a release, four are held by temp - future media lib, and two lack a source PR reference. #3388 and #3385 were unflagged by hand while diagnosing; both were legitimately released in v5.52.2.

Follows #3397