### PR TITLE
Match allowed link hosts on a literal dot

### DIFF
--- a/.github/scripts/automerge/check-no-external-links.sh
+++ b/.github/scripts/automerge/check-no-external-links.sh
@@ -14,7 +14,13 @@ set -euo pipefail
 source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 # Extended regex of hosts that do not count as external.
-ALLOWED_HOSTS="${AUTOMERGE_ALLOWED_LINK_HOSTS:-strapi\.io|docs\.strapi\.io|github\.com/strapi|market\.strapi\.io|cloud\.strapi\.io}"
+#
+# Dots are written [.] rather than \. on purpose. This string reaches awk through
+# -v, where a backslash is a STRING escape, not a regex one: awk consumes it and
+# gawk warns "escape sequence \. treated as plain .". The dot then matches any
+# character, so `strapiXio.evil.com` would have been accepted as an allowed host.
+# [.] survives -v untouched and means exactly one literal dot.
+ALLOWED_HOSTS="${AUTOMERGE_ALLOWED_LINK_HOSTS:-strapi[.]io|docs[.]strapi[.]io|github[.]com/strapi|market[.]strapi[.]io|cloud[.]strapi[.]io}"
 
 PR="${1:-}"
 require_pr_number "$PR"


### PR DESCRIPTION
The #3366 eligibility run surfaced an awk warning in the summary table, on the `no-external-links` row. It turned out to be a functional bug, not just noise.

The allowed-host list was written with backslash-escaped dots and passed to awk through `-v`, where a backslash is a string escape rather than a regex one. awk consumed it — gawk warns `escape sequence \. treated as plain .` — so the dot became a wildcard.

The consequence: `https://strapiXio.evil.com` matched `strapi.io` and was accepted as an allowed host. A lookalike domain would have passed the check.

Writing the dots as `[.]` survives `-v` untouched and means exactly one literal dot.

Verified:

- `strapi.io`, `docs.strapi.io`, `www.strapi.io` and `github.com/strapi` still pass
- `strapiXio.evil.com`, `notstrapi.io` and `evil.com` are now blocked
- The warning is gone, and the full script still returns PASS on #3366 and FAIL on #3080, which adds a real link to v6.vite.dev