### PR TITLE
Fix the self-healing PR descriptions and avoids em dashes at creation

### DIFF
--- a/.github/prompts/docs-self-healing-drafter.md
+++ b/.github/prompts/docs-self-healing-drafter.md
@@ -96,17 +96,20 @@ fi
 echo "style-lint exit: $LINT_STATUS"
 ```
 
-**Exit 1 blocks the commit.** Rewrite the offending lines yourself and re-run the gate,
-up to 3 times. Exit 2 is warnings only: log them, they do not block. Exit 0 means you can
-commit.
+Exit 1 means errors, exit 2 warnings only, exit 0 clean. **Fix every error the linter
+reports, then re-run it, up to 3 times.** For an em dash, apply the replacement the rule
+prescribes: a colon, a period, parentheses, or a restructured sentence. Never swap an em
+dash for a double hyphen, which the same linter also rejects on the next line of its own
+rule catalog.
 
-For em dashes, apply the replacement the rule prescribes: a colon, a period, parentheses,
-or a restructured sentence. Never swap an em dash for a double hyphen, which the same
-linter also rejects on the next line of its own rule catalog. If a file still exits 1
-after 3 passes, drop that PR from the run and record it in the `errors` array of the run
-summary rather than opening a PR that Pierre has to clean up by hand.
+**This never stops you from opening the PR.** If something still fails after 3 passes,
+commit and open the PR anyway, and list what is left in the `errors` array of the run
+summary. A remaining em dash costs Pierre a few seconds of editing at review time. A PR
+you did not open costs him re-reading the strapi/strapi diff and writing the page himself,
+and the source PR will not come back: the next run only looks at PRs merged in the last 24
+hours, so anything you abandon is silently lost.
 
-Once the gate is clean, commit and push:
+Once the linter is clean, or once you have exhausted the 3 passes, commit and push:
 
 ```bash
 git add .
@@ -231,7 +234,7 @@ Write a JSON summary to `/tmp/self-healing-summary.json`:
 - **Only modify files in `$DOC_REPO/docusaurus/docs/`** and `$DOC_REPO/docusaurus/static/` (for images)
 - **Follow all conventions** in `$DOC_REPO/agents/` — the Router and authoring guides are the source of truth
 - **Follow git-rules.md** — branch naming (`/cms`, `/cloud`, `/repo`), commit messages (imperative, no prefix), PR titles
-- **Never commit a file that `style-lint.sh` exits 1 on:** the gate in Step 3 is not advisory
+- **Always run `style-lint.sh` before committing** and fix what it reports, but never let it stop you from opening the PR (Step 3)
 - **Never paste a canned PR description:** write it from the actual diff, per the rules in Step 3
 - **If no PR has targets:** exit cleanly without creating anything
 - **Max 3000 lines per diff** — skip and log oversized diffs

--- a/.github/prompts/docs-self-healing-drafter.md
+++ b/.github/prompts/docs-self-healing-drafter.md
@@ -62,6 +62,13 @@ based on the Router's `doc_type`.
 
 After the Drafter has produced output for all targets:
 
