### PR TITLE
Document the publication behavior of localized POST and PUT requests

### DIFF
--- a/docusaurus/docs/cms/api/document-service/status.md
+++ b/docusaurus/docs/cms/api/document-service/status.md
@@ -36,7 +36,7 @@ By default the [Document Service API](/cms/api/document-service) returns the dra
 Passing `{ status: 'draft' }` to a Document Service API query returns the same results as not passing any `status` parameter.
 :::
 
-:::caution
+:::note
 The Document Service API defaults to `draft`, but the [REST API](/cms/api/rest/status) defaults to `published`. A `POST` or `PUT` request sent to the REST API without a `status` parameter therefore publishes immediately, which is the opposite of the behavior described on this page.
 :::
 

--- a/docusaurus/docs/cms/api/document-service/status.md
+++ b/docusaurus/docs/cms/api/document-service/status.md
@@ -36,6 +36,10 @@ By default the [Document Service API](/cms/api/document-service) returns the dra
 Passing `{ status: 'draft' }` to a Document Service API query returns the same results as not passing any `status` parameter.
 :::
 
+:::caution
+The Document Service API defaults to `draft`, but the [REST API](/cms/api/rest/status) defaults to `published`. A `POST` or `PUT` request sent to the REST API without a `status` parameter therefore publishes immediately, which is the opposite of the behavior described on this page.
+:::
+
 To select documents by how their draft and published versions relate (never-published, modified, and others), see [Document Service API: `publicationFilter`](/cms/api/document-service/publication-filter).
 
 ## Get the published version with `findOne()` {#find-one}

--- a/docusaurus/docs/cms/api/rest.md
+++ b/docusaurus/docs/cms/api/rest.md
@@ -12,6 +12,9 @@ tags:
 - singular API ID
 ---
 
+import RestPostPublishes from '/docs/snippets/rest-post-publishes-immediately.md'
+import RestPutPublishes from '/docs/snippets/rest-put-publishes-immediately.md'
+
 # REST API reference
 
 <Tldr>
@@ -311,9 +314,7 @@ If the [Internationalization (i18n) feature](/cms/features/internationalization)
 While creating a document, you can define its relations and their order (see [Managing relations through the REST API](/cms/api/rest/relations) for more details).
 :::
 
