### PR TITLE
Add a tip about the Smart Populate community plugin to the populate docs

### DIFF
--- a/docusaurus/docs/cms/api/document-service/populate.md
+++ b/docusaurus/docs/cms/api/document-service/populate.md
@@ -333,6 +333,22 @@ Dynamic zones are highly dynamic content structures by essence. Standard populat
 
 To populate component-specific nested relations, media fields, or components within a dynamic zone, you must define per-component populate queries using the `on` property (fragment population syntax).
 
+:::tip Community plugin: shorter dynamic zone populate objects
+The populate object can get long when a dynamic zone accepts many components.
+<ExternalLink to="https://github.com/notum-cz/strapi-plugin-smart-populate" text="Smart Populate"/> is a community plugin maintained by Notum.
+It reads your component schemas when Strapi starts and builds that object for you,
+so a query can pass the `smart` token instead:
+
+```js
+await strapi.documents('api::article.article').findMany({
+  populate: { testDZ: 'smart' },
+});
+```
+
+Relations inside components are populated 1 level deep by default, and can be adjusted per component.
+This plugin is not maintained by Strapi.
+:::
+
 <Endpoint
   kind="js"
   path='strapi.documents("api::article.article").findMany()'

--- a/docusaurus/docs/cms/api/document-service/populate.md
+++ b/docusaurus/docs/cms/api/document-service/populate.md
@@ -346,6 +346,7 @@ await strapi.documents('api::article.article').findMany({
 ```
 
 Relations inside components are populated 1 level deep by default, and can be adjusted per component.
+It is not a `populate=deep` plugin, a category the [REST API documentation advises against](/cms/api/rest/populate-select#population): the populate object comes from your schemas and relations are not expanded recursively.
 This plugin is not maintained by Strapi.
 :::
 

--- a/docusaurus/docs/cms/api/document-service/populate.md
+++ b/docusaurus/docs/cms/api/document-service/populate.md
@@ -335,9 +335,7 @@ To populate component-specific nested relations, media fields, or components wit
 
 :::tip Community plugin: shorter dynamic zone populate objects
 The populate object can get long when a dynamic zone accepts many components.
-<ExternalLink to="https://github.com/notum-cz/strapi-plugin-smart-populate" text="Smart Populate"/> is a community plugin maintained by Notum.
-It reads your component schemas when Strapi starts and builds that object for you,
-so a query can pass the `smart` token instead:
+<ExternalLink to="https://github.com/notum-cz/strapi-plugin-smart-populate" text="Smart Populate"/> is a community plugin that reads your component schemas when Strapi starts and builds that object for you, so a query can pass the `smart` token instead:
 
 ```js
 await strapi.documents('api::article.article').findMany({

--- a/docusaurus/docs/cms/api/rest/guides/understanding-populate.md
+++ b/docusaurus/docs/cms/api/rest/guides/understanding-populate.md
@@ -1512,6 +1512,20 @@ Dynamic zones are highly dynamic content structures by essence. When querying dy
 
 To retrieve component-specific nested relations, media fields, or components within a dynamic zone, you must define per-component populate queries using the `on` property (fragment population syntax). This is because different components in a dynamic zone can have completely different structures, and require their own unique nested queries.
 
+:::tip Community plugin: shorter dynamic zone queries
+Fragment syntax can get verbose when a dynamic zone accepts many components.
+<ExternalLink to="https://github.com/notum-cz/strapi-plugin-smart-populate" text="Smart Populate"/> is a community plugin maintained by Notum.
+It reads your component schemas when Strapi starts and builds the matching populate object.
+Once the plugin and its REST middleware are set up, a request can pass the `smart` token instead:
+
+```bash
+GET /api/articles?populate[blocks]=smart
+```
+
+Relations inside components are populated 1 level deep by default, and can be adjusted per component.
+This plugin is not maintained by Strapi.
+:::
+
 For instance, in the <ExternalLink to="https://github.com/strapi/foodadvisor" text="FoodAdvisor"/> example application:
 
 - A `blocks` dynamic zone exists on the `article` content-type <ScreenshotNumberReference number="1" />.

--- a/docusaurus/docs/cms/api/rest/guides/understanding-populate.md
+++ b/docusaurus/docs/cms/api/rest/guides/understanding-populate.md
@@ -1523,6 +1523,7 @@ GET /api/articles?populate[blocks]=smart
 ```
 
 Relations inside components are populated 1 level deep by default, and can be adjusted per component.
+It is not a `populate=deep` plugin, a category the [REST API documentation advises against](/cms/api/rest/populate-select#population): the populate object comes from your schemas and relations are not expanded recursively.
 This plugin is not maintained by Strapi.
 :::
 

--- a/docusaurus/docs/cms/api/rest/guides/understanding-populate.md
+++ b/docusaurus/docs/cms/api/rest/guides/understanding-populate.md
@@ -1514,8 +1514,7 @@ To retrieve component-specific nested relations, media fields, or components wit
 
 :::tip Community plugin: shorter dynamic zone queries
 Fragment syntax can get verbose when a dynamic zone accepts many components.
-<ExternalLink to="https://github.com/notum-cz/strapi-plugin-smart-populate" text="Smart Populate"/> is a community plugin maintained by Notum.
-It reads your component schemas when Strapi starts and builds the matching populate object.
+<ExternalLink to="https://github.com/notum-cz/strapi-plugin-smart-populate" text="Smart Populate"/> is a community plugin that reads your component schemas when Strapi starts and builds the matching populate object.
 Once the plugin and its REST middleware are set up, a request can pass the `smart` token instead:
 
 ```bash


### PR DESCRIPTION
This PR adds a tip about Smart Populate, a community plugin, in the dynamic zone sections of the REST populate guide and of the Document Service populate page. The tip says what the plugin does, shows the `smart` token in a REST query and in a Document Service call, notes that relations stay 1 level deep by default, states that it is not a `populate=deep` plugin and links to the section that advises against those, and states that Strapi does not maintain the plugin.

One thing to weigh before merging: the plugin is not listed on the Community Hub yet. It was submitted on 2026-08-27 and the review is still pending.

Direct preview link 👉 [here](https://documentation-git-cms-smart-populate-dynamic-zone-tip-strapijs.vercel.app/cms/api/rest/guides/understanding-populate)
