### PR TITLE
Update URL upload progress description in beta Media Library

### DIFF
--- a/docusaurus/docs/cms/features/media-library-beta.md
+++ b/docusaurus/docs/cms/features/media-library-beta.md
@@ -216,7 +216,11 @@ Files dropped from your computer always land in the folder you are currently bro
 3. In the _URL(s)_ field of the _Import from URL_ dialog, type or paste up to 20 URLs, one per line.
 4. Click **Upload**.
 
-Strapi downloads each file server-side and adds it to the current folder. The server reports no incremental byte count for this flow, so the upload dialog displays a moving progress bar without a percentage.
+Strapi downloads each file server-side and adds it to the current folder. The upload dialog reports byte-level progress as the server fetches each file: the progress bar advances in real time during the fetch phase, then hands off to the upload step and completes. <VersionBadge version="5.53.1+" noTooltip />
+
+:::note
+When the remote server does not include a `Content-Length` response header, the total size is unknown. The progress bar stays indeterminate for that file until the fetch completes, then completes normally.
+:::
 
 :::caution
 URLs must use the `http` or `https` protocol, and must resolve to a publicly reachable address. URLs that resolve to a private or internal address, such as `localhost` or an address on your own network, are rejected to prevent server-side request forgery.


### PR DESCRIPTION
This PR updates the URL upload section in the beta Media Library page to reflect byte-level progress reporting added in strapi/strapi#27572. The paragraph previously stated that URL uploads show only an indeterminate progress bar; it now explains that the upload dialog advances in real time as the server fetches each file, and adds a note covering the indeterminate fallback for remote servers that omit the `Content-Length` header.

Documents [#27572](https://github.com/strapi/strapi/pull/27572)

Direct preview link 👉 [here](https://documentation-git-cms-url-upload-byte-progress-strapijs.vercel.app/cms/features/media-library-beta)