+**Before committing, run the deterministic style linter and fix what it reports.**
+`style-lint.sh` is the source of truth for the mechanical style rules: it catches em
+dashes (literal and as the HTML entities `&mdash;` / `&#8212;` / `&#x2014;`), double
+hyphens used as dashes, and the rest of the catalog. The Style Checker prompt states
+the same rules, but a prompt is a probabilistic filter and this script is not: on
+2026-09-04 an em dash reached PR #3443 and Pierre had to strip it by hand.
+
 ```bash
 cd $DOC_REPO
 
@@ -72,6 +79,36 @@ cd $DOC_REPO
 BRANCH_NAME="<prefix>/<short-kebab-description>"
 
 git checkout -b "$BRANCH_NAME"
+
+# Style-lint gate. Every doc file you touched, before staging anything.
+# `git status --porcelain` rather than `git diff`, so a newly created page
+# (untracked, and the whole point of a create_page target) is linted too.
+chmod +x claude-plugins/inki/scripts/style-lint.sh
+LINT_FILES=$(git status --porcelain | awk '{print $NF}' \
+  | grep -E '^docusaurus/docs/.*\.mdx?$' || true)
+
+LINT_STATUS=0
+if [ -n "$LINT_FILES" ]; then
+  # shellcheck disable=SC2086
+  claude-plugins/inki/scripts/style-lint.sh $LINT_FILES || LINT_STATUS=$?
+fi
+# 0 = clean, 1 = errors (blocking), 2 = warnings only (not blocking)
+echo "style-lint exit: $LINT_STATUS"
+```
+
+**Exit 1 blocks the commit.** Rewrite the offending lines yourself and re-run the gate,
+up to 3 times. Exit 2 is warnings only: log them, they do not block. Exit 0 means you can
+commit.
+
+For em dashes, apply the replacement the rule prescribes: a colon, a period, parentheses,
+or a restructured sentence. Never swap an em dash for a double hyphen, which the same
+linter also rejects on the next line of its own rule catalog. If a file still exits 1
+after 3 passes, drop that PR from the run and record it in the `errors` array of the run
+summary rather than opening a PR that Pierre has to clean up by hand.
+
+Once the gate is clean, commit and push:
+
+```bash
 git add .
 git commit -m "<DOCS_CHANGE_DESCRIPTION>
 # Imperative mood, no prefix, describe the doc change. Max 80 chars."

--- a/.github/prompts/docs-self-healing-drafter.md
+++ b/.github/prompts/docs-self-healing-drafter.md
@@ -134,25 +134,71 @@ if [ ${#LABEL_ARGS[@]} -eq 0 ]; then
   LABEL_ARGS=(--label "$(jq -r '.["docs-self-healing"].labels[0]' "$CONFIG")")
 fi
 
+# Title rules:
+#   - Imperative mood, no conventional prefix (no fix:/feat:/chore:)
+#   - Describe what the DOC change does, not the source PR
+#   - The auto-doc-healing label handles identification (no title prefix needed)
+#   - Example: "Clarify admin panel redirect behavior"
+#   - NOT: "fix: use admin basename for 401 redirect path"
+#
+# Body rules: see "PR description" below. Write $DESCRIPTION before this call.
 gh pr create \
   --repo strapi/documentation \
-  --title "${TITLE_PREFIX:+$TITLE_PREFIX }<DOCS_CHANGE_DESCRIPTION>"
-  # Title rules:
-  #   - Imperative mood, no conventional prefix (no fix:/feat:/chore:)
-  #   - Describe what the DOC change does, not the source PR
-  #   - The auto-doc-healing label handles identification (no title prefix needed)
-  #   - Example: "Clarify admin panel redirect behavior"
-  #   - NOT: "fix: use admin basename for 401 redirect path" \
-  --body "$(cat <<'BODY'
-This PR updates documentation based on https://github.com/strapi/strapi/pull/<NUMBER>.
-
-Generated automatically by the docs self-healing workflow.
-Review before merging.
-BODY
-)" \
+  --title "${TITLE_PREFIX:+$TITLE_PREFIX }<DOCS_CHANGE_DESCRIPTION>" \
+  --body "$DESCRIPTION" \
   --draft \
   "${LABEL_ARGS[@]}" \
   --assignee "$ASSIGNEE"
+```
+
+### PR description
+
+The description is **written per PR, from what you actually changed**. There is no
+template to paste. It follows the same rules as every hand-written PR on this repo,
+defined in `$DOC_REPO/claude-plugins/inki/skills/_shared/pr-description-rules.md`:
+
+1. Start with `This PR ...`.
+2. 1-3 sentences, or a short bullet list, saying **what changed and why**. Name the
+   pages, the sections, the tables, the parameters. "This PR updates documentation
+   based on <URL>" says nothing and is not acceptable.
+3. Flat text only: no headings, no `Summary`, no `Test plan`, no checklist.
+4. End with a `Documents` reference to the source PR, as a markdown link:
+   `Documents [#27436](https://github.com/strapi/strapi/pull/27436)`. The bare URL
+   in the opening sentence is not a substitute.
+5. Then, on its own final line, the Vercel preview link (see below).
+6. **No boilerplate about the workflow itself.** Do not write "Generated
+   automatically by the docs self-healing workflow" or "Review before merging".
+   The `auto-doc-healing` label, the assignee and the draft status already carry
+   that information, and repeating it in prose breaks rule 3.
+7. No em dash anywhere in the description either.
+
+**Vercel preview link.** Append as the last line:
+
+```
+Direct preview link 👉 [here](https://documentation-git-<slug>-strapijs.vercel.app<page-path>)
+```
+
+`<slug>` is `$BRANCH_NAME` with `/` replaced by `-`. `<page-path>` is the primary
+changed file under `docusaurus/docs/`, stripped of that prefix and of the
+`.md`/`.mdx` extension, preferring a newly created page over a modified one. Two
+cases to respect:
+
+- **No page under `docusaurus/docs/` changed:** omit the preview line entirely. Do
+  not fall back to the preview root.
+- **Slug longer than 35 characters:** Vercel truncates the host and appends a hash,
+  so the slug-built URL will not resolve. Still include it, then append on the next
+  line: `⚠️ The branch slug for this preview URL is <N> characters long (over the
+  35-character limit), so the URL above is likely truncated and incorrect. It must be
+  fixed with `/inki:pr-fix` once Vercel has finished building the preview.`
+
+Build the whole body in a shell variable before the `gh pr create` call:
+
+```bash
+DESCRIPTION="This PR documents the audit logging of release actions: it adds the release events to the event table in the Audit Logs page, and a section to the Releases page describing what each action records and where to find it.
+
+Documents [#27436](https://github.com/strapi/strapi/pull/27436)
+
+Direct preview link 👉 [here](https://documentation-git-cms-document-release-audit-logs-strapijs.vercel.app/cms/features/releases)"
 ```
 
 Then reset the working copy before processing the next PR:
