### PR TITLE
Document private field searchability default behavior

### DIFF
--- a/docusaurus/docs/cms/features/content-type-builder.md
+++ b/docusaurus/docs/cms/features/content-type-builder.md
@@ -212,6 +212,10 @@ In the <Icon name="layout" /> Content-type Builder, fields can be added at the c
 Depending on what content-type or component is being created or edited, not all fields -including components and dynamic zones- are always available.
 :::
 
+:::info Private fields and search
+When you mark a field as **Private field**, newly created private fields are automatically set to be non-searchable (searchable: false). This prevents private content from appearing in query results when using the `_q` search parameter. Existing private fields retain their current searchability settings unless you explicitly change them. If you need a private field to be searchable, you can enable it in the field's advanced settings.
+:::
+
 <ThemedImage
   alt="Fields selection"
   sources={{


### PR DESCRIPTION
This PR updates documentation based on https://github.com/strapi/strapi/pull/27482.

The Content-Type Builder now sets newly created private fields to be non-searchable by default (searchable: false). This prevents private content from appearing in _q search results. This documentation update explains this behavior and clarifies that existing private fields keep their current searchability settings.

Generated automatically by the docs self-healing workflow (micro-edit, Haiku).
Review before merging.