### PR TITLE
Fix the response shape of the localized GET by documentId example

### DIFF
--- a/docusaurus/docs/cms/api/rest/locale.md
+++ b/docusaurus/docs/cms/api/rest/locale.md
@@ -157,33 +157,24 @@ curl 'http://localhost:1337/api/restaurants/lr5wju2og49bf820kj9kz8c3?locale=fr' 
 
 ```json
 {
-  "data": [
-    {
-      "id": 22,
-      "documentId": "lr5wju2og49bf820kj9kz8c3",
-      "Name": "Biscotte Restaurant",
-      "Description": [
-        {
-          "type": "paragraph",
-          "children": [
-            {
-              "type": "text",
-              "text": "Bienvenue au restaurant Biscotte! Le Restaurant Biscotte propose une cuisine à base de produits frais et de qualité, souvent locaux, biologiques lorsque cela est possible, et toujours produits par des producteurs passionnés."
-            }
-          ]
-        }
-      ],
-      "locale": "fr"
-    }
-  ],
-  "meta": {
-    "pagination": {
-      "page": 1,
-      "pageSize": 25,
-      "pageCount": 1,
-      "total": 3
-    }
-  }
+  "data": {
+    "id": 22,
+    "documentId": "lr5wju2og49bf820kj9kz8c3",
+    "Name": "Biscotte Restaurant",
+    "Description": [
+      {
+        "type": "paragraph",
+        "children": [
+          {
+            "type": "text",
+            "text": "Bienvenue au restaurant Biscotte! Le Restaurant Biscotte propose une cuisine à base de produits frais et de qualité, souvent locaux, biologiques lorsque cela est possible, et toujours produits par des producteurs passionnés."
+          }
+        ]
+      }
+    ],
+    "locale": "fr"
+  },
+  "meta": {}
 }
 ```
 

--- a/docusaurus/docs/cms/api/rest/locale.md
+++ b/docusaurus/docs/cms/api/rest/locale.md
@@ -172,6 +172,9 @@ curl 'http://localhost:1337/api/restaurants/lr5wju2og49bf820kj9kz8c3?locale=fr' 
         ]
       }
     ],
+    "createdAt": "2024-03-06T22:08:59.643Z",
+    "updatedAt": "2024-03-06T22:10:21.127Z",
+    "publishedAt": "2024-03-06T22:10:21.130Z",
     "locale": "fr"
   },
   "meta": {}


### PR DESCRIPTION
This PR corrects the sample response for `GET /api/restaurants/:documentId?locale=fr` on the i18n REST API page. It showed `data` as an array wrapped in `meta.pagination` with a total of 3, which is the shape returned by a find-many request. Fetching a single document by its documentId returns one object in `data` and an empty `meta`, as the core-api controller passes a single entity to transformResponse with no meta argument. The example was also missing createdAt, updatedAt, and publishedAt, which every other single-document example on the page includes.

Found while reviewing #3422, where it was out of scope.

Direct preview link 👉 [here](https://documentation-git-cms-fix-locale-findone-respon-cdee24-strapijs.vercel.app/cms/api/rest/locale)