### PR TITLE
Encode the callout scale and the doc card props in the Inki linter

### DIFF
--- a/claude-plugins/inki/references/prompts/style-checker.md
+++ b/claude-plugins/inki/references/prompts/style-checker.md
@@ -132,9 +132,11 @@ For each of the 12 rules, here is how to detect violations and what severity to 
   - The style guide scale, from lowest to highest, is `:::tip`, `:::note`, `:::prerequisites`, `:::caution`, `:::warning`, plus `:::strapi` for links to the Strapi ecosystem. `:::caution` covers mistake prevention, recommendations, and unstable behavior; `:::warning` is the top level and covers data loss, crash prevention, and unsupported behavior.
   - `:::danger` is not part of the scale. It renders the same red block titled "Warning" as `:::warning` (`docusaurus/src/theme/Admonition/index.js`, `docusaurus/src/scss/admonition.scss`), so it adds no signal. Flag it and propose `:::warning`.
   - **Severity:** error
-- **Strapi-specific (stacked alerts):**
-  - Two high-level callouts (`:::caution`, `:::warning`, `:::danger`) back to back, with nothing but blank lines between them, flatten the hierarchy: the reader sees a wall of red blocks and stops telling the severe apart from the merely annoying. Keep one alert and move the rest to prose or a bullet list.
-  - Stacked `:::note`, `:::tip`, and `:::info` blocks are common and harmless, and a `:::prerequisites` followed by a `:::caution` is the documented page-header motif. Do NOT flag either.
+- **Strapi-specific (consecutive callouts):**
+  - 3 or more callouts in a row, whatever their types, are a wall the reader stops reading. Keep one and move the rest to prose or a bullet list.
+  - Two callouts of the same type back to back are one callout: merge them into a single block, with a bullet per point.
+  - Two high-level callouts (`:::caution`, `:::warning`, `:::danger`) back to back flatten the hierarchy, and the severe stops standing out from the merely annoying. Keep one alert.
+  - A pair of different low-level types (`:::note` then `:::tip`) is harmless, and so is the documented `:::prerequisites` plus `:::caution` page-header motif, as long as the run stops at 2. Do NOT flag either.
   - **Severity:** warning
 
 ### Rule 3: Direct and neutral tone

--- a/claude-plugins/inki/references/prompts/style-checker.md
+++ b/claude-plugins/inki/references/prompts/style-checker.md
@@ -128,6 +128,14 @@ For each of the 12 rules, here is how to detect violations and what severity to 
 - **Strapi-specific (inline callouts):**
   - Bold prefixes used as callouts (`**Note:**`, `**Important:**`, `**Warning:**`, `**Caution:**`, `**Tip:**`) must be converted to Docusaurus admonitions (`:::note`, `:::caution`, `:::warning`, `:::tip`).
   - **Severity:** error
+- **Strapi-specific (callout scale):**
+  - The style guide scale, from lowest to highest, is `:::tip`, `:::note`, `:::prerequisites`, `:::caution`, `:::warning`, plus `:::strapi` for links to the Strapi ecosystem. `:::caution` covers mistake prevention, recommendations, and unstable behavior; `:::warning` is the top level and covers data loss, crash prevention, and unsupported behavior.
+  - `:::danger` is not part of the scale. It renders the same red block titled "Warning" as `:::warning` (`docusaurus/src/theme/Admonition/index.js`, `docusaurus/src/scss/admonition.scss`), so it adds no signal. Flag it and propose `:::warning`.
+  - **Severity:** error
+- **Strapi-specific (stacked alerts):**
+  - Two high-level callouts (`:::caution`, `:::warning`, `:::danger`) back to back, with nothing but blank lines between them, flatten the hierarchy: the reader sees a wall of red blocks and stops telling the severe apart from the merely annoying. Keep one alert and move the rest to prose or a bullet list.
+  - Stacked `:::note`, `:::tip`, and `:::info` blocks are common and harmless, and a `:::prerequisites` followed by a `:::caution` is the documented page-header motif. Do NOT flag either.
+  - **Severity:** warning
 
 ### Rule 3: Direct and neutral tone
 - **Detect:** Jokes, rhetorical questions, emojis (except in UI element references), casual language ("gonna", "wanna", "pretty cool", "awesome", "super")

