### PR TITLE
Scope the admin cookie path requirement to the versions it affects

### DIFF
--- a/docusaurus/docs/snippets/admin-url-cookie-path.md
+++ b/docusaurus/docs/snippets/admin-url-cookie-path.md
@@ -1,5 +1,5 @@
 :::caution Cookie path must match
-When you change `url`, you must also update [`auth.cookie.path`](/cms/configurations/admin-panel#cookie-configuration) to the same value. The cookie path defaults to `'/admin'` regardless of `url`, so if they differ, the browser will not send the authentication cookie to the new path and logins will silently fail.
+Since Strapi 5.51, the admin authentication cookie path defaults to `/admin` regardless of `url`. When you change `url`, also set [`auth.cookie.path`](/cms/configurations/admin-panel#cookie-configuration) to the same value. Otherwise the admin panel cannot read its own authentication cookie: the login request succeeds, every request after it is rejected, and the panel returns to the login page with no error.
 
 ```js title="/config/admin.js"
 module.exports = ({ env }) => ({


### PR DESCRIPTION
This PR scopes the admin cookie path warning to the versions it applies to, since the default cookie path changed in Strapi 5.51. It also corrects the stated symptom: the browser does send the refresh cookie, so requests to the admin API are authenticated at that layer. What fails is the admin panel reading its own access cookie from a page outside the cookie path, so the login request succeeds and every request after it is rejected. Verified by reproducing it on 5.53.0 with `url` set to `/dashboard`.

A fix is proposed in strapi/strapi#27619 to derive the cookie path from `url` automatically. Once that ships, this snippet should gain an upper version bound or be removed.


Direct preview link 👉 [here](https://documentation-git-repo-scope-admin-cookie-path-note-strapijs.vercel.app/snippets/admin-url-cookie-path)