### PR TITLE
Remove the self-contradicting sentence from the Media Library callout

### DIFF
--- a/docusaurus/docs/cms/features/media-library.md
+++ b/docusaurus/docs/cms/features/media-library.md
@@ -75,7 +75,6 @@ The flag changes the <Icon name="images" /> Media Library page of the admin pane
 The Media Library page displays a notice reminding you that this is a beta and that some features are still in progress. Read the [features configuration](/cms/configurations/features) documentation before enabling the flag, where the `STRAPI_FUTURE_BETA_MEDIA_LIBRARY` environment variable is also documented.
 
 You can <ExternalLink text="read more about the beta here" to="https://strapi.notion.site/Media-Library-Beta-Release-3c78f3598074810dbad6f2addfa25b6f" /> and report any issue you run into on the <ExternalLink text="strapi/strapi repository" to="https://github.com/strapi/strapi/issues" />.
-The current page still describes the stable version of the Media Library. The present documentation page has been updated to reflect the new features, and covers the behaviors of both the current stable version and the beta version of the Media Library.
 :::
 
 ## Configuration


### PR DESCRIPTION
This PR removes one sentence from the beta callout of the Media Library page, added while resolving a merge conflict in #3433.

The sentence read "The current page still describes the stable version of the Media Library. The present documentation page has been updated to reflect the new features, and covers the behaviors of both the current stable version and the beta version of the Media Library." Its first half is false, since the Usage section of that same page describes the beta UI, and its two halves contradict each other because both name the same page. The accurate version of the statement already sits three paragraphs above, in the callout: "The Usage section of this page describes the new UI. The Configuration section applies to both."

Direct preview link 👉 [here](https://documentation-git-cms-fix-media-library-callout-strapijs.vercel.app/cms/features/media-library)
