### PR TITLE
Announce the real auto-merge day in the Slack eligibility message

### DIFF
--- a/.github/workflows/automerge-cron.yml
+++ b/.github/workflows/automerge-cron.yml
@@ -9,7 +9,11 @@ name: 'Auto-merge: merge eligible PRs'
 
 on:
   schedule:
-    - cron: '0 8 * * 1-5' # 08:00 UTC, weekdays
+    # Daily, not weekdays-only. The quarantine already decides when a PR is ripe;
+    # the schedule only decides how often that is checked. Skipping weekends made
+    # a PR opened after Friday's run wait until Monday — 72h instead of the 24h
+    # the eligibility comment promises.
+    - cron: '0 8 * * *' # 08:00 UTC, daily
   workflow_dispatch:
     inputs:
       dry_run:

--- a/.github/workflows/automerge-cron.yml
+++ b/.github/workflows/automerge-cron.yml
@@ -9,11 +9,10 @@ name: 'Auto-merge: merge eligible PRs'
 
 on:
   schedule:
-    # Daily, not weekdays-only. The quarantine already decides when a PR is ripe;
-    # the schedule only decides how often that is checked. Skipping weekends made
-    # a PR opened after Friday's run wait until Monday — 72h instead of the 24h
-    # the eligibility comment promises.
-    - cron: '0 8 * * *' # 08:00 UTC, daily
+    # Weekdays only, deliberately. An unattended merge should land when someone
+    # is around to notice it went wrong — a Saturday merge sits unwatched until
+    # Monday either way, so the delay costs nothing and buys supervision.
+    - cron: '0 8 * * 1-5' # 08:00 UTC, weekdays
   workflow_dispatch:
     inputs:
       dry_run:

--- a/.github/workflows/automerge-eligibility.yml
+++ b/.github/workflows/automerge-eligibility.yml
@@ -372,23 +372,31 @@ jobs:
           SOURCE_LINE=""
           [ -n "$SOURCE" ] && SOURCE_LINE="\nCorresponding Strapi CMS PR: <https://github.com/strapi/strapi/pull/${SOURCE}|strapi/strapi#${SOURCE}>"
 
-          # The first cron run that merges this PR, named rather than guessed.
-          # "tomorrow" was wrong whenever the run happened before the 24h
-          # quarantine expired: a PR opened at 07:00 UTC is still 1h too young at
-          # the 08:00 run the next day, so it only goes in the day after. The
-          # cron is daily at 08:00 UTC, so the first eligible run is the first
-          # 08:00 that falls at least QUARANTINE_HOURS after the PR was opened.
+          # The cron run that will actually merge this PR, named rather than
+          # guessed. "tomorrow" was wrong in two ways, and both were visible on
+          # #3428: opened Friday 15:12 UTC, it announced Saturday, and the cron
+          # does not run at the weekend. It merged on the Monday.
+          #
+          # Two rules decide the day. The quarantine has to have expired by the
+          # time the run starts, and the run only happens on a weekday. So: take
+          # the moment the PR turns 24h old, pick that day's 08:00 run if it has
+          # not gone by yet, otherwise the next one, then walk forward to the
+          # first weekday.
           MERGE_AT=$(date -u -d "+$QUARANTINE_HOURS hours" '+%Y-%m-%dT%H:%M:%SZ')
           MERGE_DAY=$(date -u -d "$MERGE_AT" '+%Y-%m-%d')
           # Compared as HHMM against the 08:00 run, so 08:00:00 exactly counts as
           # ripe in time for that run rather than being pushed to the next day.
           MERGE_HHMM=$(date -u -d "$MERGE_AT" '+%H%M')
 
-          # Ripe only after that day's run has already gone by, so it waits for
-          # the next one.
           if [ "$((10#$MERGE_HHMM))" -gt 800 ]; then
             MERGE_DAY=$(date -u -d "$MERGE_DAY +1 day" '+%Y-%m-%d')
           fi
+
+          # 6 = Saturday, 7 = Sunday. At most two hops, but written as a loop so
+          # the cron schedule and this calculation cannot drift apart silently.
+          while [ "$(date -u -d "$MERGE_DAY" '+%u')" -gt 5 ]; do
+            MERGE_DAY=$(date -u -d "$MERGE_DAY +1 day" '+%Y-%m-%d')
+          done
 
           WHEN=$(date -u -d "$MERGE_DAY" '+%A %-d %B')
 

