### PR TITLE
Name the source PR in the automerge eligibility report and Slack message

### DIFF
--- a/.github/workflows/automerge-eligibility.yml
+++ b/.github/workflows/automerge-eligibility.yml
@@ -155,7 +155,7 @@ jobs:
             echo "| Page | \`$PAGE\` |"
             echo "| Size | +$ADD / −$DEL |"
             if [ -n "$SOURCE" ]; then
-              echo "| Source | [strapi/strapi#$SOURCE](https://github.com/strapi/strapi/pull/$SOURCE) |"
+              echo "| Corresponding Strapi CMS PR | [strapi/strapi#$SOURCE](https://github.com/strapi/strapi/pull/$SOURCE) |"
             fi
             echo ""
             echo "### Checks"

--- a/.github/workflows/automerge-eligibility.yml
+++ b/.github/workflows/automerge-eligibility.yml
@@ -317,10 +317,16 @@ jobs:
           # Slack link syntax is <url|text>, not Markdown.
           LINE="<${URL}|#${PR} — ${SHORT_TITLE}>"
           CONTEXT="${PAGE} · +${ADD}/−${DEL}"
-          [ -n "$SOURCE" ] && CONTEXT="${CONTEXT} · <https://github.com/strapi/strapi/pull/${SOURCE}|strapi#${SOURCE}>"
 
-          TEXT=$(printf ':hourglass_flowing_sand: *Will auto-merge tomorrow*\n%s\n%s\n\nStop it by adding the `flag: don'\''t merge` label.' \
-            "$LINE" "$CONTEXT")
+          # The upstream PR gets its own labelled line rather than a third item
+          # in the context line: "Corresponding Strapi CMS PR" is too long to sit
+          # between the page path and the diff size, and the label is what makes
+          # the link readable without opening it.
+          SOURCE_LINE=""
+          [ -n "$SOURCE" ] && SOURCE_LINE="\nCorresponding Strapi CMS PR: <https://github.com/strapi/strapi/pull/${SOURCE}|strapi/strapi#${SOURCE}>"
+
+          TEXT=$(printf ':hourglass_flowing_sand: *Will auto-merge tomorrow*\n%s\n%s%b\n\nStop it by adding the `flag: don'\''t merge` label.' \
+            "$LINE" "$CONTEXT" "$SOURCE_LINE")
 
           curl -s -X POST "https://slack.com/api/chat.postMessage" \
             -H "Authorization: Bearer $SLACK_BOT_TOKEN" \


### PR DESCRIPTION
The row linking to the upstream PR was labelled "Source", which says nothing about what it points to. It now reads "Corresponding Strapi CMS PR", in the run summary and in the Slack veto message alike.

In Slack the link moves out of the compact context line onto its own labelled line, since the label is too long to sit between the page path and the diff size:

```
:hourglass_flowing_sand: *Will auto-merge tomorrow*
#3366 — Document optional component screenshot field
cms/api/entity-service/components-dynamic-zones.md · +34/−0
Corresponding Strapi CMS PR: strapi/strapi#26863

Stop it by adding the `flag: don't merge` label.
```

Rendered both ways to check that a PR without a source reference produces no stray blank line.