@@ -185,6 +231,8 @@ Write a JSON summary to `/tmp/self-healing-summary.json`:
 - **Only modify files in `$DOC_REPO/docusaurus/docs/`** and `$DOC_REPO/docusaurus/static/` (for images)
 - **Follow all conventions** in `$DOC_REPO/agents/` — the Router and authoring guides are the source of truth
 - **Follow git-rules.md** — branch naming (`/cms`, `/cloud`, `/repo`), commit messages (imperative, no prefix), PR titles
+- **Never commit a file that `style-lint.sh` exits 1 on:** the gate in Step 3 is not advisory
+- **Never paste a canned PR description:** write it from the actual diff, per the rules in Step 3
 - **If no PR has targets:** exit cleanly without creating anything
 - **Max 3000 lines per diff** — skip and log oversized diffs
 - **Never modify workflow files, configuration files, or sidebars.js**

--- a/.github/prompts/docs-self-healing-router.md
+++ b/.github/prompts/docs-self-healing-router.md
@@ -131,11 +131,15 @@ fi
 echo "style-lint exit: $LINT_STATUS"
 ```
 
-**Exit 1 blocks the commit.** Rewrite the offending lines and re-run the gate, up to 3
-times. For an em dash, use a colon, a period, parentheses, or restructure the sentence.
-Never replace it with a double hyphen, which the same linter also rejects. If the gate
-still exits 1 after 3 passes, abandon that PR and log it rather than opening one Pierre
-has to clean up. Exit 2 is warnings only and does not block.
+Exit 1 means errors, exit 2 warnings only, exit 0 clean. **Fix every error the linter
+reports, then re-run it, up to 3 times.** For an em dash, use a colon, a period,
+parentheses, or restructure the sentence. Never replace it with a double hyphen, which the
+same linter also rejects.
+
+**This never stops you from opening the PR.** If something still fails after 3 passes,
+commit and open the PR anyway and log what is left. A remaining em dash costs Pierre a few
+seconds at review time. An abandoned PR costs him the whole page, and it will not come
+back: the next run only looks at PRs merged in the last 24 hours.
 
 ```bash
 git add .
@@ -234,6 +238,6 @@ Update `/tmp/router-results.json` to include a `doc_pr` field for micro PRs you 
 - **Never draft a section.** A micro-edit is a link, a mention, or a tip. If the change needs a new section, a rewritten section, a new page, or a new category, it is `full` and you stop at the routing decision.
 - **ONLY read diffs, the Router prompt, sidebars.js, llms.txt, and write the result file** (plus doc files for micro-edits)
 - **Max 5 PRs per run.** Log extras to stdout for the next run.
-- **Never commit a file that `style-lint.sh` exits 1 on:** the gate in Step 5 is not advisory
+- **Always run `style-lint.sh` before committing** and fix what it reports, but never let it stop you from opening the PR (Step 5)
 - **Never paste a canned PR description:** write it from the actual edit
 - **NEVER run any write operation on strapi/strapi**

--- a/.github/prompts/docs-self-healing-router.md
+++ b/.github/prompts/docs-self-healing-router.md
@@ -85,12 +85,8 @@ PR or produces a draft you were not equipped to write.
 
 If a PR has `complexity: "micro"`, you handle the full pipeline yourself — no Sonnet needed.
 
