### PR TITLE
Use bash {0} so a failing check does not abort the auto-merge eligibility run

### DIFF
--- a/.github/workflows/automerge-cron.yml
+++ b/.github/workflows/automerge-cron.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Check the absence period
         id: absence
-        shell: bash
+        shell: bash {0}
         run: |
           set -uo pipefail
 
@@ -95,7 +95,7 @@ jobs:
           DRY_RUN: ${{ inputs.dry_run }}
           SUSPENDED: ${{ steps.absence.outputs.suspended }}
           SUSPEND_REASON: ${{ steps.absence.outputs.reason }}
-        shell: bash
+        shell: bash {0}
         run: |
           set -uo pipefail
 
@@ -246,7 +246,7 @@ jobs:
           HELD_LIST: ${{ steps.merge.outputs.held_list }}
           FAILED_LIST: ${{ steps.merge.outputs.failed_list }}
           JOB_STATUS: ${{ job.status }}
-        shell: bash
+        shell: bash {0}
         run: |
           set -uo pipefail
 

--- a/.github/workflows/automerge-eligibility.yml
+++ b/.github/workflows/automerge-eligibility.yml
@@ -97,11 +97,14 @@ jobs:
           GH_TOKEN: ${{ secrets.PAT_TOKEN_PIWI }}
           AUTOMERGE_REPO: ${{ github.repository }}
           PR: ${{ github.event.pull_request.number || inputs.pr_number }}
-        # GitHub runs `run:` blocks as `bash -e` unless told otherwise, and
-        # `set -uo pipefail` does not undo that. A check exiting 1 is this
-        # step's normal output — a criterion was violated — so -e would abort
-        # the run on the first failing check and report the job as broken.
-        shell: bash
+        # A check exiting 1 is this step's normal output — it means a criterion
+        # was violated — so the shell must not treat it as a fatal error.
+        #
+        # `shell: bash {0}` is required, not `shell: bash`. The latter expands to
+        # `bash --noprofile --norc -e -o pipefail {0}`, which still carries -e:
+        # the run on 2026-08-26 stopped after 3 of 12 checks with that setting.
+        # Only the explicit `{0}` form drops it.
+        shell: bash {0}
         run: |
           set -uo pipefail
 
@@ -175,7 +178,7 @@ jobs:
           GH_TOKEN: ${{ secrets.PAT_TOKEN_PIWI }}
           PR: ${{ github.event.pull_request.number || inputs.pr_number }}
           ELIGIBLE: ${{ steps.checks.outputs.eligible }}
-        shell: bash
+        shell: bash {0}
         run: |
           set -uo pipefail
 
@@ -222,7 +225,7 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           SLACK_CHANNEL: ${{ secrets.SLACK_DOCUMENTATION_OPS_CHANNEL_ID }}
           PR: ${{ github.event.pull_request.number || inputs.pr_number }}
-        shell: bash
+        shell: bash {0}
         run: |
           set -uo pipefail
 


### PR DESCRIPTION
The fix in #3408 was wrong and the run kept failing the same way. `shell: bash` does not drop the -e flag: GitHub expands it to `bash --noprofile --norc -e -o pipefail {0}`, which the run log confirms. Only the explicit `shell: bash {0}` form runs without -e.

A check exiting 1 is the normal output of this step — it means a criterion was violated — so -e killed the loop on the first one, after 3 of 12 checks and with no verdict.

Reproduced with the real scripts against #3366, which changes 34 lines and legitimately fails the 30-line criterion:

- `bash --noprofile --norc -e -o pipefail` stops after 3 checks and exits 1, matching the observed run exactly
- `bash {0}` runs all of them, records the failure, finishes the loop and exits 0

Applied to the six steps across both workflows whose scripts expect non-zero exit codes.

Should fix #3408