### PR TITLE
Add a guide for proxying Strapi with Traefik

### DIFF
--- a/docusaurus/docs/cms/deployment.md
+++ b/docusaurus/docs/cms/deployment.md
@@ -276,6 +276,7 @@ The following guides cover serving Strapi behind a reverse proxy and running it 
 <CustomDocCard icon="gear-fine" title="Proxying with Caddy" description="Serve Strapi through a Caddy reverse proxy, with automatic HTTPS." link="/cms/deployment/guides/caddy" />
 <CustomDocCard icon="gear-fine" title="Proxying with HAProxy" description="Serve Strapi through an HAProxy load balancer over HTTPS." link="/cms/deployment/guides/haproxy" />
 <CustomDocCard icon="gear-fine" title="Proxying with Nginx" description="Serve Strapi through an Nginx reverse proxy over HTTPS." link="/cms/deployment/guides/nginx" />
+<CustomDocCard icon="gear-fine" title="Proxying with Traefik" description="Serve a containerized Strapi application through Traefik over HTTPS." link="/cms/deployment/guides/traefik" />
 <CustomDocCard icon="arrow-square-out" title="Using the PM2 process manager" link="https://forum.strapi.io/t/how-to-use-pm2-process-manager-with-strapi/" />
 </CustomDocCardsWrapper>
 

--- a/docusaurus/docs/cms/deployment/guides/traefik.md
+++ b/docusaurus/docs/cms/deployment/guides/traefik.md
@@ -54,7 +54,7 @@ Traefik adds an `X-Forwarded-For` header carrying the original client IP address
 
 <ProxyTrustHeaders />
 
-:::caution
+:::warning IP spoofing
 Setting `proxy.koa` to `true` without `proxy.maxIpsCount` leaves the count at its default of `0`, which means unlimited. Set `maxIpsCount` to the real number of proxies in front of Strapi so that only addresses added by your own infrastructure are read.
 :::
 

--- a/docusaurus/docs/cms/deployment/guides/traefik.md
+++ b/docusaurus/docs/cms/deployment/guides/traefik.md
@@ -202,7 +202,7 @@ Then confirm the rest of the chain:
 2. Upload an image in the Media Library. Its URL uses your domain rather than `localhost:1337`.
 3. Check the Strapi container logs with `docker compose logs strapi` for the real client IP address rather than the Traefik container address.
 
-## Troubleshooting
+## <Icon name="bug" /> Troubleshooting
 
 Each of the following symptoms points at one side of the setup. The symptom is in bold, followed by what causes it and what to change:
 

