### PR TITLE
Remove duplicated words

### DIFF
--- a/docusaurus/docs/cms/api/entity-service/crud.md
+++ b/docusaurus/docs/cms/api/entity-service/crud.md
@@ -18,7 +18,7 @@ The Entity Service API performs CRUD operations on content through `findOne()`, 
 
 <ESdeprecated />
 
-The [Entity Service API](/cms/api/entity-service) is built on top of the the [Query Engine API](/cms/api/query-engine) and uses it to perform CRUD operations on entities.
+The [Entity Service API](/cms/api/entity-service) is built on top of the [Query Engine API](/cms/api/query-engine) and uses it to perform CRUD operations on entities.
 
 
 The `uid` parameter used in function calls for this API is a `string` built with the following format: `[category]::[content-type]` where `category` is one of: `admin`, `plugin` or `api`.

--- a/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/default-input-validation.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/breaking-changes/default-input-validation.md
@@ -61,7 +61,7 @@ In v5, both query parameters and input data are validated.
 
 ### Notes
 
-* A `400 Bad Request` error will be thrown if the request has invalid values such as in in the following cases:
+* A `400 Bad Request` error will be thrown if the request has invalid values such as in the following cases:
 
   - relations the user do not have permission to create
   - unrecognized values that are not present on a schema

--- a/docusaurus/docs/cms/plugins/graphql.md
+++ b/docusaurus/docs/cms/plugins/graphql.md
@@ -702,7 +702,7 @@ With the Users & Permissions plugin, a GraphQL request is allowed if the appropr
 
 For instance, if a 'Category' content-type exists and is queried through GraphQL with the `Query.categories` handler, the request is allowed if the appropriate `find` permission for the 'Categories' content-type is given.
 
-To query a single category, which is done with the `Query.category` handler, the request is allowed if the the `findOne` permission is given.
+To query a single category, which is done with the `Query.category` handler, the request is allowed if the `findOne` permission is given.
 
 Please refer to the user guide on how to [define permissions with the Users & Permissions plugin](/cms/features/rbac#editing-a-role).
 </details>
@@ -1145,7 +1145,7 @@ Then on each request, send along an `Authorization` header in the form of `{ "Au
 To use API tokens for authentication, pass the token in the `Authorization` header using the format `Bearer your-api-token`.
 
 :::note
-Using API tokens in the the GraphQL Sandbox requires adding the authorization header with your token in the `HTTP HEADERS` tab:
+Using API tokens in the GraphQL Sandbox requires adding the authorization header with your token in the `HTTP HEADERS` tab:
 
 ```http
 {


### PR DESCRIPTION
## What does it do?

Removes accidental duplicated words in four documentation pages. Text-only corrections with no change to meaning or code samples.

| File | Before | After |
| --- | --- | --- |
| `cms/api/entity-service/crud.md` | "built on top of **the the** Query Engine API" | "top of the Query Engine API" |
| `cms/migration/v4-to-v5/breaking-changes/default-input-validation.md` | "such **as in in** the following cases" | "such as in the following cases" |
| `cms/plugins/graphql.md` | "allowed **if the the** `findOne` permission" | "if the `findOne` permission" |
| `cms/plugins/graphql.md` | "API tokens **in the the** GraphQL Sandbox" | "in the GraphQL Sandbox" |

## Why is it needed?

These are small copyediting fixes that improve readability. Each duplicate was manually verified to be a genuine error (intentional patterns such as operator names were excluded).