-:::note Draft & Publish
-With [Draft & Publish](/cms/features/draft-and-publish) enabled, a POST request without a `status` parameter creates the document and publishes it immediately. Pass `?status=draft` to create it as a draft (see [REST API: `status`](/cms/api/rest/status#create-update)).
-:::
+<RestPostPublishes />
 
 :::info Dynamic zones
 Each entry you send for a [dynamic zone](/cms/backend-customization/models#dynamic-zones) must include `__component` with the target component's UID (for example `shared.media`). Strapi uses that field to pick the component schema when you create or update items in the zone; without it, writes can fail validation or return success without changing data. Use the UID shown in the Content-Type Builder for each component in the zone.
@@ -418,9 +419,7 @@ const data = await response.json();
 * While updating a document, you can define its relations and their order (see [Managing relations through the REST API](/cms/api/rest/relations) for more details).
 :::
 
-:::note Draft & Publish
-With [Draft & Publish](/cms/features/draft-and-publish) enabled, a PUT request without a `status` parameter publishes the changes immediately. Pass `?status=draft` to update the draft only (see [REST API: `status`](/cms/api/rest/status#create-update)). This also applies to single types, where `PUT /api/:singularApiId` publishes the changes unless you pass `?status=draft`.
-:::
+<RestPutPublishes singleTypePath="/api/:singularApiId" />
 
 :::info Dynamic zones
 Each entry you send for a [dynamic zone](/cms/backend-customization/models#dynamic-zones) must include `__component` with the target component's UID (for example `shared.media`). Strapi uses that field to pick the component schema when you create or update items in the zone; without it, writes can fail validation or return success without changing data. Use the UID shown in the Content-Type Builder for each component in the zone.

--- a/docusaurus/docs/cms/api/rest/locale.md
+++ b/docusaurus/docs/cms/api/rest/locale.md
@@ -239,6 +239,10 @@ To create a localized document from scratch, send a POST request to the Content 
 | Create for the default locale | [`POST /api/content-type-plural-name`](#rest-create-default-locale) |
 | Create for a specific locale  | [`POST /api/content-type-plural-name?locale=fr`](#rest-create-specific-locale)
 
+:::note Draft & Publish
+With [Draft & Publish](/cms/features/draft-and-publish) enabled, a POST request without a `status` parameter creates the localized document and publishes it immediately. Pass `?status=draft` to create it as a draft (see [REST API: `status`](/cms/api/rest/status#create-update)).
+:::
+
 #### For the default locale {#rest-create-default-locale}
 
 If no locale has been passed in the request body, the document is created using the default locale for the application:
@@ -357,6 +361,10 @@ The Content-Type should have the [`createLocalization` permission](/cms/features
 
 :::note
 It is not possible to change the locale of an existing localized entry. When updating a localized entry, if you set a `locale` attribute in the request body it will be ignored.
+:::
+
+:::note Draft & Publish
+With [Draft & Publish](/cms/features/draft-and-publish) enabled, a PUT request without a `status` parameter publishes the changes immediately. Pass `?status=draft` to update the draft only (see [REST API: `status`](/cms/api/rest/status#create-update)).
 :::
 
 #### In a collection type {#rest-put-collection-type}

--- a/docusaurus/docs/cms/api/rest/locale.md
+++ b/docusaurus/docs/cms/api/rest/locale.md
@@ -364,7 +364,7 @@ It is not possible to change the locale of an existing localized entry. When upd
 :::
 
 :::note Draft & Publish
-With [Draft & Publish](/cms/features/draft-and-publish) enabled, a PUT request without a `status` parameter publishes the changes immediately. Pass `?status=draft` to update the draft only (see [REST API: `status`](/cms/api/rest/status#create-update)).
+With [Draft & Publish](/cms/features/draft-and-publish) enabled, a PUT request without a `status` parameter publishes the changes immediately. Pass `?status=draft` to update the draft only (see [REST API: `status`](/cms/api/rest/status#create-update)). This also applies to single types, where `PUT /api/:singularApiId?locale=locale-code` publishes the changes unless you pass `?status=draft`.
 :::
 
 #### In a collection type {#rest-put-collection-type}

--- a/docusaurus/docs/cms/api/rest/locale.md
+++ b/docusaurus/docs/cms/api/rest/locale.md
@@ -16,6 +16,8 @@ tags:
 import QsIntroFull from '/docs/snippets/qs-intro-full.md'
 import QsForQueryBody from '/docs/snippets/qs-for-query-body.md'
 import QsForQueryTitle from '/docs/snippets/qs-for-query-title.md'
+import RestPostPublishes from '/docs/snippets/rest-post-publishes-immediately.md'
+import RestPutPublishes from '/docs/snippets/rest-put-publishes-immediately.md'
 
 # REST API: `locale`
 
@@ -239,9 +241,7 @@ To create a localized document from scratch, send a POST request to the Content 
 | Create for the default locale | [`POST /api/content-type-plural-name`](#rest-create-default-locale) |
 | Create for a specific locale  | [`POST /api/content-type-plural-name?locale=fr`](#rest-create-specific-locale)
 
-:::note Draft & Publish
-With [Draft & Publish](/cms/features/draft-and-publish) enabled, a POST request without a `status` parameter creates the localized document and publishes it immediately. Pass `?status=draft` to create it as a draft (see [REST API: `status`](/cms/api/rest/status#create-update)).
-:::
+<RestPostPublishes documentLabel="localized document" />
 
 #### For the default locale {#rest-create-default-locale}
 
@@ -363,9 +363,7 @@ The Content-Type should have the [`createLocalization` permission](/cms/features
 It is not possible to change the locale of an existing localized entry. When updating a localized entry, if you set a `locale` attribute in the request body it will be ignored.
 :::
 
-:::note Draft & Publish
-With [Draft & Publish](/cms/features/draft-and-publish) enabled, a PUT request without a `status` parameter publishes the changes immediately. Pass `?status=draft` to update the draft only (see [REST API: `status`](/cms/api/rest/status#create-update)). This also applies to single types, where `PUT /api/:singularApiId?locale=locale-code` publishes the changes unless you pass `?status=draft`.
-:::
+<RestPutPublishes singleTypePath="/api/:singularApiId?locale=locale-code" />
 
 #### In a collection type {#rest-put-collection-type}
 

--- a/docusaurus/docs/snippets/rest-post-publishes-immediately.md
+++ b/docusaurus/docs/snippets/rest-post-publishes-immediately.md
@@ -1,0 +1,3 @@
+:::note Draft & Publish
+With [Draft & Publish](/cms/features/draft-and-publish) enabled, a POST request without a `status` parameter creates the {props.documentLabel || 'document'} and publishes it immediately. Pass `?status=draft` to create it as a draft (see [REST API: `status`](/cms/api/rest/status#create-update)).
+:::

--- a/docusaurus/docs/snippets/rest-put-publishes-immediately.md
+++ b/docusaurus/docs/snippets/rest-put-publishes-immediately.md
@@ -1,0 +1,3 @@
+:::note Draft & Publish
+With [Draft & Publish](/cms/features/draft-and-publish) enabled, a PUT request without a `status` parameter publishes the changes immediately. Pass `?status=draft` to update the draft only (see [REST API: `status`](/cms/api/rest/status#create-update)). This also applies to single types, where <code>PUT {props.singleTypePath}</code> publishes the changes unless you pass `?status=draft`.
+:::


### PR DESCRIPTION
This PR closes the remaining discoverability gaps around the REST API `status` parameter. The i18n page documented creating and updating localized documents without mentioning that a request publishes immediately unless `?status=draft` is passed, and the Document Service status page never pointed to its REST counterpart even though the two default to opposite values, draft versus published.

Comes from docs feedback [CMS-260819132404](https://app.notion.com/p/strapi/CMS-260819132404-3c18f35980748163b7effb236938842a), where a user wiring Draft & Publish from a front-end app found every document created as published and had to discover `?status=draft` on their own. The main REST pages were already covered by #3382, so this only fills what was left.

Direct preview link 👉 [here](https://documentation-git-cms-status-parameter-discoverability-strapijs.vercel.app/cms/api/rest/locale)