### PR TITLE
Remove the unused step separator from the NextSteps component

### DIFF
--- a/docusaurus/src/components/NextSteps/next-steps.module.scss
+++ b/docusaurus/src/components/NextSteps/next-steps.module.scss
@@ -57,21 +57,10 @@
   align-items: center;
   gap: 20px;
   padding: 28px 24px;
-  border-bottom: 1px solid var(--strapi-border, rgba(0, 0, 0, 0.06));
   transition: background 0.2s;
   border-radius: 12px;
   margin: 0 -24px;
   width: calc(100% + 48px);
-}
-
-// The separator belongs between steps, so only the last one drops it. A linked
-// step is wrapped in its own `<a class="stepLink">`, which makes `.step` the
-// only child there: `.step:last-child` would match on every linked step and
-// remove every separator. The rule has to look at the last child of `.steps`
-// instead, whether that child is the link wrapper or a bare unlinked step.
-.steps > :last-child .step,
-.steps > .step:last-child {
-  border-bottom: none;
 }
 
 .stepNumber {

--- a/docusaurus/src/components/NextSteps/next-steps.module.scss
+++ b/docusaurus/src/components/NextSteps/next-steps.module.scss
@@ -62,10 +62,16 @@
   border-radius: 12px;
   margin: 0 -24px;
   width: calc(100% + 48px);
+}
 
-  &:last-child {
-    border-bottom: none;
-  }
+// The separator belongs between steps, so only the last one drops it. A linked
+// step is wrapped in its own `<a class="stepLink">`, which makes `.step` the
+// only child there: `.step:last-child` would match on every linked step and
+// remove every separator. The rule has to look at the last child of `.steps`
+// instead, whether that child is the link wrapper or a bare unlinked step.
+.steps > :last-child .step,
+.steps > .step:last-child {
+  border-bottom: none;
 }
 
 .stepNumber {


### PR DESCRIPTION
This PR removes the step separator from the `<NextSteps>` component, so the rendered result matches what docs.strapi.io shows today and an unlinked step stops rendering as a lone framed box.

`.step` carried a `border-bottom` that `&:last-child` was meant to drop on the last step only. A step that has a `link` is wrapped in its own `<a class="stepLink">`, which makes `.step` the only child there, so the selector matched on every linked step and removed every separator. The border therefore never rendered on the published pages, and the declaration was dead code. It did render in one case: an unlinked step sits directly in `.steps`, keeps its border, and bleeds past the content width because `.step` carries `margin: 0 -24px`. That is visible on the deployment guides of #3461, where the PM2 step has no link until #3465 adds the page it points to.

Making the separator render was tried first and rejected: the line spans the negative margins and cuts across the block. Removing the declaration keeps the current appearance, which is the intended one, and fixes the orphan box.

Direct preview link 👉 [here](https://documentation-git-repo-fix-next-steps-separator-strapijs.vercel.app/cms/quick-start)
