### PR TITLE
Add missing pagination previous/next links to new deployment pages

### DIFF
--- a/docusaurus/docs/cms/deployment/guides.md
+++ b/docusaurus/docs/cms/deployment/guides.md
@@ -1,6 +1,8 @@
 ---
 title: Deployment guides
 description: Guides for serving Strapi behind a reverse proxy and running it under a process manager.
+pagination_prev: cms/deployment
+pagination_next: cms/deployment/guides/caddy
 displayed_sidebar: cmsSidebar
 tags:
 - deployment

--- a/docusaurus/docs/cms/deployment/guides/haproxy.md
+++ b/docusaurus/docs/cms/deployment/guides/haproxy.md
@@ -3,6 +3,8 @@ title: Proxying Strapi with HAProxy
 sidebar_label: HAProxy
 displayed_sidebar: cmsSidebar
 description: Configure Strapi and HAProxy so that a Strapi application is served through an HAProxy load balancer over HTTPS.
+pagination_prev: cms/deployment
+pagination_next: cms/deployment/guides
 tags:
 - deployment
 - deployment guide

--- a/docusaurus/docs/cms/deployment/guides/nginx.md
+++ b/docusaurus/docs/cms/deployment/guides/nginx.md
@@ -3,6 +3,8 @@ title: Proxying Strapi with Nginx
 sidebar_label: Nginx
 displayed_sidebar: cmsSidebar
 description: Configure Strapi and Nginx so that a Strapi application is served through an Nginx reverse proxy over HTTPS.
+pagination_prev: cms/deployment
+pagination_next: cms/deployment/guides
 tags:
 - deployment
 - deployment guide

--- a/docusaurus/docs/cms/deployment/guides/pm2.md
+++ b/docusaurus/docs/cms/deployment/guides/pm2.md
@@ -3,6 +3,8 @@ title: Running Strapi with PM2
 sidebar_label: PM2
 displayed_sidebar: cmsSidebar
 description: Use the PM2 process manager to keep a Strapi application running, restart it on failure, and start it again after a reboot.
+pagination_prev: cms/deployment
+pagination_next: cms/deployment/guides
 tags:
 - deployment
 - deployment guide

--- a/docusaurus/docs/cms/deployment/guides/traefik.md
+++ b/docusaurus/docs/cms/deployment/guides/traefik.md
@@ -3,6 +3,8 @@ title: Proxying Strapi with Traefik
 sidebar_label: Traefik
 displayed_sidebar: cmsSidebar
 description: Configure Strapi and Traefik so that a containerized Strapi application is served through Traefik over HTTPS.
+pagination_prev: cms/deployment
+pagination_next: cms/deployment/guides
 tags:
 - containers
 - deployment

--- a/docusaurus/static/llms-full.txt
+++ b/docusaurus/static/llms-full.txt
@@ -22976,7 +22976,7 @@ The server configuration for the admin panel can be configured with the followin
 | `port`                            | Port for the admin panel server. | string        | `8000`                                                                                                                              |
 
 :::note
-If you add a path to the `url` option, it won't prefix your application. To do so, use a proxy server like Nginx (see [optional software deployment guides](/cms/deployment#additional-resources)).
+If you add a path to the `url` option, it won't prefix your application. To do so, use a proxy server like Nginx (see [optional software deployment guides](/cms/deployment#deployment-guides)).
 :::
 
 ### Update the admin panel's path only


### PR DESCRIPTION
This PR builds upon previously merged PRs for new deployment guides and adds missing previous/next navigation links at the bottom of pages.

Direct preview link 👉 [here](https://documentation-gq7xfwsrg-strapijs.vercel.app/cms/deployment/guides)