### PR TITLE
Stop the auto-merge eligibility run aborting on the first failing check

### DIFF
--- a/.github/workflows/automerge-cron.yml
+++ b/.github/workflows/automerge-cron.yml
@@ -45,6 +45,7 @@ jobs:
 
       - name: Check the absence period
         id: absence
+        shell: bash
         run: |
           set -uo pipefail
 
@@ -94,6 +95,7 @@ jobs:
           DRY_RUN: ${{ inputs.dry_run }}
           SUSPENDED: ${{ steps.absence.outputs.suspended }}
           SUSPEND_REASON: ${{ steps.absence.outputs.reason }}
+        shell: bash
         run: |
           set -uo pipefail
 
@@ -244,6 +246,7 @@ jobs:
           HELD_LIST: ${{ steps.merge.outputs.held_list }}
           FAILED_LIST: ${{ steps.merge.outputs.failed_list }}
           JOB_STATUS: ${{ job.status }}
+        shell: bash
         run: |
           set -uo pipefail
 

--- a/.github/workflows/automerge-eligibility.yml
+++ b/.github/workflows/automerge-eligibility.yml
@@ -97,6 +97,11 @@ jobs:
           GH_TOKEN: ${{ secrets.PAT_TOKEN_PIWI }}
           AUTOMERGE_REPO: ${{ github.repository }}
           PR: ${{ github.event.pull_request.number || inputs.pr_number }}
+        # GitHub runs `run:` blocks as `bash -e` unless told otherwise, and
+        # `set -uo pipefail` does not undo that. A check exiting 1 is this
+        # step's normal output — a criterion was violated — so -e would abort
+        # the run on the first failing check and report the job as broken.
+        shell: bash
         run: |
           set -uo pipefail
 
@@ -135,7 +140,7 @@ jobs:
           for CHECK in "${CHECKS[@]}"; do
             OUT=$("$DIR/$CHECK.sh" "$PR" 2>&1)
             CODE=$?
-            DETAIL=$(echo "$OUT" | head -1 | sed 's/^\(PASS\|FAIL\|UNKNOWN\): //' | cut -c1-90)
+            DETAIL=$(echo "$OUT" | head -1 | sed -E 's/^(PASS|FAIL|UNKNOWN): //' | cut -c1-90)
 
             case "$CODE" in
               0) ICON="✅" ;;
@@ -170,6 +175,7 @@ jobs:
           GH_TOKEN: ${{ secrets.PAT_TOKEN_PIWI }}
           PR: ${{ github.event.pull_request.number || inputs.pr_number }}
           ELIGIBLE: ${{ steps.checks.outputs.eligible }}
+        shell: bash
         run: |
           set -uo pipefail
 
@@ -216,6 +222,7 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           SLACK_CHANNEL: ${{ secrets.SLACK_DOCUMENTATION_OPS_CHANNEL_ID }}
           PR: ${{ github.event.pull_request.number || inputs.pr_number }}
+        shell: bash
         run: |
           set -uo pipefail
 


### PR DESCRIPTION
The first manual run of the eligibility workflow failed. It stopped after 3 of 12 checks and reported the job as broken, when nothing was broken: #3366 simply changes 34 lines, over the 30-line limit.

GitHub runs a step as `bash -e` unless told otherwise, and `set -uo pipefail` does not undo that. A check exiting 1 is this step's normal output — it means a criterion was violated — so `-e` killed the loop at the first one.

- `shell: bash` on the six steps whose scripts expect non-zero exit codes
- The cron had the same latent bug on all three of its steps: it would have aborted on the first PR held by CI
- `sed -E` so the PASS/FAIL prefix is actually stripped from the summary table (BSD sed does not read `\|`)

Simulated against #3366: all twelve checks now run, `line-count` fails, and the verdict is "Not eligible. Failed: line-count".

Follows #3401