### PR TITLE
Rename the auto-merge workflows so they cannot be confused

### DIFF
--- a/.github/workflows/automerge-cron.yml
+++ b/.github/workflows/automerge-cron.yml
@@ -1,4 +1,4 @@
-name: Auto-merge eligible PRs
+name: 'Auto-merge: merge eligible PRs'
 
 # Merges the self-healing documentation PRs that `automerge-eligibility.yml` has
 # marked eligible, once they have sat through the quarantine.

--- a/.github/workflows/automerge-eligibility.yml
+++ b/.github/workflows/automerge-eligibility.yml
@@ -1,4 +1,4 @@
-name: Auto-merge eligibility
+name: 'Auto-merge: check eligibility'
 
 # Decides whether a self-healing documentation PR is constrained enough to merge
 # without review, and records the answer as the `automerge: eligible` label.


### PR DESCRIPTION
"Auto-merge eligibility" and "Auto-merge eligible PRs" read almost identically in the Actions list, and picking the wrong one is easy: one evaluates a PR against the criteria, the other merges what already qualifies.

- `Auto-merge: check eligibility` runs the twelve checks and owns the label
- `Auto-merge: merge eligible PRs` is the daily cron that merges what has cleared quarantine

The shared prefix groups them together and the verb says which is which. Display names only: files, triggers, logic and workflow IDs are untouched.

Follows #3406