### PR TITLE
Add the Vercel preview link to PR descriptions automatically

### DIFF
--- a/.github/workflows/add-vercel-preview-link.yml
+++ b/.github/workflows/add-vercel-preview-link.yml
@@ -1,0 +1,89 @@
+name: Add the Vercel preview link to a PR description
+
+# Runs when Vercel finishes a Preview deployment, which is the first moment the
+# preview URL exists. Reacting to `pull_request` instead would fire before the
+# deployment and would have nothing to link to.
+#
+# Security: `deployment_status` runs in the context of the base repository, so
+# the token has write access even when the pull request comes from a community
+# fork, where a `pull_request` workflow would only get a read-only token. The
+# job never checks out the pull request's code: it only calls the API, so no
+# untrusted code ever runs with that token. The workflow file used is always the
+# one on the default branch, so a fork cannot alter this job through its PR.
+on:
+  deployment_status:
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  add-preview-link:
+    # Vercel names its per-PR environment "Preview". Production deployments and
+    # failed or in-progress builds are ignored.
+    if: >
+      github.event.deployment_status.state == 'success' &&
+      github.event.deployment.environment == 'Preview'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Add the preview link when the description has none
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const MARKER = 'Direct preview link';
+            // Vercel truncates a branch slug that does not fit the 63-character
+            // DNS label and appends a hash, so a slug-built host is only
+            // reliable below this length. Past it, fall back to the immutable
+            // deployment URL the event carries.
+            const MAX_SLUG = 35;
+
+            const { owner, repo } = context.repo;
+            const sha = context.payload.deployment.sha;
+
+            // `deployment.ref` is a SHA, not a branch name, so the pull request
+            // (and its head branch) has to be resolved from the commit.
+            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner, repo, commit_sha: sha,
+            });
+            const pr = prs.find((p) => p.state === 'open');
+            if (!pr) {
+              core.info(`No open pull request for ${sha}, nothing to do.`);
+              return;
+            }
+
+            const body = pr.body || '';
+            if (body.includes(MARKER)) {
+              core.info(`PR #${pr.number} already has a preview link.`);
+              return;
+            }
+
+            // Link the page the PR adds, falling back to the most relevant page
+            // it changes. A PR touching no documentation page gets no link
+            // rather than a link to a page that does not exist.
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner, repo, pull_number: pr.number, per_page: 100,
+            });
+            const pages = files.filter((f) =>
+              f.filename.startsWith('docusaurus/docs/') && /\.mdx?$/.test(f.filename)
+            );
+            if (pages.length === 0) {
+              core.info(`PR #${pr.number} changes no documentation page.`);
+              return;
+            }
+            const page = pages.find((f) => f.status === 'added') || pages[0];
+            const path = page.filename
+              .replace(/^docusaurus\/docs/, '')
+              .replace(/\.mdx?$/, '')
+              .replace(/\/index$/, '');
+
+            const slug = pr.head.ref.replace(/\//g, '-');
+            const host = slug.length <= MAX_SLUG
+              ? `https://documentation-git-${slug}-strapijs.vercel.app`
+              : context.payload.deployment_status.environment_url;
+
+            const link = `\n\n${MARKER} 👉 [here](${host}${path})`;
+            await github.rest.pulls.update({
+              owner, repo, pull_number: pr.number, body: body + link,
+            });
+            core.info(`PR #${pr.number}: added ${host}${path}`);


### PR DESCRIPTION
This PR adds a workflow that appends the Vercel preview link to a pull request description once, when the preview deployment succeeds and the description has none.

It runs on `deployment_status` rather than on `pull_request`, for 2 reasons. The preview URL does not exist yet when a PR is opened, so a `pull_request` job would have nothing to link to. And `deployment_status` runs in the context of the base repository, so the token has write access even for a pull request opened from a community fork, where a `pull_request` job only gets a read-only token. The job never checks out the pull request's code, it only calls the API, so no untrusted code runs with that token, and the workflow file used is always the one on the default branch.

The linked page is the documentation page the PR adds, falling back to the most relevant page it changes. A PR that touches no page under `docusaurus/docs/` gets no link rather than a link to a page that does not exist. The job writes only when the description has no link yet, so a redeploy never appends a second one.

`deployment_status` carries the immutable deployment URL, not the branch URL the team uses, and its `ref` is a SHA rather than a branch name. The branch host is therefore rebuilt from the PR's head branch, and the immutable URL is used as a fallback when the branch slug is longer than the 35 characters Vercel can fit in a DNS label before truncating it and appending a hash.
