### PR TITLE
Point Marketplace links to the Strapi Community Hub

### DIFF
--- a/docusaurus/docs/cloud/advanced/email.md
+++ b/docusaurus/docs/cloud/advanced/email.md
@@ -28,7 +28,7 @@ Please be advised that Strapi is unable to provide support for third-party email
 :::prerequisites
 
 - A local Strapi project running on `v4.8.2+`.
-- Credentials for another email provider (see <ExternalLink to="https://market.strapi.io/providers" text="Strapi Market"/>).
+- Credentials for another email provider (see <ExternalLink to="https://community.strapi.io/marketplace" text="Strapi Community Hub"/>).
 
 :::
 
@@ -42,7 +42,7 @@ Configuring another email provider for use with Strapi Cloud requires 3 steps:
 
 ### Install the Provider Plugin
 
-Using either `npm` or `yarn`, install the provider plugin in your local Strapi project as a package dependency by following the instructions in the respective entry for that provider in the <ExternalLink to="https://market.strapi.io/providers" text="Marketplace"/>.
+Using either `npm` or `yarn`, install the provider plugin in your local Strapi project as a package dependency by following the instructions in the respective entry for that provider in the <ExternalLink to="https://community.strapi.io/marketplace" text="Marketplace"/>.
 
 ### Configure the Provider
 
