### PR TITLE
Fix self-healing reporting for micro PRs and add a maintainer auto-merge override

### DIFF
--- a/.github/workflows/automerge-cron.yml
+++ b/.github/workflows/automerge-cron.yml
@@ -24,6 +24,11 @@ permissions:
 
 env:
   ELIGIBLE_LABEL: 'automerge: eligible'
+  # Set by hand when the maintainer has read a PR and vouched for it despite a
+  # mechanical criterion being violated. It replaces the form verdict, nothing
+  # else: everything below this line still applies.
+  # See automerge-eligibility.yml for the rationale.
+  APPROVED_LABEL: 'automerge: approved by piwi'
   QUARANTINE_HOURS: 24
   # Checks that must be green. Deliberately an allow-list, not "everything":
   # `license/cla` is permanently pending on pipeline PRs because the CLA bot does
@@ -101,12 +106,27 @@ jobs:
         run: |
           set -uo pipefail
 
+          # Two ways in: the gate said the form is safe, or the maintainer said
+          # the content is. Passing both labels to a single `gh pr list` would
+          # AND them and match neither, so they are queried separately and the
+          # results merged on PR number.
           gh pr list --repo "$GITHUB_REPOSITORY" \
             --state open --label "$ELIGIBLE_LABEL" --limit 100 \
-            --json number,title,url,createdAt,isDraft > /tmp/eligible.json
+            --json number,title,url,createdAt,isDraft > /tmp/by-label.json
 
+          gh pr list --repo "$GITHUB_REPOSITORY" \
+            --state open --label "$APPROVED_LABEL" --limit 100 \
+            --json number,title,url,createdAt,isDraft > /tmp/by-approval.json
+
+          jq -s 'add | unique_by(.number)' /tmp/by-label.json /tmp/by-approval.json \
+            > /tmp/eligible.json
+
+          BY_LABEL=$(jq 'length' /tmp/by-label.json)
+          BY_APPROVAL=$(jq 'length' /tmp/by-approval.json)
           TOTAL=$(jq 'length' /tmp/eligible.json)
-          echo "PRs labelled '$ELIGIBLE_LABEL': $TOTAL"
+          echo "PRs labelled '$ELIGIBLE_LABEL': $BY_LABEL"
+          echo "PRs labelled '$APPROVED_LABEL': $BY_APPROVAL"
+          echo "Merge candidates after deduplication: $TOTAL"
 
           if [ "$SUSPENDED" = "true" ]; then
             echo "Auto-merge suspended: $SUSPEND_REASON"
@@ -144,6 +164,13 @@ jobs:
             SHORT=$(printf '%s' "$TITLE" | cut -c1-70)
             [ "${#TITLE}" -gt 70 ] && SHORT="${SHORT}…"
             LINK="<${URL}|#${PR} — ${SHORT}>"
+
+            # A PR merged on the maintainer's word rather than on the checks is
+            # marked as such, so the recap never presents an override as a clean
+            # pass through the gate.
+            if jq -e --argjson n "$PR" 'any(.[]; .number == $n)' /tmp/by-approval.json > /dev/null; then
+              LINK="${LINK} _(approved by piwi)_"
+            fi
 
             # Quarantine. It buys back the two collision cases the gate cannot
             # see at open time: a duplicate opened seconds later, a PR superseded

--- a/.github/workflows/automerge-eligibility.yml
+++ b/.github/workflows/automerge-eligibility.yml
@@ -39,6 +39,18 @@ permissions:
 
 env:
   ELIGIBLE_LABEL: 'automerge: eligible'
+  # The maintainer's override. The mechanical checks judge form, and form is a
+  # proxy: a change can violate a criterion and still be right. When that
+  # happens, this label records that a human read the PR and vouched for it.
+  #
+  # It is the positive counterpart of `flag: don't merge`, and it is deliberately
+  # a label rather than a relaxed criterion — the decision stays visible on the
+  # PR, attributable, and reversible by removing it.
+  #
+  # It overrides FORM ONLY. The quarantine, the required checks and the absence
+  # period still apply, and `flag: don't merge` / `flag: merge pending release`
+  # still block the merge through block-labeled-prs.yml.
+  APPROVED_LABEL: 'automerge: approved by piwi'
   SCOPE_LABEL: auto-doc-healing
   QUIET_PERIOD_MINUTES: 5
 
@@ -66,7 +78,32 @@ jobs:
             exit 0
           fi
 