-For each micro target (`add_link`, `add_mention`, `add_tip`):
-1. Read the target file from `$DOC_REPO/docusaurus/docs/<path>`
-2. Apply the edit (add the link, mention, or tip)
-3. Write the modified file back
-
-Then create the branch and PR:
+**Create the branch first, then edit.** `git clean -fd` and `git reset --hard` destroy
+uncommitted work, so any file you wrote before this block would be wiped:
 
 ```bash
 cd $DOC_REPO
@@ -106,6 +102,42 @@ git reset --hard origin/main
 
 BRANCH_NAME="<prefix>/<short-kebab-description>"
 git checkout -b "$BRANCH_NAME"
+```
+
+Now, for each micro target (`add_link`, `add_mention`, `add_tip`):
+1. Read the target file from `$DOC_REPO/docusaurus/docs/<path>`
+2. Apply the edit (add the link, mention, or tip)
+3. Write the modified file back
+
+Then run the style-lint gate, commit, and push:
+
+```bash
+# Style-lint gate. Deterministic, and the only reliable guard against the
+# mechanical style violations: em dashes (literal, and the HTML entities
+# &mdash; / &#8212; / &#x2014;), double hyphens used as dashes, and the rest of
+# the catalog. On 2026-09-04 an em dash reached PR #3443 and Pierre had to strip
+# it by hand. Micro-edits skip the Style Checker prompt, so this script is their
+# only style guard: it is not optional here.
+chmod +x claude-plugins/inki/scripts/style-lint.sh
+LINT_FILES=$(git status --porcelain | awk '{print $NF}' \
+  | grep -E '^docusaurus/docs/.*\.mdx?$' || true)
+
+LINT_STATUS=0
+if [ -n "$LINT_FILES" ]; then
+  # shellcheck disable=SC2086
+  claude-plugins/inki/scripts/style-lint.sh $LINT_FILES || LINT_STATUS=$?
+fi
+# 0 = clean, 1 = errors (blocking), 2 = warnings only (not blocking)
+echo "style-lint exit: $LINT_STATUS"
+```
+
+**Exit 1 blocks the commit.** Rewrite the offending lines and re-run the gate, up to 3
+times. For an em dash, use a colon, a period, parentheses, or restructure the sentence.
+Never replace it with a double hyphen, which the same linter also rejects. If the gate
+still exits 1 after 3 passes, abandon that PR and log it rather than opening one Pierre
+has to clean up. Exit 2 is warnings only and does not block.
+
+```bash
 git add .
 git commit -m "<DOCS_CHANGE_DESCRIPTION>"
 git push -u origin "$BRANCH_NAME"

--- a/.github/prompts/docs-self-healing-router.md
+++ b/.github/prompts/docs-self-healing-router.md
@@ -109,6 +109,13 @@ Now, for each micro target (`add_link`, `add_mention`, `add_tip`):
 2. Apply the edit (add the link, mention, or tip)
 3. Write the modified file back
 
+**Never write an em dash.** Not the character, not `&mdash;`, `&#8212;` or `&#x2014;`, and
+not a double hyphen used as a dash. Strapi documentation does not use them, and they are a
+reliable tell of unedited machine-written prose. Use a colon, a period, parentheses, or
+restructure the sentence. You are the only agent on this path: you never load
+`drafter.md`, so its Writing Rules never reach you, and this is the only place the rule is
+stated for micro-edits.
+
 Then run the style-lint gate, commit, and push:
 
 ```bash

--- a/.github/prompts/docs-self-healing-router.md
+++ b/.github/prompts/docs-self-healing-router.md
@@ -161,16 +161,11 @@ if [ ${#LABEL_ARGS[@]} -eq 0 ]; then
   LABEL_ARGS=(--label "$(jq -r '.["docs-self-healing"].labels[0]' "$CONFIG")")
 fi
 
+# Body rules: see "PR description" below. Write $DESCRIPTION before this call.
 gh pr create \
   --repo strapi/documentation \
   --title "${TITLE_PREFIX:+$TITLE_PREFIX }<DOCS_CHANGE_DESCRIPTION>" \
-  --body "$(cat <<'BODY'
-This PR updates documentation based on https://github.com/strapi/strapi/pull/<NUMBER>.
-
-Generated automatically by the docs self-healing workflow (micro-edit, Haiku).
-Review before merging.
-BODY
-)" \
+  --body "$DESCRIPTION" \
   --draft \
   "${LABEL_ARGS[@]}" \
   --assignee "$ASSIGNEE"
@@ -180,6 +175,42 @@ git reset --hard origin/main
 ```
 
 **Title rules:** Imperative mood, no conventional prefix, describe the doc change. The `auto-doc-healing` label handles identification (no title prefix needed).