@@ -92,7 +92,7 @@ export default ({ env }) => ({
 The file structure must match the above path exactly, or the configuration will not be applied to Strapi Cloud.
 :::
 
-Each provider will have different configuration settings available. Review the respective entry for that provider in the <ExternalLink to="https://market.strapi.io/providers" text="Marketplace"/>.
+Each provider will have different configuration settings available. Review the respective entry for that provider in the <ExternalLink to="https://community.strapi.io/marketplace" text="Marketplace"/>.
 
 **Example:**
 <Tabs groupId="js-ts">

--- a/docusaurus/docs/cloud/advanced/middlewares.md
+++ b/docusaurus/docs/cloud/advanced/middlewares.md
@@ -168,7 +168,7 @@ export default [
 </Tabs>
 
 :::tip
-For a full list of upload providers and their required domains, see the <ExternalLink to="https://market.strapi.io/providers" text="Strapi Market"/>.
+For a full list of upload providers and their required domains, see the <ExternalLink to="https://community.strapi.io/marketplace" text="Strapi Community Hub"/>.
 :::
 
 ## Custom CORS headers

--- a/docusaurus/docs/cloud/advanced/upload.md
+++ b/docusaurus/docs/cloud/advanced/upload.md
@@ -35,7 +35,7 @@ Please be advised that Strapi is unable to provide support for third-party uploa
 :::prerequisites
 
 - A local Strapi project running on `v4.8.2+`.
-- Credentials for a third-party upload provider (see <ExternalLink to="https://market.strapi.io/providers" text="Strapi Market"/>).
+- Credentials for a third-party upload provider (see <ExternalLink to="https://community.strapi.io/marketplace" text="Strapi Community Hub"/>).
 
 :::
 
@@ -48,7 +48,7 @@ Configuring a third-party upload provider for use with Strapi Cloud requires the
 
 ### Install the provider plugin
 
-Using either `npm` or `yarn`, install the provider plugin in your local Strapi project as a package dependency by following the instructions in the respective entry for that provider in the <ExternalLink to="https://market.strapi.io/providers" text="Marketplace"/>.
+Using either `npm` or `yarn`, install the provider plugin in your local Strapi project as a package dependency by following the instructions in the respective entry for that provider in the <ExternalLink to="https://community.strapi.io/marketplace" text="Marketplace"/>.
 
 ### Configure the provider
 
@@ -97,7 +97,7 @@ upload: {
 The file structure must match the above path exactly, or the configuration will not be applied to Strapi Cloud.
 :::
 
-Each provider will have different configuration settings available. Review the respective entry for that provider in the <ExternalLink to="https://market.strapi.io/providers" text="Marketplace"/>.
+Each provider will have different configuration settings available. Review the respective entry for that provider in the <ExternalLink to="https://community.strapi.io/marketplace" text="Marketplace"/>.
 
 **Example:**
 <Tabs groupId="js-ts">

--- a/docusaurus/docs/cms/admin-panel-customization/extension.md
+++ b/docusaurus/docs/cms/admin-panel-customization/extension.md
@@ -45,7 +45,7 @@ This section is about the admin panel bundle under `/src/admin`. To change serve
 Starting with a direct customization in `/src/admin/app` is the right default for project-specific needs. Consider moving to a plugin-based approach when one or more of these signals appear:
 
 - You are duplicating the same admin customization across several Strapi projects.
-- You want to version and distribute the extension — either internally or through the <ExternalLink text="Strapi Marketplace" to="https://market.strapi.io/"/>.
+- You want to version and distribute the extension — either internally or through the <ExternalLink text="Strapi Marketplace" to="https://community.strapi.io/marketplace"/>.
 - You need stronger automated testing independent from a single project codebase.
 - Multiple teams need shared ownership and release management for the same extension.
 

--- a/docusaurus/docs/cms/admin-panel-customization/wysiwyg-editor.md
+++ b/docusaurus/docs/cms/admin-panel-customization/wysiwyg-editor.md
@@ -24,7 +24,7 @@ This page covers customization of the **WYSIWYG markdown editor** used for `rich
 
 Strapi's [admin panel](/cms/admin-panel-customization) comes with a built-in rich text editor. To change the default editor, several options are at your disposal:
 
-- You can install a third-party plugin, such as one for CKEditor, by visiting <ExternalLink to="https://market.strapi.io/" text="Strapi's Marketplace"/>.
+- You can install a third-party plugin, such as one for CKEditor, by visiting <ExternalLink to="https://community.strapi.io/marketplace" text="Strapi's Marketplace"/>.
 - You can create your own plugin to create and register a fully custom WYSIWYG field (see [custom fields documentation](/cms/features/custom-fields)).
 
 :::tip Next steps

--- a/docusaurus/docs/cms/configurations/media-library-providers.md
+++ b/docusaurus/docs/cms/configurations/media-library-providers.md
@@ -23,7 +23,7 @@ The [Media Library](/cms/features/media-library) feature is powered by a back-en
 
 By default Strapi provides a provider that uploads files to a local `public/uploads/` directory in your Strapi project. Additional providers are available and add an extension to the core capabilities of the plugin. Use them to upload your files to another location, such as AWS S3 or Cloudinary.
 
-Strapi maintains official providers, discoverable via the <ExternalLink text="Marketplace" to="https://market.strapi.io/?types=provider"/>. Community-maintained providers are also available via <ExternalLink to="https://www.npmjs.com/search?q=strapi%20provider" text="npm"/>.
+Strapi maintains official providers, discoverable via the <ExternalLink text="Marketplace" to="https://community.strapi.io/marketplace"/>. Community-maintained providers are also available via <ExternalLink to="https://www.npmjs.com/search?q=strapi%20provider" text="npm"/>.
 
 A provider can be configured to be [private](#private-providers) to ensure asset URLs will be signed for secure access.
 
@@ -57,7 +57,7 @@ npm install @strapi/provider-upload-aws-s3 --save
 
 Newly installed providers are enabled and configured in [the `/config/plugins` file](/cms/configurations/plugins). If this file does not exist, create it first.
 
-Each provider will have different configuration settings available. Please review the respective entry for that provider on dedicated pages below for the Strapi-maintained providers, or on the provider's <ExternalLink text="Marketplace" to="https://market.strapi.io/?types=provider"/> page.
+Each provider will have different configuration settings available. Please review the respective entry for that provider on dedicated pages below for the Strapi-maintained providers, or on the provider's <ExternalLink text="Marketplace" to="https://community.strapi.io/marketplace"/> page.
 
 <MediaLibProvidersList />
 <MediaLibProvidersNotes />

--- a/docusaurus/docs/cms/features/content-manager.md
+++ b/docusaurus/docs/cms/features/content-manager.md
@@ -333,7 +333,7 @@ If Draft & Publish is enabled for your content-type (it's enabled by default), t
 | UID         | Write a unique identifier in the textbox. A "Regenerate" button, displayed on the right of the box, allows automatically generating a UID based on the content type name.                                                                                                                                                                                                |
 
 :::note
-Filling out a [custom field](/cms/features/content-type-builder#custom-fields) depends on the type of content handled by the field. Please refer to the dedicated documentation for each custom field hosted on the <ExternalLink to="https://market.strapi.io" text="Marketplace"/>.
+Filling out a [custom field](/cms/features/content-type-builder#custom-fields) depends on the type of content handled by the field. Please refer to the dedicated documentation for each custom field hosted on the <ExternalLink to="https://community.strapi.io/marketplace" text="Marketplace"/>.
 :::
 
 #### Components

--- a/docusaurus/docs/cms/features/content-type-builder.md
+++ b/docusaurus/docs/cms/features/content-type-builder.md
@@ -844,7 +844,7 @@ When using dynamic zones, different components cannot have the same field name w
 
 [Custom fields](/cms/features/custom-fields) are a way to extend Strapi’s capabilities by adding new types of fields to content-types or components. Once installed (see [Marketplace](/cms/plugins/installing-plugins-via-marketplace) documentation), custom fields are listed in the _Custom_ tab when selecting a field for a content-type.
 
-Each custom field type can have basic and advanced settings. The <ExternalLink to="https://market.strapi.io/?categories=Custom+fields" text="Marketplace"/> lists available custom fields, and hosts dedicated documentation for each custom field, including specific settings.
+Each custom field type can have basic and advanced settings. The <ExternalLink to="https://community.strapi.io/marketplace" text="Marketplace"/> lists available custom fields, and hosts dedicated documentation for each custom field, including specific settings.
 
 ### Deleting content-types
 

--- a/docusaurus/docs/cms/features/custom-fields.md
+++ b/docusaurus/docs/cms/features/custom-fields.md
@@ -32,7 +32,7 @@ Custom fields extend Strapi’s capabilities by adding new types of fields to co
 
 ## Configuration
 
-Ready-made custom fields can be found on the [Marketplace](https://market.strapi.io/?categories=Custom+fields). Once installed these, no other configuration is required, and you can start using them (see [usage](#usage)).
+Ready-made custom fields can be found on the [Marketplace](https://community.strapi.io/marketplace). Once installed these, no other configuration is required, and you can start using them (see [usage](#usage)).
 
 You can also develop your own custom field.
 
@@ -674,7 +674,7 @@ Once added to Strapi, custom fields can be added to any content type. Custom fie
 
 <!-- TODO: add screenshot of content-type builder with custom fields tab here -->
 
-Each custom field type can have basic and advanced settings. The <ExternalLink to="https://market.strapi.io/?categories=Custom+fields" text="Marketplace"/> lists available custom fields, and hosts dedicated documentation for each custom field, including specific settings.
+Each custom field type can have basic and advanced settings. The <ExternalLink to="https://community.strapi.io/marketplace" text="Marketplace"/> lists available custom fields, and hosts dedicated documentation for each custom field, including specific settings.
 
 ### In the code
 

--- a/docusaurus/docs/cms/migration/v4-to-v5/step-by-step.md
+++ b/docusaurus/docs/cms/migration/v4-to-v5/step-by-step.md
@@ -40,7 +40,7 @@ Before getting into the upgrade process itself, take the following precautions:
     * If your code is _not_ versioned with git, create a backup of your working Strapi v4 code and store it in a safe place.
 3. **Ensure the plugins you are using are compatible with Strapi 5**.
 
-  To do so, list the plugins you are using, then check compatibility for each of them by reading their dedicated documentation on the <ExternalLink to="https://market.strapi.io/plugins?version=v5" text="Marketplace"/> website.
+  To do so, list the plugins you are using, then check compatibility for each of them by reading their dedicated documentation on the <ExternalLink to="https://community.strapi.io/marketplace" text="Marketplace"/> website.
 
 ## Step 2: Run automated migrations
 

--- a/docusaurus/docs/cms/plugins-development/admin-panel-api.md
+++ b/docusaurus/docs/cms/plugins-development/admin-panel-api.md
@@ -242,7 +242,7 @@ Click on any of the following cards to get more details about a specific topic:
 </CustomDocCardsWrapper>
 
 :::tip Replacing the WYSIWYG
-The WYSIWYG editor can be replaced by taking advantage of [custom fields](/cms/features/custom-fields), for instance using the <ExternalLink to="https://market.strapi.io/plugins/@ckeditor-strapi-plugin-ckeditor" text="CKEditor custom field plugin"/>.
+The WYSIWYG editor can be replaced by taking advantage of [custom fields](/cms/features/custom-fields), for instance using the <ExternalLink to="https://community.strapi.io/marketplace/ckeditor-strapi-plugin-ckeditor" text="CKEditor custom field plugin"/>.
 :::
 
 :::info

--- a/docusaurus/docs/cms/plugins-development/developing-plugins.md
+++ b/docusaurus/docs/cms/plugins-development/developing-plugins.md
@@ -21,10 +21,10 @@ Strapi plugins extend core functionality using Admin Panel API, Server API, or M
 </Tldr>
 
 
-Strapi allows the development of plugins that work exactly like the built-in plugins or 3rd-party plugins available from the <ExternalLink to="https://market.strapi.io" text="Marketplace"/>. Once created, your plugin can be:
+Strapi allows the development of plugins that work exactly like the built-in plugins or 3rd-party plugins available from the <ExternalLink to="https://community.strapi.io/marketplace" text="Marketplace"/>. Once created, your plugin can be:
 
 - used as a local plugin, working only with a specific Strapi project,
-- or <ExternalLink to="https://market.strapi.io/submit-plugin" text="submitted to the Marketplace"/> to be shared with the community.
+- or <ExternalLink to="https://community.strapi.io/submit/plugin" text="submitted to the Marketplace"/> to be shared with the community.
 
 👉 To start developing a Strapi plugin:
 

--- a/docusaurus/docs/cms/plugins/documentation.md
+++ b/docusaurus/docs/cms/plugins/documentation.md
@@ -31,7 +31,7 @@ The Documentation plugin automates your API documentation creation. It basically
     `@strapi/plugin-documentation`
   </IdentityCardItem>
     <IdentityCardItem icon="plus-square" title="Additional resources">
-    <ExternalLink to="https://market.strapi.io/plugins/@strapi-plugin-documentation" text="Strapi Marketplace page" />
+    <ExternalLink to="https://community.strapi.io/marketplace/strapi-plugin-documentation" text="Strapi Marketplace page" />
   </IdentityCardItem>
 </IdentityCard>
 

--- a/docusaurus/docs/cms/plugins/graphql.md
+++ b/docusaurus/docs/cms/plugins/graphql.md
@@ -29,7 +29,7 @@ By default Strapi create [REST endpoints](/cms/api/rest#endpoints) for each of y
 <IdentityCard isPlugin>
   <IdentityCardItem icon="navigation-arrow" title="Location">Usable via the admin panel.<br/>Configured through both admin panel and server code, with different sets of options.</IdentityCardItem>
   <IdentityCardItem icon="package" title="Package name">`@strapi/plugin-graphql`  </IdentityCardItem>
-  <IdentityCardItem icon="plus-square" title="Additional resources"><ExternalLink to="https://market.strapi.io/plugins/@strapi-plugin-graphql" text="Strapi Marketplace page"/> </IdentityCardItem>
+  <IdentityCardItem icon="plus-square" title="Additional resources"><ExternalLink to="https://community.strapi.io/marketplace/strapi-plugin-graphql" text="Strapi Marketplace page"/> </IdentityCardItem>
 </IdentityCard>
 
 <ThemedImage

--- a/docusaurus/docs/cms/plugins/installing-plugins-via-marketplace.md
+++ b/docusaurus/docs/cms/plugins/installing-plugins-via-marketplace.md
@@ -12,13 +12,13 @@ tags:
 # Using the Marketplace
 
 <Tldr>
-The in-app Marketplace lists plugins and providers with badges, search, and “More” links to detailed Strapi Market pages. This documentation outlines browsing cards and following provider-specific instructions to install new integrations.
+The in-app Marketplace lists plugins and providers with badges, search, and “More” links to detailed Strapi Community Hub pages. This documentation outlines browsing cards and following provider-specific instructions to install new integrations.
 </Tldr>
 
 Strapi comes with built-in plugins such as [Documentation](/cms/plugins/documentation), [GraphQL](/cms/plugins/graphql), and [Sentry](/cms/plugins/sentry). The Marketplace is where users can find additional plugins to customize Strapi applications, and additional providers to extend plugins. The Marketplace is located in the admin panel, indicated by <Icon name="shopping-cart" /> _Marketplace_. In the Marketplace, users can browse or search for plugins and providers, link to detailed descriptions for each, and submit new plugins and providers.
 
-:::note strapi In-app Marketplace vs. Market website
-The Marketplace in the admin panel displays all existing plugins, regardless of the version of Strapi they are for. All plugins can also be discoverable through the <ExternalLink to="https://market.strapi.io" text="Strapi Market"/> website.
+:::note strapi In-app Marketplace vs. Community Hub website
+The Marketplace in the admin panel displays all existing plugins, regardless of the version of Strapi they are for. All plugins can also be discoverable through the <ExternalLink to="https://community.strapi.io/marketplace" text="Strapi Community Hub"/> website.
 
 Keep in mind however that v4 and v5 plugins are not cross-compatible, but that providers are compatible both with v4 and v5 plugins.
 :::
@@ -38,9 +38,9 @@ The Plugins and Providers tabs display each plugin/provider on individual cards 
   - <Icon name="seal-check" color="rgb(58,115,66)" /> to indicate it was verified by Strapi.
 - the number of times the plugin/provider was starred on GitHub and downloaded
 - the description
-- a **More** <Icon name="arrow-square-out" /> button to be redirected to the Market website for additional information, including about the version of Strapi the plugin is for, and implementation instructions
+- a **More** <Icon name="arrow-square-out" /> button to be redirected to the Community Hub website for additional information, including about the version of Strapi the plugin is for, and implementation instructions
 
-In the top right corner of the Marketplace, the **Submit plugin** button redirects to the Strapi Market where it is possible to submit your own plugin and provider.
+In the top right corner of the Marketplace, the **Submit plugin** button redirects to the Strapi Community Hub where it is possible to submit your own plugin and provider.
 
 :::tip Tips
 
@@ -56,7 +56,7 @@ To install a new plugin or provider via the Marketplace:
 1. Go to the <Icon name="shopping-cart" /> *Marketplace*.
 2. Choose the **Plugins** tab to browse available plugins or the **Providers** tab to browse available providers.
 3. Choose an available plugin/provider and click on the **More** <Icon name="arrow-square-out" /> button.
-4. Once redirected to the Strapi Market website, follow the plugin/provider-specific implementation instructions.
+4. Once redirected to the Strapi Community Hub website, follow the plugin/provider-specific implementation instructions.
 
 :::strapi Developing Strapi plugins
 Can't find a plugin that suits your use case? Feel free to [create your own](/cms/plugins-development/developing-plugins)!

--- a/docusaurus/docs/cms/plugins/sentry.md
+++ b/docusaurus/docs/cms/plugins/sentry.md
@@ -19,7 +19,7 @@ This plugin enables you to track errors in your Strapi application using Sentry.
 <IdentityCard isPlugin>
   <IdentityCardItem icon="navigation-arrow" title="Location">Only usable and configurable via server code</IdentityCardItem>
   <IdentityCardItem icon="package" title="Package name">`@strapi/plugin-sentry`</IdentityCardItem>
-  <IdentityCardItem icon="plus-square" title="Additional resources"><ExternalLink to="https://market.strapi.io/plugins/@strapi-plugin-sentry" text="Strapi Marketplace page"/> <ExternalLink to="https://sentry.io/" text="Sentry page"/></IdentityCardItem>
+  <IdentityCardItem icon="plus-square" title="Additional resources"><ExternalLink to="https://community.strapi.io/marketplace/strapi-plugin-sentry" text="Strapi Marketplace page"/> <ExternalLink to="https://sentry.io/" text="Sentry page"/></IdentityCardItem>
 </IdentityCard>
 
 By using the Sentry plugin you can:


### PR DESCRIPTION
This PR replaces every `market.strapi.io` link in the CMS and Cloud docs with its `community.strapi.io` equivalent, since the Strapi Market domain now redirects to the Community Hub. Each new URL was checked and returns the expected page: listing links go to `/marketplace`, the four plugin links go to `/marketplace/<plugin>`, and the submission link goes to `/submit/plugin`. Filter parameters that the old Market supported (`?types=provider`, `?categories=Custom+fields`, `?version=v5`) are dropped, because the Community Hub filters client-side and does not read them.

It also renames the retired "Strapi Market" brand to "Strapi Community Hub" in the seven places where it appeared as prose or link text. The in-app Marketplace in the admin panel keeps its name, and so do the "Strapi Marketplace page" labels that point at the Hub's marketplace section. The `market-assets.strapi.io` CSP value documented on the middlewares page is untouched, since that one is still the value Strapi ships.

Direct preview link 👉 [here](https://documentation-git-repo-community-hub-marketplace-urls-strapijs.vercel.app/cms/plugins/installing-plugins-via-marketplace)
