### PR TITLE
Clarify Content History and Audit Logs retention periods

### DIFF
--- a/docusaurus/docs/cms/configurations/admin-panel.md
+++ b/docusaurus/docs/cms/configurations/admin-panel.md
@@ -340,7 +340,7 @@ The [Content History](/cms/features/content-history) feature can be configured w
 | `history.retentionDays`           | How long history versions are kept, in days.<br /><br />_The value can only shorten the retention period, see the note under the table._                                                            | integer       | Defined by the license                                                                                                              |
 
 :::note Retention days for Content History
-The `history.retentionDays` value is only taken into account if it is _smaller_ than the value stored in the license information. It cannot be used to keep history versions for longer than the license allows. The license sets the retention period to 14 days on the Growth plan and 90 days on the Enterprise plan (see [Content History](/cms/features/content-history#configuration)).
+The `history.retentionDays` value is only taken into account if it is _smaller_ than the value stored in the license information. It cannot be used to keep history versions for longer than the license allows. The license sets the retention period to 14 days on the Growth plan and 30 days on the Enterprise plan, where it can be raised up to a 90-day maximum (see [Content History](/cms/features/content-history#configuration)).
 :::
 
 ## Feature flags

--- a/docusaurus/docs/cms/configurations/admin-panel.md
+++ b/docusaurus/docs/cms/configurations/admin-panel.md
@@ -337,10 +337,10 @@ The [Content History](/cms/features/content-history) feature can be configured w
 
 | Parameter                         | Description                                                                                                                                                                                        | Type          | Default                                                                                                                             |
 |-----------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|-------------------------------------------------------------------------------------------------------------------------------------|
-| `history.retentionDays`           | How long history versions are kept, in days.<br /><br />_The value can only shorten the retention period, see the note under the table._                                                            | integer       | 90                                                                                                                                  |
+| `history.retentionDays`           | How long history versions are kept, in days.<br /><br />_The value can only shorten the retention period, see the note under the table._                                                            | integer       | Defined by the license                                                                                                              |
 
 :::note Retention days for Content History
-The `history.retentionDays` value is only taken into account if it is _smaller_ than the value stored in the license information. It cannot be used to keep history versions for longer than the license allows, and versions are never kept for more than 90 days.
+The `history.retentionDays` value is only taken into account if it is _smaller_ than the value stored in the license information. It cannot be used to keep history versions for longer than the license allows. The license sets the retention period to 14 days on the Growth plan and 90 days on the Enterprise plan (see [Content History](/cms/features/content-history#configuration)).
 :::
 
 ## Feature flags

--- a/docusaurus/docs/cms/features/audit-logs.md
+++ b/docusaurus/docs/cms/features/audit-logs.md
@@ -39,6 +39,51 @@ The Audit Logs feature provides a searchable and filterable display of all activ
   }}
 />
 
+## Configuration
+
+The only configurable aspect is how long logs are kept before they are deleted.
+
+Audit Logs are not a permanent archive. Logs older than the retention period are deleted automatically. The retention period defaults to 90 days.
+
+:::caution
+Logs deleted at the end of the retention period cannot be recovered from the Audit Logs interface.
+:::
+
+### Code-based configuration
+
+The retention period is set with the [`auditLogs.retentionDays`](/cms/configurations/admin-panel#audit-logs) parameter of the `/config/admin` file.
+
+For Strapi Cloud projects, the value stored in the license information applies, unless a _smaller_ value is defined in the configuration file.
+
+<Tabs groupId="js-ts">
+<TabItem value="js" label="JavaScript">
+
+```js title="/config/admin.js"
+module.exports = ({ env }) => ({
+  // … other configuration properties
+  auditLogs: {
+    retentionDays: 30,
+  },
+});
+```
+
+</TabItem>
+<TabItem value="ts" label="TypeScript">
+
+```ts title="/config/admin.ts"
+export default ({ env }) => ({
+  // … other configuration properties
+  auditLogs: {
+    retentionDays: 30,
+  },
+});
+```
+
+</TabItem>
+</Tabs>
+
+There is no equivalent setting in the admin panel: the retention period can only be configured from the `/config/admin` file.
+
 ## Usage
 
 **Path to use the feature:** <Icon name="gear-six" /> Settings > Administration Panel - Audit Logs

--- a/docusaurus/docs/cms/features/content-history.md
+++ b/docusaurus/docs/cms/features/content-history.md
@@ -51,7 +51,7 @@ The retention period cannot be extended on the Growth plan.
 Contact the <ExternalLink to="https://strapi.io/contact-sales" text="Strapi sales team"/> to upgrade to the Enterprise plan, which offers 30 days by default and can be extended up to 90 days.
 
 :::note
-Growth projects that were already using a 30-day retention period when the 14-day default was introduced keep it. No cutoff date is planned.
+Growth projects that were already using a 30-day retention period when the 14-day default was introduced keep it.
 :::
 
 :::caution

--- a/docusaurus/docs/cms/features/content-history.md
+++ b/docusaurus/docs/cms/features/content-history.md
@@ -51,7 +51,7 @@ The retention period cannot be extended on the Growth plan.
 Contact the <ExternalLink to="https://strapi.io/contact-sales" text="Strapi sales team"/> to upgrade to the Enterprise plan, which offers 30 days by default and can be extended up to 90 days.
 
 :::note
-Growth projects that were already using a 30-day retention period when the 14-day default was introduced keep it until October 31, 2026.
+Growth projects that were already using a 30-day retention period when the 14-day default was introduced keep it. No cutoff date is planned.
 :::
 
 :::caution

--- a/docusaurus/docs/cms/features/content-history.md
+++ b/docusaurus/docs/cms/features/content-history.md
@@ -47,7 +47,8 @@ The retention period is defined by the license of your plan:
 | CMS Growth | 14 days | 14 days |
 | CMS Enterprise | 30 days | 90 days |
 
-The retention period cannot be extended on the Growth plan. On the Enterprise plan, contact the Strapi sales team to raise it up to 90 days.
+The retention period cannot be extended on the Growth plan.
+Contact the <ExternalLink to="https://strapi.io/contact-sales" text="Strapi sales team"/> to upgrade to the Enterprise plan, which offers 30 days by default and can be extended up to 90 days.
 
 :::note
 Growth projects that were already using a 30-day retention period when the 14-day default was introduced keep it until October 31, 2026.

--- a/docusaurus/docs/cms/features/content-history.md
+++ b/docusaurus/docs/cms/features/content-history.md
@@ -12,7 +12,7 @@ tags:
 <GrowthBadge /> <EnterpriseBadge/> <VersionBadge version="5.0.0" />
 
 <Tldr>
-Content History stores previous document versions so editors can compare and restore earlier states from the Content Manager. This documentation explains how to browse and restore workflows for quick rollback of mistakes. Versions are only created for content edited in the Content Manager, and are kept for 14 days on the Growth plan and 90 days on the Enterprise plan.
+Content History stores previous document versions so editors can compare and restore earlier states from the Content Manager. This documentation explains how to browse and restore workflows for quick rollback of mistakes. Versions are only created for content edited in the Content Manager, and are kept for 14 days on the Growth plan and 30 days on the Enterprise plan.
 </Tldr>
 
 The Content History feature, in the <Icon name="feather" /> Content Manager, gives you the ability to browse and restore previous versions of documents created with the [Content Manager](/cms/features/content-manager).
@@ -42,13 +42,15 @@ Content History is not a permanent archive. Versions are deleted automatically: 
 
 The retention period is defined by the license of your plan:
 
-| Plan | Retention period |
-|------|------------------|
-| CMS Growth | 14 days |
-| CMS Enterprise | 90 days |
+| Plan | Default retention period | Maximum retention period |
+|------|--------------------------|--------------------------|
+| CMS Growth | 14 days | 14 days |
+| CMS Enterprise | 30 days | 90 days |
+
+The retention period cannot be extended on the Growth plan. On the Enterprise plan, contact the Strapi sales team to raise it up to 90 days.
 
 :::note
-Growth subscriptions that were active before the 14-day retention period was introduced keep their previous 30-day retention period.
+Growth projects that were already using a 30-day retention period when the 14-day default was introduced keep it until October 31, 2026.
 :::
 
 :::caution

--- a/docusaurus/docs/cms/features/content-history.md
+++ b/docusaurus/docs/cms/features/content-history.md
@@ -12,7 +12,7 @@ tags:
 <GrowthBadge /> <EnterpriseBadge/> <VersionBadge version="5.0.0" />
 
 <Tldr>
-Content History stores previous document versions so editors can compare and restore earlier states from the Content Manager. This documentation explains how to browse and restore workflows for quick rollback of mistakes. Versions are only created for content edited in the Content Manager, and are kept for a default of 14 days.
+Content History stores previous document versions so editors can compare and restore earlier states from the Content Manager. This documentation explains how to browse and restore workflows for quick rollback of mistakes. Versions are only created for content edited in the Content Manager, and are kept for 14 days on the Growth plan and 90 days on the Enterprise plan.
 </Tldr>
 
 The Content History feature, in the <Icon name="feather" /> Content Manager, gives you the ability to browse and restore previous versions of documents created with the [Content Manager](/cms/features/content-manager).
@@ -38,7 +38,18 @@ To trace the actions performed by users of the admin panel, use [Audit Logs](/cm
 
 The only configurable aspect is how long versions are kept before they are deleted.
 
-Content History is not a permanent archive. Versions are deleted automatically: a job runs once a day, at midnight, and deletes every version older than the retention period. Regardless of the plan, versions are kept for a maximum of 90 days, counted from the creation date of each version.
+Content History is not a permanent archive. Versions are deleted automatically: a job runs once a day, at midnight, and deletes every version older than the retention period, counted from the creation date of each version.
+
+The retention period is defined by the license of your plan:
+
+| Plan | Retention period |
+|------|------------------|
+| CMS Growth | 14 days |
+| CMS Enterprise | 90 days |
+
+:::note
+Growth subscriptions that were active before the 14-day retention period was introduced keep their previous 30-day retention period.
+:::
 
 :::caution
 Versions deleted by the retention job cannot be recovered from the Content History interface.


### PR DESCRIPTION
This PR aligns the documented retention periods of Content History and Audit Logs with the values set by the license.
- Documents Content History retention as a per-plan default and maximum, 14 days on the Growth plan with no extension possible, and 30 days by default on the Enterprise plan up to a 90-day maximum, replacing the contradictory "default of 14 days" in the TL;DR and "maximum of 90 days regardless of the plan" in the Configuration section
- Notes that Growth projects already using a 30-day retention period keep it, the grandfathering having been confirmed with no cutoff date
- Removes the claim that versions are never kept for more than 90 days from the `history.retentionDays` note, and replaces the `90` default value of that parameter with a reference to the license
- Adds a Configuration section to the Audit Logs page, which never documented its 90-day retention period, and links it to the `auditLogs.retentionDays` parameter

Opened as a draft: the values still need to be applied to the entitlements.

Direct preview link 👉 [here](https://documentation-git-cms-content-history-retention-c20a32-strapijs.vercel.app/cms/features/content-history)