--- a/.github/workflows/automerge-eligibility.yml
+++ b/.github/workflows/automerge-eligibility.yml
@@ -53,6 +53,10 @@ env:
   APPROVED_LABEL: 'automerge: approved by piwi'
   SCOPE_LABEL: auto-doc-healing
   QUIET_PERIOD_MINUTES: 5
+  # Only used to tell the maintainer when the merge will happen. The cron owns
+  # the actual quarantine; this copy must be kept in step with the value in
+  # automerge-cron.yml, or the announced date drifts from the real one.
+  QUARANTINE_HOURS: 24
 
 jobs:
   evaluate:
@@ -368,8 +372,28 @@ jobs:
           SOURCE_LINE=""
           [ -n "$SOURCE" ] && SOURCE_LINE="\nCorresponding Strapi CMS PR: <https://github.com/strapi/strapi/pull/${SOURCE}|strapi/strapi#${SOURCE}>"
 
-          TEXT=$(printf ':hourglass_flowing_sand: *Will auto-merge tomorrow*\n%s\n%s%b\n\nStop it by adding the `flag: don'\''t merge` label.' \
-            "$LINE" "$CONTEXT" "$SOURCE_LINE")
+          # The first cron run that merges this PR, named rather than guessed.
+          # "tomorrow" was wrong whenever the run happened before the 24h
+          # quarantine expired: a PR opened at 07:00 UTC is still 1h too young at
+          # the 08:00 run the next day, so it only goes in the day after. The
+          # cron is daily at 08:00 UTC, so the first eligible run is the first
+          # 08:00 that falls at least QUARANTINE_HOURS after the PR was opened.
+          MERGE_AT=$(date -u -d "+$QUARANTINE_HOURS hours" '+%Y-%m-%dT%H:%M:%SZ')
+          MERGE_DAY=$(date -u -d "$MERGE_AT" '+%Y-%m-%d')
+          # Compared as HHMM against the 08:00 run, so 08:00:00 exactly counts as
+          # ripe in time for that run rather than being pushed to the next day.
+          MERGE_HHMM=$(date -u -d "$MERGE_AT" '+%H%M')
+
+          # Ripe only after that day's run has already gone by, so it waits for
+          # the next one.
+          if [ "$((10#$MERGE_HHMM))" -gt 800 ]; then
+            MERGE_DAY=$(date -u -d "$MERGE_DAY +1 day" '+%Y-%m-%d')
+          fi
+
+          WHEN=$(date -u -d "$MERGE_DAY" '+%A %-d %B')
+
+          TEXT=$(printf ':hourglass_flowing_sand: *Will auto-merge on %s* (08:00 UTC)\n%s\n%s%b\n\nStop it by adding the `flag: don'\''t merge` label.' \
+            "$WHEN" "$LINE" "$CONTEXT" "$SOURCE_LINE")
 
           curl -s -X POST "https://slack.com/api/chat.postMessage" \
             -H "Authorization: Bearer $SLACK_BOT_TOKEN" \


### PR DESCRIPTION
The Slack eligibility message said "Will auto-merge tomorrow", and on PR #3428 that was wrong twice over. The PR was opened on Friday at 15:12 UTC, so "tomorrow" meant Saturday, and the cron does not run at weekends. It merged on the Monday, three days after the promise.

The first instinct was to make the cron run daily so the message would become true. That is the wrong way round: weekdays-only is deliberate, because an unattended merge should land when someone is around to notice it went wrong, and a Saturday merge sits unwatched until Monday anyway. The schedule was right and the message was lying, so the message is what changes here.

It now names the day the merge will actually happen, from the two rules that decide it: the quarantine must have expired by the time the run starts, and the run only happens on a weekday. A PR opened Friday afternoon now says Monday.

Verified against the real timeline of #3428, which resolves to Monday 31 August, the day it actually merged, plus nine other cases covering the 08:00 boundary, PRs opened at the weekend, and the year rollover. The comment on the cron schedule now records why weekends are skipped, so the next reader does not undo it.

QUARANTINE_HOURS is duplicated in automerge-eligibility.yml to compute that date. The cron still owns the real quarantine; the copy is only for the announcement and is commented as needing to stay in step.