--- a/claude-plugins/inki/references/prompts/style-checker.md
+++ b/claude-plugins/inki/references/prompts/style-checker.md
@@ -129,14 +129,14 @@ For each of the 12 rules, here is how to detect violations and what severity to 
   - Bold prefixes used as callouts (`**Note:**`, `**Important:**`, `**Warning:**`, `**Caution:**`, `**Tip:**`) must be converted to Docusaurus admonitions (`:::note`, `:::caution`, `:::warning`, `:::tip`).
   - **Severity:** error
 - **Strapi-specific (callout scale):**
-  - The style guide scale, from lowest to highest, is `:::tip`, `:::note`, `:::prerequisites`, `:::caution`, `:::warning`, plus `:::strapi` for links to the Strapi ecosystem. `:::caution` covers mistake prevention, recommendations, and unstable behavior; `:::warning` is the top level and covers data loss, crash prevention, and unsupported behavior.
+  - The scale, from lowest to highest, is `:::info`, `:::note`, `:::tip`, `:::prerequisites`, `:::caution`, `:::warning`, plus `:::strapi` for links to the Strapi ecosystem. `:::caution` covers mistake prevention, recommendations, and unstable behavior; `:::warning` is the top level and covers data loss, crash prevention, and unsupported behavior.
   - `:::danger` is not part of the scale. It renders the same red block titled "Warning" as `:::warning` (`docusaurus/src/theme/Admonition/index.js`, `docusaurus/src/scss/admonition.scss`), so it adds no signal. Flag it and propose `:::warning`.
   - **Severity:** error
 - **Strapi-specific (consecutive callouts):**
   - 3 or more callouts in a row, whatever their types, are a wall the reader stops reading. Keep one and move the rest to prose or a bullet list.
   - Two callouts of the same type back to back are one callout: merge them into a single block, with a bullet per point.
   - Two high-level callouts (`:::caution`, `:::warning`, `:::danger`) back to back flatten the hierarchy, and the severe stops standing out from the merely annoying. Keep one alert.
-  - A pair of different low-level types (`:::note` then `:::tip`) is harmless, and so is the documented `:::prerequisites` plus `:::caution` page-header motif, as long as the run stops at 2. Do NOT flag either.
+  - A pair of different low-level types (`:::info`, `:::note`, `:::tip` in any combination) is harmless, and so is the documented `:::prerequisites` plus `:::caution` page-header motif, as long as the run stops at 2. Do NOT flag either.
   - **Severity:** warning
 
 ### Rule 3: Direct and neutral tone

--- a/claude-plugins/inki/references/templates/README.md
+++ b/claude-plugins/inki/references/templates/README.md
@@ -54,5 +54,6 @@ How to use
 - Badge (plan / status / version flags via named aliases like `<GrowthBadge>`, `<NewBadge>`) rules: `claude-plugins/inki/references/templates/components/badge.md`
 - Columns / ColumnLeft / ColumnRight (two-up side-by-side layout) rules: `claude-plugins/inki/references/templates/components/columns.md`
 - SubtleCallout (low-emphasis "good to know" aside) rules: `claude-plugins/inki/references/templates/components/subtle-callout.md`
+- CustomDocCard / CustomDocCardsWrapper (clickable navigation cards and their grid) rules: `claude-plugins/inki/references/templates/components/doc-cards.md`
 - Checklist / ChecklistItem (interactive checkbox lists) rules: `claude-plugins/inki/references/templates/components/checklist.md`
 - MermaidWithFallback (live Mermaid diagram with static fallback) rules: `claude-plugins/inki/references/templates/components/mermaid-with-fallback.md`

--- a/claude-plugins/inki/references/templates/components/doc-cards.md
+++ b/claude-plugins/inki/references/templates/components/doc-cards.md
@@ -36,7 +36,7 @@ Use `<CustomDocCard>` for a clickable card that sends the reader to another page
 | Component | Effect |
 |-----------|--------|
 | `<CustomDocCardsWrapper>` | Lays the cards out as an auto-fitting grid (`repeat(auto-fill, minmax(min(240px, 100%), 1fr))`), so the same block renders as 2 columns at normal width and more in max-width mode, and collapses to 1 column on mobile. |
-| `<ExpandableDocCardsWrapper>` | Same grid, but shows only the first `initialVisible` cards (default 4) behind a "See more..." toggle. Use it for long provider lists. |
+| `<ExpandableDocCardsWrapper>` | Same grid, but shows only the first `initialVisible` cards (default 4) behind a "See more..." toggle. Use it for long provider lists (more than 6 cards for instance). |
 
 ## Rules
 

