### PR TITLE
Add mention of 'Select all' action in Media Library bulk operations

### DIFF
--- a/docusaurus/docs/cms/features/media-library.md
+++ b/docusaurus/docs/cms/features/media-library.md
@@ -891,7 +891,7 @@ To add a focal point to an image:
 3. Click **Confirm**.
 
 :::tip
-Assets can also be deleted individually or in bulk from the main view of the Media Library. Select assets by clicking on their checkbox in the top left corner, then click the Delete icon <Icon name="trash" /> at the top of the window, below the filters and sorting options.
+Assets can also be deleted individually or in bulk from the main view of the Media Library. Select assets by clicking on their checkbox in the top left corner. You can also click the **Select all** button in the bulk actions bar to select all rendered items at once. Once selected, click the Delete icon <Icon name="trash" /> at the top of the window, below the filters and sorting options.
 :::
 
 ### Organizing assets with folders


### PR DESCRIPTION
This PR updates documentation based on https://github.com/strapi/strapi/pull/27453.

Users can now select all rendered items at once in the Media Library bulk actions bar. This enhancement improves workflow efficiency when managing multiple assets.

Generated automatically by the docs self-healing workflow (micro-edit, Haiku).
Review before merging.