### PR TITLE
Make pitfalls-add write the canonical known-pitfalls catalog first

### DIFF
--- a/claude-plugins/inki/references/prompts/integrity-known-pitfalls.md
+++ b/claude-plugins/inki/references/prompts/integrity-known-pitfalls.md
@@ -31,6 +31,7 @@ This file lists documented patterns where AI-generated documentation has produce
 | Hallucinated pattern | Correct pattern | Context |
 |---------------------|-----------------|---------|
 | "Always sanitize input/output" (universal) | Sanitization applies specifically to Content API routes | The `sanitize` utility is used in Content API controllers. Not all routes require it. |
+| A component `preview` image pointing at a Media Library upload, e.g. `"preview": "/uploads/hero_abc123.png"` | A path under the project's `public` directory, e.g. `"preview": "/_component-screenshots/hero.png"`, or an absolute URL | The `public` middleware route is `path: '/((?!uploads/).+)'` (`packages/core/core/src/middlewares/public.ts`), which explicitly excludes `/uploads/` because the upload middleware handles it. A preview pointing at `/uploads/` fails to load and silently falls back to the component's `icon`. |
 
 ### Import and export patterns
 

--- a/claude-plugins/inki/skills/pitfalls-add/SKILL.md
+++ b/claude-plugins/inki/skills/pitfalls-add/SKILL.md
@@ -7,7 +7,9 @@ user-invocable: true
 
 # /inki:pitfalls-add: add an entry to the known-pitfalls catalog
 
-The `pitfalls-checker` agent is read-only: it consults the catalog but never edits it. This skill is the writing counterpart: it adds a new, verified entry to `${CLAUDE_PLUGIN_ROOT}/references/prompts/integrity-known-pitfalls.md` so the mistake is caught automatically in every future review.
+The `pitfalls-checker` agent is read-only: it consults the catalog but never edits it. This skill is the writing counterpart: it adds a new, verified entry to the known-pitfalls catalog so the mistake is caught automatically in every future review.
+
+The catalog exists in two places. The **canonical copy** is versioned in the repo at `claude-plugins/inki/references/prompts/integrity-known-pitfalls.md`. The **plugin cache copy** (`${CLAUDE_PLUGIN_ROOT}/references/prompts/integrity-known-pitfalls.md`) is what the running plugin reads, and it is overwritten on every plugin update. Always write the canonical copy first, then mirror to the cache (Step 5): an entry written only to the cache is silently lost on the next update.
 
 ## Step 0: Parse arguments
 
@@ -33,7 +35,7 @@ Do NOT add an unverified pattern: a wrong catalog entry would generate false pos
 
 ## Step 3: Choose the category
 
-Read the catalog and pick the matching category table (e.g. "Strapi v5 identifiers", "Lifecycle and boot sequence"). If none fits, create a new category section following the existing format.
+Read the **canonical** catalog and pick the matching category table (e.g. "Strapi v5 identifiers", "Lifecycle and boot sequence"). If none fits, create a new category section following the existing format.
 
 ## Step 4: Show the proposed entry and confirm
 
@@ -46,16 +48,41 @@ Category: <name>
 
 If `AUTO=false` (default), ask for confirmation before writing. If `AUTO=true`, skip the prompt (the source verification in Step 2 is the safety gate).
 
-## Step 5: Add the entry
+## Step 5: Add the entry, canonical first
 
-Add the row to the chosen table (or the new category section), preserving the file's existing Markdown formatting. Do not reorder or rewrite existing entries.
+Write in this order. Never stop after the cache: that is how entries get lost.
+
+1. **Canonical copy (required).** Add the row to the chosen table in `claude-plugins/inki/references/prompts/integrity-known-pitfalls.md`, preserving the file's existing Markdown formatting. Do not reorder or rewrite existing entries.
+
+   Resolve an absolute path to it before writing:
+
+   ```bash
+   ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+   CANON="$ROOT/claude-plugins/inki/references/prompts/integrity-known-pitfalls.md"
+   [ -n "$ROOT" ] && [ -f "$CANON" ] && echo "$CANON" || echo "NOT_FOUND"
+   ```
+
+   This works from anywhere inside the repo, including subdirectories such as `docusaurus/`. If it prints `NOT_FOUND` (the session is running outside `strapi/documentation`, or in another repo), do **not** fall back to writing only the cache: say the canonical copy is unreachable, print the row for the user to add themselves, and stop.
+
+2. **Cache copy (mirror).** Copy the same row into `${CLAUDE_PLUGIN_ROOT}/references/prompts/integrity-known-pitfalls.md` so the entry takes effect immediately in the running session, without waiting for a plugin update.
+
+3. **Verify they match.** The two files must be identical afterwards:
+
+   ```bash
+   diff "$CANON" "${CLAUDE_PLUGIN_ROOT}/references/prompts/integrity-known-pitfalls.md"
+   ```
+
+   If the diff shows entries present in the cache but missing from the canonical copy, those are earlier cache-only additions that were never persisted. Surface them to the user and offer to sync them into the canonical copy in the same pass, re-verifying each against the source per Step 2 before doing so.
 
 ## Step 6: Report
 
-Confirm what was added and where. If the catalog lives under a synced reference, remind the user that the canonical copy may need the same edit if a sync rule applies (the catalog is a plugin reference, edited in place here).
+Confirm what was added, to which category, and in **both** locations. State explicitly that the canonical copy is versioned and needs committing, and that the cache copy is a working mirror that will be overwritten on the next plugin update.
+
+The canonical copy is a tracked file in `strapi/documentation`, so remind the user to commit it (`/inki:commit`). Do not commit it as part of an unrelated documentation change unless the user asks.
 
 ## Rules
 
 - Never add an unverified "correct pattern". Verification against the source is mandatory (Step 2).
 - Append only; never edit or remove existing catalog entries.
+- Always write the canonical copy in the repo before the plugin cache copy, and never write the cache alone. The cache is overwritten on plugin updates, so a cache-only entry is silently lost.
 - This is the only inki skill allowed to write the pitfalls catalog. The `pitfalls-checker` agent stays strictly read-only.


### PR DESCRIPTION
This PR fixes /inki:pitfalls-add writing new catalog entries only to the plugin cache. The skill pointed at ${CLAUDE_PLUGIN_ROOT}, which resolves to ~/.claude/plugins/cache/, so every entry was silently lost on the next plugin update. Step 5 now writes the versioned copy under claude-plugins/inki/references/ first, mirrors it to the cache so it takes effect immediately, and diffs the two to surface earlier cache-only entries that were never persisted. It also adds a known pitfall for component preview images pointing at a Media Library upload, verified against the public middleware route in packages/core/core/src/middlewares/public.ts.