### PR TITLE
Exclude release PRs from the docs self-healing pre-filter

### DIFF
--- a/.github/workflows/docs-self-healing.yml
+++ b/.github/workflows/docs-self-healing.yml
@@ -106,13 +106,19 @@ jobs:
           # EXCLUDED (never user-facing):
           #   chore(*), test(*), docs:, doc:, security:,
           #   refactor(*), ci(*), build(*), style(*),
+          #   release PRs ("release: 5.52.2", "Release 5.23.5 main to develop"),
           #   translations/i18n/localization (any prefix),
           #   typo, Remove/Update yarn/README,
           #   dependency upgrades with patch/minor version bumps
           #
           # KEPT (Router decides): feat, fix, enhancement, perf, and anything else
+          #
+          # NOTE: the release pattern is anchored on a version number so it only
+          # catches version-bump PRs, never PRs about the Releases feature itself
+          # (e.g. "fix(content-releases): ..." or "feat: homepage releases widget").
           jq '[.[] | select(
             (.title | test("^chore"; "i") | not) and
+            (.title | test("^\\s*release[:\\s]+v?\\d+\\.\\d+"; "i") | not) and
             (.title | test("^test[:(\\s]"; "i") | not) and
             (.title | test("^docs?:"; "i") | not) and
             (.title | test("^security:"; "i") | not) and


### PR DESCRIPTION
This PR stops release PRs such as "release: 5.52.2" from reaching the AI triage step of the docs self-healing workflow, where they consumed tokens for PRs that never need documentation. The new title filter is anchored on a version number, so it catches the release PR shapes ("release: 5.52.2", "Release 5.23.5 main to develop") without excluding PRs about the Releases feature itself, such as "fix(content-releases): ...".