+
+### PR description
+
+Write `$DESCRIPTION` from what you actually changed. There is no template to paste. The
+rules are the ones every hand-written PR on this repo follows, defined in
+`$DOC_REPO/claude-plugins/inki/skills/_shared/pr-description-rules.md`:
+
+1. Start with `This PR ...`.
+2. One or two sentences saying **what changed and why**. Name the page and what you added
+   to it. "This PR updates documentation based on <URL>" says nothing and is not
+   acceptable.
+3. Flat text only: no headings, no `Summary`, no `Test plan`, no checklist.
+4. End with a `Documents` reference to the source PR, as a markdown link:
+   `Documents [#27436](https://github.com/strapi/strapi/pull/27436)`. The bare URL in the
+   opening sentence is not a substitute.
+5. Then, on its own final line, the Vercel preview link:
+   `Direct preview link 👉 [here](https://documentation-git-<slug>-strapijs.vercel.app<page-path>)`
+   where `<slug>` is `$BRANCH_NAME` with `/` replaced by `-`, and `<page-path>` is the
+   edited file under `docusaurus/docs/` stripped of that prefix and of its `.md`/`.mdx`
+   extension. If the slug exceeds 35 characters Vercel truncates the host, so add on the
+   next line: `⚠️ The branch slug for this preview URL is <N> characters long (over the
+   35-character limit), so the URL above is likely truncated and incorrect. It must be
+   fixed with `/inki:pr-fix` once Vercel has finished building the preview.`
+6. **No boilerplate about the workflow itself.** Do not write "Generated automatically by
+   the docs self-healing workflow" or "Review before merging". The `auto-doc-healing`
+   label, the assignee and the draft status already carry that, and repeating it in prose
+   breaks rule 3.
+7. No em dash in the description either.
+
+```bash
+DESCRIPTION="This PR adds a link to the Audit Logs page from the Releases feature page, so readers discover that release actions are logged.
+
+Documents [#27436](https://github.com/strapi/strapi/pull/27436)
+
+Direct preview link 👉 [here](https://documentation-git-cms-link-audit-logs-strapijs.vercel.app/cms/features/releases)"
+```
 
 After micro-edits, add the PR to the results file with `decision: "has_targets"` and record the doc PR URL.
 
@@ -203,4 +234,6 @@ Update `/tmp/router-results.json` to include a `doc_pr` field for micro PRs you 
 - **Never draft a section.** A micro-edit is a link, a mention, or a tip. If the change needs a new section, a rewritten section, a new page, or a new category, it is `full` and you stop at the routing decision.
 - **ONLY read diffs, the Router prompt, sidebars.js, llms.txt, and write the result file** (plus doc files for micro-edits)
 - **Max 5 PRs per run.** Log extras to stdout for the next run.
+- **Never commit a file that `style-lint.sh` exits 1 on:** the gate in Step 5 is not advisory
+- **Never paste a canned PR description:** write it from the actual edit
 - **NEVER run any write operation on strapi/strapi**