--- a/docusaurus/docs/cms/deployment/guides/traefik.md
+++ b/docusaurus/docs/cms/deployment/guides/traefik.md
@@ -1,0 +1,322 @@
+---
+title: Proxying Strapi with Traefik
+sidebar_label: Traefik
+displayed_sidebar: cmsSidebar
+description: Configure Strapi and Traefik so that a containerized Strapi application is served through Traefik over HTTPS.
+tags:
+- containers
+- deployment
+- deployment guide
+- Docker
+- guides
+- proxy
+- server configuration
+- Traefik
+---
+
+# Proxying Strapi with Traefik
+
+<Tldr>
+Tell Strapi its public address and that a proxy sits in front of it, using the `server.url` and `server.proxy` options. Then add Traefik labels to the Strapi container so Traefik discovers it, routes to port 1337, and requests a certificate for your domain.
+</Tldr>
+
+Strapi listens on a plain HTTP port and does not terminate TLS itself. A reverse proxy such as Traefik sits in front of it to handle HTTPS, serve your application on port 443, and forward requests to the Strapi process. Traefik differs from the other proxies in this section: instead of a configuration file describing your routes, it watches the Docker API and reads routing rules from labels on each container. That suits deployments where containers come and go. This guide covers the Strapi configuration that makes your application proxy-aware, then the Traefik setup that routes traffic to it.
+
+:::prerequisites
+- A Strapi 5 application that starts and runs locally (see [deployment guidelines](/cms/deployment#general-guidelines)).
+- Strapi packaged as a container image (see [Docker installation](/cms/installation/docker)).
+- <ExternalLink to="https://docs.docker.com/compose/" text="Docker Compose"/> installed on the host.
+- A domain name whose DNS `A` record points at that host.
+- Ports 80 and 443 open to the public internet. Traefik needs one of them to complete the certificate challenge.
+:::
+
+## Configure Strapi for a reverse proxy
+
+Strapi needs to know the public address it is served from, and it needs to trust the headers the proxy adds. Without these 2 settings, Strapi builds URLs from `localhost:1337` and reads the proxy's IP address as the client IP.
+
+### Set the public URL
+
+The `url` option in the server configuration defines the public address of your application. Strapi uses it to build absolute URLs for password reset emails, third-party login providers, and media asset paths.
+
+Set it to the address your application's visitors use in their browser:
+
+<Tabs groupId="js-ts">
+<TabItem value="js" label="JavaScript">
+
+```js title="/config/server.js"
+module.exports = ({ env }) => ({
+  host: env('HOST', '0.0.0.0'),
+  port: env.int('PORT', 1337),
+  url: env('PUBLIC_URL', 'https://api.example.com'),
+  app: {
+    keys: env.array('APP_KEYS'),
+  },
+});
+```
+
+</TabItem>
+<TabItem value="ts" label="TypeScript">
+
+```ts title="/config/server.ts"
+export default ({ env }) => ({
+  host: env('HOST', '0.0.0.0'),
+  port: env.int('PORT', 1337),
+  url: env('PUBLIC_URL', 'https://api.example.com'),
+  app: {
+    keys: env.array('APP_KEYS'),
+  },
+});
+```
+
+</TabItem>
+</Tabs>
+
+The `host` value must stay `0.0.0.0`. Bound to `localhost`, Strapi accepts connections only from inside its own container and Traefik cannot reach it.
+
+:::caution
+Changing `/config/server.js` requires rebuilding the admin panel. Run `yarn build` or `npm run build` after saving the file, then rebuild your image.
+:::
+
+### Trust the proxy headers
+
+Traefik adds an `X-Forwarded-For` header carrying the original client IP address. Strapi ignores that header until you enable proxy support through the `proxy` options:
+
+<Tabs groupId="js-ts">
+<TabItem value="js" label="JavaScript">
+
+```js title="/config/server.js"
+module.exports = ({ env }) => ({
+  host: env('HOST', '0.0.0.0'),
+  port: env.int('PORT', 1337),
+  url: env('PUBLIC_URL', 'https://api.example.com'),
+  // highlight-start
+  proxy: {
+    koa: true,
+    maxIpsCount: 1,
+  },
+  // highlight-end
+  app: {
+    keys: env.array('APP_KEYS'),
+  },
+});
+```
+
+</TabItem>
+<TabItem value="ts" label="TypeScript">
+
+```ts title="/config/server.ts"
+export default ({ env }) => ({
+  host: env('HOST', '0.0.0.0'),
+  port: env.int('PORT', 1337),
+  url: env('PUBLIC_URL', 'https://api.example.com'),
+  // highlight-start
+  proxy: {
+    koa: true,
+    maxIpsCount: 1,
+  },
+  // highlight-end
+  app: {
+    keys: env.array('APP_KEYS'),
+  },
+});
+```
+
+</TabItem>
+</Tabs>
+
+The 2 options play different roles:
+
+| Option | Effect |
+|--------|--------|
+| `proxy.koa` | When `true`, Strapi trusts the `X-Forwarded-*` headers. Client IP, protocol, and host are read from the proxy instead of the socket. |
+| `proxy.maxIpsCount` | Number of addresses to read from the end of the forwarded header chain. Set it to `1` for a single Traefik instance, or to the number of proxies when requests pass through several. |
+
+:::caution
+Setting `proxy.koa` to `true` without `proxy.maxIpsCount` leaves the count at its default of `0`, which means unlimited. Set `maxIpsCount` to the real number of proxies in front of Strapi so that only addresses added by your own infrastructure are read.
+:::
+
+Strapi reads the header named by `proxy.ipHeader`, which defaults to `X-Forwarded-For`, and Traefik sets that same header. Traefik also sets `X-Forwarded-Proto`, which Strapi uses to mark the admin panel refresh-token cookie as `Secure`. Absolute URLs for password resets, login provider callbacks, and media assets are built from the `url` option instead, not from that header.
+
+Traefik helps here in a way that not every proxy does. By default it sanitizes the `X-Forwarded-*` headers a client sends and writes its own, so a client cannot inject a fake address into the chain. That protection depends on Traefik being the first proxy to see the request. If a CDN or load balancer sits in front of Traefik, list its addresses in the entry point's `forwardedHeaders.trustedIPs` so Traefik preserves what that upstream added, then count every proxy in the chain when you set `proxy.maxIpsCount`:
+
+```yml title="./traefik/traefik.yml"
+entryPoints:
+  websecure:
+    address: ':443'
+    forwardedHeaders:
+      trustedIPs:
+        - '203.0.113.0/24'
+```
+
+### Raise the body size limits for uploads
+
+Traefik streams request bodies through to the backend without a size cap unless you add one, so the Strapi limits are the ones that apply by default. If you upload files through the Media Library, raise them.
+
+On the Strapi side, the `body` middleware parses incoming requests. Uploaded files arrive as multipart data, so `formidable.maxFileSize` is the option that caps them. The `formLimit` and `jsonLimit` options cover ordinary form fields and JSON payloads, not the file itself:
+
+```js title="/config/middlewares.js"
+module.exports = [
+  // ...
+  {
+    name: 'strapi::body',
+    config: {
+      formLimit: '100mb', // form body
+      jsonLimit: '100mb', // JSON body
+      textLimit: '100mb', // text body
+      formidable: {
+        maxFileSize: 100 * 1024 * 1024, // uploaded file size, in bytes
+      },
+    },
+  },
+  // ...
+];
+```
+
+The Media Library provider enforces a separate `sizeLimit`, which defaults to 1 GB (see [local upload provider configuration](/cms/configurations/media-library-providers/local-upload) and [max file size](/cms/features/media-library#max-file-size) to change it).
+
+## Configure Traefik
+
+Traefik reads 2 kinds of configuration. Static configuration, which defines entry points and certificate resolvers, is set once when Traefik starts. Dynamic configuration, which defines routes, comes from container labels and is picked up as containers appear.
+
+### Write the static configuration
+
+The following file defines an entry point on each public port, redirects HTTP to HTTPS, and registers a Let's Encrypt certificate resolver:
+
+```yml title="./traefik/traefik.yml"
+entryPoints:
+  web:
+    address: ':80'
+    http:
+      redirections:
+        entryPoint:
+          to: websecure
+          scheme: https
+          permanent: true
+  websecure:
+    address: ':443'
+
+providers:
+  docker:
+    # Only route to containers that opt in with traefik.enable=true
+    exposedByDefault: false
+
+certificatesResolvers:
+  letsencrypt:
+    acme:
+      email: admin@example.com
+      storage: /acme/acme.json
+      tlsChallenge: {}
+```
+
+Setting `exposedByDefault` to `false` matters. Left at its default, Traefik publishes every container it can see, including ones you never meant to expose.
+
+### Route traffic to Strapi with labels
+
+With the static configuration in place, the Strapi container declares its own route through labels:
+
+```yml title="./docker-compose.yml"
+services:
+  traefik:
+    image: traefik:v3.7
+    ports:
+      - '80:80'
+      - '443:443'
+    volumes:
+      - ./traefik/traefik.yml:/etc/traefik/traefik.yml:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - traefik_acme:/acme
+    networks:
+      - web
+
+  strapi:
+    image: my-strapi-app
+    environment:
+      HOST: 0.0.0.0
+      PORT: 1337
+      PUBLIC_URL: https://api.example.com
+    labels:
+      - 'traefik.enable=true'
+      - 'traefik.http.routers.strapi.rule=Host(`api.example.com`)'
+      - 'traefik.http.routers.strapi.entrypoints=websecure'
+      - 'traefik.http.routers.strapi.tls.certresolver=letsencrypt'
+      - 'traefik.http.services.strapi.loadbalancer.server.port=1337'
+    networks:
+      - web
+
+volumes:
+  traefik_acme:
+
+networks:
+  web:
+```
+
+The `loadbalancer.server.port` label is the one people miss. Traefik routes to a port inside the container network, so the Strapi container needs no `ports` mapping of its own. Only Traefik publishes ports to the host, which keeps Strapi off the public interface.
+
+:::warning
+Mount a persistent volume for the certificate storage path, as shown above with `traefik_acme`. Traefik stores issued certificates in `acme.json`. Without it, every container restart requests new certificates, which reaches the <ExternalLink to="https://letsencrypt.org/docs/rate-limits/" text="Let's Encrypt rate limits"/> and leaves the site without a valid certificate until the limit resets.
+:::
+
+:::danger
+Mounting the Docker socket gives Traefik full access to the Docker API, which is equivalent to root on the host. The `:ro` flag shown above applies to the socket file rather than to the API, so it does not limit what Traefik can do through the socket. Treat it as a convention, not a boundary. Do not expose the Traefik dashboard publicly, and for a hardened deployment put the socket behind a proxy that exposes only the endpoints Traefik needs.
+:::
+
+### Cap the request body size
+
+Traefik applies no request size limit by default. To reject oversized uploads at the proxy instead of at Strapi, add the `buffering` middleware to the Strapi container's labels:
+
+```yml title="./docker-compose.yml"
+    labels:
+      # ...
+      - 'traefik.http.middlewares.strapi-limit.buffering.maxRequestBodyBytes=104857600'
+      - 'traefik.http.routers.strapi.middlewares=strapi-limit'
+```
+
+A request over the limit receives a `413` response.
+
+:::note
+The `buffering` middleware reads the entire request body before forwarding it, spilling to disk beyond a threshold. That adds latency and disk usage on every upload, which is a poor trade for a Media Library that accepts large files. If your uploads are large, leave this middleware off and let `formidable.maxFileSize` in Strapi enforce the limit instead.
+:::
+
+## Validation
+
+Bring up the stack and check that Traefik reaches Strapi. Strapi exposes a health check route at `/_health` that responds with HTTP `204 No Content` and a `strapi` header:
+
+```bash
+docker compose up -d
+curl -I https://api.example.com/_health
+```
+
+A working setup returns the status line and the header:
+
+```
+HTTP/2 204
+strapi: You are so French!
+```
+
+Then confirm the rest of the chain:
+
+1. Open `https://api.example.com/admin` in a browser and log in. The admin panel loads over HTTPS with a valid certificate.
+2. Upload an image in the Media Library. Its URL uses your domain rather than `localhost:1337`.
+3. Check the Strapi container logs with `docker compose logs strapi` for the real client IP address rather than the Traefik container address.
+
+## Troubleshooting
+
+**Traefik returns `404 page not found`.** No router matched the request. Confirm the container carries `traefik.enable=true`, that the `Host()` rule matches the domain you requested, and that both containers share the same Docker network.
+
+**Traefik returns `502 Bad Gateway`.** Traefik matched a route but could not reach Strapi. Confirm `loadbalancer.server.port` is `1337` and that Strapi is bound to `0.0.0.0` rather than `localhost`.
+
+**No certificate is issued.** The certificate challenge needs port 443 reachable from the public internet for `tlsChallenge`, and the domain's DNS `A` record must already resolve to this host. Check the Traefik logs with `docker compose logs traefik`.
+
+**Certificates are reissued on every restart.** The certificate storage path is not on a persistent volume, so `acme.json` is lost with the container.
+
+**Uploads fail with a `413` response.** The `buffering` middleware limit is lower than the file size. Raise `maxRequestBodyBytes`, or remove the middleware and let `formidable.maxFileSize` in Strapi enforce the limit.
+
+**Strapi logs the Traefik container address as the client IP.** `proxy.koa` is not set to `true`, so Strapi reads the socket address instead of the forwarded header.
+
+**Password reset emails link to `localhost:1337`.** The `url` option is unset or still points at the local address. Set it to the public URL, rebuild the admin panel, and rebuild the image.
+
+## Next steps
+
+- Review the full list of [server configuration options](/cms/configurations/server).
+- Read the [Docker installation guide](/cms/installation/docker) for building the Strapi image this guide routes to.
+- Read the [deployment guidelines](/cms/deployment) for build and environment variable requirements.

--- a/docusaurus/docs/cms/deployment/guides/traefik.md
+++ b/docusaurus/docs/cms/deployment/guides/traefik.md
@@ -156,11 +156,11 @@ networks:
 The `loadbalancer.server.port` label is the one people miss. Traefik routes to a port inside the container network, so the Strapi container needs no `ports` mapping of its own. Only Traefik publishes ports to the host, which keeps Strapi off the public interface.
 
 :::warning
-Mount a persistent volume for the certificate storage path, as shown above with `traefik_acme`. Traefik stores issued certificates in `acme.json`. Without it, every container restart requests new certificates, which reaches the <ExternalLink to="https://letsencrypt.org/docs/rate-limits/" text="Let's Encrypt rate limits"/> and leaves the site without a valid certificate until the limit resets.
-:::
+2 parts of this file carry consequences beyond Traefik itself:
 
-:::danger
-Mounting the Docker socket gives Traefik full access to the Docker API, which is equivalent to root on the host. The `:ro` flag shown above applies to the socket file rather than to the API, so it does not limit what Traefik can do through the socket. Treat it as a convention, not a boundary. Do not expose the Traefik dashboard publicly, and for a hardened deployment put the socket behind a proxy that exposes only the endpoints Traefik needs.
+- **Mount a persistent volume for the certificate storage path**, as shown above with `traefik_acme`. Traefik stores issued certificates in `acme.json`. Without it, every container restart requests new certificates, which reaches the <ExternalLink to="https://letsencrypt.org/docs/rate-limits/" text="Let's Encrypt rate limits"/> and leaves the site without a valid certificate until the limit resets.
+
+- **Mounting the Docker socket gives Traefik full access to the Docker API**, which is equivalent to root on the host. The `:ro` flag shown above applies to the socket file rather than to the API, so it does not limit what Traefik can do through the socket. Treat it as a convention, not a boundary. Do not expose the Traefik dashboard publicly, and for a hardened deployment put the socket behind a proxy that exposes only the endpoints Traefik needs.
 :::
 
 ### Cap the request body size
@@ -180,7 +180,7 @@ A request over the limit receives a `413` response.
 The `buffering` middleware reads the entire request body before forwarding it, spilling to disk beyond a threshold. That adds latency and disk usage on every upload, which is a poor trade for a Media Library that accepts large files. If your uploads are large, leave this middleware off and let `formidable.maxFileSize` in Strapi enforce the limit instead.
 :::
 
-## Validation
+## Verify the proxy setup
 
 Bring up the stack and check that Traefik reaches Strapi. Strapi exposes a health check route at `/_health` that responds with HTTP `204 No Content` and a `strapi` header:
 
@@ -204,22 +204,38 @@ Then confirm the rest of the chain:
 
 ## Troubleshooting
 
-**Traefik returns `404 page not found`.** No router matched the request. Confirm the container carries `traefik.enable=true`, that the `Host()` rule matches the domain you requested, and that both containers share the same Docker network.
+Each of the following symptoms points at one side of the setup. The symptom is in bold, followed by what causes it and what to change:
 
-**Traefik returns `502 Bad Gateway`.** Traefik matched a route but could not reach Strapi. Confirm `loadbalancer.server.port` is `1337` and that Strapi is bound to `0.0.0.0` rather than `localhost`.
+- **Traefik returns `404 page not found`.** No router matched the request. Confirm the container carries `traefik.enable=true`, that the `Host()` rule matches the domain you requested, and that both containers share the same Docker network.
 
-**No certificate is issued.** The certificate challenge needs port 443 reachable from the public internet for `tlsChallenge`, and the domain's DNS `A` record must already resolve to this host. Check the Traefik logs with `docker compose logs traefik`.
+- **Traefik returns `502 Bad Gateway`.** Traefik matched a route but could not reach Strapi. Confirm `loadbalancer.server.port` is `1337` and that Strapi is bound to `0.0.0.0` rather than `localhost`.
 
-**Certificates are reissued on every restart.** The certificate storage path is not on a persistent volume, so `acme.json` is lost with the container.
+- **No certificate is issued.** The certificate challenge needs port 443 reachable from the public internet for `tlsChallenge`, and the domain's DNS `A` record must already resolve to this host. Check the Traefik logs with `docker compose logs traefik`.
 
-**Uploads fail with a `413` response.** The `buffering` middleware limit is lower than the file size. Raise `maxRequestBodyBytes`, or remove the middleware and let `formidable.maxFileSize` in Strapi enforce the limit.
+- **Certificates are reissued on every restart.** The certificate storage path is not on a persistent volume, so `acme.json` is lost with the container.
 
-**Strapi logs the Traefik container address as the client IP.** `proxy.koa` is not set to `true`, so Strapi reads the socket address instead of the forwarded header.
+- **Uploads fail with a `413` response.** The `buffering` middleware limit is lower than the file size. Raise `maxRequestBodyBytes`, or remove the middleware and let `formidable.maxFileSize` in Strapi enforce the limit.
 
-**Password reset emails link to `localhost:1337`.** The `url` option is unset or still points at the local address. Set it to the public URL, rebuild the admin panel, and rebuild the image.
+- **Strapi logs the Traefik container address as the client IP.** `proxy.koa` is not set to `true`, so Strapi reads the socket address instead of the forwarded header.
+
+- **Password reset emails link to `localhost:1337`.** The `url` option is unset or still points at the local address. Set it to the public URL, rebuild the admin panel, and rebuild the image.
 
 ## Next steps
 
-- Review the full list of [server configuration options](/cms/configurations/server).
-- Read the [Docker installation guide](/cms/installation/docker) for building the Strapi image this guide routes to.
-- Read the [deployment guidelines](/cms/deployment) for build and environment variable requirements.
+<NextSteps title="">
+  <NextSteps.Step
+    title="Review the server configuration options"
+    description="The full list of options available in the server config file."
+    link="/cms/configurations/server"
+  />
+  <NextSteps.Step
+    title="Build the Strapi image"
+    description="The Docker installation guide covers the image this guide routes to."
+    link="/cms/installation/docker"
+  />
+  <NextSteps.Step
+    title="Read the deployment guidelines"
+    description="Build requirements and environment variables a production deployment needs."
+    link="/cms/deployment"
+  />
+</NextSteps>

--- a/docusaurus/docs/cms/deployment/guides/traefik.md
+++ b/docusaurus/docs/cms/deployment/guides/traefik.md
@@ -14,6 +14,10 @@ tags:
 - Traefik
 ---
 
+import ProxyServerUrl from '/docs/snippets/proxy-server-url.md'
+import ProxyTrustHeaders from '/docs/snippets/proxy-trust-headers.md'
+import StrapiUploadBodyLimits from '/docs/snippets/strapi-upload-body-limits.md'
+
 # Proxying Strapi with Traefik
 
 <Tldr>
@@ -36,40 +40,7 @@ Strapi needs to know the public address it is served from, and it needs to trust
 
 ### Set the public URL
 
-The `url` option in the server configuration defines the public address of your application. Strapi uses it to build absolute URLs for password reset emails, third-party login providers, and media asset paths.
-
-Set it to the address your application's visitors use in their browser:
-
-<Tabs groupId="js-ts">
-<TabItem value="js" label="JavaScript">
-
-```js title="/config/server.js"
-module.exports = ({ env }) => ({
-  host: env('HOST', '0.0.0.0'),
-  port: env.int('PORT', 1337),
-  url: env('PUBLIC_URL', 'https://api.example.com'),
-  app: {
-    keys: env.array('APP_KEYS'),
-  },
-});
-```
-
-</TabItem>
-<TabItem value="ts" label="TypeScript">
-
-```ts title="/config/server.ts"
-export default ({ env }) => ({
-  host: env('HOST', '0.0.0.0'),
-  port: env.int('PORT', 1337),
-  url: env('PUBLIC_URL', 'https://api.example.com'),
-  app: {
-    keys: env.array('APP_KEYS'),
-  },
-});
-```
-
-</TabItem>
-</Tabs>
+<ProxyServerUrl />
 
 The `host` value must stay `0.0.0.0`. Bound to `localhost`, Strapi accepts connections only from inside its own container and Traefik cannot reach it.
 
@@ -79,57 +50,9 @@ Changing `/config/server.js` requires rebuilding the admin panel. Run `yarn buil
 
 ### Trust the proxy headers
 
-Traefik adds an `X-Forwarded-For` header carrying the original client IP address. Strapi ignores that header until you enable proxy support through the `proxy` options:
+Traefik adds an `X-Forwarded-For` header carrying the original client IP address. Strapi ignores that header until you turn proxy support on.
 
-<Tabs groupId="js-ts">
-<TabItem value="js" label="JavaScript">
-
-```js title="/config/server.js"
-module.exports = ({ env }) => ({
-  host: env('HOST', '0.0.0.0'),
-  port: env.int('PORT', 1337),
-  url: env('PUBLIC_URL', 'https://api.example.com'),
-  // highlight-start
-  proxy: {
-    koa: true,
-    maxIpsCount: 1,
-  },
-  // highlight-end
-  app: {
-    keys: env.array('APP_KEYS'),
-  },
-});
-```
-
-</TabItem>
-<TabItem value="ts" label="TypeScript">
-
-```ts title="/config/server.ts"
-export default ({ env }) => ({
-  host: env('HOST', '0.0.0.0'),
-  port: env.int('PORT', 1337),
-  url: env('PUBLIC_URL', 'https://api.example.com'),
-  // highlight-start
-  proxy: {
-    koa: true,
-    maxIpsCount: 1,
-  },
-  // highlight-end
-  app: {
-    keys: env.array('APP_KEYS'),
-  },
-});
-```
-
-</TabItem>
-</Tabs>
-
-The 2 options play different roles:
-
-| Option | Effect |
-|--------|--------|
-| `proxy.koa` | When `true`, Strapi trusts the `X-Forwarded-*` headers. Client IP, protocol, and host are read from the proxy instead of the socket. |
-| `proxy.maxIpsCount` | Number of addresses to read from the end of the forwarded header chain. Set it to `1` for a single Traefik instance, or to the number of proxies when requests pass through several. |
+<ProxyTrustHeaders />
 
 :::caution
 Setting `proxy.koa` to `true` without `proxy.maxIpsCount` leaves the count at its default of `0`, which means unlimited. Set `maxIpsCount` to the real number of proxies in front of Strapi so that only addresses added by your own infrastructure are read.
@@ -152,27 +75,7 @@ entryPoints:
 
 Traefik streams request bodies through to the backend without a size cap unless you add one, so the Strapi limits are the ones that apply by default. If you upload files through the Media Library, raise them.
 
-On the Strapi side, the `body` middleware parses incoming requests. Uploaded files arrive as multipart data, so `formidable.maxFileSize` is the option that caps them. The `formLimit` and `jsonLimit` options cover ordinary form fields and JSON payloads, not the file itself:
-
-```js title="/config/middlewares.js"
-module.exports = [
-  // ...
-  {
-    name: 'strapi::body',
-    config: {
-      formLimit: '100mb', // form body
-      jsonLimit: '100mb', // JSON body
-      textLimit: '100mb', // text body
-      formidable: {
-        maxFileSize: 100 * 1024 * 1024, // uploaded file size, in bytes
-      },
-    },
-  },
-  // ...
-];
-```
-
-The Media Library provider enforces a separate `sizeLimit`, which defaults to 1 GB (see [local upload provider configuration](/cms/configurations/media-library-providers/local-upload) and [max file size](/cms/features/media-library#max-file-size) to change it).
+<StrapiUploadBodyLimits />
 
 ## Configure Traefik
 

--- a/docusaurus/docs/cms/faq.md
+++ b/docusaurus/docs/cms/faq.md
@@ -127,7 +127,7 @@ On Linux based operating systems you need root permissions to bind to any port b
 
 Likewise since Strapi is Node.js based, in order for changes with the SSL certificate to take place (say when it expires) you would need to restart your application for that change to take effect.
 
-Due to these two issues, it is recommended you use a proxy application such as [Nginx](/cms/deployment/guides/nginx), [Caddy](/cms/deployment/guides/caddy), [HAProxy](/cms/deployment/guides/haproxy), Apache, Traefik, or many others to handle your edge routing to Strapi. The [server configuration](/cms/configurations/server) has a `proxy` block for upstream proxies. Set `proxy.koa` to trust the forwarded headers, and `proxy.maxIpsCount` to the number of proxies in front of Strapi. `proxy.ipHeader` is optional and defaults to `X-Forwarded-For`. Backend plugins such as authentication providers and the upload plugin then build their URLs from the `url` option rather than from `localhost:1337`.
+Due to these two issues, it is recommended you use a proxy application such as [Nginx](/cms/deployment/guides/nginx), [Caddy](/cms/deployment/guides/caddy), [HAProxy](/cms/deployment/guides/haproxy), Apache, [Traefik](/cms/deployment/guides/traefik), or many others to handle your edge routing to Strapi. The [server configuration](/cms/configurations/server) has a `proxy` block for upstream proxies. Set `proxy.koa` to trust the forwarded headers, and `proxy.maxIpsCount` to the number of proxies in front of Strapi. `proxy.ipHeader` is optional and defaults to `X-Forwarded-For`. Backend plugins such as authentication providers and the upload plugin then build their URLs from the `url` option rather than from `localhost:1337`.
 
 ## Can I use TypeScript in a Strapi project?
 

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -54,6 +54,7 @@ const sidebars = {
             'cms/deployment/guides/caddy',
             'cms/deployment/guides/haproxy',
             'cms/deployment/guides/nginx',
+            'cms/deployment/guides/traefik',
           ],
         },
         'cms/billing-portal',


### PR DESCRIPTION
This PR adds a deployment guide for serving Strapi behind Traefik, which configures routing from container labels rather than a configuration file. It covers the `server.url` and `server.proxy` options, the Docker labels that route to port 1337, automatic certificates and the volume that persists them, `forwardedHeaders.trustedIPs` for when a CDN sits upstream, and the Docker socket exposure that comes with the Docker provider. Unlike the other proxy guides this one has no Strapi Forum predecessor, so it adds a new card to the deployment page rather than replacing a dead link.

Stacked on #3463. Review that one first.

Direct preview link 👉 [here](https://documentation-git-repo-add-traefik-proxy-guide-strapijs.vercel.app/cms/deployment/guides/traefik)