+          # A maintainer-approved PR is not re-judged. Without this, adding the
+          # approval label triggers this workflow through the `labeled` event,
+          # the checks fail again on the very criterion being overridden, and the
+          # "Update the eligibility label" step removes `automerge: eligible` —
+          # silently undoing the decision minutes after it was made.
+          if echo "$LABELS" | grep -Fxq "$APPROVED_LABEL"; then
+            echo "PR #$PR carries '$APPROVED_LABEL' — form checks skipped"
+            echo "in_scope=false" >> "$GITHUB_OUTPUT"
+            echo "approved=true" >> "$GITHUB_OUTPUT"
+            {
+              echo "## Auto-merge eligibility — #$PR"
+              echo ""
+              echo "**Approved by the maintainer — mechanical checks skipped.**"
+              echo ""
+              echo "This PR carries \`$APPROVED_LABEL\`, so its form is not judged:"
+              echo "a human read it and vouched for it."
+              echo ""
+              echo "The quarantine, the required CI checks and the absence period"
+              echo "still apply. To stop the merge, remove that label or add"
+              echo "\`flag: don't merge\`."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
           echo "in_scope=true" >> "$GITHUB_OUTPUT"
+          echo "approved=false" >> "$GITHUB_OUTPUT"
 
       # Wait for the PR to stop moving. Combined with cancel-in-progress, a push
       # during this window kills the run and restarts the clock, so the checks
@@ -198,6 +235,12 @@ jobs:
               [ -n "$UNKNOWN" ] && echo "- Could not be evaluated: \`${UNKNOWN%, }\` (treated as blocking)"
               echo ""
               echo "The \`$ELIGIBLE_LABEL\` label is not applied, or is removed if it was there."
+              echo ""
+              echo "These criteria judge form, not content. If you have read this PR"
+              echo "and it is fine as it stands, add \`$APPROVED_LABEL\`: the checks"
+              echo "are then skipped and the cron merges it after the usual"
+              echo "quarantine. Adding \`$ELIGIBLE_LABEL\` by hand does not work —"
+              echo "this workflow re-runs and removes it."
             } >> "$GITHUB_STEP_SUMMARY"
           else
             echo "eligible=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/docs-self-healing.yml
+++ b/.github/workflows/docs-self-healing.yml
@@ -481,6 +481,7 @@ jobs:
           if [ ! -f "$RESULTS_FILE" ]; then
             echo "Router did not produce results file"
             echo "has_targets=false" >> $GITHUB_OUTPUT
+            echo "micro_prs=0" >> $GITHUB_OUTPUT
             exit 0
           fi
 
@@ -525,12 +526,25 @@ jobs:
             echo "" >> $GITHUB_STEP_SUMMARY
           fi
 
-          # Sonnet only needed for "full" complexity PRs
+          # `has_targets` answers one question only: does Sonnet need to run?
+          # Micro-edits are handled by the Router itself, so they never set it.
+          #
+          # Reporting must NOT reuse this output to mean "the Router found
+          # something" — a run that produced only micro PRs has has_targets=false
+          # and would be reported as an empty run. That was the 2026-08-28 bug:
+          # PR #3418 was created and Slack announced "no documentation targets".
+          # `micro_prs` below is what the Summary and Slack steps read instead.
           if [ "$FULL" -eq 0 ]; then
             echo "has_targets=false" >> $GITHUB_OUTPUT
           else
             echo "has_targets=true" >> $GITHUB_OUTPUT
           fi