--- a/.github/scripts/automerge/check-no-em-dash.sh
+++ b/.github/scripts/automerge/check-no-em-dash.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+#
+# Criterion 13: no em dash is introduced.
+#
+# Strapi technical documentation does not use em dashes. They are also one of the
+# strongest tells of unedited AI-generated prose, which matters here: the PRs this
+# workflow evaluates are written by an agent. On 2026-09-04 an em dash reached
+# PR #3443 and had to be stripped by hand at review time.
+#
+# The real fix is upstream: the self-healing prompts now run
+# claude-plugins/inki/scripts/style-lint.sh before committing, so an em dash should
+# never reach a PR in the first place. This check is the net under that, and it is
+# only ever a test: it reports, it never edits the PR.
+#
+# Both spellings count. `&mdash;`, `&#8212;` and `&#x2014;` render as the same
+# character in MDX, so they are the same violation as the literal one.
+#
+# Not in scope: the double hyphen ( -- ), which style-lint.sh also rejects but which
+# is a separate criterion, and the en dash, which is not a documented violation.
+#
+# Two exclusions, matching style-lint.sh:
+#   - fenced code blocks, where an em dash is data rather than prose
+#   - URLs, where it is part of an address and cannot be rewritten
+
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+PR="${1:-}"
+require_pr_number "$PR"
+
+DIFF=$(pr_diff "$PR") || unknown "cannot read the diff of $REPO#$PR"
+
+EM_DASH=$'\xe2\x80\x94'
+
+FOUND=$(echo "$DIFF" | EM_DASH="$EM_DASH" awk '
+  # Track which file we are in, and skip generated llms files entirely.
+  /^diff --git/ {
+    skip = ($0 ~ /llms.*\.txt/)
+    in_fence = 0
+    next
+  }
+  skip { next }
+  /^\+\+\+|^---/ { next }
+
+  # A fence marker toggles code-block state, whether added or context.
+  {
+    line = $0
+    sub(/^[+ -]/, "", line)
+    if (line ~ /^[[:space:]]*(```|~~~)/) { in_fence = !in_fence; next }
+  }
+
+  # Added line, outside a fence.
+  /^\+/ && !in_fence {
+    line = substr($0, 2)
+
+    # Blank out URLs first: an em dash inside an address is not prose we can
+    # rewrite, and neither is one inside an entity-looking query string.
+    stripped = line
+    gsub(/https?:\/\/[^[:space:])"]*/, " ", stripped)
+
+    if (index(stripped, ENVIRON["EM_DASH"]) > 0) { print line; next }
+    if (tolower(stripped) ~ /&(mdash|#8212|#x2014);/) { print line }
+  }
+')
+
+if [ -n "$FOUND" ]; then
+  COUNT=$(echo "$FOUND" | wc -l | tr -d ' ')
+  FIRST=$(echo "$FOUND" | head -1 | cut -c1-70)
+  fail "adds $COUNT line(s) containing an em dash, first: $FIRST"
+fi
+
+pass "adds no em dash"

--- a/.github/workflows/automerge-eligibility.yml
+++ b/.github/workflows/automerge-eligibility.yml
@@ -169,6 +169,7 @@ jobs:
             check-no-external-links
             check-no-content-removal
             check-no-component-change
+            check-no-em-dash
           )
 
           VIOLATED=""

--- a/claude-plugins/inki/references/prompts/drafter.md
+++ b/claude-plugins/inki/references/prompts/drafter.md
@@ -399,6 +399,19 @@ Use components as specified in the outline's `components` field. Key components:
 
 ## Output Format
 
+### Before you output: the em dash sweep
+
+Search the content you are about to return for the em dash character and for its HTML
+entities `&mdash;`, `&#8212;`, `&#x2014;`. Rewrite every sentence that contains one, using
+a colon, a period, parentheses, or a restructure. Do the same for a double hyphen used as
+a dash.
+
+Do this every time, in every mode, even when you are confident you wrote none. The rule is
+already stated under Writing Rules and is still the most frequently violated one in
+Drafter output: it is stated 300 lines before you write the first sentence, and the em
+dash is the punctuation mark that comes most naturally to a language model mid-paragraph.
+Checking at output time is what catches it.
+
 All modes produce Markdown content wrapped in a standardized envelope using HTML comments (invisible at render time).
 
 ### Compose: `create_page`


### PR DESCRIPTION
This PR fixes the self-healing workflow so its PRs stop arriving in a state that needs hand-cleaning at review time, after #3443 came in with a canned description and an em dash.
- Both prompts now build the PR description from the actual diff, following pr-description-rules.md, instead of pasting a fixed body that named no change, carried the source PR as a bare URL, and repeated boilerplate the label, assignee and draft status already convey
- Both prompts run style-lint.sh before committing and fix what it reports, but it never stops a PR from being opened: a leftover em dash costs seconds at review, an abandoned PR costs the whole page and is silently lost since the next run only lists PRs merged in the last 24 hours
- The Drafter prompt gets an em dash sweep at output time, because it already forbade em dashes 300 lines earlier and #3443 carried one anyway, and the micro-edit path gets the rule stated for the first time, since it loads router.md only and router.md never mentioned it
- Adds check-no-em-dash.sh to the auto-merge eligibility criteria, as a pure test that reports and never edits the PR, so nothing merges automatically with an em dash in it
- Repairs two latent bugs in the same blocks: the Router git reset that ran after the file edits and would destroy them, and the broken line continuations in the Drafter gh pr create call that would drop the body, labels and draft flag
