### PR TITLE
Document Media Library MCP read tools

### DIFF
--- a/docusaurus/docs/cms/ai/for-developers.md
+++ b/docusaurus/docs/cms/ai/for-developers.md
@@ -131,7 +131,7 @@ The [Model Context Protocol (MCP)](https://modelcontextprotocol.io) is an open s
 <CustomDocCard icon="book-open" title="Docs MCP server" description="Connect the Strapi documentation to your IDE for up-to-date, reliable information." link="/cms/ai/docs-mcp-server" />
 </CustomDocCardsWrapper>
 
-The Strapi MCP server also exposes 3 read tools for the Media Library: `media_list_assets`, `media_get_asset`, and `media_list_folders`. These tools require an Admin token with the `plugin::upload.read` permission. See [Media Library tools](/cms/features/strapi-mcp-server#media-library-tools) for parameters and usage details.
+The Strapi MCP server also exposes 3 read tools for the Media Library: `media_list_assets`, `media_get_asset`, and `media_list_folders`. These tools require an Admin token with the `plugin::upload.read` permission (see [Media Library tools](/cms/features/strapi-mcp-server#media-library-tools) for parameters and usage details).
 
 ### Tips for better results with the Docs MCP server {#tips}
 

--- a/docusaurus/docs/cms/ai/for-developers.md
+++ b/docusaurus/docs/cms/ai/for-developers.md
@@ -131,6 +131,8 @@ The [Model Context Protocol (MCP)](https://modelcontextprotocol.io) is an open s
 <CustomDocCard icon="book-open" title="Docs MCP server" description="Connect the Strapi documentation to your IDE for up-to-date, reliable information." link="/cms/ai/docs-mcp-server" />
 </CustomDocCardsWrapper>
 
+The Strapi MCP server also exposes 3 read tools for the Media Library: `media_list_assets`, `media_get_asset`, and `media_list_folders`. These tools require an Admin token with the `plugin::upload.read` permission. See [Media Library tools](/cms/features/strapi-mcp-server#media-library-tools) for parameters and usage details.
+
 ### Tips for better results with the Docs MCP server {#tips}
 
 The following tips will help you fine-tune your prompts to get the best results:

--- a/docusaurus/docs/cms/features/media-library-beta.md
+++ b/docusaurus/docs/cms/features/media-library-beta.md
@@ -582,6 +582,10 @@ The Media Library feature has some endpoints that can accessed through Strapi's 
 <CustomDocCard icon="cube" title="Upload with the REST API" description="Learn how to use the Strapi's REST API to upload files through your code." link="/cms/api/rest/upload"/>
 </CustomDocCardsWrapper>
 
+### Usage with the MCP server
+
+AI clients connected to the [Strapi MCP server](/cms/features/strapi-mcp-server) can browse the Media Library through 3 read-only tools that list assets, return a single asset, and return the folder tree (see [Media Library tools](/cms/features/strapi-mcp-server#media-library-tools)).
+
 ### Use public assets in your code {#public-assets}
 
 Public assets are static files (e.g., images, video, CSS files, etc.) that you want to make accessible to the outside world.

--- a/docusaurus/docs/cms/features/media-library.md
+++ b/docusaurus/docs/cms/features/media-library.md
@@ -1078,6 +1078,10 @@ The Media Library feature has some endpoints that can accessed through Strapi's 
 <CustomDocCard icon="cube" title="Upload with the REST API" description="Learn how to use the Strapi's REST API to upload files through your code." link="/cms/api/rest/upload"/>
 </CustomDocCardsWrapper>
 
+### Usage with the MCP server
+
+AI clients connected to the [Strapi MCP server](/cms/features/strapi-mcp-server) can browse the Media Library through 3 read-only tools that list assets, return a single asset, and return the folder tree (see [Media Library tools](/cms/features/strapi-mcp-server#media-library-tools)).
+
 ### Use public assets in your code {#public-assets}
 
 Public assets are static files (e.g., images, video, CSS files, etc.) that you want to make accessible to the outside world.

--- a/docusaurus/docs/cms/features/strapi-mcp-server.md
+++ b/docusaurus/docs/cms/features/strapi-mcp-server.md
@@ -261,7 +261,7 @@ Built-in utility tools are only available in development mode (when `autoReload`
 
 <VersionBadge version="5.53.1"/>
 
-Strapi registers 3 read tools for the Media Library. All 3 require the `plugin::upload.read` permission on the Admin token. If the token does not grant that permission, the tools do not appear in `tools/list` and calling them returns a permission error.
+Strapi also registers 3 read tools for the [Media Library](/cms/features/media-library). All 3 require the `plugin::upload.read` permission on the Admin token. If the token does not grant that permission, the tools do not appear in `tools/list` and calling them returns a permission error.
 
 | Tool | Description |
 |------|-------------|

--- a/docusaurus/docs/cms/features/strapi-mcp-server.md
+++ b/docusaurus/docs/cms/features/strapi-mcp-server.md
@@ -214,7 +214,7 @@ The MCP server uses the Streamable HTTP transport protocol. Any MCP-compatible c
 
 ### Available tools
 
-The MCP server exposes 2 categories of tools: content management tools generated from your schema, and built-in utility tools.
+The MCP server exposes 3 categories of tools: content management tools generated from your schema, built-in utility tools, and Media Library tools.
 
 #### Content management tools
 
@@ -278,9 +278,9 @@ The `media_list_assets` tool accepts the following optional parameters:
 | `page` | Number | Page number, 1-indexed (default: 1). |
 | `pageSize` | Number | Number of assets per page (default: 25, max: 100). |
 | `folderId` | Number or null | Numeric folder ID to list assets from a specific folder, or `null` for root-level assets only. Omit to list all assets regardless of folder. |
-| `mime` | String | MIME type prefix filter (e.g., `"image"` matches all image MIME types). |
+| `mime` | String | MIME type filter. A value without a slash is matched as a prefix (`"image"` matches every `image/*` type), a full type is matched exactly and case-insensitively (`"image/png"`). |
 | `name` | String | Partial asset name filter (case-insensitive substring match). |
-| `sort` | String | Sort expression in `field:direction` format (e.g., `"name:asc"` or `"createdAt:desc"`). |
+| `sort` | String | Sort order (default: `createdAt:DESC`). Only 6 values are accepted: `createdAt:ASC`, `createdAt:DESC`, `name:ASC`, `name:DESC`, `updatedAt:ASC`, and `updatedAt:DESC`. The direction is uppercase and any other value is rejected. |
 
 The `media_get_asset` tool requires 1 parameter: `id`, the numeric asset ID. Document ID strings are not accepted.
 

--- a/docusaurus/docs/cms/features/strapi-mcp-server.md
+++ b/docusaurus/docs/cms/features/strapi-mcp-server.md
@@ -257,6 +257,35 @@ In addition to content management tools, Strapi registers the following built-in
 
 Built-in utility tools are only available in development mode (when `autoReload` is enabled) and do not require specific admin permissions.
 
+#### Media Library tools
+
+<VersionBadge version="5.53.1"/>
+
+Strapi registers 3 read tools for the Media Library. All 3 require the `plugin::upload.read` permission on the Admin token. If the token does not grant that permission, the tools do not appear in `tools/list` and calling them returns a permission error.
+
+| Tool | Description |
+|------|-------------|
+| `media_list_assets` | Lists Media Library assets with pagination and optional filters. |
+| `media_get_asset` | Returns a single asset by its numeric `id`. |
+| `media_list_folders` | Returns the complete folder tree as a nested structure. |
+
+Tool responses include a fixed allowlist of fields: `id`, `name`, `alternativeText`, `caption`, `url`, `mime`, `size`, `width`, `height`, `ext`, `folder`, and timestamps. Fields that could expose storage provider credentials or internal paths (`provider`, `provider_metadata`, `hash`, `formats`, `folderPath`) are never returned, even if the content type is extended later.
+
+The `media_list_assets` tool accepts the following optional parameters:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `page` | Number | Page number, 1-indexed (default: 1). |
+| `pageSize` | Number | Number of assets per page (default: 25, max: 100). |
+| `folderId` | Number or null | Numeric folder ID to list assets from a specific folder, or `null` for root-level assets only. Omit to list all assets regardless of folder. |
+| `mime` | String | MIME type prefix filter (e.g., `"image"` matches all image MIME types). |
+| `name` | String | Partial asset name filter (case-insensitive substring match). |
+| `sort` | String | Sort expression in `field:direction` format (e.g., `"name:asc"` or `"createdAt:desc"`). |
+
+The `media_get_asset` tool requires 1 parameter: `id`, the numeric asset ID. Document ID strings are not accepted.
+
+The `media_list_folders` tool accepts no parameters and returns the full folder hierarchy.
+
 ### Content management through prompts
 
 Once connected, you can interact with your Strapi content using natural language:


### PR DESCRIPTION
This PR documents the 3 Media Library MCP read tools introduced in strapi/strapi#27523. It adds a new "Media Library tools" subsection to the MCP server feature page (`cms/features/strapi-mcp-server`) covering `media_list_assets`, `media_get_asset`, and `media_list_folders`: their parameters, the required `plugin::upload.read` permission, and the field allowlist returned in tool responses. It also adds a brief mention with a cross-link in the AI for developers page (`cms/ai/for-developers`).

Documents [#27523](https://github.com/strapi/strapi/pull/27523)

Direct preview link 👉 [here](https://documentation-git-cms-document-media-library-mcp-tools-strapijs.vercel.app/cms/features/strapi-mcp-server)