### PR TITLE
End the eligibility step on an explicit exit 0

### DIFF
--- a/.github/workflows/automerge-cron.yml
+++ b/.github/workflows/automerge-cron.yml
@@ -88,6 +88,8 @@ jobs:
           echo "Today ($TODAY) is outside the absence period ($START → $END)"
           echo "suspended=false" >> "$GITHUB_OUTPUT"
 
+          exit 0
+
       - name: Merge what is eligible and ripe
         id: merge
         env:
@@ -230,6 +232,11 @@ jobs:
             echo "failed_list<<EOF"; printf '%b' "$FAILED_LIST"; echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
+          # Explicit, so the step's result never depends on whichever command
+          # happens to be last. A merge that failed is reported through
+          # failed_list and the Slack alert, not by failing this step.
+          exit 0
+
       - name: Post the daily recap to Slack
         if: always() && inputs.dry_run != true
         env:
@@ -288,3 +295,5 @@ jobs:
             -H "Content-type: application/json; charset=utf-8" \
             -d "$(jq -n --arg channel "$SLACK_CHANNEL" --arg text "$TEXT" '{channel: $channel, text: $text}')" \
             > /dev/null || echo "Slack notification failed (non-blocking)"
+
+          exit 0

--- a/.github/workflows/automerge-eligibility.yml
+++ b/.github/workflows/automerge-eligibility.yml
@@ -171,6 +171,15 @@ jobs:
             echo "**Eligible.** All checks passed." >> "$GITHUB_STEP_SUMMARY"
           fi
 
+          # The step's exit code is that of its last command, and the last one to
+          # run above is `[ -n "$UNKNOWN" ]`. When no check errored — the normal
+          # case — that test is false and returns 1, failing the step even though
+          # every check ran and the verdict was recorded.
+          #
+          # This step reports a verdict; it does not pass or fail on it. Whether
+          # the PR is eligible is carried by the `eligible` output.
+          exit 0
+
       - name: Update the eligibility label
         if: steps.scope.outputs.in_scope == 'true'
         id: label
@@ -207,6 +216,8 @@ jobs:
             echo "Label already correct, nothing to do"
             echo "newly_eligible=false" >> "$GITHUB_OUTPUT"
           fi
+
+          exit 0
 
       # The veto window. Posted once, when a PR first becomes eligible, roughly
       # 24 hours before the cron merges it.
@@ -261,3 +272,5 @@ jobs:
             -H "Content-type: application/json; charset=utf-8" \
             -d "$(jq -n --arg channel "$SLACK_CHANNEL" --arg text "$TEXT" '{channel: $channel, text: $text}')" \
             > /dev/null || echo "Slack notification failed (non-blocking)"
+
+          exit 0


### PR DESCRIPTION
All twelve checks ran, the summary table rendered, the verdict was recorded — and the step still failed. This is a different bug from the shell one fixed in #3409, and it was hidden behind it.

A step's exit code is that of its last command. The last one to run here is the test on `UNKNOWN`, inside the block that writes the verdict. When no check errored — the normal case — that variable is empty, the test returns 1, and the step fails on a perfectly good outcome.

The step reports a verdict; it does not pass or fail on it. Whether the PR is eligible is carried by the `eligible` output and read by the next step.

Reproduced against #3366, which legitimately fails the 30-line criterion:

- before: verdict "Not eligible. Failed: line-count", exit 1
- after: same verdict, exit 0

The other five steps across both workflows were not affected — they happen to end on an `echo` — but they get the same explicit ending, so no step's result depends on whichever command is last.

Should fix #3409