### PR TITLE
Link a preview only for pages under cms or cloud

### DIFF
--- a/.github/workflows/add-vercel-preview-link.yml
+++ b/.github/workflows/add-vercel-preview-link.yml
@@ -80,13 +80,15 @@ jobs:
             }
 
             // Link the page the PR adds, falling back to the most relevant page
-            // it changes. A PR touching no documentation page gets no link
-            // rather than a link to a page that does not exist.
+            // it changes. Only `cms/` and `cloud/` hold real pages: everything
+            // else under `docusaurus/docs/`, `snippets/` in particular, is a
+            // fragment imported into a page rather than a page readers open, so
+            // a PR that only touches those gets no link.
             const files = await github.paginate(github.rest.pulls.listFiles, {
               owner, repo, pull_number: pr.number, per_page: 100,
             });
             const pages = files.filter((f) =>
-              f.filename.startsWith('docusaurus/docs/') && /\.mdx?$/.test(f.filename)
+              /^docusaurus\/docs\/(cms|cloud)\//.test(f.filename) && /\.mdx?$/.test(f.filename)
             );
             if (pages.length === 0) {
               core.notice(`PR #${pr.number} changes no documentation page, no link to add.`);

--- a/claude-plugins/inki/skills/pr/SKILL.md
+++ b/claude-plugins/inki/skills/pr/SKILL.md
@@ -31,9 +31,9 @@ The link has two parts: the **deployment host** and the **page path**. Build the
 
 ### Page path
 
-Identify the primary page path from the changed files: the most important new or modified `.md`/`.mdx` file under `docusaurus/docs/`, stripped of the `docusaurus/docs/` prefix and the `.md`/`.mdx` extension (e.g. `docusaurus/docs/cms/features/users-permissions.md` → `/cms/features/users-permissions`). Prefer a newly added page over a modified one.
+Identify the primary page path from the changed files: the most important new or modified `.md`/`.mdx` file under `docusaurus/docs/cms/` or `docusaurus/docs/cloud/`, stripped of the `docusaurus/docs/` prefix and the `.md`/`.mdx` extension (e.g. `docusaurus/docs/cms/features/users-permissions.md` → `/cms/features/users-permissions`). Prefer a newly added page over a modified one. Only `cms/` and `cloud/` hold pages readers open: anything else under `docusaurus/docs/`, `snippets/` in particular, is a fragment imported into a page, so it is never the preview target.
 
-**When no page under `docusaurus/docs/` is changed** (for example a `repo/` PR touching only `claude-plugins/`, config, or tooling), there is no doc page to preview: **omit the preview line entirely** rather than building a link to a page that does not exist. Do not fall back to the preview root. Skip the rest of this step.
+**When no page under `docusaurus/docs/cms/` or `docusaurus/docs/cloud/` is changed** (a `repo/` PR touching only `claude-plugins/`, config, or tooling, or a PR touching only `docusaurus/docs/snippets/`), there is no doc page to preview: **omit the preview line entirely** rather than building a link to a page that does not exist. Do not fall back to the preview root. Skip the rest of this step.
 
 ### Deployment host
 


### PR DESCRIPTION
This PR narrows the page the preview link points at, in the workflow added in #3471 and in the `/inki:pr` skill that writes the same line by hand. Both looked for any `.md` or `.mdx` file under `docusaurus/docs/`, so a PR touching only `docusaurus/docs/snippets/` got a link to a snippet.

Only `cms/` and `cloud/` hold pages a reader opens. A snippet is a fragment imported into a page, so a PR that touches nothing else now gets no preview link at all, the same way a `repo/` PR touching only tooling already did.

The rule was not written down anywhere, which is how the 2 implementations ended up agreeing on the wrong thing, so the skill now states it explicitly rather than leaving it implied.
