### PR TITLE
Add a scope note to the negative feedback form

### DIFF
--- a/docusaurus/src/components/PageFeedback/FeedbackForm.jsx
+++ b/docusaurus/src/components/PageFeedback/FeedbackForm.jsx
@@ -77,6 +77,28 @@ export default function FeedbackForm({
           </button>
         </div>
       </div>
+      {required && (
+        <p className="pageFeedback__scopeNote">
+          Please report feedback about the documentation website only. For
+          the Strapi product, use{' '}
+          <a
+            href="https://feedback.strapi.io"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            feedback.strapi.io
+          </a>{' '}
+          (for feature requests) or{' '}
+          <a
+            href="https://github.com/strapi/strapi/issues"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            GitHub issues
+          </a>{' '}
+          (for bugs).
+        </p>
+      )}
     </form>
   );
 }

--- a/docusaurus/src/components/PageFeedback/styles.module.scss
+++ b/docusaurus/src/components/PageFeedback/styles.module.scss
@@ -114,6 +114,22 @@
     color: var(--ifm-font-color-secondary);
   }
 
+  .pageFeedback__scopeNote {
+    margin: 0;
+    font-size: 0.75rem;
+    line-height: 1.4;
+    color: var(--ifm-font-color-secondary);
+
+    a {
+      color: var(--ifm-link-color);
+      text-decoration: none;
+
+      &:hover {
+        text-decoration: none;
+      }
+    }
+  }
+
   .pageFeedback__formButtons {
     display: flex;
     gap: var(--strapi-spacing-2, 0.5rem);


### PR DESCRIPTION
This PR adds a short note below the comment field of the page feedback widget, shown only when the feedback is negative. It states that the widget is for documentation website feedback only, and links to feedback.strapi.io for product feature requests and to the strapi/strapi issues page for product bugs.