+
+          # Micro PRs actually opened by the Router (a micro target that failed
+          # to produce a PR has no .doc_pr, and must not be counted as created).
+          MICRO_PRS=$(jq '[.prs[] | select(.decision == "has_targets" and .complexity == "micro" and (.doc_pr // "") != "")] | length' "$RESULTS_FILE")
+          echo "micro_prs=$MICRO_PRS" >> $GITHUB_OUTPUT
+          echo "Micro doc PRs created by the Router: $MICRO_PRS"
 
           # Pass router results to Sonnet (only full-complexity PRs)
           {
@@ -638,9 +652,29 @@ jobs:
             exit 0
           fi
 
-          # Case 3: Router ran but found no targets — Sonnet was NOT invoked
+          # Micro PRs are created by the Router itself, so they must be reported
+          # whether or not Sonnet ran afterwards.
+          MICRO_PRS="${{ steps.check-router.outputs.micro_prs }}"
+          MICRO_PRS="${MICRO_PRS:-0}"
+
+          if [ "$MICRO_PRS" -gt 0 ] && [ -f /tmp/router-results.json ]; then
+            echo "### Micro-edit doc PRs (Haiku Router)" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "**Doc PRs created ($MICRO_PRS):**" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            jq -r '.prs[] | select(.decision == "has_targets" and .complexity == "micro" and (.doc_pr // "") != "") | "- [strapi/strapi#\(.number) — \(.title)](\(.doc_pr))"' \
+              /tmp/router-results.json >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+          fi
+
+          # Case 3: Sonnet was NOT invoked. That is only an empty run if the
+          # Router did not create micro PRs of its own.
           if [ "${{ steps.check-router.outputs.has_targets }}" != "true" ]; then
-            echo "**Result:** Router (Haiku) found no documentation targets. Sonnet was not invoked." >> $GITHUB_STEP_SUMMARY
+            if [ "$MICRO_PRS" -eq 0 ]; then
+              echo "**Result:** Router (Haiku) found no documentation targets. Sonnet was not invoked." >> $GITHUB_STEP_SUMMARY
+            else
+              echo "**Result:** All targets were micro-edits, handled by the Router. Sonnet was not invoked." >> $GITHUB_STEP_SUMMARY
+            fi
             exit 0
           fi
 
@@ -694,35 +728,59 @@ jobs:
           DATE=$(date -u '+%Y-%m-%d %H:%M UTC')
           JOB_STATUS="${{ job.status }}"
 
+          SUMMARY_FILE="/tmp/self-healing-summary.json"
+          ROUTER_FILE="/tmp/router-results.json"
+
+          # Doc PRs come from two places: micro-edits opened by the Router
+          # itself, and full drafts opened by Sonnet. Reporting only the second
+          # is what made the 2026-08-28 run announce "no documentation targets"
+          # while PR #3418 had just been created. Both are collected here, the
+          # same way the Notion step already does it.
+          MICRO_COUNT="${{ steps.check-router.outputs.micro_prs }}"
+          MICRO_COUNT="${MICRO_COUNT:-0}"
+          MICRO_LIST=""
+          if [ "$MICRO_COUNT" -gt 0 ] && [ -f "$ROUTER_FILE" ]; then
+            MICRO_LIST=$(jq -r '.prs[] | select(.decision == "has_targets" and .complexity == "micro" and (.doc_pr // "") != "") | "• <\(.doc_pr)|strapi/strapi#\(.number) — \(.title)>"' "$ROUTER_FILE")
+          fi
+
+          SONNET_COUNT=0
+          SONNET_LIST=""
+          ERRORS=0
+          if [ -f "$SUMMARY_FILE" ]; then
+            SONNET_COUNT=$(jq -r '.processed | length' "$SUMMARY_FILE")
+            SONNET_LIST=$(jq -r '.processed[] | "• <\(.doc_pr)|strapi/strapi#\(.number) — \(.title)>"' "$SUMMARY_FILE")
+            ERRORS=$(jq -r '.errors | length' "$SUMMARY_FILE")
+          fi
+
+          TOTAL_PRS=$((MICRO_COUNT + SONNET_COUNT))
+          PR_LIST=$(printf '%s\n%s' "$MICRO_LIST" "$SONNET_LIST" | grep -v '^$' || true)
+
           # Build the main message (short summary)
           if [ "$JOB_STATUS" == "failure" ]; then
             MAIN=":pepe_alarm: *Docs Self-Healing FAILED* ($DATE)\nOne or more steps failed. Check the run for details.\n<${RUN_URL}|View run>"
+          elif [ "$TOTAL_PRS" -gt 0 ]; then
+            # Any run that produced a doc PR reports it, whichever model opened it.
+            MAIN=":noted: *Docs Self-Healing* ($DATE)\n*${TOTAL_PRS} doc PR(s) created:*\n${PR_LIST}\n<${RUN_URL}|View run>"
+
+            if [ "$ERRORS" -gt 0 ]; then
+              ERROR_LIST=$(jq -r '.errors[] | "• strapi/strapi#\(.number): \(.error)"' "$SUMMARY_FILE")
+              MAIN="${MAIN}\n\n:warning: *Errors:*\n${ERROR_LIST}"
+            fi
           elif [ "${{ steps.check-prs.outputs.has_prs }}" == "false" ]; then
             MAIN=":white_check_mark: *Docs Self-Healing* ($DATE)\nNo candidate PRs after pre-filtering. No AI invoked.\n<${RUN_URL}|View run>"
           elif [ "${{ steps.check-triage.outputs.has_candidates }}" != "true" ]; then
             MAIN=":white_check_mark: *Docs Self-Healing* ($DATE)\nTriage (Haiku) eliminated all PRs. Router and Sonnet were not invoked.\n<${RUN_URL}|View run>"
           elif [ "${{ steps.check-router.outputs.has_targets }}" != "true" ]; then
             MAIN=":frog_shrug: *Docs Self-Healing* ($DATE)\nRouter (Haiku) found no documentation targets. Sonnet was not invoked.\n<${RUN_URL}|View run>"
-          else
-            SUMMARY_FILE="/tmp/self-healing-summary.json"
-            if [ -f "$SUMMARY_FILE" ]; then
-              PROCESSED=$(jq -r '.processed | length' "$SUMMARY_FILE")
-              ERRORS=$(jq -r '.errors | length' "$SUMMARY_FILE")
+          elif [ -f "$SUMMARY_FILE" ]; then
+            MAIN=":warning: *Docs Self-Healing* ($DATE)\nSonnet ran but created no PRs.\n<${RUN_URL}|View run>"
 
-              if [ "$PROCESSED" -gt 0 ]; then
-                PR_LIST=$(jq -r '.processed[] | "• <\(.doc_pr)|strapi/strapi#\(.number) — \(.title)>"' "$SUMMARY_FILE")
-                MAIN=":noted: *Docs Self-Healing* ($DATE)\n*${PROCESSED} doc PR(s) created:*\n${PR_LIST}\n<${RUN_URL}|View run>"
-              else
-                MAIN=":warning: *Docs Self-Healing* ($DATE)\nSonnet ran but created no PRs.\n<${RUN_URL}|View run>"
-              fi
-
-              if [ "$ERRORS" -gt 0 ]; then
-                ERROR_LIST=$(jq -r '.errors[] | "• strapi/strapi#\(.number): \(.error)"' "$SUMMARY_FILE")
-                MAIN="${MAIN}\n\n:warning: *Errors:*\n${ERROR_LIST}"
-              fi
-            else
-              MAIN=":warning: *Docs Self-Healing* ($DATE)\nSonnet ran but no summary file was produced.\n<${RUN_URL}|View run>"
+            if [ "$ERRORS" -gt 0 ]; then
+              ERROR_LIST=$(jq -r '.errors[] | "• strapi/strapi#\(.number): \(.error)"' "$SUMMARY_FILE")
+              MAIN="${MAIN}\n\n:warning: *Errors:*\n${ERROR_LIST}"
             fi
+          else
+            MAIN=":warning: *Docs Self-Healing* ($DATE)\nSonnet ran but no summary file was produced.\n<${RUN_URL}|View run>"
           fi
 
           # Post message to Slack


### PR DESCRIPTION
Two fixes to the self-healing pipeline, both surfaced by the run of 2026-08-28.

The Slack notification and the run summary read `has_targets` to decide whether the run produced anything. That output answers a narrower question: whether Sonnet needs to be invoked, since it is computed from the count of "full" complexity PRs only. Micro-edits are handled by the Haiku Router itself, which opens the doc PR and records its URL in router-results.json, so a run whose targets are all micro ends with `has_targets=false` and was reported as an empty run. That is how the 2026-08-28 run announced "Router (Haiku) found no documentation targets" a few seconds after the Router had opened #3418. Both reporting steps now count the micro PRs alongside Sonnet's, the way the Notion logging step already did. `has_targets` keeps its current meaning and is only consulted to explain why Sonnet did not run.

The second change adds `automerge: approved by piwi`, a maintainer override for the auto-merge eligibility gate. The mechanical checks judge form, and form is a proxy: a change can violate a criterion and still be correct. #3418 is the first case, since it adds a heading and check-no-headings refuses that outright. There was no way to act on that, because adding `automerge: eligible` by hand does not survive: the `labeled` event re-runs the eligibility workflow, the checks fail again on the same criterion, and the label is removed minutes later. The new label records that a human read the PR and vouched for it, the eligibility workflow stops re-judging a PR that carries it, and the cron merges it alongside the gate-approved ones.

The override applies to form only. The 24-hour quarantine, the required CI checks and the absence period still apply, and `flag: don't merge` and `flag: merge pending release` still block the merge through the check-labels check. PRs merged on the override are marked as such in the Slack recap so an override is never presented as a clean pass through the gate. The label itself has already been created on the repository. check-no-headings is left unchanged for now.