--- a/claude-plugins/inki/references/templates/components/doc-cards.md
+++ b/claude-plugins/inki/references/templates/components/doc-cards.md
@@ -1,0 +1,85 @@
+# CustomDocCard component (clickable navigation cards)
+
+Use `<CustomDocCard>` for a clickable card that sends the reader to another page: a section hub, a list of related guides, a set of provider pages. Wrap several cards in `<CustomDocCardsWrapper>` to lay them out as a grid. It is the most used custom component in the docs (around 150 cards), so match the surrounding page rather than inventing a variant.
+
+## When to use
+
+- A hub page that hands the reader off to its sub-pages (`cms/intro.md`, `cms/customization.md`).
+- A list of sibling guides or providers where each entry is one page (`snippets/media-library-providers-list.md`, the deployment guides on `cms/deployment.md`).
+- A single prominent onward link that deserves more weight than a prose link (`cms/configurations/environment.md` uses a one-card wrapper).
+
+## When NOT to use
+
+- The closing "what to read next" block of a tutorial. Use `<NextSteps>` instead (see `next-steps.md`); it numbers the steps and is the convention for that block.
+- An unordered "see also" list inside a section. Prose links or a bullet list read better and cost less vertical space.
+- Anything that is not a link. The whole card is a link, so a card with no `link` renders as a dead box.
+
+## No import
+
+- Do NOT add an import line. `CustomDocCard`, `CustomDocCardsWrapper` and `ExpandableDocCardsWrapper` are registered as global MDX components in `docusaurus/src/theme/MDXComponents.js`, so they work directly in any `.md`/`.mdx` page.
+- The names are case-sensitive in MDX and have no aliases.
+
+## Props
+
+`docusaurus/src/components/CustomDocCard.js` destructures exactly these 5 props. Anything else is ignored silently, with no build error and no visible sign on the page.
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `title` | `string` | (none) | The card label, rendered as its `<h2>`. Always supply it. |
+| `link` | `string` | (none) | Target of the card. Internal paths start with `/` and carry no `.md` extension (`/cms/deployment/guides/nginx`); external links are full URLs. |
+| `description` | `string` | (none) | One-line explanation under the title. Optional: without it the card is a title-only box. |
+| `icon` | `string` | (none) | A Phosphor icon name, rendered as `ph-fill ph-<icon>` before the title (`icon="plug"`, `icon="arrow-square-out"`). See `icon.md` for the icon set. |
+| `small` | boolean | `false` | Adds the `custom-doc-card--small` modifier, for the compact full-width variant used in stacked lists outside a wrapper. |
+
+### Wrappers
+
+| Component | Effect |
+|-----------|--------|
+| `<CustomDocCardsWrapper>` | Lays the cards out as an auto-fitting grid (`repeat(auto-fill, minmax(min(240px, 100%), 1fr))`), so the same block renders as 2 columns at normal width and more in max-width mode, and collapses to 1 column on mobile. |
+| `<ExpandableDocCardsWrapper>` | Same grid, but shows only the first `initialVisible` cards (default 4) behind a "See more..." toggle. Use it for long provider lists. |
+
+## Rules
+
+1. **There is no `emoji` prop.** `<CustomDocCard emoji="🔗" … />` renders a card with no icon at all, and nothing reports the mistake. Use `icon` with a Phosphor name instead; `icon="arrow-square-out"` is the house icon for an outbound link. The confusion comes from `<SubtleCallout>`, which *does* take an `emoji`. The `unknown-card-prop` rule in `scripts/style-lint.sh` catches this.
+2. **Keep descriptions to one short line.** The description renders inside `text--truncate`, so it is clipped to a single line with an ellipsis. Do not paste the page's frontmatter `description` verbatim: rewrite it to fit, around 60 to 70 characters.
+3. **Be consistent within a block.** Every card in one wrapper should carry the same set of props. A grid where some cards have a description and others do not, or where only some have an icon, reads as broken rather than as emphasis.
+4. **`small` belongs outside a wrapper.** The compact variant is for the stacked, full-width lists. Inside `<CustomDocCardsWrapper>` the grid already sizes the cards, and the canonical wrapper usages do not pass `small`.
+5. **Blank lines around the wrapper.** Leave a blank line after the opening `<CustomDocCardsWrapper>` and before the closing tag when the cards are separated by blank lines, so MDX parses the block predictably.
+
+## Canonical examples
+
+### A grid of sibling guides
+
+From `docs/cms/deployment.md`:
+
+```mdx
+<CustomDocCardsWrapper>
+<CustomDocCard icon="plugs-connected" title="Proxying with Nginx" description="Serve Strapi through an Nginx reverse proxy over HTTPS." link="/cms/deployment/guides/nginx" />
+<CustomDocCard icon="repeat" title="Using the PM2 process manager" description="Keep Strapi running with PM2, and start it again after a reboot." link="/cms/deployment/guides/pm2" />
+</CustomDocCardsWrapper>
+```
+
+### The multi-line form
+
+From `docs/snippets/media-library-providers-list.md`. Both forms are accepted; the multi-line one reads better past 3 props:
+
+```mdx
+<CustomDocCardsWrapper>
+<CustomDocCard
+  icon="plug"
+  title="Amazon S3"
+  description="Official provider for file uploads to Amazon S3."
+  link="/cms/configurations/media-library-providers/amazon-s3"
+/>
+</CustomDocCardsWrapper>
+```
+
+### A single onward card
+
+From `docs/cms/configurations/environment.md`. A one-card wrapper is a legitimate way to give one link card weight:
+
+```mdx
+<CustomDocCardsWrapper>
+<CustomDocCard icon="chalkboard-simple" title="Access and cast variables" description="Learn how to access and cast environment variables with the env() utility." link="/cms/configurations/guides/access-cast-environment-variables" />
+</CustomDocCardsWrapper>
+```

