### PR TITLE
Fix the word boundary probe in the Inki style linter

### DIFF
--- a/claude-plugins/inki/scripts/style-lint.sh
+++ b/claude-plugins/inki/scripts/style-lint.sh
@@ -106,13 +106,16 @@ strip_excluded_content() {
 }
 
 # Helper: case-insensitive word match using grep -Ei with word boundaries
-# macOS grep -E does not support \b, so we use [[:<:]] and [[:>:]] on macOS
-# and \b on Linux.
-word_boundary_start='[[:<:]]'
-word_boundary_end='[[:>:]]'
-if grep -E '\b' /dev/null 2>/dev/null; then
+# GNU grep -E supports \b; the BSD grep shipped with macOS does not and uses
+# [[:<:]] and [[:>:]] instead. Probe with real input: matching against an empty
+# file always exits 1, so an exit-status probe on /dev/null can never succeed
+# and would leave every platform on the BSD classes.
+if printf 'x' | grep -qE '\bx\b' 2>/dev/null; then
   word_boundary_start='\b'
   word_boundary_end='\b'
+else
+  word_boundary_start='[[:<:]]'
+  word_boundary_end='[[:>:]]'
 fi
 
 lint_file() {


### PR DESCRIPTION
This PR fixes the word boundary probe in the inki style linter. It ran `grep -E '\b'` against `/dev/null`, which matches nothing and exits 1 on every platform, so the GNU branch was never taken and Linux fell through to the BSD-only `[[:<:]]` classes that GNU grep rejects. The result was that the easy-words, casual-language, multi-action-step, spelled-number and all-caps checks silently produced no findings on Linux, with their errors going to stderr while the script still exited 0. Probing with real input fixes the detection. The script is not referenced by any workflow, so this changes only what `/inki:style-check` and the style-checker agent report.