--- a/claude-plugins/inki/scripts/style-lint.sh
+++ b/claude-plugins/inki/scripts/style-lint.sh
@@ -428,7 +428,7 @@ check_bold_overuse() {
 #                        of red and the severe stops standing out from the merely
 #                        annoying.
 #
-# A pair of different low-level types (:::note then :::tip) is harmless and is
+# A pair of different low-level types (:::info, :::note, :::tip) is harmless and is
 # not flagged, and neither is the documented :::prerequisites plus :::caution
 # page-header motif, as long as the run stops at two.
 # A fenced block between two callouts ends the run, since the second one then

--- a/claude-plugins/inki/scripts/style-lint.sh
+++ b/claude-plugins/inki/scripts/style-lint.sh
@@ -216,6 +216,17 @@ lint_file() {
       has_errors=1
     fi
 
+    # `:::danger` is not part of the style guide scale, which goes
+    # tip -> note -> prerequisites -> caution -> warning. `warning` is the top
+    # level and covers data loss, crash prevention, and unsupported behavior.
+    # In this repo both keywords render the same red block titled "Warning"
+    # (`src/theme/Admonition/index.js`, `src/scss/admonition.scss`), so `danger`
+    # adds no signal and only diverges from the documented scale.
+    if echo "$line" | grep -qE '^[[:space:]]*:::danger([[:space:]]|$)'; then
+      echo "error:${line_num}:danger-admonition::::danger is not in the style guide -- use :::warning (top level: data loss, crash prevention)"
+      has_errors=1
+    fi
+
     # Multi-action steps: numbered list items with joining words
     if echo "$line" | grep -qE '^[[:space:]]*[0-9]+\.[[:space:]]'; then
       if echo "$line" | grep -qEi "(,?[[:space:]]*${word_boundary_start}then${word_boundary_end}|${word_boundary_start}and then${word_boundary_end}|${word_boundary_start}and also${word_boundary_end}|,?[[:space:]]*${word_boundary_start}next${word_boundary_end})"; then
@@ -343,6 +354,7 @@ lint_file() {
   # so bold inside code is never counted. Paragraphs are blocks of consecutive
   # non-blank lines; the finding is reported on the paragraph's first line.
   check_bold_overuse "$file" "$stripped"
+  check_stacked_alerts "$file"
 }
 
 # Counts **bold** spans per paragraph and warns when a paragraph carries more
@@ -395,6 +407,73 @@ check_bold_overuse() {
       }
     }
   ' <<< "$stripped")
+
+  if [[ -n "$findings" ]]; then
+    echo "$findings"
+    has_warnings=1
+  fi
+}
+
+# Two high-level callouts in a row flatten the hierarchy: the reader sees a wall
+# of red blocks and stops telling the severe apart from the merely annoying.
+# Keep one alert and move the rest to prose or a bullet list.
+# Only the top of the style guide scale counts (caution, warning, and the legacy
+# danger): stacking note/tip/info blocks is common and harmless, and a
+# :::prerequisites followed by a :::caution is the documented page-header motif.
+# Reported on the opening line of the second callout. Blank lines between the two
+# do not clear the finding; a fenced block does, since the second callout then
+# carries its own context. Reads the original file rather than the stripped
+# content, where fenced blocks have already collapsed into blank lines.
+check_stacked_alerts() {
+  local file="$1"
+
+  local findings
+  findings=$(awk '
+    BEGIN {
+      in_code = 0; in_frontmatter = 0; line_num = 0
+      open_type = ""; closed_type = ""
+      alerts = "caution warning danger"
+    }
+
+    function is_alert(type) {
+      return index(alerts, type) > 0
+    }
+
+    {
+      line_num++
+
+      # Skip YAML frontmatter (--- delimited block at the top of the file).
+      if (line_num == 1 && $0 == "---") { in_frontmatter = 1; next }
+      if (in_frontmatter) { if ($0 == "---") in_frontmatter = 0; next }
+
+      # A fenced block between the two callouts separates them.
+      if ($0 ~ /^[[:space:]]*```/) { in_code = !in_code; closed_type = ""; next }
+      if (in_code) next
+
+      # Blank lines keep the pending state: ::: then a blank line then :::warning
+      # is still two stacked alerts.
+      if ($0 ~ /^[[:space:]]*$/) next
+
+      # Opening line of a callout (:::warning, :::caution Title). Nested
+      # callouts (::::) are left alone.
+      if (match($0, /^:::[a-zA-Z]+/)) {
+        type = substr($0, 4, RLENGTH - 3)
+
+        if (closed_type != "" && is_alert(closed_type) && is_alert(type)) {
+          print "warning:" line_num ":stacked-alerts:" closed_type " callout directly followed by a " type " one -- keep one alert and move the rest to prose or a list"
+        }
+
+        open_type = type
+        closed_type = ""
+        next
+      }
+
+      # Closing line of a callout.
+      if ($0 ~ /^:::[[:space:]]*$/) { closed_type = open_type; open_type = ""; next }
+
+      closed_type = ""
+    }
+  ' "$file")
 
   if [[ -n "$findings" ]]; then
     echo "$findings"

--- a/claude-plugins/inki/scripts/style-lint.sh
+++ b/claude-plugins/inki/scripts/style-lint.sh
@@ -355,6 +355,7 @@ lint_file() {
   # non-blank lines; the finding is reported on the paragraph's first line.
   check_bold_overuse "$file" "$stripped"
   check_admonition_stacks "$file"
+  check_doc_card_props "$file"
 }
 
 # Counts **bold** spans per paragraph and warns when a paragraph carries more
@@ -512,6 +513,63 @@ check_admonition_stacks() {
   if [[ -n "$findings" ]]; then
     echo "$findings"
     has_warnings=1
+  fi
+}
+
+# `<CustomDocCard>` silently ignores any prop it does not read. The component
+# (`docusaurus/src/components/CustomDocCard.js`) destructures exactly
+# `title`, `description`, `link`, `icon` and `small`, so an `emoji` prop renders
+# a card with no icon at all and no error anywhere. `<SubtleCallout>` does take
+# an `emoji`, which is why this check is scoped to the card component instead of
+# the prop name.
+# Handles the multi-line form of the tag, and skips fenced blocks so that a
+# documented anti-pattern in an example is not flagged.
+check_doc_card_props() {
+  local file="$1"
+
+  local findings
+  findings=$(awk '
+    BEGIN {
+      in_code = 0; in_card = 0; line_num = 0
+      known = " title description link icon small "
+    }
+
+    {
+      line_num++
+
+      if ($0 ~ /^[[:space:]]*```/) { in_code = !in_code; next }
+      if (in_code) next
+
+      line = $0
+      if (!in_card) {
+        if (line !~ /<CustomDocCard/) next
+        sub(/.*<CustomDocCard/, "", line)
+        in_card = 1
+      }
+
+      # Drop attribute values before looking for prop names, so that a query
+      # string in a link (`?a=b`) is not read as a prop.
+      work = line
+      gsub(/"[^"]*"/, "", work)
+
+      while (match(work, /[a-zA-Z][a-zA-Z0-9_-]*[[:space:]]*=/)) {
+        prop = substr(work, RSTART, RLENGTH)
+        sub(/[[:space:]]*=$/, "", prop)
+
+        if (index(known, " " prop " ") == 0) {
+          print "error:" line_num ":unknown-card-prop:<CustomDocCard> has no \"" prop "\" prop, so it is ignored at render time -- supported props are title, description, link, icon and small"
+        }
+
+        work = substr(work, RSTART + RLENGTH)
+      }
+
+      if (work ~ />/) in_card = 0
+    }
+  ' "$file")
+
+  if [[ -n "$findings" ]]; then
+    echo "$findings"
+    has_errors=1
   fi
 }
 

--- a/claude-plugins/inki/scripts/style-lint.sh
+++ b/claude-plugins/inki/scripts/style-lint.sh
@@ -354,7 +354,7 @@ lint_file() {
   # so bold inside code is never counted. Paragraphs are blocks of consecutive
   # non-blank lines; the finding is reported on the paragraph's first line.
   check_bold_overuse "$file" "$stripped"
-  check_stacked_alerts "$file"
+  check_admonition_stacks "$file"
 }
 
 # Counts **bold** spans per paragraph and warns when a paragraph carries more
@@ -414,29 +414,56 @@ check_bold_overuse() {
   fi
 }
 
-# Two high-level callouts in a row flatten the hierarchy: the reader sees a wall
-# of red blocks and stops telling the severe apart from the merely annoying.
-# Keep one alert and move the rest to prose or a bullet list.
-# Only the top of the style guide scale counts (caution, warning, and the legacy
-# danger): stacking note/tip/info blocks is common and harmless, and a
-# :::prerequisites followed by a :::caution is the documented page-header motif.
-# Reported on the opening line of the second callout. Blank lines between the two
-# do not clear the finding; a fenced block does, since the second callout then
-# carries its own context. Reads the original file rather than the stripped
-# content, where fenced blocks have already collapsed into blank lines.
-check_stacked_alerts() {
+# Consecutive callouts, separated by nothing but blank lines, are checked for
+# three distinct defects:
+#
+#   admonition-run       3 or more in a row, whatever the types: a wall of
+#                        callouts the reader stops reading.
+#   same-type-admonitions  two callouts of the same type back to back: they are
+#                        one callout, and their points belong in one block as
+#                        bullets.
+#   stacked-alerts       two high-level callouts (caution, warning, the legacy
+#                        danger) back to back: the hierarchy flattens into a wall
+#                        of red and the severe stops standing out from the merely
+#                        annoying.
+#
+# A pair of different low-level types (:::note then :::tip) is harmless and is
+# not flagged, and neither is the documented :::prerequisites plus :::caution
+# page-header motif, as long as the run stops at two.
+# A fenced block between two callouts ends the run, since the second one then
+# carries its own context; a fenced block inside a callout does not.
+# Reads the original file rather than the stripped content, where fenced blocks
+# have already collapsed into blank lines.
+check_admonition_stacks() {
   local file="$1"
 
   local findings
   findings=$(awk '
     BEGIN {
-      in_code = 0; in_frontmatter = 0; line_num = 0
-      open_type = ""; closed_type = ""
+      in_code = 0; in_frontmatter = 0; in_admonition = 0
+      line_num = 0; run = 0; run_start = 0
       alerts = "caution warning danger"
     }
 
     function is_alert(type) {
       return index(alerts, type) > 0
+    }
+
+    # End of a run of consecutive callouts: report what the run contains.
+    function flush_run() {
+      if (run >= 3) {
+        print "warning:" run_start ":admonition-run:" run " admonitions in a row -- a wall of callouts, keep one and move the rest to prose or a list"
+      }
+
+      for (i = 2; i <= run; i++) {
+        if (types[i] == types[i - 1]) {
+          print "warning:" lines[i] ":same-type-admonitions:two " types[i] " callouts in a row -- merge them into one, with a bullet per point"
+        } else if (is_alert(types[i]) && is_alert(types[i - 1])) {
+          print "warning:" lines[i] ":stacked-alerts:" types[i - 1] " callout directly followed by a " types[i] " one -- keep one alert and move the rest to prose or a list"
+        }
+      }
+
+      run = 0
     }
 
     {
@@ -446,33 +473,40 @@ check_stacked_alerts() {
       if (line_num == 1 && $0 == "---") { in_frontmatter = 1; next }
       if (in_frontmatter) { if ($0 == "---") in_frontmatter = 0; next }
 
-      # A fenced block between the two callouts separates them.
-      if ($0 ~ /^[[:space:]]*```/) { in_code = !in_code; closed_type = ""; next }
+      # Fenced blocks. One inside a callout is part of it; one between callouts
+      # ends the run.
+      if ($0 ~ /^[[:space:]]*```/) {
+        in_code = !in_code
+        if (!in_code && !in_admonition) flush_run()
+        next
+      }
       if (in_code) next
 
-      # Blank lines keep the pending state: ::: then a blank line then :::warning
-      # is still two stacked alerts.
+      # Blank lines keep the run open: ::: then a blank line then :::note is
+      # still two stacked callouts.
       if ($0 ~ /^[[:space:]]*$/) next
 
-      # Opening line of a callout (:::warning, :::caution Title). Nested
-      # callouts (::::) are left alone.
+      # Opening line of a callout (:::note, :::warning Title). Nested callouts
+      # (::::) are left alone.
       if (match($0, /^:::[a-zA-Z]+/)) {
         type = substr($0, 4, RLENGTH - 3)
 
-        if (closed_type != "" && is_alert(closed_type) && is_alert(type)) {
-          print "warning:" line_num ":stacked-alerts:" closed_type " callout directly followed by a " type " one -- keep one alert and move the rest to prose or a list"
-        }
-
-        open_type = type
-        closed_type = ""
+        if (run == 0) run_start = line_num
+        run++
+        types[run] = type
+        lines[run] = line_num
+        in_admonition = 1
         next
       }
 
-      # Closing line of a callout.
-      if ($0 ~ /^:::[[:space:]]*$/) { closed_type = open_type; open_type = ""; next }
+      # Closing line of a callout. The run stays open.
+      if ($0 ~ /^:::[[:space:]]*$/) { in_admonition = 0; next }
 
-      closed_type = ""
+      # Any other prose: inside a callout it is its body, outside it ends the run.
+      if (!in_admonition) flush_run()
     }
+
+    END { flush_run() }
   ' "$file")
 
   if [[ -n "$findings" ]]; then


### PR DESCRIPTION
This PR encodes 2 sets of component conventions in the Inki style linter, in the style checker prompt, and in the authoring guides.

Callouts:

- `danger-admonition` (error) flags `:::danger`, which is not part of the scale (info, note, tip, prerequisites, caution, warning) and renders the same red block titled "Warning" as `:::warning`, so it adds no signal.
- `admonition-run` (warning) flags 3 or more callouts in a row, whatever their types: a wall the reader stops reading.
- `same-type-admonitions` (warning) flags 2 callouts of the same type back to back, which are one callout and belong in a single block with a bullet per point.
- `stacked-alerts` (warning) flags 2 high-level callouts (caution, warning, danger) back to back, which flattens the hierarchy into a wall of red.

A pair of different low-level types, and the documented `:::prerequisites` plus `:::caution` page-header motif, are deliberately not flagged as long as the run stops at 2.

Doc cards:

- `unknown-card-prop` (error) flags any prop `<CustomDocCard>` does not read. The component destructures exactly `title`, `description`, `link`, `icon` and `small`, so the `emoji` prop found on 62 of the 152 cards in the docs renders a card with no icon and reports nothing. `<SubtleCallout>` does take an `emoji`, so the rule is scoped to the card component rather than to the prop name.
- `templates/components/doc-cards.md` documents the card components, which had no authoring guide despite being the most used custom component in the docs: the real props, the 2 wrappers, the single-line truncation of `description`, and the `emoji` trap.

Measured on the 343 pages under `docusaurus/docs`: 5 `:::danger` occurrences, 14 runs of 3 or more callouts, 8 same-type pairs, 1 stacked alert, and 62 dead `emoji` props. Scoping matters: a first version of the run check flagged any 2 consecutive callouts and fired 122 times, mostly on harmless note and tip pairs. Neither the plugin version nor the changelog is bumped, following #3466.
